### PR TITLE
[cppyy] disable error prone `test06_variadic_sfinae`

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -154,6 +154,8 @@ class TestTEMPLATES:
         assert cppyy.gbl.isSomeInt()           == False
         assert cppyy.gbl.isSomeInt(1, 2, 3)    == False
 
+    @mark.xfail(run = False, reason = "This test causes the interpreter to raises errors and" \
+    "should not be run until further investigated")
     def test06_variadic_sfinae(self):
         """Attribute testing through SFINAE"""
 
@@ -180,7 +182,7 @@ class TestTEMPLATES:
         assert select_template_arg[0, Obj1, Obj2].argument == Obj1
         assert select_template_arg[1, Obj1, Obj2].argument == Obj2
         # TODO: the following crashes deep inside cling/clang ...
-        #raises(TypeError, getattr, select_template_arg[2, Obj1, Obj2], 'argument')
+        # raises(TypeError, getattr, select_template_arg[2, Obj1, Obj2], 'argument')
 
         # This is a bit subtle: to be able to use typedefs in templates, builtin
         # types are present as subclasses that carry __cpp_name__, hence the result


### PR DESCRIPTION
This test leads to the following interpreter error when parsing the `AttrTesting` class defined in `libtemplatesDict.so`

```
input_line_25:7:55: error: address of overloaded function 'has_var1' is ambiguous
      new (ret) (bool) (((bool (&)(AttrTesting::Obj1))AttrTesting::has_var1<AttrTesting::Obj1>)(*(AttrTesting::Obj1*)args[0]));
                                                      ^
input_line_21:9:16: note: candidate function [with T = AttrTesting::Obj1]
constexpr auto has_var1(T t) -> decltype(t.var1, true)
               ^
input_line_21:15:16: note: candidate function [with Args = <AttrTesting::Obj1>]
constexpr bool has_var1(Args...)
               ^
input_line_25:11:44: error: address of overloaded function 'has_var1' is ambiguous
      (void)(((bool (&)(AttrTesting::Obj1))AttrTesting::has_var1<AttrTesting::Obj1>)(*(AttrTesting::Obj1*)args[0]));
                                           ^
input_line_21:9:16: note: candidate function [with T = AttrTesting::Obj1]
constexpr auto has_var1(T t) -> decltype(t.var1, true)
               ^
input_line_21:15:16: note: candidate function [with Args = <AttrTesting::Obj1>]
constexpr bool has_var1(Args...)
```

This causes failures on `fedora41`
