### PR TITLE
[skip-CI][Doc] Fix broken links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The primary branch for development is `master`.
 
 > [!IMPORTANT]
 > We require PRs to cleanly apply to master without a merge commit, i.e. through "fast-forward".
-> Please follow the [coding conventions](https://root.cern.ch/coding-conventions), as this is a simple item for
+> Please follow the [coding conventions](https://root.cern/contribute/coding_conventions/), as this is a simple item for
 > reviewers to otherwise get stuck on.
 > To make your (and our own) life easier, we provide a
 > [`clang-format` configuration file](https://github.com/root-project/root/blob/master/.clang-format) as well
@@ -118,7 +118,7 @@ ROOT has automated CI tests :cop: that are used for pull requests:
     The results are posted to the pull request.
     Compared to ROOT's nightly builds, PRs are tested with less tests, on less platforms.
 - *Linting check*: `ruff` automatically checks that a PR adheres to the project's
-    [style guide](https://github.com/root-project/root/blob/master/.ruff.toml).
+    [style guide](https://github.com/root-project/root/blob/master/ruff.toml).
     If any linting violations are found, it provides you with a detailed report that you should address in your PR.
 - *Formatting check*: 
     - `clang-format`: automatically checks that a PR

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ for the benefit of its community.
 
 ## Contribution Guidelines
 - [How to contribute](https://github.com/root-project/root/blob/master/CONTRIBUTING.md)
-- [Coding conventions](https://root.cern/coding-conventions)
-- [Meetings](https://root.cern/meetings)
+- [Coding conventions](https://root.cern/contribute/coding_conventions/)
+- [Meetings](https://root.cern/for_developers/meetings/)
 
 ## Cite
 When citing ROOT, please use both the reference reported below and the DOI specific to your ROOT version available [on Zenodo](https://zenodo.org/badge/latestdoi/10994345) [![DOI](https://zenodo.org/badge/10994345.svg)](https://zenodo.org/badge/latestdoi/10994345). For example, you can copy-paste and fill in the following citation:
@@ -56,7 +56,7 @@ For instructions on how to build ROOT from these source files, see https://root.
 Our ["Getting started with ROOT"](https://root.cern/learn) page is then the perfect place to get familiar with ROOT.
 
 ## Help and Support
-- [Forum](https://root.cern/forum/)
+- [Forum](https://root-forum.cern.ch/)
 - [Issue tracker](https://github.com/root-project/root/issues)
   * [Previous now read-only Jira issue tracker](https://sft.its.cern.ch/jira/projects/ROOT/issues/ROOT-5820?filter=allopenissues)
 - [Documentation](https://root.cern/guides/reference-guide)


### PR DESCRIPTION
# This Pull request:
Fixes some broken links in the project GitHub markdown pages.

## Changes or fixes:

- Two links in CONTRIBUTING.md
- Three links in README.md

## Checklist:
Not applicable to this PR

- [ ] tested changes locally 
- [ ] updated the docs (if necessary)

This PR fixes # 
I haven't found any issue signaling this problem

