### PR TITLE
[core] update comment on version format

### DIFF
--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -118,7 +118,7 @@ protected:
 
    TString         fConfigOptions;                    ///< ROOT ./configure set build options
    TString         fConfigFeatures;                   ///< ROOT ./configure detected build features
-   TString         fVersion;                          ///< ROOT version (from CMZ VERSQQ) ex 0.05/01
+   TString         fVersion;                          ///< ROOT version as TString, example: 0.05.01
    Int_t           fVersionInt = 0;                   ///< ROOT version in integer format (501)
    Int_t           fVersionCode = 0;                  ///< ROOT version code as used in RVersion.h
    Int_t           fVersionDate = 0;                  ///< Date of ROOT version (ex 951226)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The version no longer follows CMZ versqq (https://www.cppm.in2p3.fr/leptop/new/leptop.f)

but uses also a dot for the patch separator

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)
