### PR TITLE
[reve] Send data to clients only to active connections

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
@@ -132,7 +132,7 @@ public:
 
    void ReserveItems(Int_t items_size) { fItemList->fItems.reserve(items_size); }
    void AddItem(void *data_ptr, const std::string& n, const std::string& t);
-   void ClearItems() { fItemList->fItems.clear(); }
+   void ClearItems();
 
    Bool_t SingleRnrState() const override { return kTRUE; }
    Bool_t SetRnrState(Bool_t) override;

--- a/graf3d/eve7/inc/ROOT/REveManager.hxx
+++ b/graf3d/eve7/inc/ROOT/REveManager.hxx
@@ -274,6 +274,7 @@ public:
    std::shared_ptr<ROOT::RWebWindow> GetWebWindow() const { return fWebWindow; }
 
    // void Send(void* buff, unsigned connid);
+   void SendToAllConnections(const std::string &data);
    void Send(unsigned connid, const std::string &data);
    void SendBinary(unsigned connid, const void *data, std::size_t len);
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -453,3 +453,10 @@ Int_t REveDataCollection::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
    return ret;
 }
 
+void REveDataCollection::ClearItems()
+{
+   for (size_t i = 0; i < fItemList->fItems.size(); ++i) {
+      delete fItemList->fItems[i];
+   }
+   fItemList->fItems.clear();
+}

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -1015,7 +1015,7 @@ void REveManager::SendSceneChanges()
    // send  begin message
    nlohmann::json jobj = {};
    jobj["content"] = "BeginChanges";
-   fWebWindow->Send(0, jobj.dump());
+   SendToAllConnections(jobj.dump());
 
    // send the change json
    fWorld->SendChangesToSubscribers();
@@ -1051,7 +1051,7 @@ void REveManager::SendSceneChanges()
       }
       gEveLogEntries.clear();
    }
-   fWebWindow->Send(0, jobj.dump());
+   SendToAllConnections(jobj.dump());
 }
 
 //
@@ -1145,6 +1145,13 @@ void REveManager::ConnectEveViewer(REveViewer* view)
 }
 
 //____________________________________________________________________
+void REveManager::SendToAllConnections(const std::string &data)
+{
+   for (auto &conn : fConnList) {
+      fWebWindow->Send(conn.fId, data);
+   }
+}
+
 void REveManager::Send(unsigned connid, const std::string &data)
 {
    fWebWindow->Send(connid, data);


### PR DESCRIPTION
Here are two corrections needed for the case of event display instance periodically looping over hundred thousand events. E.g. live event display visualization.