### PR TITLE
[ntuple] Add some Internal helpers needed for Attributes

### DIFF
--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -33,7 +33,10 @@ class TVirtualStreamerInfo;
 namespace ROOT {
 
 namespace Internal {
+class RNTupleFileWriter;
 class RRawFile;
+
+TDirectory *GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer);
 }
 
 class RNTupleWriteOptions;
@@ -104,6 +107,8 @@ A stand-alone version of RNTuple can remove the TFile based writer.
 */
 // clang-format on
 class RNTupleFileWriter {
+   friend TDirectory *GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer);
+
 public:
    /// The key length of a blob. It is always a big key (version > 1000) with class name RBlob.
    static constexpr std::size_t kBlobKeyLen = 42;

--- a/tree/ntuple/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleModel.hxx
@@ -46,6 +46,7 @@ class RProjectedFields;
 
 ROOT::RFieldZero &GetFieldZeroOfModel(RNTupleModel &model);
 RProjectedFields &GetProjectedFieldsOfModel(RNTupleModel &model);
+const RProjectedFields &GetProjectedFieldsOfModel(const RNTupleModel &model);
 
 // clang-format off
 /**
@@ -139,6 +140,7 @@ that were used for writing and are no longer connected to a page sink.
 class RNTupleModel {
    friend ROOT::RFieldZero &Internal::GetFieldZeroOfModel(RNTupleModel &);
    friend Internal::RProjectedFields &Internal::GetProjectedFieldsOfModel(RNTupleModel &);
+   friend const Internal::RProjectedFields &Internal::GetProjectedFieldsOfModel(const RNTupleModel &);
 
 public:
    /// User-provided function that describes the mapping of existing source fields to projected fields in terms

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -313,6 +313,8 @@ public:
 
    virtual ROOT::NTupleSize_t GetNEntries() const = 0;
 
+   virtual TDirectory *GetUnderlyingDirectory() const { return nullptr; }
+
    /// Physically creates the storage container to hold the ntuple (e.g., a keys a TFile or an S3 bucket)
    /// Init() associates column handles to the columns referenced by the model
    void Init(RNTupleModel &model)

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -98,6 +98,8 @@ public:
    RPageSinkFile(RPageSinkFile &&) = default;
    RPageSinkFile &operator=(RPageSinkFile &&) = default;
    ~RPageSinkFile() override;
+
+   TDirectory *GetUnderlyingDirectory() const final { return ROOT::Internal::GetUnderlyingDirectory(*fWriter); }
 }; // class RPageSinkFile
 
 // clang-format off

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -1548,3 +1548,11 @@ void ROOT::Internal::RNTupleFileWriter::WriteTFileSkeleton(int defaultCompressio
       fileSimple.Write(&padding, sizeof(padding));
    fileSimple.fKeyOffset = fileSimple.fFilePos;
 }
+
+TDirectory *ROOT::Internal::GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer)
+{
+   if (auto *proper = std::get_if<ROOT::Internal::RNTupleFileWriter::RFileProper>(&writer.fFile)) {
+      return proper->fDirectory;
+   }
+   return nullptr;
+}

--- a/tree/ntuple/src/RNTupleModel.cxx
+++ b/tree/ntuple/src/RNTupleModel.cxx
@@ -41,6 +41,12 @@ ROOT::RFieldZero &ROOT::Internal::GetFieldZeroOfModel(ROOT::RNTupleModel &model)
 
 ROOT::Internal::RProjectedFields &ROOT::Internal::GetProjectedFieldsOfModel(ROOT::RNTupleModel &model)
 {
+   return const_cast<ROOT::Internal::RProjectedFields &>(
+      GetProjectedFieldsOfModel(const_cast<const ROOT::RNTupleModel &>(model)));
+}
+
+const ROOT::Internal::RProjectedFields &ROOT::Internal::GetProjectedFieldsOfModel(const ROOT::RNTupleModel &model)
+{
    if (model.IsExpired()) {
       throw RException(R__FAIL("invalid use of expired model"));
    }


### PR DESCRIPTION
- const version of GetProjectedFieldsOfModel()
- RPageSink::GetUnderlyingDirectory()

These functionalities are needed in the RNTuple Attribute prototype (they are both Internal so there is no long-term implication of adding them).


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


