### PR TITLE
[v630][ci] Make alma10 regular build

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma10.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10.txt
@@ -3,4 +3,5 @@ builtin_vdt=ON
 builtin_zlib=ON
 builtin_zstd=ON
 ccache=ON
+mysql=OFF
 tmva-cpu=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -230,11 +230,10 @@ jobs:
             overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: alma9
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
+          - image: alma10
+            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
           - image: ubuntu22
             overrides: ["imt=Off", "LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
-          - image: alma10
-            is_special: true
-            overrides: ["LLVM_ENABLE_ASSERTIONS=On"]
     runs-on:
       - self-hosted
       - linux


### PR DESCRIPTION
AlmaLinux 10 is now released, so the builds should not be marked as
special anymore.