### PR TITLE
[core] Add #include <iterator> to StringUtils.hxx

### DIFF
--- a/core/foundation/inc/ROOT/StringUtils.hxx
+++ b/core/foundation/inc/ROOT/StringUtils.hxx
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <numeric>
+#include <iterator>
 
 namespace ROOT {
 


### PR DESCRIPTION
Required for std::next.

mac-beta seems to fail on the CI without it.