### PR TITLE
[coverage] Switch to alma10.

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -98,7 +98,7 @@ jobs:
       INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') }}
 
     container:
-      image: registry.cern.ch/root-ci/alma9:buildready
+      image: registry.cern.ch/root-ci/alma10:buildready
       options: '--security-opt label=disable --rm'
 
     steps:
@@ -156,7 +156,7 @@ jobs:
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      Debug
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    $INCREMENTAL
                     --coverage       true
                     --base_ref       ${{ github.base_ref }}
@@ -171,7 +171,7 @@ jobs:
         run: ".github/workflows/root-ci-config/build_root.py
                     --binaries       ${{ inputs.binaries }}
                     --buildtype      ${{ inputs.buildtype }}
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    ${{ inputs.incremental }}
                     --coverage       true
                     --base_ref       ${{ inputs.base_ref }}
@@ -185,7 +185,7 @@ jobs:
         if:   github.event_name == 'schedule'
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      Debug
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    false
                     --coverage       true
                     --base_ref       ${{ github.ref_name }}


### PR DESCRIPTION
This should resolve the 'new' error:
```
      ./codecov --verbose upload-coverage --fail-on-error --git-service github --env OS,PYTHON --file /github/home/ROOT-CI/build/cobertura-cov.xml --flag unittests --gcov-executable gcov --name codecov-umbrella
[PYI-168326:ERROR] Failed to load Python shared library '/tmp/_MEI1ejdfE/libpython3.12.so.1.0': dlopen: /lib64/libm.so.6: version `GLIBC_2.35' not found (required by /tmp/_MEI1ejdfE/libpython3.12.so.1.0)
```
seen here: https://github.com/root-project/root/actions/runs/15290208792/job/43008143771
