### PR TITLE
[roottest] Use `PYTHON_DEPS` argument also in Roottest macro

### DIFF
--- a/roottest/cmake/modules/RoottestMacros.cmake
+++ b/roottest/cmake/modules/RoottestMacros.cmake
@@ -783,7 +783,7 @@ endmacro(ROOTTEST_SETUP_EXECTEST)
 function(ROOTTEST_ADD_TEST testname)
   CMAKE_PARSE_ARGUMENTS(ARG "WILLFAIL;RUN_SERIAL"
                             "OUTREF;ERRREF;OUTREF_CINTSPECIFIC;OUTCNV;PASSRC;MACROARG;WORKING_DIR;INPUT;ENABLE_IF;DISABLE_IF;TIMEOUT;RESOURCE_LOCK"
-                            "TESTOWNER;COPY_TO_BUILDDIR;MACRO;EXEC;COMMAND;PRECMD;POSTCMD;OUTCNVCMD;FAILREGEX;PASSREGEX;DEPENDS;OPTS;LABELS;ENVIRONMENT;FIXTURES_SETUP;FIXTURES_CLEANUP;FIXTURES_REQUIRED;PROPERTIES"
+                            "TESTOWNER;COPY_TO_BUILDDIR;MACRO;EXEC;COMMAND;PRECMD;POSTCMD;OUTCNVCMD;FAILREGEX;PASSREGEX;DEPENDS;OPTS;LABELS;ENVIRONMENT;FIXTURES_SETUP;FIXTURES_CLEANUP;FIXTURES_REQUIRED;PROPERTIES;PYTHON_DEPS"
                             ${ARGN})
 
   # Test name
@@ -889,6 +889,11 @@ function(ROOTTEST_ADD_TEST testname)
   # Mark the test as known to fail.
   if(ARG_WILLFAIL)
     set(willfail WILLFAIL)
+  endif()
+
+  # List of python packages required to run this test.
+  if(ARG_PYTHON_DEPS)
+    set(pythondeps ${ARG_PYTHON_DEPS})
   endif()
 
   # Add ownership and test labels.
@@ -1081,6 +1086,7 @@ function(ROOTTEST_ADD_TEST testname)
                         ${failregex}
                         ${passregex}
                         ${copy_to_builddir}
+                        PYTHON_DEPS ${pythondeps}
                         DEPENDS ${deplist}
                         FIXTURES_SETUP ${fixtures_setup}
                         FIXTURES_CLEANUP ${fixtures_cleanup}

--- a/roottest/python/JupyROOT/CMakeLists.txt
+++ b/roottest/python/JupyROOT/CMakeLists.txt
@@ -23,7 +23,8 @@ foreach(pyfile ${pyfiles})
   get_filename_component(SHORTPYFILE ${pyfile} NAME_WE)
   if (NOT ${SHORTPYFILE} STREQUAL "__init__")
     ROOTTEST_ADD_TEST(${SHORTPYFILE}_doctest
-                      COMMAND ${Python3_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile})
+                      COMMAND ${Python3_EXECUTABLE} ${DOCTEST_LAUNCHER} ${pyfile}
+                      PYTHON_DEPS IPython)
   endif()
 endforeach()
 
@@ -33,7 +34,8 @@ foreach(NOTEBOOK ${NOTEBOOKS})
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${NOTEBOOK}
                     COMMAND ${Python3_EXECUTABLE} ${NBDIFFUTIL} ${NOTEBOOK}
-                    RUN_SERIAL)
+                    RUN_SERIAL
+                    PYTHON_DEPS jupyter)
 endforeach()
 
 if(ROOT_imt_FOUND)
@@ -43,7 +45,8 @@ if(ROOT_imt_FOUND)
   ROOTTEST_ADD_TEST(${NOTEBOOKBASE}_notebook
                     COPY_TO_BUILDDIR ${IMT_NB}
                     COMMAND ${Python3_EXECUTABLE} ${NBDIFFUTIL} ${IMT_NB} "OFF"
-                    RUN_SERIAL)
+                    RUN_SERIAL
+                    PYTHON_DEPS jupyter)
 endif()
 
 endif()


### PR DESCRIPTION
Follows up on #5938, adding support for the `PYTHON_DEPS` argument also to the `ROOTTEST_ADD_TEST` macro.

Use this functionality to disable JupyROOT tests if the relevant libraries are not available.