### PR TITLE
[636][metacling] Add missing lock to TCling::Evaluate.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7715,6 +7715,8 @@ void TCling::CodeComplete(const std::string& line, size_t& cursor,
 /// Get the interpreter value corresponding to the statement.
 int TCling::Evaluate(const char* code, TInterpreterValue& value)
 {
+   R__LOCKGUARD_CLING(gInterpreterMutex);
+
    auto V = reinterpret_cast<cling::Value*>(value.GetValAddr());
    auto compRes = fInterpreter->evaluate(code, *V);
    return compRes!=cling::Interpreter::kSuccess ? 0 : 1 ;


### PR DESCRIPTION
BP of #18938

The return value has its own storage and can be used without a lock.

(cherry picked from commit 3ecb1d14febe9fb23d3d034e50fae411cada6191)


