### PR TITLE
Save memory. Do not link to LLVM libraries in parallel

### DIFF
--- a/core/clingutils/test/CMakeLists.txt
+++ b/core/clingutils/test/CMakeLists.txt
@@ -31,3 +31,6 @@ if(NOT builtin_clang)
 endif()
 
 ROOT_ADD_UNITTEST_DIR(Core RIO ${CLING_LIBRARIES} $<TARGET_OBJECTS:ClingUtils>)
+
+# Save memory. Do not link to LLVM libraries in parallel
+add_dependencies(coreclingutilstestUnit CppInterOpTests)

--- a/interpreter/CppInterOp/unittests/CppInterOp/CMakeLists.txt
+++ b/interpreter/CppInterOp/unittests/CppInterOp/CMakeLists.txt
@@ -65,6 +65,9 @@ target_link_libraries(CppInterOpTests
   clangCppInterOp
 )
 
+# Save memory. Do not link to LLVM libraries in parallel
+add_dependencies(CppInterOpTests DynamicLibraryManagerTests)
+
 set_output_directory(CppInterOpTests
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${EXTRA_PATH_TEST_BINARIES}
   LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${EXTRA_PATH_TEST_BINARIES}
@@ -115,6 +118,9 @@ set_output_directory(DynamicLibraryManagerTests
 )
 
 add_dependencies(DynamicLibraryManagerTests TestSharedLib)
+
+# Save memory. Do not link to LLVM libraries in parallel
+add_dependencies(DynamicLibraryManagerTests Cling)
 
 #export_executable_symbols_for_plugins(TestSharedLib)
 add_subdirectory(TestSharedLib)


### PR DESCRIPTION
# This Pull request:

Linking to the built-in static LLVM libraries uses a lot ov memory. Linking more than one such target in parallel can exhaust the memory. This PR adds dependencies to prevent this.

Compare

https://github.com/root-project/root/blob/a32e7d0eb6ff583c3420e32b4198d20cd7e8ebd4/core/metacling/src/CMakeLists.txt#L126-L127
