### PR TITLE
[ci] Fail CI if missing override instead of just warning

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -369,7 +369,7 @@ jobs:
             is_special: true
           - image: alma8
           - image: alma9
-            overrides: ["CMAKE_BUILD_TYPE=Debug", "CMAKE_CXX_FLAGS=-Wsuggest-override"]
+            overrides: ["CMAKE_BUILD_TYPE=Debug"]
           - image: alma10
           - image: ubuntu22
             overrides: ["imt=Off", "CMAKE_BUILD_TYPE=Debug"]
@@ -378,7 +378,7 @@ jobs:
           - image: ubuntu2504
             overrides: ["CMAKE_CXX_STANDARD=23"]
           - image: debian125
-            overrides: ["CMAKE_CXX_STANDARD=20", "dev=ON"]
+            overrides: ["CMAKE_CXX_STANDARD=20", "dev=ON", "CMAKE_CXX_FLAGS=-Wsuggest-override"]
           # Special builds
           - image: alma9
             is_special: true

--- a/core/multiproc/inc/TMPWorkerExecutor.h
+++ b/core/multiproc/inc/TMPWorkerExecutor.h
@@ -201,7 +201,7 @@ class TMPWorkerExecutor<F, void, void> : public TMPWorker {
 public:
    explicit TMPWorkerExecutor(F func) : TMPWorker(), fFunc(func) {}
    ~TMPWorkerExecutor() {}
-   void HandleInput(MPCodeBufPair &msg)
+   void HandleInput(MPCodeBufPair &msg) override
    {
       unsigned code = msg.first;
       TSocket *s = GetSocket();

--- a/roottest/root/io/abstractclass/DataBlock1.h
+++ b/roottest/root/io/abstractclass/DataBlock1.h
@@ -11,12 +11,12 @@ class DataBlock1 : public DataBlockBase, public PureAbstractInterface {
   DataBlock1();
   virtual ~DataBlock1();
  
-  virtual Short_t      GetXyzzy() const;
-  virtual Short_t      GetAbc()   const;
+  Short_t      GetXyzzy() const override;
+  Short_t      GetAbc()   const override;
 
  private:
 
-  ClassDef(DataBlock1,1)
+  ClassDefOverride(DataBlock1,1)
 };
 
 inline Short_t DataBlock1::GetXyzzy() const { return fRawBlock[0]; }

--- a/roottest/root/io/abstractclass/DataBlock2.h
+++ b/roottest/root/io/abstractclass/DataBlock2.h
@@ -11,12 +11,12 @@ class DataBlock2 : public DataBlockBase, public PureAbstractInterface {
   DataBlock2();
   virtual ~DataBlock2();
  
-  virtual Short_t      GetXyzzy() const;
-  virtual Short_t      GetAbc()   const;
+  Short_t      GetXyzzy() const override;
+  Short_t      GetAbc()   const override;
 
  private:
 
-  ClassDef(DataBlock2,1)
+  ClassDefOverride(DataBlock2,1)
 };
 
 inline Short_t DataBlock2::GetXyzzy() const { return fRawBlock[0]; }

--- a/roottest/root/io/abstractclass/DataBlockBase.h
+++ b/roottest/root/io/abstractclass/DataBlockBase.h
@@ -13,7 +13,7 @@ class DataBlockBase : public TObject {
   inline const Int_t*  GetData() const { return fRawBlock; }
   inline Int_t         GetSize() const { return fSize; }
 
-  virtual void         Print(Option_t *option="") const;
+  void         Print(Option_t *option="") const override;
 
  protected:   // allow derived classes direct access to the data
 
@@ -22,7 +22,7 @@ class DataBlockBase : public TObject {
 
  private:
 
-  ClassDef(DataBlockBase,1)
+  ClassDefOverride(DataBlockBase,1)
 };
 
 #endif

--- a/roottest/root/io/arrayobject/foo.h
+++ b/roottest/root/io/arrayobject/foo.h
@@ -13,7 +13,7 @@ public:
   Int_t i;
   Float_t f;
   
-  ClassDef(foobj,1)
+  ClassDefOverride(foobj,1)
 };
 
 class foo {

--- a/roottest/root/io/clones/RtObj.h
+++ b/roottest/root/io/clones/RtObj.h
@@ -6,10 +6,5 @@ class RtObj : public T
   public:
     RtObj() {}
     RtObj( const T & val ) : T(val) {}
-    ClassDefT(RtObj,1)
+    ClassDefOverride(RtObj,1)
  } ;
-
-ClassDefT2(RtObj,T)
-
-ClassImpT(RtObj,T)
-

--- a/roottest/root/io/compression/Event.h
+++ b/roottest/root/io/compression/Event.h
@@ -148,7 +148,7 @@ public:
                  Event();
                  Event(Int_t i);
    virtual      ~Event();
-   void          Clear(Option_t *option ="");
+   void          Clear(Option_t *option ="") override;
    TDatime      &GetDatime() {return fDatime;}
    static void   Reset(Option_t *option ="");
    void          ResetHistogramPointer() {fH=0;}
@@ -179,7 +179,7 @@ public:
 
    UShortVector* GetUshort() { return &fUshort; }
 
-   ClassDef(Event,1)  //Event structure
+   ClassDefOverride(Event,1)  //Event structure
 };
 
 
@@ -238,7 +238,7 @@ public:
    Short_t       GetValid()  const { return fValid; }
    virtual void  SetValid(Int_t valid=1) { fValid = valid; }
 
-   ClassDef(Track,1)  //A track segment
+   ClassDefOverride(Track,1)  //A track segment
 };
 
 class BigTrack : public Track {
@@ -252,7 +252,7 @@ public:
    BigTrack(Float_t random, Int_t special);
    virtual ~BigTrack() { }
 
-   ClassDef(BigTrack,1)  //A Big track
+   ClassDefOverride(BigTrack,1)  //A Big track
 };
 
 

