### PR TITLE
[core] do not append objects to TFiles opened in READ mode

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -199,6 +199,8 @@ Bool_t TDirectory::AddDirectoryStatus()
 void TDirectory::Append(TObject *obj, Bool_t replace /* = kFALSE */)
 {
    if (!obj || !fList) return;
+   if (!IsWritable())
+      return;
 
    if (replace && obj->GetName() && obj->GetName()[0]) {
       TObject *old;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

see https://root-forum.cern.ch/t/how-to-get-the-string-branch-created-in-geant4/63662/4?u=ferhue