### PR TITLE
[CMake] Fix compile definitions being passed to rootcling as -D-Dxxx.

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -968,6 +968,17 @@ if(xrootd AND NOT builtin_xrootd)
       endif()
     endif()
   endif()
+
+  if(XRootD_VERSION VERSION_LESS 5.8.4)
+    # Remove -D from XRootD's exported compile definitions. https://github.com/xrootd/xrootd/issues/2543
+    foreach(XRDTarget XRootD::XrdCl XRootD::XrdUtils)
+      if(TARGET ${XRDTarget})
+        get_target_property(PROP ${XRDTarget} INTERFACE_COMPILE_DEFINITIONS)
+        list(TRANSFORM PROP REPLACE "^-D" "")
+        set_property(TARGET ${XRDTarget} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${PROP})
+      endif()
+    endforeach()
+  endif()
 endif()
 
 if(builtin_xrootd)


### PR DESCRIPTION
When passing compile definitions to cling, ROOT unconditionally adds -D. Some projects such as XRootD already have -D in their definition, leading to an error such as:
While building module 'NetxNG':
<command line>:4:9: error: macro name must be an identifier \#define -D_FILE_OFFSET_BITS 64

The "canonical" way in CMake would be to not have explicit `-D`s in the COMPILE_DEFINITIONS property, so we can work around the issue https://github.com/xrootd/xrootd/issues/2543 (fixed in 5.8.4) by overwriting XRootD's COMPILE_DEFINITIONS property.