### PR TITLE
[tree] Fix suspicious use of memcpy in TLeaf*

### DIFF
--- a/tree/tree/src/TLeafD.cxx
+++ b/tree/tree/src/TLeafD.cxx
@@ -88,8 +88,11 @@ void TLeafD::Import(TClonesArray *list, Int_t n)
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset, 8*fLen);
-      else       memcpy(&fValue[j],&kDoubleUndefined,  8*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset, 8*fLen);
+      else       
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kDoubleUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafD32.cxx
+++ b/tree/tree/src/TLeafD32.cxx
@@ -101,7 +101,8 @@ void TLeafD32::Import(TClonesArray *list, Int_t n)
       if (clone)
          memcpy(&fValue[j], clone + fOffset, 8 * fLen);
       else
-         memcpy(&fValue[j], &kDoubleUndefined, 8 * fLen);
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kDoubleUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafF.cxx
+++ b/tree/tree/src/TLeafF.cxx
@@ -92,8 +92,11 @@ void TLeafF::Import(TClonesArray *list, Int_t n)
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset,  4*fLen);
-      else       memcpy(&fValue[j],&kFloatUndefined, 4*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset,  4*fLen);
+      else       
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kFloatUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafF16.cxx
+++ b/tree/tree/src/TLeafF16.cxx
@@ -105,7 +105,8 @@ void TLeafF16::Import(TClonesArray *list, Int_t n)
       if (clone)
          memcpy(&fValue[j], clone + fOffset, 4 * fLen);
       else
-         memcpy(&fValue[j], &kFloatUndefined, 4 * fLen);
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kFloatUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafG.cxx
+++ b/tree/tree/src/TLeafG.cxx
@@ -142,13 +142,16 @@ bool TLeafG::IncludeRange(TLeaf *input)
 
 void TLeafG::Import(TClonesArray *list, Int_t n)
 {
-   const Int_t kIntUndefined = -9999;
+   const Long_t kIntUndefined = -9999;
    Int_t j = 0;
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset, 8*fLen);
-      else       memcpy(&fValue[j],&kIntUndefined,  8*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset, 8*fLen);
+      else
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kIntUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafI.cxx
+++ b/tree/tree/src/TLeafI.cxx
@@ -136,8 +136,11 @@ void TLeafI::Import(TClonesArray *list, Int_t n)
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset, 4*fLen);
-      else       memcpy(&fValue[j],&kIntUndefined,  4*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset, 4*fLen);
+      else
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kIntUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafL.cxx
+++ b/tree/tree/src/TLeafL.cxx
@@ -142,13 +142,16 @@ bool TLeafL::IncludeRange(TLeaf *input)
 
 void TLeafL::Import(TClonesArray *list, Int_t n)
 {
-   const Int_t kIntUndefined = -9999;
+   const Long_t kIntUndefined = -9999;
    Int_t j = 0;
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset, 8*fLen);
-      else       memcpy(&fValue[j],&kIntUndefined,  8*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset, 8*fLen);
+      else
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kIntUndefined;
       j += fLen;
    }
 }

--- a/tree/tree/src/TLeafS.cxx
+++ b/tree/tree/src/TLeafS.cxx
@@ -132,8 +132,11 @@ void TLeafS::Import(TClonesArray *list, Int_t n)
    char *clone;
    for (Int_t i=0;i<n;i++) {
       clone = (char*)list->UncheckedAt(i);
-      if (clone) memcpy(&fValue[j],clone + fOffset, 2*fLen);
-      else       memcpy(&fValue[j],&kShortUndefined,  2*fLen);
+      if (clone)
+         memcpy(&fValue[j],clone + fOffset, 2*fLen);
+      else       
+         for (Int_t k = 0; k < fLen; ++k)
+            fValue[j + k] = kShortUndefined;
       j += fLen;
    }
 }


### PR DESCRIPTION
The code is memcpy'ing an unpredictable number of bytes from the stack, which is sketchy at best. It looks like the intention of the original code was to fill an array with k*Undefined values, so this commit changes it to use a for loop to do it.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

