### PR TITLE
[meta] Correctly treat data member types containing functions

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1652,7 +1652,36 @@ static void ResolveTypedefImpl(const char *tname,
             prevScope = cursor+1;
             break;
          }
+         case '(':
          case '<': {
+            // We move on in presence of function pointers, i.e. if we find '(*)' (with spaces which could be in
+            // between), for example cases like:
+            // pair<dd4hep::sim::Geant4Sensitive*,Geant4HitCollection*(*)(const std::string&,const std::string&,Geant4Sensitive*)>
+            // This honors #18842 without breaking #18833.
+            auto nStars = 0u;
+            auto next = cursor + 1;
+            for (; next != cursor && nStars < 2 && next < len; next++) {
+               if (' ' == tname[next]) {
+                  // We simply skip spaces
+                  continue;
+               } else if ('*' == tname[next]) {
+                  nStars++;
+               } else if (')' == tname[next]) {
+                  if (nStars == 1) {
+                     cursor = next;
+                  } else {
+                     break;
+                  }
+               } else {
+                  // if the token is not ' ', '*', or ')' we move on
+                  break;
+               }
+            }
+            // If we found '(*)' (with potentially spaces in between the characters)
+            // we move on with the parsing
+            if (cursor == next)
+               break;
+
             // push information on stack
             if (modified) {
                result += std::string(tname+prevScope,cursor+1-prevScope);
@@ -1683,6 +1712,11 @@ static void ResolveTypedefImpl(const char *tname,
                if (modified) result += " >";
                return;
             }
+            if ( (cursor+1)<len && tname[cursor+1] == ')') {
+               ++cursor;
+               if (modified) result += ")";
+               return;
+            }
             if ( (cursor+1) >= len) {
                return;
             }
@@ -1699,7 +1733,7 @@ static void ResolveTypedefImpl(const char *tname,
             while ((cursor+1)<len && tname[cursor+1] == ' ') ++cursor;
 
             auto next = cursor+1;
-            if (strncmp(tname+next,"const",5) == 0 && ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ']'))
+            if (strncmp(tname+next,"const",5) == 0 && ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == ']'))
             {
                // A first const after the type needs to be move in the front.
                if (!modified) {
@@ -1719,7 +1753,7 @@ static void ResolveTypedefImpl(const char *tname,
                cursor += 5;
                end_of_type = cursor+1;
                prevScope = end_of_type;
-               if ((next+5)==len || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == '[') {
+               if ((next+5)==len || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == '[') {
                   break;
                }
             } else if (next!=len && tname[next] != '*' && tname[next] != '&') {
@@ -1736,7 +1770,7 @@ static void ResolveTypedefImpl(const char *tname,
             // check and skip const (followed by *,&, ,) ... what about followed by ':','['?
             auto next = cursor+1;
             if (strncmp(tname+next,"const",5) == 0) {
-               if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == '[') {
+               if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == '[') {
                   next += 5;
                }
             }
@@ -1745,7 +1779,7 @@ static void ResolveTypedefImpl(const char *tname,
                ++next;
                // check and skip const (followed by *,&, ,) ... what about followed by ':','['?
                if (strncmp(tname+next,"const",5) == 0) {
-                  if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == '[') {
+                  if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>'|| tname[next+5] == ')' || tname[next+5] == '[') {
                      next += 5;
                   }
                }
@@ -1765,13 +1799,15 @@ static void ResolveTypedefImpl(const char *tname,
             if (modified) result += ',';
             return;
          }
+         case ')':
          case '>': {
+            char c = tname[cursor];
             if (modified && prevScope) {
                result += std::string(tname+prevScope,(end_of_type == 0 ? cursor : end_of_type)-prevScope);
             }
             ResolveTypedefProcessType(tname,len,cursor,constprefix,start_of_type,end_of_type,mod_start_of_type,
                                       modified, result);
-            if (modified) result += '>';
+            if (modified) result += c;
             return;
          }
          default:

--- a/core/foundation/test/testClassEdit.cxx
+++ b/core/foundation/test/testClassEdit.cxx
@@ -271,6 +271,9 @@ TEST(TClassEdit, ResolveTypedef)
    gInterpreter->Declare("typedef const int cmytype_t;");
    EXPECT_STREQ("const int", TClassEdit::ResolveTypedef("mytype_t").c_str());
    EXPECT_STREQ("const int", TClassEdit::ResolveTypedef("cmytype_t").c_str());
+   // #18833
+   const char* type_18833 = "pair<TAttMarker*,TGraph*(  *  )(const std::string&,const std::string&,TH1F*) >";
+   EXPECT_STREQ(type_18833, TClassEdit::ResolveTypedef(type_18833).c_str());
 }
 
 // ROOT-11000

--- a/roottest/root/meta/rootcling/CMakeLists.txt
+++ b/roottest/root/meta/rootcling/CMakeLists.txt
@@ -28,3 +28,8 @@ ROOTTEST_ADD_TEST(selectUnion
 ROOTTEST_ADD_TEST(ROOT10798
                   COMMAND ${ROOT_rootcling_CMD} -f ROOT10798Dict.cxx ${CMAKE_CURRENT_SOURCE_DIR}/ROOT10798LinkDef.h)
 
+# Issue #18833
+ROOTTEST_GENERATE_DICTIONARY(streamerInfoStdFunctionDict streamerInfoStdFunction.h LINKDEF streamerInfoStdFunction.xml)
+ROOTTEST_ADD_TEST(streamerInfoStdFunction
+                  MACRO streamerInfoStdFunction.C
+                  DEPENDS ${GENERATE_DICTIONARY_TEST})

--- a/roottest/root/meta/rootcling/streamerInfoStdFunction.C
+++ b/roottest/root/meta/rootcling/streamerInfoStdFunction.C
@@ -1,0 +1,68 @@
+int streamerInfoStdFunction()
+{
+   gSystem->Load("streamerInfoStdFunctionDict");
+   const auto clName = "egammaMVACalibTool";
+   auto c = TClass::GetClass(clName);
+   c->BuildRealData();
+   if (!c) {
+      std::cerr << "Class " << clName << "not found!" << std::endl;
+      return 1;
+   }
+
+   const std::vector<const char *> dmNames = {"m_funcs", "m_collections"};
+   TDataMember *dms[2];
+   auto i = 0u;
+   for (auto dmName : dmNames) {
+      dms[i] = c->GetDataMember(dmName);
+      if (!dms[i]) {
+         std::cerr << "Data member " << dmName << "not found!" << std::endl;
+         return 2;
+      }
+      ++i;
+   }
+
+   const std::vector<const char *> dmRefTypeNames = {
+      "vector<vector<function<float(int,const Foo*)> > >",
+      "vector<pair<string,pair<Geant4Sensitive*,Geant4HitCollection*(*)(const std::string&,const std::string&,Geant4Sensitive*)> > >"};
+
+   i = 0u;
+   for (auto dmRefTypeName : dmRefTypeNames) {
+      std::string dmTypeName = dms[i]->GetTypeName();
+      if (dmTypeName != dmRefTypeName) {
+         const auto dmName = dms[i]->GetName();
+         std::cerr << "Data member " << dmName << " is supposed to be of type " << dmRefTypeName
+                   << " but it seems to be  pf type " << dmTypeName << std::endl;
+         return 3;
+      }
+      ++i;
+   }
+
+   auto si = c->GetStreamerInfo();
+
+   if (!si) {
+      std::cerr << "Class " << clName
+                << " does not seem to have a valid TStreamerInfo. Something seems to be terribly wrong." << std::endl;
+      return 4;
+   }
+
+   si->Build();
+
+   for (int j : {0, 1}) {
+      auto se = si->GetElem(j);
+      if (!se) {
+         std::cerr << "The element number " << j << " of the TStreamerInfo of class " << clName
+                   << " does not seem to exist. We expect two of them." << std::endl;
+         return 5;
+      }
+      std::string seName = se->GetName();
+      std::string seTypeName = se->GetTypeName();
+      if (seName != dmNames[j] || seTypeName != dmRefTypeNames[j]) {
+         std::cerr << "The element number " << j << " of the TStreamerInfo of class " << clName << " is called "
+                   << seName << " and has a type called " << seTypeName << ", while it should be called " << dmNames[j]
+                   << " of type " << dmRefTypeNames[j] << std::endl;
+         return 6;
+      }
+   }
+
+   return 0;
+}

--- a/roottest/root/meta/rootcling/streamerInfoStdFunction.h
+++ b/roottest/root/meta/rootcling/streamerInfoStdFunction.h
@@ -1,0 +1,16 @@
+#include <functional>
+#include <vector>
+#include <string>
+#include <map>
+
+struct Foo {};
+struct Geant4Sensitive {};
+struct Geant4HitCollection {};
+struct egammaMVACalibTool {
+   typedef Geant4HitCollection *(*create_t)(const std::string &, const std::string &, Geant4Sensitive *);
+   typedef std::pair<std::string, std::pair<Geant4Sensitive *, create_t>> HitCollection;
+   typedef std::vector<HitCollection> HitCollections;
+
+   std::vector<std::vector<std::function<float(int, const Foo *)>>> m_funcs;
+   HitCollections m_collections;
+};

--- a/roottest/root/meta/rootcling/streamerInfoStdFunction.xml
+++ b/roottest/root/meta/rootcling/streamerInfoStdFunction.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+   <class name="egammaMVACalibTool" />
+</lcgdict>
+


### PR DESCRIPTION
This commit fixes #18833, by reverting 0f8670. 
It also honours #18842, without breaking DD4HEP.
Moreover it adds back a test and enhances it.
