### PR TITLE
[xcode26] Misc fixes

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
@@ -15,7 +15,6 @@ builtin_openssl=ON
 builtin_pcre=ON
 builtin_tbb=ON
 builtin_unuran=ON
-builtin_vc=ON
 builtin_vdt=ON
 builtin_veccore=ON
 builtin_xrootd=ON

--- a/math/mathcore/inc/Math/StdEngine.h
+++ b/math/mathcore/inc/Math/StdEngine.h
@@ -13,6 +13,7 @@
 #ifndef ROOT_Math_StdEngine
 #define ROOT_Math_StdEngine
 
+#include <cstdint>
 #include <random>
 
 namespace ROOT {

--- a/math/minuit2/inc/Minuit2/MnPlot.h
+++ b/math/minuit2/inc/Minuit2/MnPlot.h
@@ -14,6 +14,7 @@
 
 #include <ROOT/RSpan.hxx>
 
+#include <algorithm>
 #include <vector>
 #include <utility>
 

--- a/tmva/tmva/inc/TMVA/Pattern.h
+++ b/tmva/tmva/inc/TMVA/Pattern.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef> // for size_t
+#include <utility>
 #include <vector>
 
 


### PR DESCRIPTION
- [ci] Remove built-in Vc from mac-beta builds: https://github.com/VcDevel/Vc/issues/367
- Missing include for uint64_t
- And more...