### PR TITLE
[tutorials] check gPad in gl tutorials

### DIFF
--- a/tutorials/visualisation/gl/glViewerExercise.C
+++ b/tutorials/visualisation/gl/glViewerExercise.C
@@ -62,7 +62,8 @@ void AnimateCamera()
       dollyStep = -dollyStep;
 
    // modify frustum
-   TGLViewer *v = (TGLViewer *)gPad->GetViewer3D();
+   TGLViewer *v = gPad ? (TGLViewer *)gPad->GetViewer3D() : nullptr;
+   if (!v) return;
    if (camera < 3) {
       fov += fovStep;
       if (fov > 130.0 || fov < 5.0)
@@ -86,7 +87,8 @@ void AnimateCamera()
 void glViewerExercise()
 {
    gROOT->ProcessLine(".x nucleus.C");
-   TGLViewer *v = (TGLViewer *)gPad->GetViewer3D();
+   TGLViewer *v = gPad ? (TGLViewer *)gPad->GetViewer3D() : nullptr;
+   if (!v) return;
 
    // Random draw style
    Int_t style = randGen.Integer(3);

--- a/tutorials/visualisation/gl/viewer3DLocal.C
+++ b/tutorials/visualisation/gl/viewer3DLocal.C
@@ -532,6 +532,9 @@ void viewer3DLocal()
    printf("We do not implement raw tesselation of sphere - hence will not appear in viewers\n");
    printf("which do not support in natively (non-GL viewer).\n\n");
 
+   // macro uses GL features not supported in web graphics
+   gROOT->SetWebDisplay("off");
+
    MyGeom *myGeom = new MyGeom;
    myGeom->Draw("ogl");
 }

--- a/tutorials/visualisation/gl/viewer3DMaster.C
+++ b/tutorials/visualisation/gl/viewer3DMaster.C
@@ -423,6 +423,9 @@ void viewer3DMaster()
    printf("\n\nviewer3DMaster: This frame demonstates master frame use of 3D viewer architecture.\n");
    printf("Creates two boxes and a square based pyramid, described in master frame.\n\n");
 
+   // macro uses GL features not supported in web graphics
+   gROOT->SetWebDisplay("off");
+
    MyGeom *myGeom = new MyGeom;
    myGeom->Draw("ogl");
 }


### PR DESCRIPTION
If run in web mode canvas not automatically created and therefore `gPad` can be `nullptr`. 
Add simple check to avoid crash.

Disable web mode for viewer3DLocal.C and viewer3DMaster.C while features with TBuffer3D not supported by web graphics yet.

Fixes https://github.com/root-project/root/issues/19045