### PR TITLE
[v634] [cling] Add ROOT lock to LookupHelper::findType

### DIFF
--- a/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
+++ b/interpreter/cling/lib/Interpreter/EnterUserCodeRAII.h
@@ -11,6 +11,7 @@
 #define CLING_ENTERUSERCODERAII_H
 
 #include "cling/Interpreter/Interpreter.h"
+#include "cling/Interpreter/InterpreterAccessRAII.h"
 #include "cling/Interpreter/InterpreterCallbacks.h"
 
 namespace cling {
@@ -34,25 +35,7 @@ struct EnterUserCodeRAII {
   }
 };
 
-struct LockCompilationDuringUserCodeExecutionRAII {
-  /// Callbacks used to un/lock.
-  InterpreterCallbacks* fCallbacks;
-  /// Info provided to UnlockCompilationDuringUserCodeExecution().
-  void* fStateInfo = nullptr;
-  LockCompilationDuringUserCodeExecutionRAII(InterpreterCallbacks* callbacks):
-  fCallbacks(callbacks) {
-    if (fCallbacks)
-      fStateInfo = fCallbacks->LockCompilationDuringUserCodeExecution();
-  }
-
-  LockCompilationDuringUserCodeExecutionRAII(Interpreter& interp):
-  LockCompilationDuringUserCodeExecutionRAII(interp.getCallbacks()) {}
-
-  ~LockCompilationDuringUserCodeExecutionRAII() {
-    if (fCallbacks)
-      fCallbacks->UnlockCompilationDuringUserCodeExecution(fStateInfo);
-  }
-};
+using LockCompilationDuringUserCodeExecutionRAII = cling::InterpreterAccessRAII;
 }
 
 #endif // CLING_ENTERUSERCODERAII_H

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -26,6 +26,8 @@
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
 
+#include "EnterUserCodeRAII.h"
+
 using namespace clang;
 
 namespace cling {
@@ -464,6 +466,13 @@ namespace cling {
     QualType TheQT;
 
     if (typeName.empty()) return TheQT;
+
+    // findType is called from TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling
+    // which is called indirectly from TClassEdit::GetNormalizedName via
+    // the ResolvedTypedef code paths.  Through that code path nothing is
+    // taking the ROOT/Interpreter lock and since this code can modify the
+    // interpreter, we do need to take lock.
+    LockCompilationDuringUserCodeExecutionRAII LCDUCER(*m_Interpreter);
 
     // Could trigger deserialization of decls.
     Interpreter::PushTransactionRAII RAII(m_Interpreter);

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -472,7 +472,7 @@ namespace cling {
     // the ResolvedTypedef code paths.  Through that code path nothing is
     // taking the ROOT/Interpreter lock and since this code can modify the
     // interpreter, we do need to take lock.
-    LockCompilationDuringUserCodeExecutionRAII LCDUCER(*m_Interpreter);
+    InterpreterAccessRAII LockAccess(*m_Interpreter);
 
     // Could trigger deserialization of decls.
     Interpreter::PushTransactionRAII RAII(m_Interpreter);


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/18237 and and https://github.com/root-project/root/pull/18551

This fixes #18236

As seen in cms-sw/cmssw#47763 (comment)
there are cases where the ROOT global lock is taken too late:

In the stack trace below the lock is requested on frame #7 where as
it should really be (also) requested on frame #12 as soon as the
transaction is being generated.

```
 #6  0x00001501421f55ea in ROOT::TVirtualRWMutex::Lock() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #7  0x0000150133a680ca in TCling::HandleNewTransaction(cling::Transaction const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #8  0x0000150133a85778 in TCling::UpdateListsOnCommitted(cling::Transaction const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #9  0x0000150133b60018 in cling::MultiplexInterpreterCallbacks::TransactionCommitted(cling::Transaction const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #10 0x0000150133bec069 in cling::IncrementalParser::commitTransaction(llvm::PointerIntPair<cling::Transaction*, 2u, cling::IncrementalParser::EParseResult, llvm::PointerLikeTypeTraits<cling::Transaction*>, llvm::PointerIntPairInfo<cling::Transaction*, 2u, llvm::PointerLikeTypeTraits<cling::Transaction*> > >&, bool) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #11 0x0000150133b5663a in cling::Interpreter::PushTransactionRAII::~PushTransactionRAII() () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #12 0x0000150133b6b883 in cling::LookupHelper::findType(llvm::StringRef, cling::LookupHelper::DiagSetting) const () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #13 0x00001501339b6b06 in ROOT::TMetaUtils::TClingLookupHelper::GetPartiallyDesugaredNameWithScopeHandling(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCling.so
 #14 0x00001501422f1458 in ResolveTypedefProcessType(char const*, unsigned int, unsigned int, bool, unsigned int, unsigned int, unsigned int, bool&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) [clone .constprop.0] () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #15 0x00001501422f1a0f in ResolveTypedefImpl(char const*, unsigned int, unsigned int&, bool&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #16 0x00001501422f2ef3 in TClassEdit::ResolveTypedef[abi:cxx11](char const*, bool) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #17 0x00001501422f5c20 in TClassEdit::TSplitType::ShortType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #18 0x00001501422f6888 in TClassEdit::GetNormalizedName(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::basic_string_view<char, std::char_traits<char> >) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so
 #19 0x000015014232e795 in ROOT::Internal::GetDemangledTypeName[abi:cxx11](std::type_info const&) () from /cvmfs/cms-ib.cern.ch/sw/x86_64/nweek-02883/el8_amd64_gcc12/cms/cmssw-patch/CMSSW_15_1_RNTUPLE_X_2025-03-31-2300/external/el8_amd64_gcc12/lib/libCore.so

```

(cherry picked from commit 7c1f0a0)# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

