### PR TITLE
Fix for CMAKE_SOURCE_DIR with special characters `. and +`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,8 +328,7 @@ foreach(dir_to_copy ${directories_to_copy})
   file(GLOB_RECURSE artifacts_in ${dir_to_copy}/*)
   list(FILTER artifacts_in EXCLUDE REGEX "\.(d|swp|so|dylib|lib|dll|pcm|bak)$")
 
-  set(artifacts_out ${artifacts_in})
-  list(TRANSFORM artifacts_out REPLACE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+  string(REPLACE ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} artifacts_out "${artifacts_in}")
   list(APPEND all_artifacts ${artifacts_out})
 
   add_custom_command(OUTPUT ${artifacts_out}


### PR DESCRIPTION
# This Pull request:

Fixes the ninja cyclic dependency issue reported in https://github.com/root-project/root/issues/18998 due to special character `+` in the `CMAKE_SOURCE_DIR`. Instead of using `list(TRANSFORM ...)` (which uses regexp) to replace `CMAKE_SOURCE_DIR` with `CMAKE_BINARY_DIR` this PR suggests to use [string(REPLACE )](https://cmake.org/cmake/help/latest/command/string.html#replace) which does a string substitution 

## Changes or fixes:

ninja, build system, cyclic dependency issue

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #18998

