### PR TITLE
[v636][ci] Make alma10 regular build

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -367,6 +367,7 @@ jobs:
           - image: alma8
           - image: alma9
             overrides: ["CMAKE_BUILD_TYPE=Debug"]
+          - image: alma10
           - image: ubuntu22
             overrides: ["imt=Off", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2404
@@ -393,8 +394,6 @@ jobs:
             is_special: true
             property: clang
             overrides: ["CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
-          - image: alma10
-            is_special: true
           # Disable GPU builds until the DNS problem is solved  
           # - image: ubuntu2404-cuda
           #   is_special: true


### PR DESCRIPTION
AlmaLinux 10 is now released, so the builds should not be marked as special anymore.