### PR TITLE
[webgui] let suppress warnings from webgui components

### DIFF
--- a/gui/browserv7/src/RWebBrowserImp.cxx
+++ b/gui/browserv7/src/RWebBrowserImp.cxx
@@ -14,6 +14,7 @@
 
 #include "TROOT.h"
 #include "TSeqCollection.h" // needed in gROOT->GetListOfFiles()->FindObject
+#include "TEnv.h"
 
 #include <iostream>
 
@@ -71,7 +72,13 @@ RWebBrowserImp::~RWebBrowserImp()
 void RWebBrowserImp::ShowWarning()
 {
    static bool show_warn = true;
-   if (!show_warn) return;
+   if (!show_warn)
+      return;
+
+   TString value = gEnv->GetValue("WebGui.Warning", "yes");
+   if ((value != "yes") && (value != "1"))
+      return;
+
    show_warn = false;
 
    std::cout << "\n"

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -129,13 +129,18 @@ void RWebWindowsManager::AssignMainThrd()
 void RWebWindowsManager::SetLoopbackMode(bool on)
 {
    gWebWinLoopbackMode = on;
+   bool print_warning = RWebWindowWSHandler::GetBoolEnv("WebGui.Warning", 1) == 1;
    if (!on) {
-      printf("\nWARNING!\n");
-      printf("Disabling loopback mode may leads to security problem.\n");
-      printf("See https://root.cern/about/security/ for more information.\n\n");
+      if (print_warning) {
+         printf("\nWARNING!\n");
+         printf("Disabling loopback mode may leads to security problem.\n");
+         printf("See https://root.cern/about/security/ for more information.\n\n");
+      }
       if (!gWebWinUseSessionKey) {
-         printf("Enforce session key to safely work on public network.\n");
-         printf("One may call RWebWindowsManager::SetUseSessionKey(false); to disable it.\n");
+         if (print_warning) {
+            printf("Enforce session key to safely work on public network.\n");
+            printf("One may call RWebWindowsManager::SetUseSessionKey(false); to disable it.\n");
+         }
          gWebWinUseSessionKey = true;
       }
    }


### PR DESCRIPTION
Introduce `WebGui.Warning` rootrc variable which can disable printing of warnings from WebGui components.

Use in `RWebWindowsManager::SetLoopbackMode` and in starting of web-based TBrowser