### PR TITLE
[Minuit2] Only compute global correlation matrix when needed

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -62,6 +62,11 @@ The following people have contributed to this new version:
 
 ## Math
 
+### Minimizer interface
+
+* The function `double ROOT::Math::Minimizer::GlobalCC(unsigned int ivar)` was changed to `std::vector<double> ROOT::Math::Minimizer::GlobalCC()`, always returning the full list of global correlations.
+  This change was needed because global correlations are not unconditionally computed and cached in the minimizer anymore. Only computing them when calling `GlobalCC()` avoids unneeded overhead when global correlations are not required.
+
 ### Minuit2
 
 * Behavior change: building ROOT using `minuit2_omp=ON` option no longer enables OpenMP parallelization by default. One has to call now additionally GradientCalculator::SetParallelOMP().

--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -283,7 +283,7 @@ public:
       return ( tmp < 0) ? 0 : CovMatrix(i,j) / std::sqrt( tmp );
    }
 
-   virtual double GlobalCC(unsigned int ivar) const;
+   virtual std::vector<double> GlobalCC() const;
 
    virtual bool GetMinosError(unsigned int ivar , double & errLow, double & errUp, int option = 0);
    virtual bool Hesse();

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -209,13 +209,7 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
       // minos errors are set separately when calling Fitter::CalculateMinosErrors()
 
       // globalCC
-      fGlobalCC.reserve(npar);
-      for (unsigned int i = 0; i < npar; ++i) {
-         double globcc = min->GlobalCC(i);
-         if (globcc < 0) break; // it is not supported by that minimizer
-         fGlobalCC.push_back(globcc);
-      }
-
+      fGlobalCC = min->GlobalCC();
    }
 
 }
@@ -280,16 +274,8 @@ bool FitResult::Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, const
       }
 
       // update global CC
-      if (fGlobalCC.size() != npar) fGlobalCC.resize(npar);
-      for (unsigned int i = 0; i < npar; ++i) {
-         double globcc = min->GlobalCC(i);
-         if (globcc < 0) {
-            fGlobalCC.clear();
-            break; // it is not supported by that minimizer
-         }
-         fGlobalCC[i] = globcc;
-      }
-
+      fGlobalCC = min->GlobalCC();
+      fGlobalCC.resize(npar); // pad with zeros
    }
    return true;
 }

--- a/math/mathcore/src/Minimizer.cxx
+++ b/math/mathcore/src/Minimizer.cxx
@@ -167,10 +167,9 @@ bool Minimizer::GetHessianMatrix(double *hMat) const
  * other parameters which is most strongly correlated with i.
  * Minimizer must overload method if implemented
  */
-double Minimizer::GlobalCC(unsigned int ivar) const
+std::vector<double> Minimizer::GlobalCC() const
 {
-   MATH_UNUSED(ivar);
-   return -1;
+   return {};
 }
 
 /**

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -170,7 +170,7 @@ public:
    int CovMatrixStatus() const override;
 
    ///global correlation coefficient for variable i
-   double GlobalCC(unsigned int ) const override;
+   std::vector<double> GlobalCC() const override;
 
    /// minos error for variable i, return false if Minos failed
    bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0) override;

--- a/math/minuit/src/TMinuitMinimizer.cxx
+++ b/math/minuit/src/TMinuitMinimizer.cxx
@@ -730,16 +730,26 @@ int TMinuitMinimizer::CovMatrixStatus() const {
    return fMinuit->fISW[1];
 }
 
-double TMinuitMinimizer::GlobalCC(unsigned int i) const {
-   // global correlation coefficient for parameter i
-   if (!fMinuit) return 0;
-   if (!fMinuit->fGlobcc) return 0;
-   if (int(i) >= fMinuit->fNu) return 0;
-   // get internal number in Minuit
-   int iin = fMinuit->fNiofex[i];
-   // index in TMinuit starts from 1
-   if (iin < 1) return 0;
-   return fMinuit->fGlobcc[iin-1];
+std::vector<double> TMinuitMinimizer::GlobalCC() const
+{
+   std::vector<double> out;
+   // global correlation coefficients
+   if (!fMinuit)
+      return out;
+   if (!fMinuit->fGlobcc)
+      return out;
+   out.resize(fMinuit->fNu);
+   for (int i = 0; i < fMinuit->fNu; ++i) {
+      // get internal number in Minuit
+      int iin = fMinuit->fNiofex[i];
+      // index in TMinuit starts from 1
+      if (iin < 1) {
+         out.clear();
+         break;
+      }
+      out[i] = fMinuit->fGlobcc[iin - 1];
+   }
+   return out;
 }
 
 bool TMinuitMinimizer::GetMinosError(unsigned int i, double & errLow, double & errUp, int ) {

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -216,7 +216,7 @@ public:
       is most strongly correlated with i.
       If the variable is fixed or const the return value is zero
     */
