### PR TITLE
[cppyy] Use ROOT dictionary generation macro in cppyy tests

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -22,23 +22,13 @@ std_streams
 templates
 stltypes)
 
-if(MSVC)
-    set(DICT_GEN ${CMAKE_BINARY_DIR}/bin/rootcling.exe)
-else()
-    set(DICT_GEN ${CMAKE_BINARY_DIR}/bin/rootcling)
-endif()
-
 foreach(DICT ${CPPYY_TEST_DICTS})
     # Generate dictionary for the tests
-    add_custom_command(OUTPUT ${DICT}_rflx_rdict.pcm ${DICT}_rflx.cpp
-                       COMMAND ${DICT_GEN} ${DICT}_rflx.cpp -f --rmf ${DICT}Dict.rootmap --rml ${DICT}Dict.so ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml
-                       DEPENDS rootcling ${DICT}.h ${DICT}.xml)
-
-    # Create shared necessary libraries for the tests
-    add_library(${DICT}Dict SHARED ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.cxx ${DICT}_rflx.cpp)
+    ROOT_GENERATE_DICTIONARY(G__${DICT}Dict ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml)
+    # Create necessary shared libraries for the tests
+    add_library(${DICT}Dict SHARED ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.cxx G__${DICT}Dict.cxx)
     target_include_directories(${DICT}Dict PUBLIC ${Python3_INCLUDE_DIRS} ${CMAKE_BINARY_DIR}/include)
     target_link_libraries(${DICT}Dict PUBLIC Python3::Python ROOT::Core)
-    set_target_properties(${DICT}Dict PROPERTIES PREFIX "")
     target_compile_options(${DICT}Dict PRIVATE "-w")
 endforeach()
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
@@ -3,7 +3,7 @@ from pytest import raises, mark
 from support import setup_make, IS_MAC
 
 currpath = os.getcwd()
-test_dct = currpath + "/example01Dict"
+test_dct = currpath + "/libexample01Dict"
 
 
 class TestACLASSLOADER:

--- a/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
@@ -3,7 +3,7 @@ from pytest import mark, raises, skip
 from support import setup_make, pylong, IS_WINDOWS, ispypy
 
 currpath = os.getcwd()
-test_dct = currpath + "/advancedcppDict"
+test_dct = currpath + "/libadvancedcppDict"
 
 
 class TestADVANCEDCPP:
@@ -156,7 +156,7 @@ class TestADVANCEDCPP:
         import cppyy
         gbl = cppyy.gbl
 
-        lib2 = cppyy.load_reflection_info("advancedcpp2Dict")
+        lib2 = cppyy.load_reflection_info("libadvancedcpp2Dict")
 
         assert gbl.a_ns      is gbl.a_ns
         assert gbl.a_ns.d_ns is gbl.a_ns.d_ns

--- a/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
@@ -3,7 +3,7 @@ from pytest import raises
 from support import setup_make
 
 currpath = os.getcwd()
-test_dct = currpath + "/conversionsDict"
+test_dct = currpath + "/libconversionsDict"
 
 
 class TestCONVERSIONS:

--- a/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
@@ -4,7 +4,7 @@ from support import setup_make, ispypy
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/cpp11featuresDict"
+test_dct = currpath + "/libcpp11featuresDict"
 
 
 class TestCPP11FEATURES:

--- a/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong, IS_MAC_ARM
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/crossinheritanceDict"
+test_dct = currpath + "/libcrossinheritanceDict"
 
 
 class TestCROSSINHERITANCE:

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -3,7 +3,7 @@ from pytest import mark, raises, skip
 from support import setup_make, pylong, pyunicode, IS_MAC_ARM
 
 currpath = os.getcwd()
-test_dct = currpath + "/datatypesDict"
+test_dct = currpath + "/libdatatypesDict"
 
 
 class TestDATATYPES:

--- a/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
@@ -4,7 +4,7 @@ from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/doc_helperDict"
+test_dct = currpath + "/libdoc_helperDict"
 
 
 class TestDOCFEATURES:

--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -4,7 +4,7 @@ from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/fragileDict"
+test_dct = currpath + "/libfragileDict"
 
 
 class TestFRAGILE:

--- a/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong, pyunicode, IS_WINDOWS, ispypy
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/datatypesDict"
+test_dct = currpath + "/libdatatypesDict"
 
 
 class TestLOWLEVEL:

--- a/bindings/pyroot/cppyy/cppyy/test/test_operators.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_operators.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong, maxvalue, IS_WINDOWS, IS_MAC
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/operatorsDict"
+test_dct = currpath + "/liboperatorsDict"
 
 
 class TestOPERATORS:

--- a/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
@@ -4,7 +4,7 @@ from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/overloadsDict"
+test_dct = currpath + "/liboverloadsDict"
 
 
 class TestOVERLOADS:

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong, ispypy
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/example01Dict"
+test_dct = currpath + "/libexample01Dict"
 
 
 class TestPYTHONIFY:

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/pythonizablesDict"
+test_dct = currpath + "/libpythonizablesDict"
 
 
 class TestClassPYTHONIZATION:

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -5,7 +5,7 @@ from support import setup_make, pylong, pyunicode, maxvalue, ispypy
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/stltypesDict"
+test_dct = currpath + "/libstltypesDict"
 
 
 # after CPython's Lib/test/seq_tests.py

--- a/bindings/pyroot/cppyy/cppyy/test/test_streams.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_streams.py
@@ -4,7 +4,7 @@ from support import setup_make
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/std_streamsDict"
+test_dct = currpath + "/libstd_streamsDict"
 
 
 class TestSTDStreams:

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -4,7 +4,7 @@ from support import setup_make, pylong
 
 
 currpath = os.getcwd()
-test_dct = currpath + "/templatesDict"
+test_dct = currpath + "/libtemplatesDict"
 
 
 class TestTEMPLATES:


### PR DESCRIPTION
This fixes build errors with `builtin_clang=OFF` that appeared after https://github.com/root-project/root/pull/18671.