### PR TITLE
[Python] Don't include JsMVA in builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,6 +345,9 @@ file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} etc/*)
 # Exclude the *.in files, just like in the install tree
 list(FILTER artifact_files EXCLUDE REGEX "\.(in)$")
 
+# Exclude etc/notebook/JsMVA
+list(FILTER artifact_files EXCLUDE REGEX "^etc/notebook/JsMVA/")
+
 foreach(artifact_file ${artifact_files})
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
@@ -625,6 +628,7 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
   endif()
   install(DIRECTORY etc/ DESTINATION ${CMAKE_INSTALL_SYSCONFDIR} USE_SOURCE_PERMISSIONS
                          ${DIR_PERMISSIONS}
+                         PATTERN "notebook/JsMVA" EXCLUDE
                          PATTERN "system.rootrc" EXCLUDE
                          PATTERN "system.rootauthrc" EXCLUDE
                          PATTERN "system.rootdaemonrc" EXCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,7 @@ add_custom_command(OUTPUT ${stamp_file}
 
 
 #---Copy files to the build area at build time---------------------------------
-set(directories_to_copy etc test icons fonts macros tutorials)
+set(directories_to_copy test icons fonts macros tutorials)
 if(http)
   list(APPEND directories_to_copy js)
 endif()
@@ -336,6 +336,25 @@ foreach(dir_to_copy ${directories_to_copy})
       COMMENT "Copy ${dir_to_copy}"
       DEPENDS ${artifacts_in})
 endforeach()
+
+#---Copy etc/* files individually to the build area at build time---------------------------------
+# The reason why we don't copy these files with copy_directory as above is that
+# we want to exclude a subset of the files.
+file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} etc/*)
+
+# Exclude the *.in files, just like in the install tree
+list(FILTER artifact_files EXCLUDE REGEX "\.(in)$")
+
+foreach(artifact_file ${artifact_files})
+  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
+    COMMENT "Copying ${CMAKE_SOURCE_DIR}/${artifact_file}"
+    DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
+  list(APPEND all_artifacts ${CMAKE_BINARY_DIR}/${artifact_file})
+endforeach()
+
+unset(artifact_files)
+
 
 add_custom_target(move_artifacts DEPENDS ${stamp_file} ${all_artifacts})
 

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -71,12 +71,12 @@ list(APPEND PYROOT_EXTRA_HEADERS
      inc/TPyDispatcher.h)
 
 set(py_sources
-  ROOT/JsMVA/DataLoader.py
-  ROOT/JsMVA/Factory.py
-  ROOT/JsMVA/JPyInterface.py
-  ROOT/JsMVA/JsMVAMagic.py
-  ROOT/JsMVA/OutputTransformer.py
-  ROOT/JsMVA/__init__.py
+  #ROOT/JsMVA/DataLoader.py
+  #ROOT/JsMVA/Factory.py
+  #ROOT/JsMVA/JPyInterface.py
+  #ROOT/JsMVA/JsMVAMagic.py
+  #ROOT/JsMVA/OutputTransformer.py
+  #ROOT/JsMVA/__init__.py
   ROOT/_application.py
   ROOT/_asan.py
   ROOT/_facade.py

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -180,7 +180,7 @@ if _is_ipython:
     ip = get_ipython()
     if hasattr(ip, "kernel"):
         import JupyROOT
-        from . import JsMVA
+        # from . import JsMVA
 
 # Register cleanup
 import atexit


### PR DESCRIPTION
The JsMVA package is undocumented, [untested](https://github.com/root-project/root/blob/master/roottest/python/JsMVA/CMakeLists.txt), and lagging behind in terms
of the [JsROOT version that it uses](https://github.com/root-project/root/issues/12441).

At this point, there is no clear reason for including it in the ROOT
builds, so this commit suggests to remove it from the build and install
tree temporarily, until we are sure that it works (also with the newest
JsROOT version).

Alternative to #12484.

Closes #12441.