### PR TITLE
[cppyy] expect failures in numba tests, disable chrono test

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
@@ -349,7 +349,7 @@ class TestCPP11FEATURES:
             c = cppyy.gbl.std.nullopt
             assert cppyy.gbl.callopt(c)
 
-    @mark.xfail()
+    @mark.xfail(run = False, reason = "Crashes")
     def test11_chrono(self):
         """Use of chrono and overloaded operator+"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_numba.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_numba.py
@@ -93,6 +93,7 @@ class TestNUMBA:
 
         return fast_time < slow_time
 
+    @mark.xfail(reason = "Numba tests comparing execution times are sensitive and fail sporadically")
     def test01_compiled_free_func(self):
         """Numba-JITing of a compiled free function"""
 
@@ -151,7 +152,8 @@ class TestNUMBA:
         assert (go_fast(x) == go_slow(x)).all()
         assert self.compare(go_slow, go_fast, 100000, x)
 
-    @mark.xfail(condition=IS_MAC, reason="Fails on OSX")
+    @mark.xfail(reason = "Numba tests comparing execution times are sensitive and fail sporadically. \
+                Fails on OS X")
     def test03_proxy_argument_for_field(self):
         """Numba-JITing of a free function taking a proxy argument for field access"""
 
@@ -185,7 +187,8 @@ class TestNUMBA:
         assert((go_fast(x, d) == go_slow(x, d)).all())
         assert self.compare(go_slow, go_fast, 10000, x, d)
 
-    @mark.xfail(reason="Fails on \"fedora41\" and OSX")
+    @mark.xfail(reason = "Numba tests comparing execution times are sensitive and fail sporadically. \
+                Fails on OS X")
     def test04_proxy_argument_for_method(self):
         """Numba-JITing of a free function taking a proxy argument for method access"""
 
@@ -304,7 +307,8 @@ class TestNUMBA:
                 val = getattr(nl[ntype], m)()
                 assert access_field(getattr(ns, 'M%d'%i)(val)) == val
 
-    @mark.xfail(condition=IS_MAC, reason="Fails on OSX")
+    @mark.xfail(reason = "Numba tests comparing execution times are sensitive and fail sporadically. \
+                Fails on OS X")
     def test08_object_returns(self):
         """Numba-JITing of a function that returns an object"""
 


### PR DESCRIPTION
The numba extension does not necessarily always outperform a pure python hotloop and can lead to sporadic failures in tests that compare execution times. This patch continues running these tests, while expecting failures so the CI is no longer fragile.

