### PR TITLE
[v634][ci] Use builtin compression libraries for special alma9 builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -250,11 +250,11 @@ jobs:
           - image: alma9
             is_special: true
             property: march_native
-            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "fortran=OFF"]
+            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "fortran=OFF", "builtin_zlib=ON", "builtin_zstd=ON"]
           - image: alma9
             is_special: true
             property: arm64
-            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "ccache=ON"]
+            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "ccache=ON", "builtin_zlib=ON", "builtin_zstd=ON"]
             architecture: ARM64
           - image: alma9-clang
             is_special: true


### PR DESCRIPTION
This should resolve the new test failues on `alma9 march_native` and `alma9 arm64` that showed up the the transition from AlmaLinux 9.5 to AlmaLinux 9.6.