### PR TITLE
Ignore warnings from uring IO

### DIFF
--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -78,6 +78,18 @@ static struct ForbidDiagnostics {
         return;
       }
 
+      if (level == kWarning && strcmp(location, "RIoUring") == 0 &&
+          strstr(msg, "io_uring is unexpectedly not available because:") != nullptr) {
+         std::cerr << "Warning in " << location << " " << msg << std::endl;
+         return;
+      }
+
+      if (level == kWarning && strcmp(location, "RRawFileUnix") == 0 &&
+          strcmp(msg, "io_uring setup failed, falling back to blocking I/O in ReadV") == 0) {
+         std::cerr << "Warning in " << location << " " << msg << std::endl;
+         return;
+      }
+
       FAIL() << "Received unexpected diagnostic of severity "
          << level
          << " at '" << location << "' reading '" << msg << "'.\n"


### PR DESCRIPTION
Tests randomly fail because the uring memory is exhausted.

Here are some examples:
```
[ RUN      ] RNTuple.RandomAccess
.../root-6.36.00/core/testsupport/src/TestSupport.cxx:79: Failure
Failed
Received unexpected diagnostic of severity 2000 at 'RIoUring' reading 'io_uring is unexpectedly not available because:
Failed to allocate memory for the smallest possible io_uring instance. 'memlock' memory has been exhausted for this user'.
Suppress those using ROOT/TestSupport.hxx
.../root-6.36.00/core/testsupport/src/TestSupport.cxx:79: Failure
Failed
Received unexpected diagnostic of severity 2000 at 'RRawFileUnix' reading 'io_uring setup failed, falling back to blocking I/O in ReadV'.
Suppress those using ROOT/TestSupport.hxx
[  FAILED  ] RNTuple.RandomAccess (20472 ms)

[ RUN      ] RNTupleDSTest.ChainMT
.../root-6.34.08/core/testsupport/src/TestSupport.cxx:79: Failure
Failed
Received unexpected diagnostic of severity 2000 at 'RIoUring' reading 'io_uring is unexpectedly not available because:
Failed to allocate memory for the smallest possible io_uring instance. 'memlock' memory has been exhausted for this user'.
Suppress those using ROOT/TestSupport.hxx
.../root-6.34.08/core/testsupport/src/TestSupport.cxx:79: Failure
Failed
Received unexpected diagnostic of severity 2000 at 'RRawFileUnix' reading 'io_uring setup failed, falling back to blocking I/O in ReadV'.
Suppress those using ROOT/TestSupport.hxx
[  FAILED  ] RNTupleDSTest.ChainMT (1004 ms)
```
