### PR TITLE
[df] Remove dependency from RNTupleUtil in test

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -57,7 +57,7 @@ ROOT_ADD_GTEST(dataframe_snapshot_emptyoutput dataframe_snapshot_emptyoutput.cxx
 ROOT_GENERATE_DICTIONARY(DummyDict ${CMAKE_CURRENT_SOURCE_DIR}/DummyHeader.hxx
                          MODULE dataframe_snapshot_emptyoutput LINKDEF DummyHeaderLinkDef.hxx OPTIONS -inlineInputHeader
                          DEPENDENCIES ROOTVecOps GenVector)
-ROOT_ADD_GTEST(dataframe_snapshot_ntuple dataframe_snapshot_ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTupleUtil)
+ROOT_ADD_GTEST(dataframe_snapshot_ntuple dataframe_snapshot_ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple)
 endif()
 
 ROOT_ADD_GTEST(dataframe_datasetspec dataframe_datasetspec.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
@@ -5,7 +5,6 @@
 #include "ROOT/RNTupleModel.hxx"
 #include "ROOT/RNTupleWriter.hxx"
 #include "ROOT/RNTupleReader.hxx"
-#include "ROOT/RNTupleInspector.hxx" // For testing compression settings
 
 #include "TROOT.h"
 #include "TSystem.h"
@@ -17,7 +16,6 @@
 using ROOT::RNTupleModel;
 using ROOT::RNTupleReader;
 using ROOT::RNTupleWriter;
-using ROOT::Experimental::RNTupleInspector;
 
 using namespace ROOT::RDF;
 
@@ -116,8 +114,9 @@ TEST(RDFSnapshotRNTuple, Compression)
 
    EXPECT_EQ(columns, sdf->GetColumnNames());
 
-   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
-   EXPECT_EQ(404, inspector->GetCompressionSettings());
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   auto compSettings = *reader->GetDescriptor().GetClusterDescriptor(0).GetColumnRange(0).GetCompressionSettings();
+   EXPECT_EQ(404, compSettings);
 }
 
 class RDFSnapshotRNTupleTest : public ::testing::Test {


### PR DESCRIPTION
So it can actually be compiled and run even with `root7=OFF`.
