### PR TITLE
[ntuple] Add `RNTupleProcessor::PrintStructure`

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -142,6 +142,8 @@ protected:
    /// with respect to the processor's position in the chain.
    virtual void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) = 0;
 
+   virtual void PrintStructureImpl(std::ostream &output) const = 0;
+
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create a new base RNTupleProcessor.
    ///
@@ -195,6 +197,8 @@ public:
    ///
    /// \return A reference to the entry used by the processor.
    const ROOT::REntry &GetEntry() const { return *fEntry; }
+
+   void PrintStructure(std::ostream &output = std::cout) { PrintStructureImpl(output); }
 
    // clang-format off
    /**
@@ -382,6 +386,8 @@ private:
    /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
    void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
 
+   void PrintStructureImpl(std::ostream &output) const final;
+
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleProcessor for processing a single RNTuple.
    ///
@@ -436,6 +442,8 @@ private:
    ///
    /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
    void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
+
+   void PrintStructureImpl(std::ostream &output) const final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleChainProcessor.
@@ -508,6 +516,8 @@ private:
    /// auxiliary model are stored as a anonymous record, and subsequently registered as subfields in the join model.
    /// This way, they can be accessed from the processor's entry as `auxNTupleName.fieldName`.
    void SetModel(std::unique_ptr<ROOT::RNTupleModel> primaryModel, std::unique_ptr<ROOT::RNTupleModel> auxModel);
+
+   void PrintStructureImpl(std::ostream &output) const final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Construct a new RNTupleJoinProcessor.

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -218,6 +218,20 @@ TEST_F(RNTupleProcessorTest, BaseWithBareModel)
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
 }
 
+TEST_F(RNTupleProcessorTest, PrintStructureSingle)
+{
+   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
+
+   std::ostringstream os;
+   proc->PrintStructure(os);
+
+   const std::string exp = "+-----------------------------+\n"
+                           "| ntuple                      |\n"
+                           "| test_ntuple_processor1.root |\n"
+                           "+-----------------------------+\n";
+   EXPECT_EQ(exp, os.str());
+}
+
 TEST_F(RNTupleProcessorTest, ChainedChain)
 {
    std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
@@ -413,4 +427,91 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedSameName)
                                                  "is already present in the model of the primary processor; rename "
                                                  "the auxiliary processor to avoid conflicts"));
    }
+}
+
+TEST_F(RNTupleProcessorTest, PrintStructureChainedJoin)
+{
+   std::vector<std::unique_ptr<RNTupleProcessor>> innerProcs;
+   innerProcs.push_back(
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {}));
+   innerProcs.push_back(
+      RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {}));
+
+   auto proc = RNTupleProcessor::CreateChain(std::move(innerProcs));
+
+   std::ostringstream os;
+   proc->PrintStructure(os);
+
+   const std::string exp = "+-----------------------------+ +-----------------------------+\n"
+                           "| ntuple                      | | ntuple_aux                  |\n"
+                           "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                           "+-----------------------------+ +-----------------------------+\n"
+                           "+-----------------------------+ +-----------------------------+\n"
+                           "| ntuple                      | | ntuple_aux                  |\n"
+                           "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                           "+-----------------------------+ +-----------------------------+\n";
+   EXPECT_EQ(exp, os.str());
+}
+
+TEST_F(RNTupleProcessorTest, PrintStructureJoinedChain)
+{
+   auto primaryChain =
+      RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}});
+   auto auxiliaryChain =
+      RNTupleProcessor::CreateChain({{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[1], fFileNames[1]}});
+
+   auto proc = RNTupleProcessor::CreateJoin(std::move(primaryChain), std::move(auxiliaryChain), {});
+
+   std::ostringstream os;
+   proc->PrintStructure(os);
+
+   const std::string exp = "+-----------------------------+ +-----------------------------+\n"
+                           "| ntuple                      | | ntuple_aux                  |\n"
+                           "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                           "+-----------------------------+ +-----------------------------+\n"
+                           "+-----------------------------+ +-----------------------------+\n"
+                           "| ntuple                      | | ntuple_aux                  |\n"
+                           "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                           "+-----------------------------+ +-----------------------------+\n";
+   EXPECT_EQ(exp, os.str());
+}
+
+TEST_F(RNTupleProcessorTest, PrintStructureJoinedChainAsymmetric)
+{
+   auto primaryChain =
+      RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}, {fNTupleNames[0], fFileNames[0]}});
+   auto auxiliaryChain = RNTupleProcessor::CreateChain({{fNTupleNames[1], fFileNames[1]}});
+
+   auto proc1 = RNTupleProcessor::CreateJoin(std::move(primaryChain), std::move(auxiliaryChain), {});
+
+   std::ostringstream os1;
+   proc1->PrintStructure(os1);
+
+   const std::string exp1 = "+-----------------------------+ +-----------------------------+\n"
+                            "| ntuple                      | | ntuple_aux                  |\n"
+                            "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                            "+-----------------------------+ +-----------------------------+\n"
+                            "+-----------------------------+\n"
+                            "| ntuple                      |\n"
+                            "| test_ntuple_processor1.root |\n"
+                            "+-----------------------------+\n";
+   EXPECT_EQ(exp1, os1.str());
+
+   primaryChain = RNTupleProcessor::CreateChain({{fNTupleNames[0], fFileNames[0]}});
+   auxiliaryChain = RNTupleProcessor::CreateChain({{fNTupleNames[1], fFileNames[1]}, {fNTupleNames[1], fFileNames[1]}});
+
+   auto proc2 = RNTupleProcessor::CreateJoin(std::move(primaryChain), std::move(auxiliaryChain), {});
+
+   std::ostringstream os2;
+   proc2->PrintStructure(os2);
+
+   const std::string exp2 = "+-----------------------------+ +-----------------------------+\n"
+                            "| ntuple                      | | ntuple_aux                  |\n"
+                            "| test_ntuple_processor1.root | | test_ntuple_processor2.root |\n"
+                            "+-----------------------------+ +-----------------------------+\n"
+                            "                                +-----------------------------+\n"
+                            "                                | ntuple_aux                  |\n"
+                            "                                | test_ntuple_processor2.root |\n"
+                            "                                +-----------------------------+\n";
+   EXPECT_EQ(exp2, os2.str());
 }

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -278,3 +278,26 @@ TEST_F(RNTupleChainProcessorTest, TMemFile)
    EXPECT_EQ(nEntries, 10);
    EXPECT_EQ(nEntries, proc->GetNEntriesProcessed());
 }
+
+TEST_F(RNTupleChainProcessorTest, PrintStructure)
+{
+   auto proc = RNTupleProcessor::CreateChain(
+      {{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}, {fNTupleName, fFileNames[2]}});
+
+   std::ostringstream os;
+   proc->PrintStructure(os);
+
+   const std::string exp = "+-----------------------------+\n"
+                           "| ntuple                      |\n"
+                           "| test_ntuple_chain_proces... |\n"
+                           "+-----------------------------+\n"
+                           "+-----------------------------+\n"
+                           "| ntuple                      |\n"
+                           "| test_ntuple_chain_proces... |\n"
+                           "+-----------------------------+\n"
+                           "+-----------------------------+\n"
+                           "| ntuple                      |\n"
+                           "| test_ntuple_chain_proces... |\n"
+                           "+-----------------------------+\n";
+   EXPECT_EQ(exp, os.str());
+}

--- a/tree/ntuple/test/ntuple_processor_join.cxx
+++ b/tree/ntuple/test/ntuple_processor_join.cxx
@@ -318,3 +318,17 @@ TEST_F(RNTupleJoinProcessorTest, TMemFile)
 
    EXPECT_EQ(5, proc->GetNEntriesProcessed());
 }
+
+TEST_F(RNTupleJoinProcessorTest, PrintStructure)
+{
+   auto proc = RNTupleProcessor::CreateJoin({fNTupleNames[1], fFileNames[1]}, {fNTupleNames[2], fFileNames[2]}, {});
+
+   std::ostringstream os;
+   proc->PrintStructure(os);
+
+   const std::string exp = "+-----------------------------+ +-----------------------------+\n"
+                           "| ntuple2                     | | ntuple3                     |\n"
+                           "| test_ntuple_join_process... | | test_ntuple_join_process... |\n"
+                           "+-----------------------------+ +-----------------------------+\n";
+   EXPECT_EQ(exp, os.str());
+}


### PR DESCRIPTION
`PrintStructure` graphically shows how different RNTuples are composed, which can be useful for, among others, debugging purposes.

For example, a processor representing a join between a single primary ntuple and a chain of two auxiliary ntuples will be represented as follows:

```
+-----------------------------+ +-----------------------------+
| ntuple                      | | ntuple_aux                  |
| ntuple.root                 | | ntuple_aux1.root            |
+-----------------------------+ +-----------------------------+
                                +-----------------------------+
                                | ntuple_aux                  |
                                | ntuple_aux2.root            |
                                +-----------------------------+
```
More example outputs can be found in the unit tests.
