### PR TITLE
Fix test for 32 bit architectures

### DIFF
--- a/interpreter/CppInterOp/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/interpreter/CppInterOp/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -158,7 +158,8 @@ TEST(ScopeReflectionTest, SizeOf) {
   EXPECT_EQ(Cpp::SizeOf(Decls[4]), (size_t)0);
   EXPECT_EQ(Cpp::SizeOf(Decls[5]), (size_t)1);
   EXPECT_EQ(Cpp::SizeOf(Decls[6]), (size_t)4);
-  EXPECT_EQ(Cpp::SizeOf(Decls[7]), (size_t)16);
+  struct B {short a; double b;};
+  EXPECT_EQ(Cpp::SizeOf(Decls[7]), sizeof(B));
 }
 
 

--- a/interpreter/CppInterOp/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/interpreter/CppInterOp/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -78,7 +78,8 @@ TEST(TypeReflectionTest, GetSizeOfType) {
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[1])), 1);
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[2])), 4);
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[3])), 8);
-  EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[4])), 16);
+  struct B {int a; double b;};
+  EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[4])), sizeof(B));
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetTypeFromScope(Decls[5])), 0);
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[6])),
             sizeof(intptr_t));


### PR DESCRIPTION
The size of the struct isdifferent on 32 bit architectures.
```
[ RUN      ] TypeReflectionTest.GetSizeOfType
/builddir/build/BUILD/root-6.36.00-build/root-6.36.00/interpreter/CppInterOp/unittests/CppInterOp/TypeReflectionTest.cpp:79: Failure
Expected equality of these values:
  Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[4]))
    Which is: 12
  16
[  FAILED  ] TypeReflectionTest.GetSizeOfType (23 ms)

[ RUN      ] ScopeReflectionTest.SizeOf
/builddir/build/BUILD/root-6.36.00-build/root-6.36.00/interpreter/CppInterOp/unittests/CppInterOp/ScopeReflectionTest.cpp:161: Failure
Expected equality of these values:
  Cpp::SizeOf(Decls[7])
    Which is: 12
  (size_t)16
    Which is: 16
[  FAILED  ] ScopeReflectionTest.SizeOf (26 ms)
```
