### PR TITLE
[cppyy] Fix incremental builds with rootcling, disable leakcheck tests

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 foreach(DICT ${CPPYY_TEST_DICTS})
     # Generate dictionary for the tests
     add_custom_command(OUTPUT ${DICT}_rflx_rdict.pcm ${DICT}_rflx.cpp
-                       COMMAND ${DICT_GEN} ${DICT}_rflx.cpp --rmf ${DICT}Dict.rootmap --rml ${DICT}Dict.so ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml
+                       COMMAND ${DICT_GEN} ${DICT}_rflx.cpp -f --rmf ${DICT}Dict.rootmap --rml ${DICT}Dict.so ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml
                        DEPENDS rootcling ${DICT}.h ${DICT}.xml)
 
     # Create shared necessary libraries for the tests

--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -54,7 +54,8 @@ test_datatypes
 test_doc_features
 test_eigen
 test_fragile
-test_leakcheck
+# The leakcheck test is disabled due to it's sporadic nature, especially fragile on VMs
+# test_leakcheck
 test_lowlevel
 test_numba
 test_operators


### PR DESCRIPTION
These leakcheck tests, similar to the regression test for https://github.com/root-project/root/issues/15703 that was dropped, tend to sporadically fail and should be disabled
