### PR TITLE
[tree] Double32/Float16 avoid overwriting title from base class since it contains leafcounter

### DIFF
--- a/tree/tree/inc/TLeafD32.h
+++ b/tree/tree/inc/TLeafD32.h
@@ -52,7 +52,7 @@ public:
    void            ReadValue(std::istream &s, Char_t delim = ' ') override;
    void            SetAddress(void *add = nullptr) override;
 
-   ClassDefOverride(TLeafD32, 1); // A TLeaf for a 24 bit truncated floating point data type.
+   ClassDefOverride(TLeafD32, 2); // A TLeaf for a 24 bit truncated floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafF16.h
+++ b/tree/tree/inc/TLeafF16.h
@@ -51,7 +51,7 @@ public:
    void            ReadValue(std::istream &s, Char_t delim = ' ') override;
    void            SetAddress(void *add = nullptr) override;
 
-   ClassDefOverride(TLeafF16, 1); // A TLeaf for a 24 bit truncated floating point data type.
+   ClassDefOverride(TLeafF16, 2); // A TLeaf for a 24 bit truncated floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -249,7 +249,8 @@ TString TLeaf::GetFullName() const
 TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
 {
    countval = 1;
-   const char* name = GetTitle();
+   auto slash = fTitle.First("/"); // for truncated types D32 F16
+   const char *name = (slash == TString::kNPOS) ? fTitle.Data() : TString(fTitle(0, slash)).Data();
    char* bleft = (char*) strchr(name, '[');
    if (!bleft) {
       return nullptr;

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -250,7 +250,8 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
 {
    countval = 1;
    auto slash = fTitle.First("/"); // for truncated types D32 F16
-   const char *name = (slash == TString::kNPOS) ? fTitle.Data() : TString(fTitle(0, slash)).Data();
+   TStrig sname = (slash == TString::kNPOS) ? fTitle : TString(fTitle(0, slash));
+   const char *name = sname.Data();
    char* bleft = (char*) strchr(name, '[');
    if (!bleft) {
       return nullptr;

--- a/tree/tree/src/TLeaf.cxx
+++ b/tree/tree/src/TLeaf.cxx
@@ -250,7 +250,7 @@ TLeaf* TLeaf::GetLeafCounter(Int_t& countval) const
 {
    countval = 1;
    auto slash = fTitle.First("/"); // for truncated types D32 F16
-   TStrig sname = (slash == TString::kNPOS) ? fTitle : TString(fTitle(0, slash));
+   TString sname = (slash == TString::kNPOS) ? fTitle : TString(fTitle(0, slash));
    const char *name = sname.Data();
    char* bleft = (char*) strchr(name, '[');
    if (!bleft) {

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -49,11 +49,10 @@ TLeafD32::TLeafD32(TBranch *parent, const char *name, const char *type) : TLeaf(
    fPointer = nullptr;
    fElement = nullptr;
    
-   if (strchr(type, '[')) {
+   auto bracket = strchr(type, '[');
+   if (bracket) {
       fTitle.Append("/").Append(type);
-      fElement = new TStreamerElement(Form("%s_Element", name), type, 0, 0, "Double32_t");
-   } else {
-      fTitle = type;
+      fElement = new TStreamerElement(Form("%s_Element", name), bracket, 0, 0, "Double32_t");
    }
 }
 
@@ -208,10 +207,10 @@ void TLeafD32::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(TLeafD32::Class(), this);
 
-      if (fTitle.Contains("[")) {
+      if (fTitle.Contains("/[")) {
          auto slash = fTitle.First("/");
-         TString type = fTitle(slash + 1, fTitle.Length() - slash - 1);
-         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), type.Data(), 0, 0, "Double32_t");
+         TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
+         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Double32_t");
       }
    } else {
       R__b.WriteClassBuffer(TLeafD32::Class(), this);

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -205,6 +205,8 @@ void TLeafD32::SetAddress(void *add)
 void TLeafD32::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
+      delete fElement;
+      fElement = nullptr;
       UInt_t R__s, R__c;
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
       R__b.ReadClassBuffer(TLeafD32::Class(), this, R__v, R__s, R__c);

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -48,10 +48,13 @@ TLeafD32::TLeafD32(TBranch *parent, const char *name, const char *type) : TLeaf(
    fValue = nullptr;
    fPointer = nullptr;
    fElement = nullptr;
-   fTitle = type;
-
-   if (strchr(type, '['))
+   
+   if (strchr(type, '[')) {
+      fTitle.Append("/").Append(type);
       fElement = new TStreamerElement(Form("%s_Element", name), type, 0, 0, "Double32_t");
+   } else {
+      fTitle = type;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -205,8 +208,11 @@ void TLeafD32::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(TLeafD32::Class(), this);
 
-      if (fTitle.Contains("["))
-	 fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Double32_t");
+      if (fTitle.Contains("[")) {
+         auto slash = fTitle.First("/");
+         TString type = fTitle(slash + 1, fTitle.Length() - slash - 1);
+         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), type.Data(), 0, 0, "Double32_t");
+      }
    } else {
       R__b.WriteClassBuffer(TLeafD32::Class(), this);
    }

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -48,7 +48,7 @@ TLeafD32::TLeafD32(TBranch *parent, const char *name, const char *type) : TLeaf(
    fValue = nullptr;
    fPointer = nullptr;
    fElement = nullptr;
-   
+
    auto bracket = strchr(type, '[');
    if (bracket) {
       fTitle.Append("/").Append(type);
@@ -205,9 +205,15 @@ void TLeafD32::SetAddress(void *add)
 void TLeafD32::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
-      R__b.ReadClassBuffer(TLeafD32::Class(), this);
-
-      if (fTitle.Contains("/[")) {
+      UInt_t R__s, R__c;
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      R__b.ReadClassBuffer(TLeafD32::Class(), this, R__v, R__s, R__c);
+      if (R__v < 2) {
+         if (fTitle.Contains("[")) {
+            fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Double32_t");
+            fTitle = "/" + fTitle;
+         }
+      } else if (fTitle.Contains("/[")) {
          auto slash = fTitle.First("/");
          TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
          fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Double32_t");

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -51,7 +51,7 @@ TLeafD32::TLeafD32(TBranch *parent, const char *name, const char *type) : TLeaf(
 
    auto bracket = strchr(type, '[');
    if (bracket) {
-      fTitle.Append("/").Append(type);
+      fTitle.Append('/').Append(type);
       fElement = new TStreamerElement(Form("%s_Element", name), bracket, 0, 0, "Double32_t");
    }
 }
@@ -210,14 +210,12 @@ void TLeafD32::Streamer(TBuffer &R__b)
       UInt_t R__s, R__c;
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
       R__b.ReadClassBuffer(TLeafD32::Class(), this, R__v, R__s, R__c);
-      if (R__v < 2) {
-         if (fTitle.Contains("[")) {
-            fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Double32_t");
-            fTitle = "/" + fTitle;
-         }
-      } else if (fTitle.Contains("/[")) {
+      if (R__v < 2 && fTitle.BeginsWith("d[")) {
+         fTitle.Prepend('/');
+      }
+      if (fTitle.Contains("/d[")) {
          auto slash = fTitle.First("/");
-         TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
+         TString bracket = fTitle(slash + 2, fTitle.Length() - slash - 2);
          fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Double32_t");
       }
    } else {

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -49,11 +49,10 @@ TLeafF16::TLeafF16(TBranch *parent, const char *name, const char *type) : TLeaf(
    fPointer = nullptr;
    fElement = nullptr;
 
-   if (strchr(type, '[')) {
-      fTitle.Append("/").Append(type);
-      fElement = new TStreamerElement(Form("%s_Element", name), type, 0, 0, "Float16_t");
-   } else {
-      fTitle = type;
+   auto bracket = strchr(type, '[');
+   if (bracket) {
+      fTitle.Append("/").Append(bracket);
+      fElement = new TStreamerElement(Form("%s_Element", name), bracket, 0, 0, "Float16_t");
    }
 }
 
@@ -221,10 +220,10 @@ void TLeafF16::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(TLeafF16::Class(), this);
 
-      if (fTitle.Contains("[")) {
+      if (fTitle.Contains("/[")) {
          auto slash = fTitle.First("/");
-         TString type = fTitle(slash + 1, fTitle.Length() - slash - 1);
-         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), type.Data(), 0, 0, "Float16_t");
+         TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
+         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Float16_t");
       }
    } else {
       R__b.WriteClassBuffer(TLeafF16::Class(), this);

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -48,10 +48,13 @@ TLeafF16::TLeafF16(TBranch *parent, const char *name, const char *type) : TLeaf(
    fValue = nullptr;
    fPointer = nullptr;
    fElement = nullptr;
-   fTitle = type;
 
-   if (strchr(type, '['))
+   if (strchr(type, '[')) {
+      fTitle.Append("/").Append(type);
       fElement = new TStreamerElement(Form("%s_Element", name), type, 0, 0, "Float16_t");
+   } else {
+      fTitle = type;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -218,8 +221,11 @@ void TLeafF16::Streamer(TBuffer &R__b)
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(TLeafF16::Class(), this);
 
-      if (fTitle.Contains("["))
-	 fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Float16_t");
+      if (fTitle.Contains("[")) {
+         auto slash = fTitle.First("/");
+         TString type = fTitle(slash + 1, fTitle.Length() - slash - 1);
+         fElement = new TStreamerElement(Form("%s_Element", fName.Data()), type.Data(), 0, 0, "Float16_t");
+      }
    } else {
       R__b.WriteClassBuffer(TLeafF16::Class(), this);
    }

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -218,9 +218,15 @@ void TLeafF16::SetAddress(void *add)
 void TLeafF16::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
-      R__b.ReadClassBuffer(TLeafF16::Class(), this);
-
-      if (fTitle.Contains("/[")) {
+      UInt_t R__s, R__c;
+      Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
+      R__b.ReadClassBuffer(TLeafF16::Class(), this, R__v, R__s, R__c);
+      if (R__v < 2) {
+         if (fTitle.Contains("[")) {
+            fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Float16_t");
+            fTitle = "/" + fTitle;
+         }
+      } else if (fTitle.Contains("/[")) {
          auto slash = fTitle.First("/");
          TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
          fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Float16_t");

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -51,7 +51,7 @@ TLeafF16::TLeafF16(TBranch *parent, const char *name, const char *type) : TLeaf(
 
    auto bracket = strchr(type, '[');
    if (bracket) {
-      fTitle.Append("/").Append(bracket);
+      fTitle.Append('/').Append(type);
       fElement = new TStreamerElement(Form("%s_Element", name), bracket, 0, 0, "Float16_t");
    }
 }
@@ -223,14 +223,12 @@ void TLeafF16::Streamer(TBuffer &R__b)
       UInt_t R__s, R__c;
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
       R__b.ReadClassBuffer(TLeafF16::Class(), this, R__v, R__s, R__c);
-      if (R__v < 2) {
-         if (fTitle.Contains("[")) {
-            fElement = new TStreamerElement(Form("%s_Element", fName.Data()), fTitle.Data(), 0, 0, "Float16_t");
-            fTitle = "/" + fTitle;
-         }
-      } else if (fTitle.Contains("/[")) {
+      if (R__v < 2 && fTitle.BeginsWith("f[")) {
+         fTitle.Prepend('/');
+      }
+      if (fTitle.Contains("/f[")) {
          auto slash = fTitle.First("/");
-         TString bracket = slash == TString::kNPOS ? fTitle : fTitle(slash + 1, fTitle.Length() - slash - 1);
+         TString bracket = fTitle(slash + 2, fTitle.Length() - slash - 2);
          fElement = new TStreamerElement(Form("%s_Element", fName.Data()), bracket.Data(), 0, 0, "Float16_t");
       }
    } else {

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -218,6 +218,8 @@ void TLeafF16::SetAddress(void *add)
 void TLeafF16::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
+      delete fElement;
+      fElement = nullptr;
       UInt_t R__s, R__c;
       Version_t R__v = R__b.ReadVersion(&R__s, &R__c);
       R__b.ReadClassBuffer(TLeafF16::Class(), this, R__v, R__s, R__c);

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -1,6 +1,8 @@
 #include "TFile.h"
 #include "TSystem.h"
 #include "TTree.h"
+#include "TLeaf.h"
+#include "TBranch.h"
 
 #include "gtest/gtest.h"
 
@@ -56,4 +58,20 @@ TEST(TTreeTruncatedDatatypes, float16double32leaves)
    delete t;
    f.Close();
    gSystem->Unlink(ofileName);
+}
+
+// https://its.cern.ch/jira/browse/ROOT-10149
+TEST(TTreeTruncatedDatatypes, LeafCounter)
+{
+   TTree t("t", "t");
+   int n;
+   Double32_t arr[64];
+   t.Branch("n", &n);
+   t.Branch("arr", arr, "arr[n]/d[0,0,10]");
+   auto b = t.GetBranch("arr");
+   auto l = b->GetLeaf("arr");
+   int len;
+   auto b_c = l->GetLeafCounter(len);
+   EXPECT_NE(b_c, nullptr);
+   EXPECT_EQ(b_c->GetName(), "n");
 }

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -71,29 +71,53 @@ TEST(TTreeTruncatedDatatypes, LeafCounter)
       Double32_t arr[64];
       t->Branch("n", &n);
       t->Branch("arr", arr, "arr[n]/d[0,0,10]");
-      auto b = t->GetBranch("arr");
-      EXPECT_NE(b, nullptr);
-      auto l = b->GetLeaf("arr");
-      EXPECT_NE(l, nullptr);
-      int len;
-      auto b_c = l->GetLeafCounter(len);
-      EXPECT_NE(b_c, nullptr);
-      EXPECT_EQ(b_c->GetName(), "n");
+      t->Branch("arr_def", arr, "arr_def[n]/d");
+      t->Branch("arr_fix", arr, "arr_fix[64]/d[0,0,10]");
+      t->Branch("arr_fix_def", arr, "arr_fix_def[64]/d");
+      t->Branch("single", arr, "single/d[0,0,10]");
+      t->Branch("single_def", arr, "single_def/d");
+      for (auto name : {"arr", "arr_def", "arr_fix", "arr_fix_def", "single", "single_def"}) {
+         auto b = t->GetBranch(name);
+         EXPECT_NE(b, nullptr);
+         auto l = b->GetLeaf(name);
+         EXPECT_NE(l, nullptr);
+         int len;
+         auto b_c = l->GetLeafCounter(len);
+         if (strcmp(name, "arr") == 0 || strcmp(name, "arr_def") == 0) {
+            EXPECT_NE(b_c, nullptr);
+            EXPECT_STREQ(b_c->GetName(), "n");
+         } else if (strcmp(name, "arr_fix") == 0 || strcmp(name, "arr_fix_def") == 0) {
+            EXPECT_EQ(b_c, nullptr);
+            EXPECT_EQ(len, 64);
+         } else if (strcmp(name, "single") == 0 || strcmp(name, "single_def") == 0) {
+            EXPECT_EQ(b_c, nullptr);
+            EXPECT_EQ(len, 1);
+         }
+      }
       t->Write();
       f.Close();
    }
    {
       TFile f(ofileName, "READ");
       TTree *t = f.Get<TTree>("t");
-      EXPECT_NE(t, nullptr);
-      auto b = t->GetBranch("arr");
-      EXPECT_NE(b, nullptr);
-      auto l = b->GetLeaf("arr");
-      EXPECT_NE(l, nullptr);
-      int len;
-      auto b_c = l->GetLeafCounter(len);
-      EXPECT_NE(b_c, nullptr);
-      EXPECT_EQ(b_c->GetName(), "n");
+      for (auto name : {"arr", "arr_def", "arr_fix", "arr_fix_def", "single", "single_def"}) {
+         auto b = t->GetBranch(name);
+         EXPECT_NE(b, nullptr);
+         auto l = b->GetLeaf(name);
+         EXPECT_NE(l, nullptr);
+         int len;
+         auto b_c = l->GetLeafCounter(len);
+         if (strcmp(name, "arr") == 0 || strcmp(name, "arr_def") == 0) {
+            EXPECT_NE(b_c, nullptr);
+            EXPECT_STREQ(b_c->GetName(), "n");
+         } else if (strcmp(name, "arr_fix") == 0 || strcmp(name, "arr_fix_def") == 0) {
+            EXPECT_EQ(b_c, nullptr);
+            EXPECT_EQ(len, 64);
+         } else if (strcmp(name, "single") == 0 || strcmp(name, "single_def") == 0) {
+            EXPECT_EQ(b_c, nullptr);
+            EXPECT_EQ(len, 1);
+         }
+      }
       f.Close();
    }
    gSystem->Unlink(ofileName);

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -63,15 +63,38 @@ TEST(TTreeTruncatedDatatypes, float16double32leaves)
 // https://its.cern.ch/jira/browse/ROOT-10149
 TEST(TTreeTruncatedDatatypes, LeafCounter)
 {
-   TTree t("t", "t");
-   int n;
-   Double32_t arr[64];
-   t.Branch("n", &n);
-   t.Branch("arr", arr, "arr[n]/d[0,0,10]");
-   auto b = t.GetBranch("arr");
-   auto l = b->GetLeaf("arr");
-   int len;
-   auto b_c = l->GetLeafCounter(len);
-   EXPECT_NE(b_c, nullptr);
-   EXPECT_EQ(b_c->GetName(), "n");
+   {
+      const auto ofileName = "leafcounter10149.root";
+      TFile f(ofileName, "RECREATE");
+      TTree *t = new TTree("t", "t");
+      int n;
+      Double32_t arr[64];
+      t->Branch("n", &n);
+      t->Branch("arr", arr, "arr[n]/d[0,0,10]");
+      auto b = t->GetBranch("arr");
+      EXPECT_NE(b, nullptr);
+      auto l = b->GetLeaf("arr");
+      EXPECT_NE(l, nullptr);
+      int len;
+      auto b_c = l->GetLeafCounter(len);
+      EXPECT_NE(b_c, nullptr);
+      EXPECT_EQ(b_c->GetName(), "n");
+      t->Write();
+      f.Close();
+   }
+   {
+      TFile f(ofileName, "READ");
+      TTree *t = f.Get<TTree>("t");
+      EXPECT_NE(t, nullptr);
+      auto b = t->GetBranch("arr");
+      EXPECT_NE(b, nullptr);
+      auto l = b->GetLeaf("arr");
+      EXPECT_NE(l, nullptr);
+      int len;
+      auto b_c = l->GetLeafCounter(len);
+      EXPECT_NE(b_c, nullptr);
+      EXPECT_EQ(b_c->GetName(), "n");
+      f.Close();
+   }
+   gSystem->Unlink(ofileName);
 }

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -63,8 +63,8 @@ TEST(TTreeTruncatedDatatypes, float16double32leaves)
 // https://its.cern.ch/jira/browse/ROOT-10149
 TEST(TTreeTruncatedDatatypes, LeafCounter)
 {
+   const auto ofileName = "leafcounter10149.root";
    {
-      const auto ofileName = "leafcounter10149.root";
       TFile f(ofileName, "RECREATE");
       TTree *t = new TTree("t", "t");
       int n;

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -129,7 +129,7 @@ TEST(TTreeTruncatedDatatypes, LeafCounter)
          int n;
          Double32_t arr[64];
          t->SetBranchAddress("n", &n);
-         t->SetBranchAddress(name, &arr);
+         t->SetBranchAddress(name, arr);
          for (Long64_t i = 0; i < nEntries; ++i) {
             t->GetEntry(i);
             EXPECT_EQ(n, i + 1);

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -64,7 +64,7 @@ TEST(TTreeTruncatedDatatypes, float16double32leaves)
 TEST(TTreeTruncatedDatatypes, LeafCounter)
 {
    const auto ofileName = "leafcounter10149.root";
-   Long64_t nEntries = 1;
+   Long64_t nEntries = 10; // must be < 63
    {
       TFile f(ofileName, "RECREATE");
       TTree *t = new TTree("t", "t");
@@ -97,7 +97,7 @@ TEST(TTreeTruncatedDatatypes, LeafCounter)
       }
       // Fill tree
       for (Long64_t i = 0; i < nEntries; ++i) {
-         n = i;
+         n = i + 1; // Setting this to n = i; causes issues when i = 0
          for (int j = 0; j < 64; ++j) {
             arr[j] = i + 0.01 * j;
          }
@@ -132,6 +132,7 @@ TEST(TTreeTruncatedDatatypes, LeafCounter)
          t->SetBranchAddress(name, &arr);
          for (Long64_t i = 0; i < nEntries; ++i) {
             t->GetEntry(i);
+            EXPECT_EQ(n, i + 1);
             if (strcmp(name, "arr") == 0 || strcmp(name, "arr_def") == 0) {
                for (int j = 0; j < n; ++j) {
                   EXPECT_FLOAT_EQ(i + 0.01 * j, arr[j]);

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -129,7 +129,7 @@ TEST(TTreeTruncatedDatatypes, LeafCounter)
          int n;
          Double32_t arr[64];
          t->SetBranchAddress("n", &n);
-         t->SetBranchAddress(name, arr);
+         t->SetBranchAddress(name, &arr);
          for (Long64_t i = 0; i < nEntries; ++i) {
             t->GetEntry(i);
             if (strcmp(name, "arr") == 0 || strcmp(name, "arr_def") == 0) {

--- a/tree/tree/test/TTreeTruncatedDatatypes.cxx
+++ b/tree/tree/test/TTreeTruncatedDatatypes.cxx
@@ -64,7 +64,7 @@ TEST(TTreeTruncatedDatatypes, float16double32leaves)
 TEST(TTreeTruncatedDatatypes, LeafCounter)
 {
    const auto ofileName = "leafcounter10149.root";
-   Long64_t nEntries = 100;
+   Long64_t nEntries = 1;
    {
       TFile f(ofileName, "RECREATE");
       TTree *t = new TTree("t", "t");


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-10149

fyi @Triple-S

Context: https://github.com/root-project/root/commit/5b2bc099fc20399ac7622a8324545f1dca6fdd0f#diff-cb6d6533f05ffb9510627ac9d183f78821be4214f1b640ae050d4bac271c1daaR50 from https://github.com/root-project/root/pull/3463

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)