### PR TITLE
[skip-ci] do not nudge on issues closed as not planned

### DIFF
--- a/.github/actions/issues-nudge.js
+++ b/.github/actions/issues-nudge.js
@@ -39,7 +39,7 @@ async function iterate_issues() {
   const { search: { nodes: issues } } = await graphql(
     `
       {
-        search(query: "repo:root-project/root is:issue is:closed no:project", type: ISSUE, first: 100) {
+        search(query: "repo:root-project/root is:issue is:closed no:project reason:completed", type: ISSUE, first: 100) {
           nodes {
             ... on Issue {
               number


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

See current status of https://github.com/root-project/root/issues/?q=is%3Aissue%20is%3Aclosed%20no%3Aproject%20reason%3Acompleted

I get daily emails about adding a "Project" to closed issues (which I have no rights to close). It's probably unnecessary to force won't fix issues to have a project called "Fixed in not applicable".

So reduce the number of emails by only complaining about completed issues.

An alternative would be to make the JS query add the project automatically instead of relying on the user.

Another alternative would be to collect all issues in the same single email and centralize that task into a single person, rather than having N emails for all non-completed issues.