### PR TITLE
[ntuple] Handle missing values in RNTupleProcessor

### DIFF
--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -35,10 +35,7 @@ class RNTupleReader;
 
 namespace Experimental {
 class RNTupleFillContext;
-class RNTupleProcessor;
-class RNTupleSingleProcessor;
-class RNTupleChainProcessor;
-class RNTupleJoinProcessor;
+class RNTupleProcessorEntry;
 } // namespace Experimental
 
 // clang-format off
@@ -55,10 +52,7 @@ class REntry {
    friend class RNTupleModel;
    friend class RNTupleReader;
    friend class Experimental::RNTupleFillContext;
-   friend class Experimental::RNTupleProcessor;
-   friend class Experimental::RNTupleSingleProcessor;
-   friend class Experimental::RNTupleChainProcessor;
-   friend class Experimental::RNTupleJoinProcessor;
+   friend class Experimental::RNTupleProcessorEntry;
 
 private:
    /// The entry must be linked to a specific model, identified by a model ID

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -336,10 +336,10 @@ public:
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
-      using value_type = RNTupleProcessorEntry;
+      using value_type = ROOT::NTupleSize_t;
       using difference_type = std::ptrdiff_t;
-      using pointer = RNTupleProcessorEntry *;
-      using reference = const RNTupleProcessorEntry &;
+      using pointer = ROOT::NTupleSize_t *;
+      using reference = ROOT::NTupleSize_t &;
 
       RIterator(RNTupleProcessor &processor, ROOT::NTupleSize_t entryNumber)
          : fProcessor(processor), fCurrentEntryNumber(entryNumber)
@@ -364,7 +364,7 @@ public:
          return obj;
       }
 
-      reference operator*() { return *fProcessor.fEntry; }
+      reference operator*() { return fCurrentEntryNumber; }
 
       friend bool operator!=(const iterator &lh, const iterator &rh)
       {

--- a/tree/ntuple/test/ntuple_join_table.cxx
+++ b/tree/ntuple/test/ntuple_join_table.cxx
@@ -274,42 +274,43 @@ TEST(RNTupleJoinTable, Partitions)
    }
    auto proc = RNTupleProcessor::CreateChain(openSpec);
 
-   auto i = proc->GetEntry().GetPtr<std::uint32_t>("i");
-   auto run = proc->GetEntry().GetPtr<int16_t>("run");
+   auto i = proc->GetValuePtr<std::uint32_t>("i");
+   auto iPtr = i.GetPtr();
+   auto run = proc->GetValuePtr<int16_t>("run");
 
    // When getting the entry indexes for all partitions, we expect multiple resulting entry indexes (i.e., one entry
    // index for each ntuple in the chain).
-   *i = 0;
+   *iPtr = 0;
    std::unordered_map<RNTupleJoinTable::PartitionKey_t, std::vector<ROOT::NTupleSize_t>> expectedEntryIdxMap = {
       {1, {0}},
       {2, {0}},
       {3, {0, 0}},
    };
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 2, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}, {1, 2, 3}));
 
    expectedEntryIdxMap = {
       {1, {0}},
       {3, {0, 0}},
    };
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}, {1, 3}));
 
    // Calling GetEntryIndexes with a partition key not present in the join table shouldn't fail; it should just return
    // an empty vector.
-   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({i.get()}, 4));
+   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({iPtr.get()}, 4));
 
    // Similarly, calling GetEntryIndexes with a partition key that is present in the join table but a join value that
    // isn't shouldn't fail; it should just return an empty vector.
