### PR TITLE
[RDF] fix typo in called test function

### DIFF
--- a/tree/dataframe/test/dataframe_friends.cxx
+++ b/tree/dataframe/test/dataframe_friends.cxx
@@ -388,7 +388,7 @@ TEST(RDFAndFriendsNoFixture, IndexedFriendChain)
 
 TEST(RDFAndFriendsNoFixture, IndexedFriendTree)
 {
-   TestIndexedFriendChain();
+   TestIndexedFriendTree();
 }
 
 #ifdef R__USE_IMT


### PR DESCRIPTION
Since title of test and called function do not match. It seems a copy-paste typo from the function just above?