### PR TITLE
[v6-36][cmake][win][skip-ci] fix duplicate symbol error

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -138,7 +138,7 @@ if(MSVC)
       __std_terminate
       cling_runtime_internal_throwIfInvalidPointer
   )
-  if(MSVC_VERSION GREATER_EQUAL 1933)
+  if(MSVC_VERSION GREATER_EQUAL 1933 AND MSVC_VERSION LESS 1943)
     set(cling_exports ${cling_exports}
         __std_find_trivial_1
         __std_find_trivial_2


### PR DESCRIPTION
Fix the following compiler error:
```
msvcprt.lib(vector_algorithms.obj) : error LNK2005: __std_find_trivial_1 already defined in libCling.lib(libCling.dll)
```
when compiling `roottest-root-io-datamodelevolution`