-   *i = 99;
-   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({i.get()}, 3));
+   *iPtr = 99;
+   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({iPtr.get()}, 3));
 
    expectedEntryIdxMap.clear();
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 2, 3}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}, {1, 2, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({iPtr.get()}, {1, 3}));
 
    for (auto it = proc->begin(); it != proc->end(); it++) {
-      auto entryIdxs = joinTable->GetEntryIndexes({i.get()}, *run);
+      auto entryIdxs = joinTable->GetEntryIndexes({iPtr.get()}, *run);
 
       // Because two ntuples store their events under run number 3 and their entries for `i` are identical, two entry
       // indexes are expected. For the other case (run == 1 and run == 2), only one entry index is expected.

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -163,19 +163,11 @@ TEST_F(RNTupleProcessorTest, BaseWithModel)
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
 
-   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, std::move(model));
-
-   auto x = proc->GetValuePtr<float>("x");
-
    try {
-      proc->GetValuePtr<void>("y");
-      FAIL() << "fields not present in the model passed to the processor shouldn't be readable";
+      RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]}, std::move(model));
+      FAIL() << "processors should only accept bare models";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: y"));
-   }
-
-   for (const auto &idx : *proc) {
-      EXPECT_FLOAT_EQ(static_cast<float>(idx), *x);
+      EXPECT_THAT(err.what(), testing::HasSubstr("only bare RNTupleModels can be used to create an RNTupleProcessor"));
    }
 }
 

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -83,24 +83,21 @@ TEST(RNTupleChainProcessor, EmptySpec)
 
 TEST_F(RNTupleChainProcessorTest, SingleNTuple)
 {
-   int nEntries = 0;
    auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}});
 
    auto x = proc->GetValuePtr<float>("x");
 
-   for (const auto &_ : *proc) {
-      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
+   for (const auto &idx : *proc) {
+      EXPECT_EQ(idx + 1, proc->GetNEntriesProcessed());
+      EXPECT_EQ(idx, proc->GetCurrentEntryNumber());
 
       EXPECT_FLOAT_EQ(static_cast<float>(proc->GetCurrentEntryNumber()), *x);
    }
-   EXPECT_EQ(nEntries, 5);
-   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+   EXPECT_EQ(5, proc->GetNEntriesProcessed());
 }
 
 TEST_F(RNTupleChainProcessorTest, Basic)
 {
-   std::uint64_t nEntries = 0;
    auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}});
 
    EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
@@ -114,17 +111,16 @@ TEST_F(RNTupleChainProcessorTest, Basic)
    auto x = proc->GetValuePtr<float>("x");
    auto y = proc->GetValuePtr<std::vector<float>>("y");
 
-   for (const auto &_ : *proc) {
-      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
+   for (const auto &idx : *proc) {
+      EXPECT_EQ(idx + 1, proc->GetNEntriesProcessed());
+      EXPECT_EQ(idx, proc->GetCurrentEntryNumber());
 
-      EXPECT_EQ(static_cast<float>(nEntries - 1), *x);
+      EXPECT_EQ(static_cast<float>(idx), *x);
 
-      std::vector<float> yExp = {static_cast<float>(nEntries - 1), static_cast<float>((nEntries - 1) * 2)};
+      std::vector<float> yExp = {static_cast<float>(idx), static_cast<float>((idx) * 2)};
       EXPECT_EQ(yExp, *y);
    }
-   EXPECT_EQ(nEntries, 8);
-   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+   EXPECT_EQ(8, proc->GetNEntriesProcessed());
 }
 
 TEST_F(RNTupleChainProcessorTest, WithModel)
@@ -144,8 +140,9 @@ TEST_F(RNTupleChainProcessorTest, WithModel)
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: y"));
    }
 
-   for (const auto &_ : *proc) {
-      EXPECT_EQ(static_cast<float>(proc->GetNEntriesProcessed() - 1), *x);
+   for (const auto &idx : *proc) {
+      EXPECT_FLOAT_EQ(static_cast<float>(idx), *x);
+      EXPECT_EQ(fldX, x.GetPtr());
    }
 }
 
@@ -166,9 +163,8 @@ TEST_F(RNTupleChainProcessorTest, WithBareModel)
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: x"));
    }
 
-   for (const auto &_ : *proc) {
-      std::vector<float> yExp = {static_cast<float>(proc->GetNEntriesProcessed() - 1),
-                                 static_cast<float>((proc->GetNEntriesProcessed() - 1) * 2)};
+   for (const auto &idx : *proc) {
+      std::vector<float> yExp = {static_cast<float>(idx), static_cast<float>((idx) * 2)};
       EXPECT_EQ(yExp, *y);
    }
 }
@@ -205,8 +201,6 @@ TEST_F(RNTupleChainProcessorTest, EmptyNTuples)
 
    std::vector<RNTupleOpenSpec> ntuples = {{fNTupleName, fileGuard.GetPath()}, {fNTupleName, fFileNames[0]}};
 
-   std::uint64_t nEntries = 0;
-
    // Empty ntuples are skipped (as long as their model complies)
    auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fileGuard.GetPath()},
                                               {fNTupleName, fFileNames[0]},
