### PR TITLE
[v7] macro load lib no longer needed

### DIFF
--- a/tutorials/visualisation/webgui/browserv7/browser.cxx
+++ b/tutorials/visualisation/webgui/browserv7/browser.cxx
@@ -15,9 +15,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-// macro must be here to let macro work on Windows
-R__LOAD_LIBRARY(libROOTBrowserv7)
-
 #include <ROOT/RBrowser.hxx>
 
 void browser()

--- a/tutorials/visualisation/webgui/browserv7/filedialog.cxx
+++ b/tutorials/visualisation/webgui/browserv7/filedialog.cxx
@@ -20,9 +20,6 @@
 // To start OpenFile dialog in sync mode, call `root "filedialog.cxx(1)" -q`.
 // Once file is selected, root execution will be stopped.
 
-// macro must be here to let macro work on Windows
-R__LOAD_LIBRARY(libROOTBrowserv7)
-
 #include <ROOT/RFileDialog.hxx>
 
 void filedialog(int kind = 0)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

according to https://its.cern.ch/jira/projects/ROOT/issues/ROOT-10480