### PR TITLE
[CMake] Avoid unneeded artifacts in the library installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,22 +518,29 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
-# FIXME: move installation of PCMS in ROOT_GENERATE_DICTIONARY().
-# We are excluding directories, which are accidentaly copied via unxpected behaviour of install(DIRECTORY ..)
-install(
-   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   FILES_MATCHING
-   PATTERN "*.pcm"
-   PATTERN "JupyROOT" EXCLUDE
-   PATTERN "python*" EXCLUDE
-   PATTERN "cmake" EXCLUDE
-   PATTERN "pkgconfig" EXCLUDE
-)
-
 # modules.idx
 if(runtime_cxxmodules)
+
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
+
+  # Explicitly install the the modules that are built by Clang implicitly. See
+  # also the comment in rootcling_impl.cxx about the "horrible workaround" to
+  # fix the incremental builds. The list needs to be kept up to date manually,
+  # it is better than globbing for all pcm files from the library output
+  # directory.
+  set(implicit_pcm_files
+      Cling_Runtime.pcm
+      Cling_Runtime_Extra.pcm
+      ROOT_Config.pcm
+      _Builtin_stddef.pcm
+      libc.pcm
+      std.pcm
+  )
+  foreach(implicit_pcm_file ${implicit_pcm_files})
+    install(FILES ${library_output_dir}/${implicit_pcm_file} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endforeach()
+  unset(implicit_pcm_files)
+
   get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
   if(WIN32)
     set(modules_idx_cmd COMMAND ${CMAKE_COMMAND} -E env PATH="${library_output_dir}\\\;%PATH%"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,7 +525,6 @@ install(
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
    FILES_MATCHING
    PATTERN "*.pcm"
-   PATTERN "modules.idx"
    PATTERN "JupyROOT" EXCLUDE
    PATTERN "python*" EXCLUDE
    PATTERN "cmake" EXCLUDE
@@ -553,6 +552,8 @@ if(runtime_cxxmodules)
   add_dependencies(modules_idx ${modules_idx_deps})
   set_property(TARGET modules_idx PROPERTY modules_idx_file ${library_output_dir}/modules.idx)
   set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${library_output_dir}/modules.timestamp")
+
+  install(FILES ${library_output_dir}/modules.idx DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(tutorials)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,22 +518,36 @@ else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
-# FIXME: move installation of PCMS in ROOT_GENERATE_DICTIONARY().
-# We are excluding directories, which are accidentaly copied via unxpected behaviour of install(DIRECTORY ..)
-install(
-   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
-   DESTINATION ${CMAKE_INSTALL_LIBDIR}
-   FILES_MATCHING
-   PATTERN "*.pcm"
-   PATTERN "JupyROOT" EXCLUDE
-   PATTERN "python*" EXCLUDE
-   PATTERN "cmake" EXCLUDE
-   PATTERN "pkgconfig" EXCLUDE
-)
-
 # modules.idx
 if(runtime_cxxmodules)
+
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
+
+  # Explicitly install the modules that are built by Clang implicitly. See
+  # also the comment in rootcling_impl.cxx about the "horrible workaround" to
+  # fix the incremental builds. The list needs to be kept up to date manually,
+  # it is better than globbing for all pcm files from the library output
+  # directory. The platform-dependent system modules match the LoadModule()
+  # calls in TCling.cxx.
+  set(implicit_pcm_files
+      Cling_Runtime.pcm
+      Cling_Runtime_Extra.pcm
+      ROOT_Config.pcm
+      _Builtin_stddef.pcm
+      std.pcm
+  )
+  if(WIN32)
+    list(APPEND implicit_pcm_files vcruntime.pcm services.pcm)
+  elseif(APPLE)
+    list(APPEND implicit_pcm_files Darwin.pcm)
+  else()
+    list(APPEND implicit_pcm_files libc.pcm)
+  endif()
+  foreach(implicit_pcm_file ${implicit_pcm_files})
+    install(FILES ${library_output_dir}/${implicit_pcm_file} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endforeach()
+  unset(implicit_pcm_files)
+
   get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
   if(WIN32)
     set(modules_idx_cmd COMMAND ${CMAKE_COMMAND} -E env PATH="${library_output_dir}\\\;%PATH%"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -121,10 +121,17 @@ target_compile_definitions(Core PRIVATE
 if (runtime_cxxmodules)
   list(APPEND core_implicit_modules "-mSystemByproducts")
   # Force generation of _Builtin_intrinsics from Core.
-  list(APPEND core_implicit_modules "-m" "_Builtin_intrinsics" "-mByproduct" "_Builtin_intrinsics")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_Stage1_NoRTTI")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_C")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Rtypes")
+  list(APPEND core_implicit_modules "-m" "_Builtin_intrinsics")
+
+  set(byproducts _Builtin_intrinsics ROOT_Foundation_Stage1_NoRTTI ROOT_Foundation_C ROOT_Rtypes)
+  foreach(byproduct ${byproducts})
+    list(APPEND core_implicit_modules "-mByproduct" "${byproduct}")
+    install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${byproduct}.pcm DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endforeach()
+
+  list(APPEND core_implicit_modules "-mByproduct" "")
+  list(APPEND core_implicit_modules "-mByproduct" "")
+  list(APPEND core_implicit_modules "-mByproduct" "")
 endif(runtime_cxxmodules)
 
 get_target_property(CORE_DICT_HEADERS Core DICT_HEADERS)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -121,10 +121,14 @@ target_compile_definitions(Core PRIVATE
 if (runtime_cxxmodules)
   list(APPEND core_implicit_modules "-mSystemByproducts")
   # Force generation of _Builtin_intrinsics from Core.
-  list(APPEND core_implicit_modules "-m" "_Builtin_intrinsics" "-mByproduct" "_Builtin_intrinsics")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_Stage1_NoRTTI")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Foundation_C")
-  list(APPEND core_implicit_modules "-mByproduct" "ROOT_Rtypes")
+  list(APPEND core_implicit_modules "-m" "_Builtin_intrinsics")
+
+  set(byproducts _Builtin_intrinsics ROOT_Foundation_Stage1_NoRTTI ROOT_Foundation_C ROOT_Rtypes)
+  foreach(byproduct ${byproducts})
+    list(APPEND core_implicit_modules "-mByproduct" "${byproduct}")
+    install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${byproduct}.pcm DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  endforeach()
+  unset(byproducts)
 endif(runtime_cxxmodules)
 
 get_target_property(CORE_DICT_HEADERS Core DICT_HEADERS)


### PR DESCRIPTION
Avoid unneeded artifacts in the library installation directory, in particular empty directories if the Python interfaces are installed in a directory other than the library installation directory.

Motivated by:
  * https://github.com/root-project/root/issues/11431

More detail in the commit description.