### PR TITLE
[webgeom] provide warnings that checker not implemented #18881 [6.34]

### DIFF
--- a/geom/webviewer/inc/ROOT/RGeoPainter.hxx
+++ b/geom/webviewer/inc/ROOT/RGeoPainter.hxx
@@ -32,13 +32,13 @@ public:
    TVirtualGeoTrack *AddTrack(Int_t, Int_t, TObject *) override;
    void       AddTrackPoint(Double_t *, Double_t *, Bool_t =kFALSE) override;
    void       BombTranslation(const Double_t *, Double_t *) override {}
-   void       CheckPoint(Double_t =0, Double_t =0, Double_t =0, Option_t * ="", Double_t = 0.) override {}
-   void       CheckShape(TGeoShape *, Int_t, Int_t, Option_t *) override {}
-   void       CheckBoundaryErrors(Int_t =1000000, Double_t =-1.) override {}
-   void       CheckBoundaryReference(Int_t =-1) override {}
-   void       CheckGeometryFull(Bool_t =kTRUE, Bool_t =kTRUE, Int_t =10000, const Double_t * = nullptr) override {}
-   void       CheckGeometry(Int_t, Double_t, Double_t, Double_t) const override {}
-   void       CheckOverlaps(const TGeoVolume *, Double_t =0.1, Option_t * ="") const override {}
+   void       CheckPoint(Double_t =0, Double_t =0, Double_t =0, Option_t * ="", Double_t = 0.) override;
+   void       CheckShape(TGeoShape *, Int_t, Int_t, Option_t *) override;
+   void       CheckBoundaryErrors(Int_t =1000000, Double_t =-1.) override;
+   void       CheckBoundaryReference(Int_t =-1) override;
+   void       CheckGeometryFull(Bool_t =kTRUE, Bool_t =kTRUE, Int_t =10000, const Double_t * = nullptr) override;
+   void       CheckGeometry(Int_t, Double_t, Double_t, Double_t) const override;
+   void       CheckOverlaps(const TGeoVolume *, Double_t =0.1, Option_t * ="") const override;
    Int_t      CountVisibleNodes() override { return 0; }
    void       DefaultAngles() override {}
    void       DefaultColors() override {}

--- a/geom/webviewer/src/RGeoPainter.cxx
+++ b/geom/webviewer/src/RGeoPainter.cxx
@@ -110,3 +110,47 @@ void RGeoPainter::DrawVolume(TGeoVolume *vol, Option_t *opt)
    // start browser
    fViewer->Show();
 }
+
+static int gWebGeomWarnCnt = 0;
+
+void RGeoPainter::CheckPoint(Double_t, Double_t, Double_t, Option_t *, Double_t)
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckPoint", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckShape(TGeoShape *, Int_t, Int_t, Option_t *)
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckShape", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckBoundaryErrors(Int_t, Double_t)
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckBoundaryErrors", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckBoundaryReference(Int_t)
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckBoundaryReference", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckGeometryFull(Bool_t, Bool_t, Int_t, const Double_t *)
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckGeometryFull", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckGeometry(Int_t, Double_t, Double_t, Double_t) const
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckGeometry", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}
+
+void RGeoPainter::CheckOverlaps(const TGeoVolume *, Double_t, Option_t *) const
+{
+   if (gWebGeomWarnCnt++ < 5)
+      Warning("CheckOverlaps", "Not implemented in web mode, run --web=off to activate TGeoChecker");
+}


### PR DESCRIPTION
TGeoChecker can be used only with `--web=off` mode. To avoid confusion print warning that checker methods not implemented. Later checker can be moved into separate library and used intepdendent from GL painters

Backport of https://github.com/root-project/root/pull/18890
