### PR TITLE
[RF] Don't schema evolve TRefArray to proxy list if there are no proxies

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -10,7 +10,7 @@
 #pragma read sourceClass="RooAbsArg" targetClass="RooAbsArg" version="[1-4]" source="TList _proxyList" target="_proxyList" \
     code="{ for (TObject * tmpObj : onfile._proxyList) { _proxyList.Add(tmpObj); } }"
 #pragma read sourceClass="RooAbsArg" targetClass="RooAbsArg" version="[5]" source="TRefArray _proxyList" target="_proxyList" \
-  code="{ _proxyList.GetSize() ; if (onfile._proxyList.GetSize()>0) { RooAbsArg::_ioEvoList[newObj] = std::make_unique<TRefArray>(onfile._proxyList); } }"
+  code="{ _proxyList.GetSize() ; if (onfile._proxyList.GetSize()>0) { RooAbsArg::addToIoEvoList(newObj, onfile._proxyList); } }"
 #pragma read sourceClass="RooAbsArg" targetClass="RooAbsArg" version="[1-6]"\
   source="RooRefCountList _serverList" target="_serverList" \
   code="{ _serverList = RooSTLRefCountList<RooAbsArg>::convert(onfile._serverList); }"

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -679,9 +679,8 @@ private:
   friend class RooFitResult;
 
  public:
-  static std::map<RooAbsArg*,std::unique_ptr<TRefArray>> _ioEvoList; // temporary holding list for proxies needed in schema evolution
- protected:
-  static std::stack<RooAbsArg*> _ioReadStack ; // reading stack
+  // Used internally for schema evolution.
+  static void addToIoEvoList(RooAbsArg *newObj, TRefArray const &onfileProxyList);
   /// \endcond
 
  private:

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -103,9 +103,23 @@ bool RooAbsArg::_verboseDirty(false) ;
 bool RooAbsArg::_inhibitDirty(false) ;
 bool RooAbsArg::inhibitDirty() const { return _inhibitDirty && !_localNoInhibitDirty; }
 
-std::map<RooAbsArg*,std::unique_ptr<TRefArray>> RooAbsArg::_ioEvoList;
-std::stack<RooAbsArg*> RooAbsArg::_ioReadStack ;
+namespace {
 
+auto &ioEvoList()
+{
+   // temporary holding list for proxies needed in schema evolution
+   static std::map<RooAbsArg *, std::unique_ptr<TRefArray>> ioEvoListInstance;
+   return ioEvoListInstance;
+}
+
+// reading stack
+auto &ioReadStack()
+{
+   static std::stack<RooAbsArg *> ioReadStackInstance;
+   return ioReadStackInstance;
+}
+
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
@@ -2374,14 +2388,19 @@ void RooAbsArg::SetNameTitle(const char *name, const char *title)
 void RooAbsArg::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
-     _ioReadStack.push(this) ;
+     ioReadStack().push(this) ;
      R__b.ReadClassBuffer(RooAbsArg::Class(),this);
-     _ioReadStack.pop() ;
+     ioReadStack().pop() ;
      _namePtr = RooNameReg::instance().constPtr(GetName()) ;
      _isConstant = getAttribute("Constant") ;
    } else {
      R__b.WriteClassBuffer(RooAbsArg::Class(),this);
    }
+}
+
+void RooAbsArg::addToIoEvoList(RooAbsArg *newObj, TRefArray const &onfileProxyList)
+{
+   ioEvoList()[newObj] = std::make_unique<TRefArray>(onfileProxyList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2398,8 +2417,8 @@ void RooAbsArg::Streamer(TBuffer &R__b)
 void RooAbsArg::ioStreamerPass2()
 {
   // Handling of v5-v6 migration (TRefArray _proxyList --> RooRefArray _proxyList)
-  auto iter = _ioEvoList.find(this);
-  if (iter != _ioEvoList.end()) {
+  auto iter = ioEvoList().find(this);
+  if (iter != ioEvoList().end()) {
 
     // Transfer contents of saved TRefArray to RooRefArray now
     if (!_proxyList.GetEntriesFast())
@@ -2408,7 +2427,7 @@ void RooAbsArg::ioStreamerPass2()
        _proxyList.Add(iter->second->At(i));
     }
     // Delete TRefArray and remove from list
-    _ioEvoList.erase(iter);
+    ioEvoList().erase(iter);
   }
 }
 
@@ -2426,7 +2445,7 @@ void RooAbsArg::ioStreamerPass2()
 void RooAbsArg::ioStreamerPass2Finalize()
 {
   // Handling of v5-v6 migration (TRefArray _proxyList --> RooRefArray _proxyList)
-  for (const auto& iter : _ioEvoList) {
+  for (const auto& iter : ioEvoList()) {
 
     // Transfer contents of saved TRefArray to RooRefArray now
     if (!iter.first->_proxyList.GetEntriesFast())
@@ -2436,7 +2455,7 @@ void RooAbsArg::ioStreamerPass2Finalize()
     }
   }
 
-  _ioEvoList.clear();
+  ioEvoList().clear();
 }
 
 
@@ -2466,7 +2485,7 @@ void RooRefArray::Streamer(TBuffer &R__b)
       // Schedule deferred processing of TRefArray into proxy list. Doesn't
       // need to be done if there are no proxies anyway.
       if(!refArray->IsEmpty()) {
-         RooAbsArg::_ioEvoList[RooAbsArg::_ioReadStack.top()] = std::move(refArray);
+         ioEvoList()[ioReadStack().top()] = std::move(refArray);
       }
 
    } else {


### PR DESCRIPTION
If there are no proxies for a given RooAbsArg, we don't need to
schedeule the schema evolution of it's proxies. This saves both CPU and
memory usage, since the old proxy TRefArrays are kept around in a
temporary map until the full workspace is read.

This also prevents spurious crashes in the schema evolution of large
workspaces, that can happen for example when the schema evolution of the RooRealVars in a RooFit dataset are interfering with the schema evolution of the variables in the main workspace.

Closes https://github.com/root-project/root/issues/18847.

Also, refactor the RooAbsArg schema evolution to not use global variables.