### PR TITLE
[skip-ci][coverage] Fix typo in workflow command

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -180,7 +180,7 @@ jobs:
                     --binaries       ${{ inputs.binaries }}
                     --buildtype      ${{ inputs.buildtype }}
                     --platform       alma9
-                    --incremental    {{ inputs.incremental }}
+                    --incremental    ${{ inputs.incremental }}
                     --coverage       true
                     --base_ref       ${{ inputs.base_ref }}
                     --sha            ${{ github.sha }}


### PR DESCRIPTION
Fixes https://github.com/root-project/root/actions/runs/15213020746/job/42791613768

```
Run .github/workflows/root-ci-config/build_root.py --binaries       true --buildtype      Debug --platform       alma9 --incremental    {{ inputs.incremental }} --coverage       true --base_ref       master --sha            5dbc9611e1efb03eb7de96ee4ee47d0ef833bef3 --head_ref       master --head_sha       master --repository     https://github.com/root-project/root 
##[debug]sh -e /__w/_temp/2073e9ca-7a31-45ba-b0f3-9532d3a901a2.sh
Using wrapper for podman, see `less $(which docker)` for details
Using wrapper for podman, see `less $(which docker)` for details
usage: build_root.py [-h] [--platform PLATFORM] [--dockeropts DOCKEROPTS]
                     [--incremental INCREMENTAL] [--buildtype BUILDTYPE]
                     [--coverage COVERAGE] [--sha SHA] [--base_ref BASE_REF]
                     [--pull_repository PULL_REPOSITORY] [--head_ref HEAD_REF]
                     [--head_sha HEAD_SHA] [--binaries BINARIES]
                     [--architecture ARCHITECTURE] [--repository REPOSITORY]
build_root.py: error: unrecognized arguments: inputs.incremental }}
Error: Process completed with exit code 2.
```