### PR TITLE
Remove deprecated _TDirectory_getattr pythonization

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -11,7 +11,7 @@
 
 ### Minuit2
 
-* Behavior change: building ROOT using `minuit2_omp=ON` option no longer enables OpenMP parallelization by default. One has to call now additionaly GradientCalculator::SetParallelOMP().
+* Behavior change: building ROOT using `minuit2_omp=ON` option no longer enables OpenMP parallelization by default. One has to call now additionally GradientCalculator::SetParallelOMP().
 
 ## RooFit
 
@@ -61,6 +61,19 @@ RooAbsData *dataForChan = found != splits.end() ? found->get() : nullptr;
   to numbers such as 8 would share one 3-d histogram among 8 threads, greatly reducing the memory consumption. This might slow down execution if the histograms
   are filled at very high rates. Use lower number in this case.
 
+## PyROOT
+
+### Deprecate the attribute pythonization of `TDirectory` in favor of item-getting syntax
+
+Since ROOT 6.32, the recommended way to get objects from a `TFile` or any `TDirectory` in general is via `__getitem__`:
+
+```python
+tree = my_file["my_tree"] # instead of my_file.my_tree, which gave you a deprecation warning since ROOT 6.32
+```
+
+The deprecated pythonization with the `__getattr__` syntax is now removed.
+It was originally schedeuled for removal in 6.34 according to the 6.32 release notes, but since it was still used quite a bit,
+the deprecation period was extended.
 
 ## JavaScript ROOT
 - A new configuration option `Jupyter.JSRoot` was added in .rootrc to set the default mode for JSROOT in Jupyter notebooks (on or off).

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tdirectory.py
@@ -76,27 +76,6 @@ def _TDirectory_getitem(self, key):
     return result
 
 
-def _TDirectory_getattr(self, attr):
-    """For temporary backwards compatibility."""
-    import warnings
-
-    result = self.Get(attr)
-    if not result:
-        raise AttributeError(f"{repr(self)} object has no attribute '{attr}'")
-
-    cl_name = type(self).__cpp_name__
-    warnings.warn(
-        f'The attribute syntax for {cl_name} is deprecated and will be removed in ROOT 6.34. Please use {cl_name}["{attr}"] instead of {cl_name}.{attr}',
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    # Caching behavior seems to be more clear to the user; can always override said
-    # behavior (i.e. re-read from file) with an explicit Get() call
-    setattr(self, attr, result)
-    return result
-
-
 def _TDirectory_WriteObject(self, obj, *args):
     """
     Implements the WriteObject method of TDirectory
@@ -126,7 +105,6 @@ def _ipython_key_completions_(self):
 def pythonize_tdirectory():
     klass = cppyy.gbl.TDirectory
     klass.__getitem__ = _TDirectory_getitem
-    klass.__getattr__ = _TDirectory_getattr
     klass._WriteObject = klass.WriteObject
     klass.WriteObject = _TDirectory_WriteObject
     klass._ipython_key_completions_ = _ipython_key_completions_

--- a/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
+++ b/bindings/pyroot/pythonizations/test/tdirectoryfile_attrsyntax_get.py
@@ -5,7 +5,7 @@ import ROOT
 
 class TDirectoryFileReadWrite(unittest.TestCase):
     """
-    Test for the attr syntax and Get method of TDirectoryFile.
+    Test for the getitem syntax and Get method of TDirectoryFile.
     """
 
     nbins = 8
@@ -38,23 +38,23 @@ class TDirectoryFileReadWrite(unittest.TestCase):
         self.assertEqual(self.xmax, xaxis.GetXmax())
 
     # Tests
-    def test_readHisto_attrsyntax(self):
-        self.checkHisto(self.dir0.h)
-        self.checkHisto(self.dir0.dir1.h1)
-        self.checkHisto(self.dir0.dir1.dir2.h2)
+    def test_readHisto_itemsyntax(self):
+        self.checkHisto(self.dir0["h"])
+        self.checkHisto(self.dir0["dir1"]["h1"])
+        self.checkHisto(self.dir0["dir1"]["dir2"]["h2"])
 
     def test_readHisto(self):
         self.checkHisto(self.dir0.Get("h"))
         self.checkHisto(self.dir0.Get("dir1/h1"))
         self.checkHisto(self.dir0.Get("dir1/dir2/h2"))
 
-    def test_caching_getattr(self):
+    def test_caching_getitem(self):
         # check that object is not cached initially
-        self.assertFalse("h" in self.dir0.__dict__)
-        self.dir0.h
+        self.assertFalse(hasattr(self.dir0, "_cached_items"))
+        self.dir0["h"]
         # check that the value in __dict__ is actually the object
         # inside the directory
-        self.assertTrue(self.dir0.__dict__['h'] is self.dir0.h)
+        self.assertTrue(self.dir0._cached_items['h'] is self.dir0["h"])
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -42,11 +42,11 @@ class TFileOpenReadWrite(unittest.TestCase):
         self.assertEqual(self.xmax, xaxis.GetXmax())
 
     # Tests
-    def test_readHisto_attrsyntax(self):
+    def test_readHisto_itemsyntax(self):
         f = ROOT.TFile.Open(self.filename)
-        self.checkHisto(f.h)
-        self.checkHisto(f.dir1.h1)
-        self.checkHisto(f.dir1.dir2.h2)
+        self.checkHisto(f["h"])
+        self.checkHisto(f["dir1"]["h1"])
+        self.checkHisto(f["dir1"]["dir2"]["h2"])
 
     def test_readHisto(self):
         f = ROOT.TFile.Open(self.filename)
@@ -54,14 +54,14 @@ class TFileOpenReadWrite(unittest.TestCase):
         self.checkHisto(f.Get("dir1/h1"))
         self.checkHisto(f.Get("dir1/dir2/h2"))
 
-    def test_caching_getattr(self):
+    def test_caching_getitem(self):
         f = ROOT.TFile.Open(self.filename)
         # check that object is not cached initially
-        self.assertFalse("h" in f.__dict__)
-        f.h
+        self.assertFalse(hasattr(f, "_cached_items"))
+        f["h"]
         # check that the value in __dict__ is actually the object
         # inside the directory
-        self.assertTrue(f.__dict__['h'] is f.h)
+        self.assertTrue(f._cached_items['h'] is f["h"])
 
     def test_oserror(self):
         # check that an OSError is raised when an inexistent file is opened


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

- Removes the deprecated `_TDirectory_getattr` pythonization that, according to the deprecation notice, should have already been removed in 6.34.

I just saw this while scrolling through and did no local testing. Do whatever you want with this ;)

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)


