### PR TITLE
[Minuit2] Correctly copy ROOT's `std::span` headers for standalone build

### DIFF
--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -42,11 +42,10 @@ include(copy_standalone.cmake)
 # We need the std::span backport. This can be removed once the minimum C++
 # standard gets raised to C++20, which should happen if also the minimum C++
 # standard of ROOT gets raised and the std::span backport in RSpan is removed.
-include_directories(../../core/foundation/inc/)
 set(SPAN_HEADERS RSpan.hxx span.hxx)
-copy_standalone(SOURCE ../../core/foundation/inc/ROOT DESTINATION . OUTPUT SPAN_HEADERS
+copy_standalone(SOURCE ../../core/foundation/inc/ROOT DESTINATION inc/ROOT OUTPUT SPAN_HEADERS
                 FILES ${SPAN_HEADERS})
-install(FILES ${SPAN_HEADERS} DESTINATION include/ROOT)
+install(FILES ${SPAN_HEADERS} DESTINATION include/Minuit2/ROOT)
 
 
 # Copy these files in if needed


### PR DESCRIPTION
Correctly copy ROOT's `std::span` headers to setup the Minuit2 standalone build.

Now the treatment of the `std::span` headers follows the same approach that is already taken for other headers that are copied from ROOT Math:

See https://github.com/root-project/root/blob/master/math/minuit2/src/math/CMakeLists.txt#L36 See https://github.com/root-project/root/blob/master/math/minuit2/src/math/CMakeLists.txt#L97

Closes #18974.