### PR TITLE
[roottest] fix cmake fixture name  for io/bigevent [skip-ci]

### DIFF
--- a/roottest/root/io/bigevent/CMakeLists.txt
+++ b/roottest/root/io/bigevent/CMakeLists.txt
@@ -21,4 +21,4 @@ ROOTTEST_ADD_TEST(write
 
 ROOTTEST_ADD_TEST(read
   COMMAND ./IoBigEventGenerator 10 1 1 20
-  FIXTURES_REQUIRED io-bigevent-generator-fixture root-io-bigevent-write-fixture)
+  FIXTURES_REQUIRED root-io-bigevent-generator-fixture root-io-bigevent-write-fixture)


### PR DESCRIPTION
Add missing prefix