### PR TITLE
[v632] [cling] The LookupHelper routines need the ROOT lock.

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -53,6 +53,7 @@
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Utils/AST.h"
+#include "cling/Interpreter/EnterUserCodeRAII.h"
 
 #include "llvm/Support/Path.h"
 #include "llvm/Support/FileSystem.h"
@@ -528,6 +529,9 @@ void TClingLookupHelper::GetPartiallyDesugaredName(std::string &nameLong)
 bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nondef,
                                                          const std::string &nameLong)
 {
+   // We are going to use and possibly update the interpreter information.
+   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
+
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    clang::QualType t = lh.findType(nondef.c_str(), ToLHDS(WantDiags()));
    if (!t.isNull()) {
@@ -543,6 +547,9 @@ bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nond
 
 bool TClingLookupHelper::IsDeclaredScope(const std::string &base, bool &isInlined)
 {
+   // We are going to use and possibly update the interpreter information.
+   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
+
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    const clang::Decl *scope = lh.findScope(base.c_str(), ToLHDS(WantDiags()), nullptr);
 
@@ -576,6 +583,9 @@ bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::s
    }
 
    if (fAutoParse) fAutoParse(tname.c_str());
+
+   // We are going to use and possibly update the interpreter information.
+   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
 
    // Since we already check via other means (TClassTable which is populated by
    // the dictonary loading, and the gROOT list of classes and enums, which are

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -53,7 +53,7 @@
 #include "cling/Interpreter/Transaction.h"
 #include "cling/Interpreter/Interpreter.h"
 #include "cling/Utils/AST.h"
-#include "cling/Interpreter/EnterUserCodeRAII.h"
+#include "cling/Interpreter/InterpreterAccessRAII.h"
 
 #include "llvm/Support/Path.h"
 #include "llvm/Support/FileSystem.h"
@@ -530,7 +530,7 @@ bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nond
                                                          const std::string &nameLong)
 {
    // We are going to use and possibly update the interpreter information.
-   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
 
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    clang::QualType t = lh.findType(nondef.c_str(), ToLHDS(WantDiags()));
@@ -548,7 +548,7 @@ bool TClingLookupHelper::IsAlreadyPartiallyDesugaredName(const std::string &nond
 bool TClingLookupHelper::IsDeclaredScope(const std::string &base, bool &isInlined)
 {
    // We are going to use and possibly update the interpreter information.
-   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
 
    const cling::LookupHelper& lh = fInterpreter->getLookupHelper();
    const clang::Decl *scope = lh.findScope(base.c_str(), ToLHDS(WantDiags()), nullptr);
@@ -585,7 +585,7 @@ bool TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(const std::s
    if (fAutoParse) fAutoParse(tname.c_str());
 
    // We are going to use and possibly update the interpreter information.
-   LockCompilationDuringUserCodeExecutionRAII LCDUCER(*interp);
+   cling::InterpreterAccessRAII LockAccess(*fInterpreter);
 
    // Since we already check via other means (TClassTable which is populated by
    // the dictonary loading, and the gROOT list of classes and enums, which are

--- a/interpreter/cling/include/cling/Interpreter/InterpreterAccessRAII.h
+++ b/interpreter/cling/include/cling/Interpreter/InterpreterAccessRAII.h
@@ -1,0 +1,43 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:  Vassil Vassilev <vvasilev@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_INTERPRETERACCESSRAII_H
+#define CLING_INTERPRETERACCESSRAII_H
+
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterCallbacks.h"
+
+namespace cling {
+///\brief Locks and unlocks access to the interpreter.
+struct InterpreterAccessRAII {
+  /// Callbacks used to un/lock.
+  InterpreterCallbacks* fCallbacks;
+  /// Info provided to UnlockCompilationDuringUserCodeExecution().
+  void* fStateInfo = nullptr;
+
+  InterpreterAccessRAII(InterpreterCallbacks* callbacks):
+    fCallbacks(callbacks)
+  {
+    if (fCallbacks)
+      // The return value is alway a nullptr.
+      fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
+  }
+
+  InterpreterAccessRAII(Interpreter& interp):
+    InterpreterAccessRAII(interp.getCallbacks()) {}
+
+  ~InterpreterAccessRAII()
+  {
+    if (fCallbacks)
+      fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
+  }
+};
+}
+
+#endif // CLING_ENTERUSERCODERAII_H

--- a/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
+++ b/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
@@ -11,6 +11,7 @@
 #define CLING_ENTERUSERCODERAII_H
 
 #include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterAccessRAII.h"
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 namespace cling {
@@ -34,25 +35,7 @@ struct EnterUserCodeRAII {
   }
 };
 
-struct LockCompilationDuringUserCodeExecutionRAII {
-  /// Callbacks used to un/lock.
-  InterpreterCallbacks* fCallbacks;
-  /// Info provided to UnlockCompilationDuringUserCodeExecution().
-  void* fStateInfo = nullptr;
-  LockCompilationDuringUserCodeExecutionRAII(InterpreterCallbacks* callbacks):
-  fCallbacks(callbacks) {
-    if (fCallbacks)
-      fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
-  }
-
-  LockCompilationDuringUserCodeExecutionRAII(Interpreter& interp):
-  LockCompilationDuringUserCodeExecutionRAII(interp.getCallbacks()) {}
-
-  ~LockCompilationDuringUserCodeExecutionRAII() {
-    if (fCallbacks)
-      fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
-  }
-};
+using LockCompilationDuringUserCodeExecutionRAII = cling::InterpreterAccessRAII;
 }
 
 #endif // CLING_ENTERUSERCODERAII_H

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -26,6 +26,8 @@
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
 
+#include "EnterUserCodeRAII.h"
+
 using namespace clang;
 
 namespace cling {
@@ -473,6 +475,13 @@ namespace cling {
     QualType TheQT;
 
     if (typeName.empty()) return TheQT;
+
+    // findType is called from TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling
+    // which is called indirectly from TClassEdit::GetNormalizedName via
+    // the ResolvedTypedef code paths.  Through that code path nothing is
+    // taking the ROOT/Interpreter lock and since this code can modify the
+    // interpreter, we do need to take lock.
+    LockCompilationDuringUserCodeExecutionRAII LCDUCER(*m_Interpreter);
 
     // Could trigger deserialization of decls.
     Interpreter::PushTransactionRAII RAII(m_Interpreter);

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -481,7 +481,7 @@ namespace cling {
     // the ResolvedTypedef code paths.  Through that code path nothing is
     // taking the ROOT/Interpreter lock and since this code can modify the
     // interpreter, we do need to take lock.
-    LockCompilationDuringUserCodeExecutionRAII LCDUCER(*m_Interpreter);
+    InterpreterAccessRAII LockAccess(*m_Interpreter);
 
     // Could trigger deserialization of decls.
     Interpreter::PushTransactionRAII RAII(m_Interpreter);


### PR DESCRIPTION
Backport of #18522, #18237 and #18551
