### PR TITLE
[cppyy test] Do not generate rootmap file.

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -22,6 +22,7 @@ std_streams
 templates
 stltypes)
 
+set(CMAKE_ROOTTEST_NOROOTMAP ON)
 foreach(DICT ${CPPYY_TEST_DICTS})
     # Generate dictionary for the tests
     ROOT_GENERATE_DICTIONARY(G__${DICT}Dict ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml)
@@ -31,6 +32,7 @@ foreach(DICT ${CPPYY_TEST_DICTS})
     target_link_libraries(${DICT}Dict PUBLIC Python3::Python ROOT::Core)
     target_compile_options(${DICT}Dict PRIVATE "-w")
 endforeach()
+unset(CMAKE_ROOTTEST_NOROOTMAP)
 
 # Tests list
 set(CPPYY_TESTS


### PR DESCRIPTION
The libraries are explicitly loaded