@@ -215,12 +209,10 @@ TEST_F(RNTupleChainProcessorTest, EmptyNTuples)
 
    auto x = proc->GetValuePtr<float>("x");
 
-   for (const auto &_ : *proc) {
-      EXPECT_EQ(static_cast<float>(nEntries), *x);
-      ++nEntries;
+   for (const auto &idx : *proc) {
+      EXPECT_EQ(static_cast<float>(idx), *x);
    }
-   EXPECT_EQ(nEntries, 8);
-   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+   EXPECT_EQ(8, proc->GetNEntriesProcessed());
 }
 
 namespace ROOT::Experimental::Internal {
@@ -279,13 +271,11 @@ TEST_F(RNTupleChainProcessorTest, TMemFile)
 
    auto x = proc->GetValuePtr<float>("x");
 
-   std::uint64_t nEntries = 0;
-   for ([[maybe_unused]] const auto &entry : *proc) {
-      EXPECT_EQ(++nEntries, proc->GetNEntriesProcessed());
-      EXPECT_EQ(nEntries - 1, proc->GetCurrentEntryNumber());
+   for (const auto &idx : *proc) {
+      EXPECT_EQ(idx + 1, proc->GetNEntriesProcessed());
+      EXPECT_EQ(idx, proc->GetCurrentEntryNumber());
 
-      EXPECT_EQ(static_cast<float>(nEntries - 1), *x);
+      EXPECT_EQ(static_cast<float>(idx), *x);
    }
-   EXPECT_EQ(nEntries, 10);
-   EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
+   EXPECT_EQ(10, proc->GetNEntriesProcessed());
 }

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -128,21 +128,11 @@ TEST_F(RNTupleChainProcessorTest, WithModel)
    auto model = RNTupleModel::Create();
    auto fldX = model->MakeField<float>("x");
 
-   auto proc =
-      RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, std::move(model));
-
-   auto x = proc->GetValuePtr<float>("x");
-
    try {
-      proc->GetValuePtr<std::vector<float>>("y");
-      FAIL() << "fields not present in the model passed to the processor shouldn't be readable";
+      RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, std::move(model));
+      FAIL() << "processors should only accept bare models";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: y"));
-   }
-
-   for (const auto &idx : *proc) {
-      EXPECT_FLOAT_EQ(static_cast<float>(idx), *x);
-      EXPECT_EQ(fldX, x.GetPtr());
+      EXPECT_THAT(err.what(), testing::HasSubstr("only bare RNTupleModels can be used to create an RNTupleProcessor"));
    }
 }
 

--- a/tree/ntuple/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/test/ntuple_processor_join.cxx
@@ -221,37 +221,13 @@ TEST_F(RNTupleJoinProcessorTest, WithModel)
    auto auxModel = RNTupleModel::Create();
    auto fldY = auxModel->MakeField<std::vector<float>>("y");
 
-   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {"i"},
-                                            std::move(primaryModel), std::move(auxModel));
-
-   auto i = proc->GetValuePtr<int>("i");
-   auto x = proc->GetValuePtr<float>("x");
-   auto y = proc->GetValuePtr<std::vector<float>>("ntuple2.y");
-
    try {
-      proc->GetValuePtr<float>("ntuple2.z");
-      FAIL() << "fields not present in the model passed to the processor shouldn't be readable";
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {"i"},
+                                   std::move(primaryModel), std::move(auxModel));
+      FAIL() << "processors should only accept bare models";
    } catch (const ROOT::RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name: ntuple2.z"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("only bare RNTupleModels can be used to create an RNTupleProcessor"));
    }
-
-   std::vector<float> yExpected;
-
-   for (const auto &idx : *proc) {
-      EXPECT_EQ(proc->GetCurrentEntryNumber(), idx);
-
-      EXPECT_EQ(proc->GetCurrentEntryNumber() * 2, *i);
-      EXPECT_EQ(*fldI, *i);
-
-      EXPECT_FLOAT_EQ(*i * 0.5f, *x);
-      EXPECT_FLOAT_EQ(*fldX, *x);
-
-      yExpected = {static_cast<float>(*i * 0.2), 3.14, static_cast<float>(*i * 1.3)};
-      EXPECT_EQ(yExpected, *y);
-      EXPECT_EQ(*fldY, *y);
-   }
-
-   EXPECT_EQ(5, proc->GetNEntriesProcessed());
 }
 
 TEST_F(RNTupleJoinProcessorTest, WithBareModel)

