### PR TITLE
[df] Add missing dict dependency for datasource_tree

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -106,7 +106,8 @@ ROOT_GENERATE_DICTIONARY(ClassWithNestedSameNameDict
                          ${CMAKE_CURRENT_SOURCE_DIR}/ClassWithNestedSameName.hxx
                          MODULE datasource_tree
                          LINKDEF ClassWithNestedSameNameLinkDef.hxx
-                         OPTIONS -inlineInputHeader)
+                         OPTIONS -inlineInputHeader
+                         DEPENDENCIES RIO)
 
 #### TESTS REQUIRING EXTRA ROOT FEATURES ####
 if (imt)


### PR DESCRIPTION
Fix runtime failures (seen on Debian notes):
```
<<< cling interactive line includer >>>: fatal error: module file '/github/home/ROOT-CI/build/lib/RIO.pcm' is out of date and needs to be rebuilt: module file out of date
it means to be say
```
but this is a lie, it is meant to say:
```
<<< cling interactive line includer >>>: fatal error: module file '/github/home/ROOT-CI/build/tree/dataframe/test/datasource_tree.pcm' is out of date and needs to be rebuilt: module file out of date as it depends on the new file '/github/home/ROOT-CI/build/lib/RIO.pcm'
```
