### PR TITLE
[core] Do not select template instances if their template arguments are invalid decls in the AST

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -4,6 +4,9 @@
 * The `RooStats::HLFactory` class that was deprecated in ROOT 6.36 is now removed. It provided little advantage over using the RooWorkspace directly or any of the other higher-level frameworks that exist in the RooFit ecosystem.
 * The build options `mysql`, `odbc` and `pgsql`, that were deprecated in ROOT 6.36, are now removed.
 
+## Core Libraries
+* Behavior change: when selecting a template instantiation for a dictionary, all the template arguments have to be fully defined - the forward declarations are not enough any more. The error prompted by the dictionary generator will be `Warning: Unused class rule: MyTemplate<MyFwdDeclaredClass>`.
+
 ## Math
 
 ### Minuit2

--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -225,7 +225,7 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
          return kName;
       }
    } else if (fHasNameAttribute) {
-      if (name_value == name) {
+      if (name_value == name && !decl->isInvalidDecl()) {
          const_cast<BaseSelectionRule*>(this)->SetMatchFound(true);
          return kName;
       } else if (fCXXRecordDecl == nullptr ||
@@ -236,7 +236,7 @@ BaseSelectionRule::EMatchType BaseSelectionRule::Match(const clang::NamedDecl *d
             = fHasFromTypedefAttribute ? nullptr : ROOT::TMetaUtils::ScopeSearch(name_value.c_str(), *fInterp,
                                                    true /*diagnose*/, nullptr);
 
-         if ( target ) {
+         if ( target && !target->isInvalidDecl()) {
             const_cast<BaseSelectionRule*>(this)->fCXXRecordDecl = target;
          } else {
             // If the lookup failed, let's not try it again, so mark the value has invalid.

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -698,13 +698,6 @@ namespace cling {
                   TagDecl* TD = TagTy->getDecl();
                   if (TD) {
                     TheDecl = TD->getDefinition();
-                    // NOTE: if (TheDecl) ... check for theDecl->isInvalidDecl()
-                    if (TD && TD->isInvalidDecl()) {
-                      printf("Warning: FindScope got an invalid tag decl\n");
-                    }
-                    if (TheDecl && TheDecl->isInvalidDecl()) {
-                      printf("ERROR: FindScope about to return an invalid decl\n");
-                    }
                     if (!TheDecl && instantiateTemplate) {
 
                       // Make sure it is not just forward declared, and

--- a/roottest/root/meta/rootcling/CMakeLists.txt
+++ b/roottest/root/meta/rootcling/CMakeLists.txt
@@ -33,3 +33,8 @@ ROOTTEST_GENERATE_DICTIONARY(streamerInfoStdFunctionDict streamerInfoStdFunction
 ROOTTEST_ADD_TEST(streamerInfoStdFunction
                   MACRO streamerInfoStdFunction.C
                   DEPENDS ${GENERATE_DICTIONARY_TEST})
+
+# Issue #18982
+ROOTTEST_ADD_TEST(selectTemplateInvalidArg
+                  COMMAND ${ROOT_rootcling_CMD} -f selectTemplateInvalidArg.Dict.cc ${CMAKE_CURRENT_SOURCE_DIR}/selectTemplateInvalidArg.h ${CMAKE_CURRENT_SOURCE_DIR}/selectTemplateInvalidArg.LinkDef.h
+                  ERRREF selectTemplateInvalidArg.ref)

--- a/roottest/root/meta/rootcling/selectTemplateInvalidArg.LinkDef.h
+++ b/roottest/root/meta/rootcling/selectTemplateInvalidArg.LinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CLING__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class RtObj2<TNamed>+;
+
+#endif

--- a/roottest/root/meta/rootcling/selectTemplateInvalidArg.h
+++ b/roottest/root/meta/rootcling/selectTemplateInvalidArg.h
@@ -1,0 +1,14 @@
+#include <TObject.h>
+
+template <class T>
+class RtObj2 : public T
+ {
+  public:
+    RtObj2() {}
+    RtObj2( const T & val ) : T(val) {}
+    ClassDefT(RtObj2,1)
+ } ;
+
+ClassDefT2(RtObj2,T)
+
+ClassImpT(RtObj2,T)

--- a/roottest/root/meta/rootcling/selectTemplateInvalidArg.ref
+++ b/roottest/root/meta/rootcling/selectTemplateInvalidArg.ref
@@ -1,0 +1,1 @@
+Warning: Unused class rule: RtObj2<TNamed>


### PR DESCRIPTION
for example, when they are only forward declared.
Side effect: less lookups are carried out during the selection, therefore less memory and runtime is used for dictionary generation.

Fixes #18982 