--- a/tutorials/io/ntuple/ntpl012_processor_chain.C
+++ b/tutorials/io/ntuple/ntpl012_processor_chain.C
@@ -64,17 +64,20 @@ void Read(const std::vector<RNTupleOpenSpec> &ntuples)
    TH1F hPx("h", "This is the px distribution", 100, -4, 4);
    hPx.SetFillColor(48);
 
-   auto model = ROOT::RNTupleModel::Create();
-   auto ptrPx = model->MakeField<std::vector<float>>("vpx");
+   auto model = ROOT::RNTupleModel::CreateBare();
+   model->MakeField<std::vector<float>>("vpx");
 
-   // By passing a model to the processor, we can use the pointers to field values created upon model creation during
-   // processing. When no model is provided, a default model is created based on the first ntuple specified.
-   // Access to the entry values in this case can be achieved through RNTupleProcessor::GetEntry() or through its
-   // iterator.
+   // By passing a model to the processor, we can instruct the RNTupleProcessor to only read a particular subset of
+   // fields. Because the RNTupleProcessor adds some additional bookkeeping to the standard REntry, only bare models
+   // (i.e., models without a default entry) can be passed. When no model is provided, a default model is created based
+   // on the first ntuple specified.
+   // Access to the entry values in both cases is provided through RNTupleProcessor::GetValuePtr() (see below).
    auto processor = RNTupleProcessor::CreateChain(ntuples, std::move(model));
    int prevProcessorNumber{-1};
 
