### PR TITLE
[cmake] add -Wno-error to mathcore and minuit

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -203,6 +203,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MathCore
     ${MATHCORE_BUILTINS}
 )
 
+if(NOT MSVC)
+  target_compile_options(MathCore PRIVATE -Wno-error)
+endif()
+
 target_include_directories(MathCore PRIVATE ${Vc_INCLUDE_DIR})
 target_include_directories(MathCore PRIVATE ${VecCore_INCLUDE_DIRS})
 

--- a/math/minuit/CMakeLists.txt
+++ b/math/minuit/CMakeLists.txt
@@ -30,6 +30,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Minuit
     -writeEmptyRootPCM
 )
 
+if(NOT MSVC)
+  target_compile_options(Minuit PRIVATE -Wno-error)
+endif()
+
 if (CMAKE_BUILD_TYPE STREQUAL Optimized)
   target_compile_options(Minuit PRIVATE "-fno-fast-math")
 endif()


### PR DESCRIPTION
In MathCore and Minuit there are warnings stemming from -Winconsistent-missing-override (like:
 'Gradient' overrides a member function but is not marked 'override').

Applying the suggested fix doesn't work because the functions in question are only conditionally overriding a base class function, depending on the type used as their CRTP argument.

This should probably be fixed in a better way, but in the meantime this commit allows building ROOT with dev=ON, which now fails.