-   double GlobalCC(unsigned int i) const override;
+   std::vector<double> GlobalCC() const override;
 
    /**
       get the minos error for parameter i, return false if Minos failed

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -64,7 +64,7 @@ public:
    // user external representation
    const MnUserParameters &Parameters() const { return fParameters; }
    const MnUserCovariance &Covariance() const { return fCovariance; }
-   const MnGlobalCorrelationCoeff &GlobalCC() const { return fGlobalCC; }
+   MnGlobalCorrelationCoeff GlobalCC() const;
 
    // hessian (inverse of covariance matrix)
    MnUserCovariance Hessian() const;
@@ -161,7 +161,6 @@ private:
 
    MnUserParameters fParameters;
    MnUserCovariance fCovariance;
-   MnGlobalCorrelationCoeff fGlobalCC;
 
    std::vector<double> fIntParameters;
    MnUserCovariance fIntCovariance;

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -38,11 +38,7 @@ public:
    /// default constructor (invalid state)
    MnUserParameterState()
       : fValid(false),
-        fCovarianceValid(false),
         fCovStatus(-1),
-        fFVal(0),
-        fEDM(0),
-        fNFcn(0),
         fParameters(MnUserParameters()),
         fCovariance(MnUserCovariance()),
         fIntParameters(std::vector<double>()),
@@ -157,11 +153,11 @@ public:
 
 private:
    bool fValid;
-   bool fCovarianceValid;
+   bool fCovarianceValid = false;
    int fCovStatus; // covariance matrix status
-   double fFVal;
-   double fEDM;
-   unsigned int fNFcn;
+   double fFVal = 0.;
+   double fEDM = 0.;
+   unsigned int fNFcn = 0;
 
    MnUserParameters fParameters;
    MnUserCovariance fCovariance;

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -37,8 +37,15 @@ class MnUserParameterState {
 public:
    /// default constructor (invalid state)
    MnUserParameterState()
-      : fValid(false), fCovarianceValid(false), fGCCValid(false), fCovStatus(-1), fFVal(0), fEDM(0), fNFcn(0),
-        fParameters(MnUserParameters()), fCovariance(MnUserCovariance()), fIntParameters(std::vector<double>()),
+      : fValid(false),
+        fCovarianceValid(false),
+        fCovStatus(-1),
+        fFVal(0),
+        fEDM(0),
+        fNFcn(0),
+        fParameters(MnUserParameters()),
+        fCovariance(MnUserCovariance()),
+        fIntParameters(std::vector<double>()),
         fIntCovariance(MnUserCovariance())
    {
    }
@@ -78,7 +85,6 @@ public:
 
    bool IsValid() const { return fValid; }
    bool HasCovariance() const { return fCovarianceValid; }
-   bool HasGlobalCC() const { return fGCCValid; }
 
    double Fval() const { return fFVal; }
    double Edm() const { return fEDM; }
@@ -152,7 +158,6 @@ public:
 private:
    bool fValid;
    bool fCovarianceValid;
-   bool fGCCValid;
    int fCovStatus; // covariance matrix status
    double fFVal;
    double fEDM;

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -856,7 +856,7 @@ std::vector<double> Minuit2Minimizer::GlobalCC() const
    // is most strongly correlated with i.
 
    std::vector<double> out;
-   auto const &globalCC = fState.GlobalCC();
+   MnGlobalCorrelationCoeff globalCC = fState.GlobalCC();
    // no info available when minimization has failed or has some problems
    if (!globalCC.IsValid())
       return out;

--- a/math/minuit2/src/Minuit2Minimizer.cxx
+++ b/math/minuit2/src/Minuit2Minimizer.cxx
@@ -849,21 +849,27 @@ double Minuit2Minimizer::Correlation(unsigned int i, unsigned int j) const
    return 0;
 }
 
-double Minuit2Minimizer::GlobalCC(unsigned int i) const
+std::vector<double> Minuit2Minimizer::GlobalCC() const
 {
    // get global correlation coefficient for the parameter i. This is a number between zero and one which gives
    // the correlation between the i-th parameter  and that linear combination of all other parameters which
    // is most strongly correlated with i.
 
-   if (i >= fDim)
-      return 0;
+   std::vector<double> out;
+   auto const &globalCC = fState.GlobalCC();
    // no info available when minimization has failed or has some problems
-   if (!fState.HasGlobalCC())
-      return 0;
-   if (fState.Parameter(i).IsFixed() || fState.Parameter(i).IsConst())
-      return 0;
-   unsigned int k = fState.IntOfExt(i);
-   return fState.GlobalCC().GlobalCC()[k];
+   if (!globalCC.IsValid())
+      return out;
+   out.resize(fDim);
+   for (unsigned int i = 0; i < fDim; ++i) {
+      if (fState.Parameter(i).IsFixed() || fState.Parameter(i).IsConst())
+         out[i] = 0;
+      else {
+         unsigned int k = fState.IntOfExt(i);
+         out[i] = globalCC.GlobalCC()[k];
+      }
+   }
+   return out;
 }
 
 bool Minuit2Minimizer::GetMinosError(unsigned int i, double &errLow, double &errUp, int runopt)

--- a/math/minuit2/src/MnPrint.cxx
+++ b/math/minuit2/src/MnPrint.cxx
@@ -293,7 +293,7 @@ std::ostream &operator<<(std::ostream &os, const MnUserParameterState &state)
       os << state.Covariance();
    else
       os << "matrix is not present or not valid";
-   if (state.HasGlobalCC())
+   if (state.GlobalCC().IsValid())
       os << "\n  Global correlation coefficients: " << state.GlobalCC();
 
    os.precision(pr);

--- a/math/minuit2/src/MnUserParameterState.cxx
+++ b/math/minuit2/src/MnUserParameterState.cxx
@@ -20,19 +20,11 @@ namespace Minuit2 {
 // construct from user parameters (before minimization)
 //
 MnUserParameterState::MnUserParameterState(std::span<const double> par, std::span<const double> err)
-   : fValid(true),
-     fCovarianceValid(false),
-     fCovStatus(-1),
-     fFVal(0.),
-     fEDM(0.),
-     fNFcn(0),
-     fParameters(MnUserParameters(par, err)),
-     fIntParameters(par.begin(), par.end())
+   : fValid(true), fCovStatus(-1), fParameters(MnUserParameters(par, err)), fIntParameters(par.begin(), par.end())
 {
 }
 
-MnUserParameterState::MnUserParameterState(const MnUserParameters &par)
-   : fValid(true), fCovarianceValid(false), fCovStatus(-1), fFVal(0.), fEDM(0.), fNFcn(0), fParameters(par)
+MnUserParameterState::MnUserParameterState(const MnUserParameters &par) : fValid(true), fCovStatus(-1), fParameters(par)
 {
    // construct from user parameters (before minimization)
 
@@ -50,7 +42,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters &par)
 // construct from user parameters + errors (before minimization)
 //
 MnUserParameterState::MnUserParameterState(std::span<const double> par, std::span<const double> cov, unsigned int nrow)
-   : fValid(true), fCovStatus(-1), fFVal(0.), fEDM(0.), fNFcn(0), fIntParameters(par.begin(), par.end())
+   : fValid(true), fCovStatus(-1), fIntParameters(par.begin(), par.end())
 {
    // construct from user parameters + errors (before minimization) using std::vector for parameter error and    // an
    // std::vector of size n*(n+1)/2 for the covariance matrix  and n (rank of cov matrix)
@@ -66,7 +58,7 @@ MnUserParameterState::MnUserParameterState(std::span<const double> par, std::spa
 }
 
 MnUserParameterState::MnUserParameterState(std::span<const double> par, const MnUserCovariance &cov)
-   : fValid(true), fCovStatus(-1), fFVal(0.), fEDM(0.), fNFcn(0), fIntParameters(par.begin(), par.end())
+   : fValid(true), fCovStatus(-1), fIntParameters(par.begin(), par.end())
 {
    // construct from user parameters + errors (before minimization) using std::vector (params) and MnUserCovariance
    // class
@@ -82,7 +74,7 @@ MnUserParameterState::MnUserParameterState(std::span<const double> par, const Mn
 }
 
 MnUserParameterState::MnUserParameterState(const MnUserParameters &par, const MnUserCovariance &cov)
-   : fValid(true), fCovStatus(-1), fFVal(0.), fEDM(0.), fNFcn(0), fParameters(par)
+   : fValid(true), fCovStatus(-1), fParameters(par)
 {
    // construct from user parameters + errors (before minimization) using
    // MnUserParameters and MnUserCovariance objects
@@ -102,7 +94,7 @@ MnUserParameterState::MnUserParameterState(const MnUserParameters &par, const Mn
 //
 //
 MnUserParameterState::MnUserParameterState(const MinimumState &st, double up, const MnUserTransformation &trafo)
-   : fValid(st.IsValid()), fCovarianceValid(false), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()), fNFcn(st.NFcn())
+   : fValid(st.IsValid()), fCovStatus(-1), fFVal(st.Fval()), fEDM(st.Edm()), fNFcn(st.NFcn())
 {
    //
    // construct from internal parameters (after minimization)

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -613,11 +613,11 @@ double correlation(std::vector<double> const &covMat, unsigned int i, unsigned i
 void RooMinimizer::fillCorrMatrix(RooFitResult &fitRes)
 {
    const std::size_t nParams = _fcn->getNDim();
-   std::vector<double> globalCC;
    TMatrixDSym corrs(nParams);
    TMatrixDSym covs(nParams);
+   std::vector<double> globalCC = _minimizer->GlobalCC();
+   globalCC.resize(nParams); // pad with zeros
    for (std::size_t ic = 0; ic < nParams; ic++) {
-      globalCC.push_back(_result->fGlobalCC[ic]);
       for (std::size_t ii = 0; ii < nParams; ii++) {
          corrs(ic, ii) = correlation(_result->fCovMatrix, ic, ii);
          covs(ic, ii) = covMatrix(_result->fCovMatrix, ic, ii);
@@ -1256,7 +1256,6 @@ void RooMinimizer::fillResult(bool isValid)
    // if minimizer provides error provides also error matrix
    // clear in case of re-filling an existing result
    _result->fCovMatrix.clear();
-   _result->fGlobalCC.clear();
 
    if (min.Errors() != nullptr) {
       updateErrors();
@@ -1312,10 +1311,6 @@ void RooMinimizer::updateErrors()
       }
    }
    // minos errors are set separately when calling Fitter::CalculateMinosErrors()
-
-   // update global CC
-   _result->fGlobalCC = min.GlobalCC();
-   _result->fGlobalCC.resize(npar); // pad with zeros
 }
 
 double RooMinimizer::FitResult::lowerError(unsigned int i) const

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -1314,15 +1314,8 @@ void RooMinimizer::updateErrors()
    // minos errors are set separately when calling Fitter::CalculateMinosErrors()
 
    // update global CC
-   _result->fGlobalCC.resize(npar);
-   for (unsigned int i = 0; i < npar; ++i) {
-      double globcc = min.GlobalCC(i);
-      if (globcc < 0) {
-         _result->fGlobalCC.clear();
-         break; // it is not supported by that minimizer
-      }
-      _result->fGlobalCC[i] = globcc;
-   }
+   _result->fGlobalCC = min.GlobalCC();
+   _result->fGlobalCC.resize(npar); // pad with zeros
 }
 
 double RooMinimizer::FitResult::lowerError(unsigned int i) const


### PR DESCRIPTION
The function `double ROOT::Math::Minimizer::GlobalCC(unsigned int ivar)` was changed to `std::vector<double> ROOT::Math::Minimizer::GlobalCC()`, always returning the full list of global correlations.

This change was needed because global correlations are not unconditionally computed and cached in the minimizer anymore. Only computing them when calling `GlobalCC()` avoids unneeded overhead when global correlations are not required.