### PR TITLE
Fix option B with logx

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -2290,7 +2290,7 @@ void TGraphPainter::PaintGrapHist(TGraph *theGraph, Int_t npoints, const Double_
             gxwork[1] = xhigh;
             gywork[1] = yhigh;
             ComputeLogs(2, optionZ);
-            if (xlow < rwxmax && xhigh > rwxmin)
+            if (xlow < uxmax && xhigh > uxmin)
                gPad->PaintBox(gxworkl[0],gyworkl[0],gxworkl[1],gyworkl[1]);
             if (!optionBins) {
                xlow  = xlow+delta;


### PR DESCRIPTION
The option 'B' allows drawing a histogram as a bar chart, with a user-defined bar width and bar offset. This option does not really make sense in log scale along the X-axis, but it is nevertheless supported. This case had a problem, as noted in [this forum post](https://root-forum.cern.ch/t/histogram-painting-with-bar-option-on-log-scale/63675). As mentioned in the replies, there was a workaround with the option 'BAR'. Nonetheless, this PR fixes the problem, which was due to a faulty comparison between quantities in logarithmic scale and linear scale.
