### PR TITLE
[metacling] Add missing lock to TCling::Evaluate.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7729,6 +7729,8 @@ void TCling::CodeComplete(const std::string& line, size_t& cursor,
 /// Get the interpreter value corresponding to the statement.
 int TCling::Evaluate(const char* code, TInterpreterValue& value)
 {
+   R__LOCKGUARD_CLING(gInterpreterMutex);
+
    auto V = reinterpret_cast<cling::Value*>(value.GetValAddr());
    auto compRes = fInterpreter->evaluate(code, *V);
    return compRes!=cling::Interpreter::kSuccess ? 0 : 1 ;


### PR DESCRIPTION
The return value has its own storage and can be used without a lock.

See #18863 for reproducer (in particular https://github.com/root-project/root/issues/18863#issuecomment-2927500035)

Fixes #18863