### PR TITLE
[Python] Use relative install path for pythonization library

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -212,7 +212,7 @@ target_link_libraries(PyROOT INTERFACE cppyy_backend cppyy ROOTPythonizations)
 
 # Define library output directories for build and install trees
 set(pymoduledir_build "${localruntimedir}/ROOT")
-set(pymoduledir_install "${CMAKE_INSTALL_FULL_PYTHONDIR}/ROOT")
+set(pymoduledir_install "${CMAKE_INSTALL_PYTHONDIR}/ROOT")
 
 # To make sure that the library also ends up in the right subdirectory in the
 # build directory tree.
@@ -232,7 +232,7 @@ if(NOT MSVC)
   # Make sure that relative RUNPATH to main ROOT libraries is always correct.
 
   file(RELATIVE_PATH pymoduledir_to_libdir_build ${pymoduledir_build} "${localruntimedir}")
-  file(RELATIVE_PATH pymoduledir_to_libdir_install ${pymoduledir_install} "${CMAKE_INSTALL_FULL_LIBDIR}")
+  file(RELATIVE_PATH pymoduledir_to_libdir_install ${CMAKE_INSTALL_PREFIX}/${pymoduledir_install} "${CMAKE_INSTALL_FULL_LIBDIR}")
 
   if(APPLE)
     set_target_properties(${libname} PROPERTIES


### PR DESCRIPTION
Absolute install paths can't be used for CMake targets on Windows of macOS. Commit 9bb2f50 changed the install paths of the pythonization library to be absolute paths, so that it's simple to calculate the relative paths. But this broke the installation step on Windows and macOS, and therefore has to be reverted. For the `rpath` step, the full path is obtained with `CMAKE_INSTALL_PREFIX`, and it was checked that the rpaths are still correctly computed, similar to https://github.com/root-project/root/pull/18969#discussion_r2128987289

```txt
[nix-shell:~/code/root]$ readelf -d root_build/lib/ROOT/libROOTPythonizations.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../:/home/rembserj/code/root/root_build/lib::/nix/store/0896fyzn4l1gczab8qmlsliipq0js31x-nix-shell/lib:/nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib:/nix/store/x613hzkhr7mhv65p4l7fbmjkmc2mnhhp-gcc-15.1.0-lib/lib]

[nix-shell:~/code/root]$ readelf -d root_install/lib/root/ROOT/libROOTPythonizations.so | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../:/nix/store/0896fyzn4l1gczab8qmlsliipq0js31x-nix-shell/lib:/nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib:/nix/store/x613hzkhr7mhv65p4l7fbmjkmc2mnhhp-gcc-15.1.0-lib/lib]
```

Thanks @bellenot for figuring out the problem!