### PR TITLE
[cmake] Use cfitsio sources from the lcg website

### DIFF
--- a/builtins/cfitsio/CMakeLists.txt
+++ b/builtins/cfitsio/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 ExternalProject_Add(
   BUILTIN_CFITSIO
   PREFIX ${CFITSIO_PREFIX}
-  URL https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-${CFITSIO_VERSION}.tar.gz
+  URL https://lcgpackages.web.cern.ch/tarFiles/sources/cfitsio-${CFITSIO_VERSION}.tar.gz
   URL_HASH SHA256=95900cf95ae760839e7cb9678a7b2fad0858d6ac12234f934bd1cb6bfc246ba9
   CMAKE_ARGS -G ${CMAKE_GENERATOR}
              -DCMAKE_POLICY_VERSION_MINIMUM=3.5


### PR DESCRIPTION
and not NASA's as all other packages.

(cherry picked from commit 2ae01b55e8c0f79cced60077f86509c0cae33109)


