### PR TITLE
[tree] avoid resetting index in entry list copy constructor

### DIFF
--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -287,8 +287,8 @@ TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
    fFileName = elist.fFileName;
    fStringHash = elist.fStringHash;
    fTreeNumber = elist.fTreeNumber;
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
+   fLastIndexQueried = elist.fLastIndexQueried;
+   fLastIndexReturned = elist.fLastIndexReturned;
    fN = elist.fN;
    fShift = elist.fShift;
    fLists = nullptr;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-10807

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)