### PR TITLE
[ntuple] Add RMiniFile::GetNTupleProperAtOffset

### DIFF
--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -68,6 +68,8 @@ private:
    /// Used when the file turns out to be a TFile container. The ntuplePath variable is either the ntuple name
    /// or an ntuple name preceded by a directory (`myNtuple` or `foo/bar/myNtuple` or `/foo/bar/myNtuple`)
    RResult<RNTuple> GetNTupleProper(std::string_view ntuplePath);
+   /// Loads an RNTuple anchor from a TFile at the given file offset (unzipping it if necessary).
+   RResult<RNTuple> GetNTupleProperAtOffset(std::uint64_t keyOffset);
 
    /// Searches for a key with the given name and type in the key index of the directory starting at offsetDir.
    /// The offset points to the start of the TDirectory DATA section, without the key and without the name and title

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -754,6 +754,14 @@ ROOT::RResult<ROOT::RNTuple> ROOT::Internal::RMiniFileReader::GetNTupleProper(st
       return R__FAIL("no RNTuple named '" + std::string(ntupleName) + "' in file '" + fRawFile->GetUrl() + "'");
    }
 
+   auto res = GetNTupleProperAtOffset(offset);
+   return res;
+}
+
+ROOT::RResult<ROOT::RNTuple> ROOT::Internal::RMiniFileReader::GetNTupleProperAtOffset(std::uint64_t keyOffset)
+{
+   auto offset = keyOffset;
+   RTFKey key;
    ReadBuffer(&key, sizeof(key), offset);
    offset = key.GetSeekKey() + key.fKeyLen;
 


### PR DESCRIPTION
# This Pull request:
refactors a bit `RMIniFile::GetNTupleProper` adding a `GetNTupleProperAtLocation` subroutine to load the anchor once its location in the file is known. This will be useful for the RNTuple Attributes prototype as it will need to load the Attributes' anchor from the same file from a known location.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

