### PR TITLE
Revert "[camke][win][skip-ci] fix duplicate symbol error"

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -138,7 +138,7 @@ if(MSVC)
       __std_terminate
       cling_runtime_internal_throwIfInvalidPointer
   )
-  if(MSVC_VERSION GREATER_EQUAL 1933 AND MSVC_VERSION LESS 1943)
+  if(MSVC_VERSION GREATER_EQUAL 1933)
     set(cling_exports ${cling_exports}
         __std_find_trivial_1
         __std_find_trivial_2


### PR DESCRIPTION
This reverts commit 8a7d481b02afa3f3b05b56e21c10424f65849847.
