### PR TITLE
Check for existing type before removing whitespaces

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -160,25 +160,26 @@ public:
 class TClingLookupHelper : public TClassEdit::TInterpreterLookupHelper {
 public:
    typedef bool (*ExistingTypeCheck_t)(const std::string &tname, std::string &result);
+   typedef bool (*CheckInClassTable_t)(const std::string &tname, std::string &result);
    typedef bool (*AutoParse_t)(const char *name);
 
 private:
    cling::Interpreter *fInterpreter;
    TNormalizedCtxt    *fNormalizedCtxt;
    ExistingTypeCheck_t fExistingTypeCheck;
+   CheckInClassTable_t fCheckInClassTable;
    AutoParse_t         fAutoParse;
    bool               *fInterpreterIsShuttingDownPtr;
    const int          *fPDebug; // debug flag, might change at runtime thus *
    bool WantDiags() const { return fPDebug && *fPDebug > 5; }
 
 public:
-   TClingLookupHelper(cling::Interpreter &interpreter, TNormalizedCtxt &normCtxt,
-                      ExistingTypeCheck_t existingTypeCheck,
-                      AutoParse_t autoParse,
-                      bool *shuttingDownPtr,
+   TClingLookupHelper(cling::Interpreter &interpreter, TNormalizedCtxt &normCtxt, ExistingTypeCheck_t existingTypeCheck,
+                      CheckInClassTable_t CheckInClassTable, AutoParse_t autoParse, bool *shuttingDownPtr,
                       const int *pgDebug = nullptr);
    virtual ~TClingLookupHelper() { /* we're not owner */ }
 
+   bool CheckInClassTable(const std::string &tname, std::string &result) override;
    bool ExistingTypeCheck(const std::string &tname, std::string &result) override;
    void GetPartiallyDesugaredName(std::string &nameLong) override;
    bool IsAlreadyPartiallyDesugaredName(const std::string &nondef, const std::string &nameLong) override;

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -522,17 +522,16 @@ AnnotatedRecordDecl::AnnotatedRecordDecl(long index,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TClingLookupHelper::TClingLookupHelper(cling::Interpreter &interpreter,
-                                       TNormalizedCtxt &normCtxt,
-                                       ExistingTypeCheck_t existingTypeCheck,
-                                       AutoParse_t autoParse,
-                                       bool *shuttingDownPtr,
-                                       const int* pgDebug /*= 0*/):
-   fInterpreter(&interpreter),fNormalizedCtxt(&normCtxt),
-   fExistingTypeCheck(existingTypeCheck),
-   fAutoParse(autoParse),
-   fInterpreterIsShuttingDownPtr(shuttingDownPtr),
-   fPDebug(pgDebug)
+TClingLookupHelper::TClingLookupHelper(cling::Interpreter &interpreter, TNormalizedCtxt &normCtxt,
+                                       ExistingTypeCheck_t existingTypeCheck, CheckInClassTable_t CheckInClassTable,
+                                       AutoParse_t autoParse, bool *shuttingDownPtr, const int *pgDebug /*= 0*/)
+   : fInterpreter(&interpreter),
+     fNormalizedCtxt(&normCtxt),
+     fExistingTypeCheck(existingTypeCheck),
+     fCheckInClassTable(CheckInClassTable),
+     fAutoParse(autoParse),
+     fInterpreterIsShuttingDownPtr(shuttingDownPtr),
+     fPDebug(pgDebug)
 {
 }
 
@@ -547,6 +546,17 @@ bool TClingLookupHelper::ExistingTypeCheck(const std::string &tname,
 
    if (fExistingTypeCheck) return fExistingTypeCheck(tname,result);
    else return false;
+}
+
+bool TClingLookupHelper::CheckInClassTable(const std::string &tname, std::string &result)
+{
+   if (tname.empty())
+      return false;
+
+   if (fCheckInClassTable)
+      return fCheckInClassTable(tname, result);
+   else
+      return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -4498,7 +4498,7 @@ int RootClingMain(int argc,
 
    // We are now ready (enough is loaded) to init the list of opaque typedefs.
    ROOT::TMetaUtils::TNormalizedCtxt normCtxt(interp.getLookupHelper());
-   ROOT::TMetaUtils::TClingLookupHelper helper(interp, normCtxt, nullptr, nullptr, nullptr);
+   ROOT::TMetaUtils::TClingLookupHelper helper(interp, normCtxt, nullptr, nullptr, nullptr, nullptr);
    TClassEdit::Init(&helper);
 
    // flags used only for the pragma parser:

--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -124,6 +124,7 @@ namespace TClassEdit {
       TInterpreterLookupHelper() { }
       virtual ~TInterpreterLookupHelper();
 
+      virtual bool CheckInClassTable(const std::string &, std::string &) = 0;
       virtual bool ExistingTypeCheck(const std::string & /*tname*/,
                                      std::string & /*result*/) = 0;
       virtual void GetPartiallyDesugaredName(std::string & /*nameLong*/) = 0;

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -904,6 +904,21 @@ void TClassEdit::GetNormalizedName(std::string &norm_name, std::string_view name
    }
 
    AtomicTypeNameHandlerRAII nameHandler(norm_name);
+   if (gInterpreterHelper) {
+      // Early check whether there is an existing type corresponding to `norm_name`
+      // It is *crucial* to run this block here, before `norm_name` gets split
+      // and reconstructed in the following lines. The reason is that we need
+      // to make string comparisons in `ExistingTypeCheck` and they will give
+      // different results if `norm_name` loses whitespaces. A notable example
+      // is when looking for registered alternate names of a custom user class
+      // present in the class dictionary.
+      std::string typeresult;
+      if (gInterpreterHelper->CheckInClassTable(norm_name, typeresult)) {
+         if (!typeresult.empty()) {
+            norm_name = typeresult;
+         }
+      }
+   }
 
    // Remove the std:: and default template argument and insert the Long64_t and change basic_string to string.
    TClassEdit::TSplitType splitname(norm_name.c_str(),(TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd | TClassEdit::kDropStlDefault | TClassEdit::kKeepOuterConst));

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1011,6 +1011,24 @@ bool TClingLookupHelper__ExistingTypeCheck(const std::string &tname,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Check if the class name is present in TClassTable.
+///
+/// \param[in] tname class name to check.
+/// \param[out] result If a class name has an alternative name registered in
+///                    TClassTable, it will be copied into this string.
+bool TClingLookupHelper__CheckInClassTable(const std::string &tname, std::string &result)
+{
+   result.clear();
+
+   if (gROOT->GetListOfClasses()->FindObject(tname.c_str()) || TClassTable::Check(tname.c_str(), result)) {
+      // This is a known class.
+      return true;
+   }
+
+   return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 TCling::TUniqueString::TUniqueString(Long64_t size)
 {
@@ -1586,10 +1604,9 @@ TCling::TCling(const char *name, const char *title, const char* const argv[], vo
 
    // We are now ready (enough is loaded) to init the list of opaque typedefs.
    fNormalizedCtxt = new ROOT::TMetaUtils::TNormalizedCtxt(fInterpreter->getLookupHelper());
-   fLookupHelper = new ROOT::TMetaUtils::TClingLookupHelper(*fInterpreter, *fNormalizedCtxt,
-                                                            TClingLookupHelper__ExistingTypeCheck,
-                                                            TClingLookupHelper__AutoParse,
-                                                            &fIsShuttingDown);
+   fLookupHelper = new ROOT::TMetaUtils::TClingLookupHelper(
+      *fInterpreter, *fNormalizedCtxt, TClingLookupHelper__ExistingTypeCheck, TClingLookupHelper__CheckInClassTable,
+      TClingLookupHelper__AutoParse, &fIsShuttingDown);
    TClassEdit::Init(fLookupHelper);
 
    // Disallow auto-parsing in rootcling

--- a/roottest/root/ntuple/CMakeLists.txt
+++ b/roottest/root/ntuple/CMakeLists.txt
@@ -1,7 +1,3 @@
-if(NOT ROOT_root7_FOUND)
-  return()
-endif()
-
 ROOTTEST_ADD_TEST(test_Basics
                   MACRO basics.C
                   OUTREF test_basics.ref)

--- a/roottest/root/ntuple/atlas-datavector/AtlasLikeDataVector.hxx
+++ b/roottest/root/ntuple/atlas-datavector/AtlasLikeDataVector.hxx
@@ -1,0 +1,67 @@
+#ifndef ATLASLIKEDATAVECTOR
+#define ATLASLIKEDATAVECTOR
+
+// Mimicks the DataVector hierarchy as found in athena
+
+#include <RootMetaSelection.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <cstddef>
+
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/tools/DVLNoBase.h#L32
+namespace DataModel_detail {
+struct NoBase {};
+} // namespace DataModel_detail
+
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/DataVector.h#L632
+template <class T>
+struct DataVectorBase {
+   typedef DataModel_detail::NoBase Base;
+};
+
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/DataVector.h#L792
+template <class T, class BASE = typename DataVectorBase<T>::Base>
+class AtlasLikeDataVector : public BASE {};
+
+namespace SG {
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/AuxVectorData.h#L164
+class AuxVectorData {
+public:
+   AuxVectorData() = default;
+};
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/AuxVectorBase.h#L96
+class AuxVectorBase : public AuxVectorData {
+public:
+   AuxVectorBase() = default;
+};
+} // namespace SG
+
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/DataVector.h#L2058
+template <class T>
+class AtlasLikeDataVector<T, DataModel_detail::NoBase> : public SG::AuxVectorBase {};
+
+namespace ROOT::Meta::Selection {
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/DataVector.h#L3422
+template <class T, class BASE>
+class AtlasLikeDataVector : KeepFirstTemplateArguments<1>, SelectNoInstance {};
+} // namespace ROOT::Meta::Selection
+
+struct CustomStruct {
+   float a{};
+   std::vector<float> v1{};
+   std::vector<std::vector<float>> v2{};
+   std::string s{};
+   std::byte b{};
+};
+
+namespace {
+// https://gitlab.cern.ch/atlas/athena/-/blob/26885cbcf82f069cddff6cd30c123572e362d8fa/Control/AthContainers/AthContainers/AthContainersDict.h#L29
+struct DUMMY_INSTANTIATION {
+   AtlasLikeDataVector<CustomStruct, DataModel_detail::NoBase> dummy1;
+   ROOT::Meta::Selection::AtlasLikeDataVector<CustomStruct, DataModel_detail::NoBase> dummy2;
+};
+} // namespace
+
+#endif // ATLASLIKEDATAVECTOR

--- a/roottest/root/ntuple/atlas-datavector/CMakeLists.txt
+++ b/roottest/root/ntuple/atlas-datavector/CMakeLists.txt
@@ -1,0 +1,59 @@
+# Reproducer of https://github.com/root-project/root/issues/19022
+
+# TODO: Figure out how to load the dictionary in the writing test on Windows
+if(MSVC AND NOT win_broken_tests)
+ return()
+endif()
+
+# Generate the dictionary for the ATLAS-like container class
+# Note that we use a selection.xml file, not a LinkDef, as this is what
+# is done in Athena as well. Also note that in the selection we have a rule
+# that uses a pattern AtlasLikeDataVector<CustomStruct,*> so we don't rely
+# on an explicit declaration of the full class template with 2 arguments.
+ROOTTEST_GENERATE_DICTIONARY(
+    AtlasLikeDataVectorDict
+    ${CMAKE_CURRENT_SOURCE_DIR}/AtlasLikeDataVector.hxx
+    LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/selection.xml
+    FIXTURES_SETUP atlas_datavector_dict_setup
+)
+
+# Generate a shared library from the dictionary sources
+add_library(AtlasLikeDataVector SHARED AtlasLikeDataVectorDict.cxx)
+target_link_libraries(AtlasLikeDataVector Core RIO ROOTNTuple) 
+add_dependencies(AtlasLikeDataVector AtlasLikeDataVectorDict)
+
+# Generate an executable to write an RNTuple with a field of type
+# AtlasLikeDataVector<CustomStruct>. Note that we don't link explicitly
+# the executable against the shared library, but the information of the
+# dictionary should be autoloaded, thus the rule to drop the second template
+# argument should kick in when writing the class to disk.
+ROOTTEST_GENERATE_EXECUTABLE(
+    write
+    write.cxx
+    LIBRARIES Core RIO ROOTNTuple
+    FIXTURES_REQUIRED atlas_datavector_dict_setup
+    FIXTURES_SETUP atlas_datavector_write_setup)
+
+# Generate an executable to read back the RNTuple with a field of type
+# AtlasLikeDataVector<CustomStruct>. Note that we don't link explicitly
+# the executable against the shared library, but the information of the
+# dictionary should be autoloaded, thus the rule to drop the second template
+# argument should kick in when reading the field.
+ROOTTEST_GENERATE_EXECUTABLE(
+    read
+    read.cxx
+    LIBRARIES Core RIO ROOTNTuple gtest gtest_main
+    FIXTURES_REQUIRED atlas_datavector_dict_setup
+    FIXTURES_SETUP atlas_datavector_read_setup)
+
+ROOTTEST_ADD_TEST(write
+    EXEC ${CMAKE_CURRENT_BINARY_DIR}/write
+    FIXTURES_REQUIRED atlas_datavector_write_setup
+    FIXTURES_SETUP atlas_datavector_write_done)
+
+# In the reading test we rely on the templated call that uses the shortened
+# class type AtlasLikeDataVector<CustomStruct>, so we need to include the header
+ROOTTEST_ADD_TEST(read
+    EXEC ${CMAKE_CURRENT_BINARY_DIR}/read
+    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/AtlasLikeDataVector.hxx
+    FIXTURES_REQUIRED "atlas_datavector_read_setup;atlas_datavector_write_done")

--- a/roottest/root/ntuple/atlas-datavector/read.cxx
+++ b/roottest/root/ntuple/atlas-datavector/read.cxx
@@ -1,0 +1,33 @@
+#include <string>
+
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+
+#include <gtest/gtest.h>
+
+#include "AtlasLikeDataVector.hxx"
+
+TEST(RNTupleAtlasDataVector, Read)
+{
+   const auto typeNameBefore = ROOT::RField<AtlasLikeDataVector<CustomStruct>>::TypeName();
+   const std::string expectedBefore{"AtlasLikeDataVector<CustomStruct,DataModel_detail::NoBase>"};
+   // Make sure no autoloading happened yet
+   ASSERT_EQ(typeNameBefore, expectedBefore);
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", "test_ntuple_datavector.root");
+   const auto &entry = reader->GetModel().GetDefaultEntry();
+   // The following call should not throw an exception
+   ASSERT_NO_THROW(entry.GetPtr<AtlasLikeDataVector<CustomStruct>>("my_field"));
+
+   const auto typeNameAfter = ROOT::RField<AtlasLikeDataVector<CustomStruct>>::TypeName();
+   const std::string expectedAfter{"AtlasLikeDataVector<CustomStruct>"};
+   // Make sure autoloading happened and the rule to suppress the second template argument kicked in
+   ASSERT_EQ(typeNameAfter, expectedAfter);
+}
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/roottest/root/ntuple/atlas-datavector/selection.xml
+++ b/roottest/root/ntuple/atlas-datavector/selection.xml
@@ -1,0 +1,6 @@
+<lcgdict>
+	<class name="CustomStruct" />
+	<class name="SG::AuxVectorData" />
+	<class name="SG::AuxVectorBase" />
+	<class pattern="AtlasLikeDataVector<CustomStruct,*>" />
+</lcgdict>

--- a/roottest/root/ntuple/atlas-datavector/write.cxx
+++ b/roottest/root/ntuple/atlas-datavector/write.cxx
@@ -1,0 +1,11 @@
+#include <ROOT/RField.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+int main()
+{
+   auto model = ROOT::RNTupleModel::Create();
+   model->AddField(ROOT::RFieldBase::Create("my_field", "AtlasLikeDataVector<CustomStruct>").Unwrap());
+   auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", "test_ntuple_datavector.root");
+   writer->Fill();
+}


### PR DESCRIPTION
Fixes #19022 

See first commit description for an explanation.

Third commit provides a reproducer of the linked issue, removing the first commit will produce the same exception from RField