--- a/roottest/root/io/evolution/equivalent/ioReadRuleEquivalentCode.h
+++ b/roottest/root/io/evolution/equivalent/ioReadRuleEquivalentCode.h
@@ -4,7 +4,7 @@ class A:public TObject{
 
 public:
    A(){}
-   ClassDef(A,1)
+   ClassDefOverride(A,1)
 
 };
 
@@ -13,7 +13,7 @@ class B:public TObject{
 public:
    B(){}
    void initializeTransients(){transient_=2;}
-   ClassDef(B,1)
+   ClassDefOverride(B,1)
 private:
    double transient_; //!
 

--- a/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.h
+++ b/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.h
@@ -277,19 +277,19 @@ public:
    * 
    * @param option  Passed on to TH2::Reset verbatim
    */
-  void Clear(Option_t* option="");
+  void Clear(Option_t* option="") override;
   /** 
    * browse this object 
    * 
    * @param b Browser 
    */
-  void Browse(TBrowser* b);
+  void Browse(TBrowser* b) override;
   /** 
    * This is a folder 
    * 
    * @return Always true
    */
-  Bool_t IsFolder() const { return kTRUE; } // Always true 
+  Bool_t IsFolder() const override { return kTRUE; } // Always true 
 
   Bool_t IsSecondaryCorrected() const { return TestBit(kSecondary); }
   Bool_t IsVertexBiasCorrected() const { return TestBit(kVertexBias); }
@@ -303,7 +303,7 @@ public:
    * 
    * @param option Passed verbatim to TH2::Print 
    */
-  void Print(Option_t* option="") const;
+  void Print(Option_t* option="") const override;
   /** 
    * Set the z coordinate of the interaction point
    * 
@@ -401,7 +401,7 @@ public:
    * 
    * @return Name of object 
    */
-  const Char_t* GetName() const { return (fIsMC ? "ForwardMC" : "Forward"); }
+  const Char_t* GetName() const override { return (fIsMC ? "ForwardMC" : "Forward"); }
   /** 
    * Check if event meets the passses requirements.   
    *
@@ -497,7 +497,7 @@ protected:
   UShort_t fNClusters;  // Number of SPD clusters in |eta|<1
   /** Invalid value for interaction point @f$z@f$ coordiante */
   static const Float_t fgkInvalidIpZ; // Invalid IpZ value 
-  ClassDef(AliAODForwardMult,5); // AOD forward multiplicity 
+  ClassDefOverride(AliAODForwardMult,5); // AOD forward multiplicity 
 };
 
 //____________________________________________________________________

