### PR TITLE
Don't import `cppyy` before ROOT in cmdLineUtils

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -18,7 +18,6 @@ import os
 import sys
 from time import sleep
 from itertools import zip_longest
-import cppyy
 
 def fileno(file_or_fd):
     """
@@ -196,6 +195,8 @@ def isDirectoryKey(key):
     """
     Return True if the object, corresponding to the key, inherits from TDirectory
     """
+    import cppyy
+
     classname = key.GetClassName()
     cl = ROOT.gROOT.GetClass(classname)
     if cl == cppyy.nullptr:
@@ -208,6 +209,8 @@ def isTreeKey(key):
     """
     Return True if the object, corresponding to the key, inherits from TTree
     """
+    import cppyy
+
     classname = key.GetClassName()
     cl = ROOT.gROOT.GetClass(classname)
     if cl == cppyy.nullptr:
@@ -220,6 +223,8 @@ def isTHnSparseKey(key):
     """
     Return True if the object, corresponding to the key, inherits from THnSparse
     """
+    import cppyy
+
     classname = key.GetClassName()
     cl = ROOT.gROOT.GetClass(classname)
     if cl == cppyy.nullptr:


### PR DESCRIPTION
If you import `cppyy` before ROOT, you get these warnings by default:

```txt
/home/rembserj/code/root/root_install/lib/root/cppyy_backend/loader.py:147: UserWarning: No precompiled header available (cannot import name 'get_cppversion' from 'cppyy_backend._get_cppflags' (/home/rembserj/code/root/root_install/lib/root/cppyy_backend/_get_cppflags.py)); this may impact performance.
  warnings.warn('No precompiled header available (%s); this may impact performance.' % msg)
/home/rembserj/code/root/root_install/lib/root/cppyy/__init__.py:378: UserWarning: CPyCppyy API not found (tried: /nix/store/8w718rm43x7z73xhw9d6vh8s4snrq67h-python3-3.12.10/include/site/python3.12); set CPPYY_API_PATH envar to the 'CPyCppyy' API directory to fix
  warnings.warn("CPyCppyy API not found (tried: %s); "
```

Doing the import locally, so it happens after `import ROOT`, avoids these warnings.