### PR TITLE
[RFC][io] TTree::Show unfold vectors

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5827,7 +5827,14 @@ void TStreamerInfo::PrintValueAux(char *ladd, Int_t atype, TStreamerElement *aEl
                std::string *st = (std::string*)(ladd);
                printf("%s",st->c_str());
             } else {
-               printf("(%s*)0x%zx",aElement->GetClass()->GetName(),(size_t)(ladd));
+               TString cname = aElement->GetClass()->GetName();
+               if (cname.BeginsWith("vector")) {
+                  if (cname.Contains("<int>"))
+                     printf("%d", *((Int_t*)ladd));
+               }
+               else {
+                  printf("(%s*)0x%zx",aElement->GetClass()->GetName(),(size_t)(ladd));
+               }
             }
          } else {
             printf("(unknown_type*)0x%zx",(size_t)(ladd));

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -4004,8 +4004,15 @@ void TBranchElement::PrintValue(Int_t lenmax) const
          GetInfoImp()->PrintValueSTL(GetName(), ((TBranchElement*) this)->GetCollectionProxy(), prID, fOffset, lenmax);
       }
    } else {
-      if (GetInfoImp()) {
-         GetInfoImp()->PrintValue(GetName(), object, prID, -1, lenmax);
+      if (fSTLtype == ROOT::kNotSTL) {
+         if (GetInfoImp()) {
+            GetInfoImp()->PrintValue(GetName(), object, prID, -1, lenmax);
+         }
+      } else {
+          TVirtualCollectionProxy::TPushPop helper(((TBranchElement*) this)->GetCollectionProxy(), object);
+          if (info) {
+             info->PrintValueSTL(GetName(), ((TBranchElement*) this)->GetCollectionProxy(), 0, fOffset, lenmax);
+          }
       }
    }
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-4302

shows:
```
======> EVENT:0
 x               = 3, 5
```

If this hack is acceptable, I can extend it to all the other possible int / float types, etc.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