--- a/roottest/root/io/evolution/pragma_read/v2/AliAODForwardHeader.h
+++ b/roottest/root/io/evolution/pragma_read/v2/AliAODForwardHeader.h
@@ -108,7 +108,7 @@ public:
    * 
    * @param option  Not used
    */
-  void Clear(Option_t* option="");
+  void Clear(Option_t* option="") override;
   /** 
    * Set the trigger mask 
    * 
@@ -271,25 +271,25 @@ public:
    * 
    * @param option Passed verbatim to TH2::Print 
    */
-  void Print(Option_t* option="") const;
+  void Print(Option_t* option="") const override;
   /** 
    * Get the name of the object 
    * 
    * @return Name of object 
    */
-  const Char_t* GetName() const { return "ForwardHeader"; }
+  const Char_t* GetName() const override { return "ForwardHeader"; }
   /** 
    * browse this object 
    * 
    * @param b Browser 
    */
-  void Browse(TBrowser* b);
+  void Browse(TBrowser* b) override;
   /** 
    * This is a folder 
    * 
    * @return Always true
    */
-  Bool_t IsFolder() const { return kTRUE; } // Always true 
+  Bool_t IsFolder() const override { return kTRUE; } // Always true 
   /* @} */
   /** 
    * @{
@@ -354,7 +354,7 @@ protected:
   UShort_t fNClusters;  // Number of SPD clusters in |eta|<1
   /** Invalid value for interaction point @f$z@f$ coordiante */
   static const Float_t fgkInvalidIpZ; // Invalid IpZ value 
-  ClassDef(AliAODForwardHeader,1); // AOD forward header 
+  ClassDefOverride(AliAODForwardHeader,1); // AOD forward header 
 };
 
 //____________________________________________________________________

--- a/roottest/root/io/evolution/pragma_read/v2/AliAODForwardMult.h
+++ b/roottest/root/io/evolution/pragma_read/v2/AliAODForwardMult.h
@@ -175,19 +175,19 @@ public:
    * 
    * @param option  Passed on to TH2::Reset verbatim
    */
-  void Clear(Option_t* option="");
+  void Clear(Option_t* option="") override;
   /** 
    * browse this object 
    * 
    * @param b Browser 
    */
-  void Browse(TBrowser* b);
+  void Browse(TBrowser* b) override;
   /** 
    * This is a folder 
    * 
    * @return Always true
    */
-  Bool_t IsFolder() const { return kTRUE; } // Always true 
+  Bool_t IsFolder() const override { return kTRUE; } // Always true 
   /** 
    * @return @c true if secondary corrected
    */
@@ -237,13 +237,13 @@ public:
    * 
    * @param option Passed verbatim to TH2::Print 
    */
-  void Print(Option_t* option="") const;
+  void Print(Option_t* option="") const override;
   /** 
    * Get the name of the object 
    * 
    * @return Name of object 
    */
