### PR TITLE
[cppyy] disable tests failing with mac-beta ARM64

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
@@ -1,6 +1,6 @@
 import py, sys, pytest, os
 from pytest import mark, raises
-from support import setup_make, ispypy
+from support import setup_make, ispypy, IS_MAC_ARM
 
 
 currpath = os.getcwd()

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -2356,6 +2356,7 @@ class TestDATATYPES:
         assert str(bt(1)) == 'True'
         assert str(bt(0)) == 'False'
 
+    @mark.xfail(condition=IS_MAC_ARM, reason="Fails on mac-beta ARM64")
     def test49_addressof_method(self):
         """Use of addressof for (const) methods"""
 


### PR DESCRIPTION
Disabling tests that fail on mac-beta ARM64