-   for (const auto &entry : *processor) {
+   auto ptrPx = processor->GetValuePtr<std::vector<float>>("vpx");
+
+   for (const auto &_ : *processor) {
       // The RNTupleProcessor provides some additional bookkeeping information. The local entry number is reset each
       // a new ntuple in the chain is opened for processing.
       if (static_cast<int>(processor->GetCurrentProcessorNumber()) > prevProcessorNumber) {

--- a/tutorials/io/ntuple/ntpl015_processor_join.C
+++ b/tutorials/io/ntuple/ntpl015_processor_join.C
@@ -24,15 +24,15 @@
 using ROOT::Experimental::RNTupleOpenSpec;
 using ROOT::Experimental::RNTupleProcessor;
 
-const std::string kMainNTupleName = "mainNTuple";
+const std::string kPrimaryNTupleName = "mainNTuple";
 const std::string kMainNTuplePath = "main_ntuple.root";
 const std::string kAuxNTupleName = "auxNTuple";
 const std::string kAuxNTuplePath = "aux_ntuple.root";
 
-// Number of events to generate for the auxiliary ntuple. The main ntuple will have a fifth of this number.
+// Number of events to generate for the auxiliary ntuple. The primary ntuple will have a fifth of this number.
 constexpr int kNEvents = 10000;
 
-void WriteMain(std::string_view ntupleName, std::string_view ntupleFileName)
+void WritePrimary(std::string_view ntupleName, std::string_view ntupleFileName)
 {
    auto model = ROOT::RNTupleModel::Create();
 
@@ -41,7 +41,7 @@ void WriteMain(std::string_view ntupleName, std::string_view ntupleFileName)
 
    auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), ntupleName, ntupleFileName);
 
-   // The main ntuple only contains a subset of the entries present in the auxiliary ntuple.
+   // The primary ntuple only contains a subset of the entries present in the auxiliary ntuple.
    for (int i = 0; i < kNEvents; i += 5) {
       *fldI = i;
       *fldVpx = gRandom->Gaus();
@@ -49,7 +49,7 @@ void WriteMain(std::string_view ntupleName, std::string_view ntupleFileName)
       writer->Fill();
    }
 
-   std::cout << "Wrote " << writer->GetNEntries() << " to the main RNTuple" << std::endl;
+   std::cout << "Wrote " << writer->GetNEntries() << " to the primary RNTuple" << std::endl;
 }
 
 void WriteAux(std::string_view ntupleName, std::string_view ntupleFileName)
@@ -77,23 +77,23 @@ void Read()
    TH1F hPy("h", "This is the px + py distribution", 100, -4, 4);
    hPy.SetFillColor(48);
 
-   // The first specified ntuple is the main ntuple and will be used to drive the processor loop. The subsequent
-   // list of ntuples (in this case, only one) are auxiliary and will be joined with the entries from the main ntuple.
-   // We specify field "i" as the join field. This field, which should be present in all ntuples specified is used to
-   // identify which entries belong together. Multiple join fields can be specified, in which case the combination of
-   // field values is used. It is possible to specify up to 4 join fields. Providing an empty list of join fields
-   // signals to the processor that all entries are aligned.
+   // The first specified ntuple is the primary ntuple and will be used to drive the processor loop. The subsequent
+   // list of ntuples (in this case, only one) are auxiliary and will be joined with the entries from the primary
+   // ntuple. We specify field "i" as the join field. This field, which should be present in all ntuples specified is
+   // used to identify which entries belong together. Multiple join fields can be specified, in which case the
+   // combination of field values is used. It is possible to specify up to 4 join fields. Providing an empty list of
+   // join fields signals to the processor that all entries are aligned.
    auto processor =
-      RNTupleProcessor::CreateJoin({kMainNTupleName, kMainNTuplePath}, {kAuxNTupleName, kAuxNTuplePath}, {"i"});
+      RNTupleProcessor::CreateJoin({kPrimaryNTupleName, kMainNTuplePath}, {kAuxNTupleName, kAuxNTuplePath}, {"i"});
 
-   float px, py;
-   for (const auto &entry : *processor) {
-      // Fields from the main ntuple are accessed by their original name.
-      px = *entry.GetPtr<float>("vpx");
-      // Fields from auxiliary ntuples are accessed by prepending the name of the auxiliary ntuple.
-      py = *entry.GetPtr<float>(kAuxNTupleName + ".vpy");
+   // Access to the processor's entry values is provided through RNTupleProcessor::GetValuePtr().
+   // Fields from the primary ntuple are accessed by their original name.
+   auto px = processor->GetValuePtr<float>("vpx");
+   // Fields from auxiliary ntuples are accessed by prepending the name of the auxiliary ntuple.
+   auto py = processor->GetValuePtr<float>(kAuxNTupleName + ".vpy");
 
-      hPy.Fill(px + py);
+   for (const auto &_ : *processor) {
+      hPy.Fill(*px + *py);
    }
 
    std::cout << "Processed a total of " << processor->GetNEntriesProcessed() << " entries" << std::endl;
@@ -103,7 +103,7 @@ void Read()
 
 void ntpl015_processor_join()
 {
-   WriteMain(kMainNTupleName, kMainNTuplePath);
+   WritePrimary(kPrimaryNTupleName, kMainNTuplePath);
    WriteAux(kAuxNTupleName, kAuxNTuplePath);
 
    Read();


### PR DESCRIPTION
When an entry managed by the `RNTupleProcessor` contains missing data for certain fields, for example because they are missing in a subsequent chain or auxiliary ntuple, we need a way to signal to the user that the resulting entry has missing data and is therefore invalid.

The `RNTupleProcessorValuePtr`, together with the `RNTupleProcessorEntry` (which is a thin wrapper around `REntry`) capture this requirement by only returning actual data if the entry is marked as "valid" by the processor. Its use can be seen in action in the `MissingEntries` test in [`ntuple_processor_join.cxx`](https://github.com/enirolf/root/blob/38e21aaabf3f9d64248d466647035a94ffa8c02e/tree/ntuple/test/ntuple_processor_join.cxx).

With the addition of `RNTupleValuePtr`, pointers to the values of an RNTupleModel's default entry, returned by e.g., `MakeField` should not be used together with the RNTupleProcessor anymore, because they may contain incorrect data. More specifically, when a particular field's
data could not be loaded for a certain entry, it will retain its previous value. The `RNTupleValuePtr` adds appropriate checks for this, but to prevent users from using pointers returned from a model's default entry, we only allow RNTupleProcessors to be created from bare models.

Finally, this PR changes the iterator provided by the `RNTupleProcessor` from the full entry to only the (global) entry index. Providing the full entry was already a bit questionable, because it would allow users to call `GetPtr` or related functions *inside* of the loop, which we want to avoid. Other than that, there is (currently) no additional useful information one can obtain from the full entry.
