### PR TITLE
[Python] Check for identity and not equality where appropriate

### DIFF
--- a/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
+++ b/bindings/pyroot/pythonizations/test/tdirectory_attrsyntax.py
@@ -49,7 +49,7 @@ class TDirectoryReadWrite(unittest.TestCase):
         self.dir0["h"]
         # check that the cached value in is actually the object
         # inside the directory
-        self.assertEqual(self.dir0._cached_items["h"], self.dir0["h"])
+        self.assertTrue(self.dir0._cached_items["h"] is self.dir0["h"])
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
+++ b/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
@@ -54,7 +54,7 @@ class TDirectoryFileReadWrite(unittest.TestCase):
         self.dir0.h
         # check that the value in __dict__ is actually the object
         # inside the directory
-        self.assertEqual(self.dir0.__dict__['h'], self.dir0.h)
+        self.assertTrue(self.dir0.__dict__['h'] is self.dir0.h)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -61,7 +61,7 @@ class TFileOpenReadWrite(unittest.TestCase):
         f.h
         # check that the value in __dict__ is actually the object
         # inside the directory
-        self.assertEqual(f.__dict__['h'], f.h)
+        self.assertTrue(f.__dict__['h'] is f.h)
 
     def test_oserror(self):
         # check that an OSError is raised when an inexistent file is opened

--- a/roottest/python/memory/PyROOT_memorytests.py
+++ b/roottest/python/memory/PyROOT_memorytests.py
@@ -68,7 +68,7 @@ class Memory1TestCase( MyTestCase ):
       a = TH1F( 'memtest_th1f', 'title', 100, -1., 1. )
 
     # locate it
-      self.assertEqual( a, gROOT.FindObject( 'memtest_th1f' ) )
+      self.assertTrue( a is gROOT.FindObject( 'memtest_th1f' ) )
 
     # destroy it
       del a


### PR DESCRIPTION
There are several unit tests that assert if different variables actually
point to the same histogram object, using the `==` operator.

Until now, this was correct by accident, because the default equality
check for TObject-derived classes in PyROOT is to call
`TObject::IsEqual()`, which does checks the pointer identity (if not
overridden is not implemented). See:
https://github.com/root-project/root/blob/master/bindings/pyroot/pythonizations/src/TObjectPyz.cxx#L49

Since PR https://github.com/root-project/root/pull/17950 (introduction of UHI interface), an equality operator is
implemented for histograms on the Python side. Therefore, we really need
to correctly use Pythons `is` function to explicitly check for identity
(meaning both variables point to the same object).