-  const Char_t* GetName() const { return (fIsMC ? "ForwardMC" : "Forward"); }
+  const Char_t* GetName() const override { return (fIsMC ? "ForwardMC" : "Forward"); }
   /** 
    * Create a backward compatiblity header 
    * 
@@ -263,7 +263,7 @@ protected:
   TH2D     fHist;       // Histogram of d^2N_{ch}/(deta dphi) for this event
   AliAODForwardHeader* fHeader; //! Cached header 
 
-  ClassDef(AliAODForwardMult,6); // AOD forward multiplicity 
+  ClassDefOverride(AliAODForwardMult,6); // AOD forward multiplicity 
 };
 
 #endif

--- a/roottest/root/io/json/test_classes.h
+++ b/roottest/root/io/json/test_classes.h
@@ -305,7 +305,7 @@ class TJsonEx4 : public TJsonEx1 {
          strcpy((char*)fStr4, "--- normal string value ---");
       }
 
-      void Print()
+      void Print() override
       {
           TJsonEx1::Print();
           std::cout << "   fStr1 = " << fStr1 << std::endl;

--- a/roottest/root/io/rootcint/foo.hh
+++ b/roottest/root/io/rootcint/foo.hh
@@ -9,7 +9,7 @@ class foo
 {
 public:
   void a();
-  ClassDef (foo, 1);
+  ClassDefOverride (foo, 1);
 };
 
 }

--- a/roottest/root/io/treeproblem/Foo.h
+++ b/roottest/root/io/treeproblem/Foo.h
@@ -24,7 +24,7 @@ public:
   Int_t GetFoo() const { return fFoo; }
   void  Print(Option_t * = "") const;
 
-  ClassDef(Foo,1) // DOCUMENT ME
+  ClassDefOverride(Foo,1) // DOCUMENT ME
 };
 
 #endif

--- a/roottest/root/io/treeproblem/Foo.h
+++ b/roottest/root/io/treeproblem/Foo.h
@@ -22,7 +22,7 @@ public:
 
   void  SetFoo(Int_t foo=0) { fFoo = foo; }
   Int_t GetFoo() const { return fFoo; }
-  void  Print(Option_t * = "") const;
+  void  Print(Option_t * = "") const override;
 
   ClassDefOverride(Foo,1) // DOCUMENT ME
 };

--- a/roottest/root/io/xml/test_classes.h
+++ b/roottest/root/io/xml/test_classes.h
@@ -204,7 +204,7 @@ class TXmlEx4 : public TXmlEx1 {
          delete[] fStr3;
       }
 
-      void Print()
+      void Print() override
       {
           TXmlEx1::Print();
           std::cout << "   fStr1 = " << fStr1 << std::endl;

--- a/roottest/root/meta/iotypeioname/classes.h
+++ b/roottest/root/meta/iotypeioname/classes.h
@@ -48,7 +48,7 @@ private:
    SuperCluster m_sc;
    Particle m_part;
 
-ClassDef(Container,1);
+ClassDefOverride(Container,1);
 };
 
 #endif

--- a/roottest/root/ntuple/streamerfield/Event_v2.hxx
+++ b/roottest/root/ntuple/streamerfield/Event_v2.hxx
@@ -17,7 +17,7 @@ struct StreamerDerived : public StreamerBase {
    int fSecond = 2;
    virtual ~StreamerDerived() = default;
 
-   ClassDef(StreamerDerived, 2)
+   ClassDefOverride(StreamerDerived, 2)
 };
 
 struct StreamerContainer {

--- a/roottest/root/ntuple/streamerfield/Event_v3.hxx
+++ b/roottest/root/ntuple/streamerfield/Event_v3.hxx
@@ -17,7 +17,7 @@ struct StreamerDerived : public StreamerBase {
    int fFirst = 1;
    virtual ~StreamerDerived() = default;
 
-   ClassDef(StreamerDerived, 3)
+   ClassDefOverride(StreamerDerived, 3)
 };
 
 struct StreamerContainer {


### PR DESCRIPTION
Currently, many override warnings remain unnoticed since the gcc-problem-matcher of the GitHub CI does not work correctly, and it's also easy to forget those annotations if you do not visit the "Files changed" tab.

If some devs later use dev=ON and testing=ON, this leads to failures for compilers that auto-enable -Winconsistent-missing-override.

To prevent this, we enable the suggest-override warning in the build of debian with dev=ON instead of in the one from alma, this way we are sure of always failing if some does a PR that forgets an override, forcing pull-requesters to fix their issues before merging.

Within this PR: also fix missing overrides uncovered by turning ON this flag in the dev=ON build.

