### PR TITLE
[math] Add missing includes for std::iterator

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <iterator> // for std::make_move_iterator
 #include <limits> // for numeric_limits
 #include <memory> // uninitialized_value_construct
 #include <new>


### PR DESCRIPTION
This should fix the error:

```
2025-06-17T14:18:21.1084400Z [ 53%] Built target StreamerFieldXMLDict
2025-06-17T14:18:21.1339530Z [ 53%] Generating G__ROOTVecOps.cxx, ../../lib/ROOTVecOps.pcm
2025-06-17T14:18:21.4156690Z In file included from input_line_10:3:
2025-06-17T14:18:21.4163110Z build/include/ROOT/RVec.hxx:345:36: error: no member named 'make_move_iterator' in namespace 'std'
2025-06-17T14:18:21.4286310Z       std::uninitialized_copy(std::make_move_iterator(I), std::make_move_iterator(E), Dest);
```
on mac-beta



