### PR TITLE
[test] Correct typo in linkdef pragma

### DIFF
--- a/roottest/root/treeformula/stl/mapvector.C
+++ b/roottest/root/treeformula/stl/mapvector.C
@@ -15,7 +15,7 @@ public:
 };
 
 #ifdef __MAKECINT__
-#pragma link C++ pair<int,std::vector<int> >+;
+#pragma link C++ class pair<int,std::vector<int> >+;
 #endif
 
 using namespace std;


### PR DESCRIPTION
the class std::pair<int,std::vector<int>> was not selected correctly.

This macro, aclic'd in a test, sporadically failed on macbeta.