### PR TITLE
[GenVector] Make most vector and point classes nothrow move constructible.

### DIFF
--- a/math/genvector/inc/Math/GenVector/Cartesian2D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian2D.h
@@ -47,7 +47,7 @@ public :
    /**
       Default constructor  with x=y=0
    */
-   Cartesian2D() : fX(0.0), fY(0.0)  {  }
+   constexpr Cartesian2D() noexcept = default;
 
    /**
       Constructor from x,y  coordinates
@@ -61,24 +61,6 @@ public :
    template <class CoordSystem>
    explicit constexpr Cartesian2D(const CoordSystem & v)
       : fX(v.X()), fY(v.Y()) {  }
-
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-   /**
-      copy constructor
-    */
-   Cartesian2D(const Cartesian2D & v) :
-      fX(v.X()), fY(v.Y())  {  }
-
-   /**
-      assignment operator
-    */
-   Cartesian2D & operator= (const Cartesian2D & v) {
-      fX = v.X();
-      fY = v.Y();
-      return *this;
-   }
 
    /**
       Set internal data based on 2 Scalar numbers
@@ -208,9 +190,8 @@ private:
    /**
       (Contiguous) data containing the coordinates values x and y
    */
-   T  fX;
-   T  fY;
-
+   T fX = 0;
+   T fY = 0;
 };
 
 

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -54,12 +54,12 @@ public :
    /**
       Default constructor  with x=y=z=0
    */
-   Cartesian3D() : fX(0.0), fY(0.0), fZ(0.0) {  }
+   constexpr Cartesian3D() noexcept = default;
 
    /**
       Constructor from x,y,z coordinates
    */
-   Cartesian3D(Scalar xx, Scalar yy, Scalar zz) : fX(xx), fY(yy), fZ(zz) {  }
+   constexpr Cartesian3D(Scalar xx, Scalar yy, Scalar zz) noexcept : fX(xx), fY(yy), fZ(zz) {}
 
    /**
       Construct from any Vector or coordinate system implementing
@@ -68,24 +68,6 @@ public :
    template <class CoordSystem>
    explicit constexpr Cartesian3D(const CoordSystem & v)
       : fX(v.X()), fY(v.Y()), fZ(v.Z()) {  }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-   /**
-      copy constructor
-    */
-   Cartesian3D(const Cartesian3D & v) :
-      fX(v.X()), fY(v.Y()), fZ(v.Z()) {  }
-
-   /**
-      assignment operator
-    */
-   Cartesian3D & operator= (const Cartesian3D & v) {
-      fX = v.x();
-      fY = v.y();
-      fZ = v.z();
-      return *this;
-   }
 
    /**
       Set internal data based on an array of 3 Scalar numbers
@@ -239,10 +221,9 @@ public :
 
 
 private:
-
-   T fX;  // x coordinate
-   T fY;  // y coordinate
-   T fZ;  // z coordinate
+   T fX = 0; // x coordinate
+   T fY = 0; // y coordinate
+   T fZ = 0; // z coordinate
 };
 
 

--- a/math/genvector/inc/Math/GenVector/Cylindrical3D.h
+++ b/math/genvector/inc/Math/GenVector/Cylindrical3D.h
@@ -49,13 +49,12 @@ public :
    /**
       Default constructor with rho=z=phi=0
    */
-   Cylindrical3D() : fRho(0), fZ(0), fPhi(0) {  }
+   constexpr Cylindrical3D() noexcept = default;
 
    /**
       Construct from rho eta and phi values
    */
-   Cylindrical3D(Scalar rho, Scalar zz, Scalar phi) :
-      fRho(rho), fZ(zz), fPhi(phi) { Restrict(); }
+   constexpr Cylindrical3D(Scalar rho, Scalar zz, Scalar phi) noexcept : fRho(rho), fZ(zz), fPhi(phi) { Restrict(); }
 
    /**
       Construct from any Vector or coordinate system implementing
@@ -64,25 +63,6 @@ public :
    template <class CoordSystem >
    explicit constexpr Cylindrical3D( const CoordSystem & v ) :
       fRho( v.Rho() ),  fZ( v.Z() ),  fPhi( v.Phi() ) { Restrict(); }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-    */
-   Cylindrical3D(const Cylindrical3D & v) :
-      fRho(v.Rho() ),  fZ(v.Z() ),  fPhi(v.Phi() )  {   }
-
-   /**
-      assignment operator
-    */
-   Cylindrical3D & operator= (const Cylindrical3D & v) {
-      fRho = v.Rho();
-      fZ   = v.Z();
-      fPhi = v.Phi();
-      return *this;
-   }
 
    /**
       Set internal data based on an array of 3 Scalar numbers ( rho, z , phi)
@@ -238,11 +218,9 @@ public:
 
 
 private:
-
-   T fRho;
-   T fZ;
-   T fPhi;
-
+   T fRho = 0;
+   T fZ = 0;
+   T fPhi = 0;
 };
 
   } // end namespace Math

--- a/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
+++ b/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
@@ -55,13 +55,15 @@ public :
   /**
      Default constructor with rho=eta=phi=0
    */
-  CylindricalEta3D() : fRho(0), fEta(0), fPhi(0) {  }
+  constexpr CylindricalEta3D() noexcept = default;
 
   /**
      Construct from rho eta and phi values
    */
-  CylindricalEta3D(Scalar rho, Scalar eta, Scalar phi) :
-             fRho(rho), fEta(eta), fPhi(phi) { Restrict(); }
+  constexpr CylindricalEta3D(Scalar rho, Scalar eta, Scalar phi) noexcept : fRho(rho), fEta(eta), fPhi(phi)
+  {
+     Restrict();
+  }
 
   /**
      Construct from any Vector or coordinate system implementing
@@ -80,25 +82,6 @@ public :
         fRho *= v.Z() / Z();
     }
   }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-   */
-   CylindricalEta3D(const CylindricalEta3D & v) :
-      fRho(v.Rho() ),  fEta(v.Eta() ),  fPhi(v.Phi() )  {   }
-
-   /**
-      assignment operator
-   */
-   CylindricalEta3D & operator= (const CylindricalEta3D & v) {
-      fRho = v.Rho();
-      fEta = v.Eta();
-      fPhi = v.Phi();
-      return *this;
-   }
 
    /**
       Set internal data based on an array of 3 Scalar numbers
@@ -271,12 +254,10 @@ public:
 
 #endif
 
-
-private:
-   T fRho;
-   T fEta;
-   T fPhi;
-
+  private:
+     T fRho = 0;
+     T fEta = 0;
+     T fPhi = 0;
 };
 
   } // end namespace Math

--- a/math/genvector/inc/Math/GenVector/Polar2D.h
+++ b/math/genvector/inc/Math/GenVector/Polar2D.h
@@ -53,7 +53,7 @@ public :
    /**
       Default constructor with r=1,phi=0
    */
-   Polar2D() : fR(1.), fPhi(0) {  }
+   constexpr Polar2D() noexcept = default;
 
    /**
       Construct from the polar coordinates:  r and phi
@@ -67,25 +67,6 @@ public :
    template <class CoordSystem >
    explicit constexpr Polar2D( const CoordSystem & v ) :
       fR(v.R() ),  fPhi(v.Phi() )  { Restrict(); }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-    */
-   Polar2D(const Polar2D & v) :
-      fR(v.R() ),  fPhi(v.Phi() )  {   }
-
-   /**
-      assignment operator
-    */
-   Polar2D & operator= (const Polar2D & v) {
-      fR     = v.R();
-      fPhi   = v.Phi();
-      return *this;
-   }
-
 
    /**
       Set internal data based on 2 Scalar numbers
@@ -213,8 +194,8 @@ public:
 #endif
 
 private:
-   T fR;
-   T fPhi;
+   T fR = 1.;
+   T fPhi = 0.;
 };
 
 

--- a/math/genvector/inc/Math/GenVector/Polar3D.h
+++ b/math/genvector/inc/Math/GenVector/Polar3D.h
@@ -53,12 +53,12 @@ public :
    /**
       Default constructor with r=theta=phi=0
    */
-   Polar3D() : fR(0), fTheta(0), fPhi(0) {  }
+   constexpr Polar3D() noexcept = default;
 
    /**
       Construct from the polar coordinates:  r, theta and phi
    */
-   Polar3D(T r,T theta,T phi) : fR(r), fTheta(theta), fPhi(phi) { Restrict(); }
+   constexpr Polar3D(T r, T theta, T phi) noexcept : fR(r), fTheta(theta), fPhi(phi) { Restrict(); }
 
    /**
       Construct from any Vector or coordinate system implementing
@@ -67,25 +67,6 @@ public :
    template <class CoordSystem >
    explicit constexpr Polar3D( const CoordSystem & v ) :
       fR(v.R() ),  fTheta(v.Theta() ),  fPhi(v.Phi() )  { Restrict(); }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-    */
-   Polar3D(const Polar3D & v) :
-      fR(v.R() ),  fTheta(v.Theta() ),  fPhi(v.Phi() )  {   }
-
-   /**
-      assignment operator
-    */
-   Polar3D & operator= (const Polar3D & v) {
-      fR     = v.R();
-      fTheta = v.Theta();
-      fPhi   = v.Phi();
-      return *this;
-   }
 
    /**
       Set internal data based on an array of 3 Scalar numbers
@@ -237,9 +218,9 @@ public:
 #endif
 
 private:
-   T fR;
-   T fTheta;
-   T fPhi;
+   T fR = 0;
+   T fTheta = 0;
+   T fPhi = 0;
 };
 
 

--- a/math/genvector/inc/Math/GenVector/PositionVector3D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector3D.h
@@ -66,15 +66,14 @@ namespace ROOT {
          Default constructor. Construct an empty object with zero values
       */
 
-      constexpr PositionVector3D() : fCoordinates() { }
+      constexpr PositionVector3D() noexcept = default;
 
       /**
          Construct from three values of type <em>Scalar</em>.
          In the case of a XYZPoint the values are x,y,z
          In the case of  a polar vector they are r,theta,phi
       */
-      constexpr PositionVector3D(const Scalar & a, const Scalar & b, const Scalar & c) :
-        fCoordinates ( a , b,  c)  { }
+      constexpr PositionVector3D(const Scalar &a, const Scalar &b, const Scalar &c) noexcept : fCoordinates(a, b, c) {}
 
      /**
           Construct from a position vector expressed in different

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -63,13 +63,15 @@ public :
    /**
       Default constructor gives zero 4-vector
    */
-   PtEtaPhiE4D() : fPt(0), fEta(0), fPhi(0), fE(0) { }
+   constexpr PtEtaPhiE4D() noexcept = default;
 
    /**
       Constructor  from pt, eta, phi, e values
    */
-   PtEtaPhiE4D(Scalar pt, Scalar eta, Scalar phi, Scalar e) :
-      fPt(pt), fEta(eta), fPhi(phi), fE(e) { Restrict(); }
+   constexpr PtEtaPhiE4D(Scalar pt, Scalar eta, Scalar phi, Scalar e) noexcept : fPt(pt), fEta(eta), fPhi(phi), fE(e)
+   {
+      Restrict();
+   }
 
    /**
       Generic constructor from any 4D coordinate system implementing
@@ -78,27 +80,6 @@ public :
    template <class CoordSystem >
    explicit constexpr PtEtaPhiE4D(const CoordSystem & c) :
       fPt(c.Pt()), fEta(c.Eta()), fPhi(c.Phi()), fE(c.E())  { }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // so we decided to re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-    */
-   PtEtaPhiE4D(const PtEtaPhiE4D & v) :
-      fPt(v.fPt), fEta(v.fEta), fPhi(v.fPhi), fE(v.fE) { }
-
-   /**
-      assignment operator
-    */
-   PtEtaPhiE4D & operator = (const PtEtaPhiE4D & v) {
-      fPt  = v.fPt;
-      fEta = v.fEta;
-      fPhi = v.fPhi;
-      fE   = v.fE;
-      return *this;
-   }
-
 
    /**
       Set internal data based on an array of 4 Scalar numbers
@@ -358,16 +339,13 @@ public:
 
    void SetM(Scalar m);
 
-
 #endif
 
 private:
-
-   ScalarType fPt;
-   ScalarType fEta;
-   ScalarType fPhi;
-   ScalarType fE;
-
+   ScalarType fPt = 0.;
+   ScalarType fEta = 0.;
+   ScalarType fPhi = 0.;
+   ScalarType fE = 0.;
 };
 
 

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -83,26 +83,6 @@ public :
    explicit constexpr PtEtaPhiM4D(const CoordSystem & c) :
       fPt(c.Pt()), fEta(c.Eta()), fPhi(c.Phi()), fM(c.M())  { RestrictPhi(); }
 
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // so we decided to re-implement them ( there is no no need to have them with g++4)
-
-   /**
-      copy constructor
-    */
-   PtEtaPhiM4D(const PtEtaPhiM4D & v) :
-      fPt(v.fPt), fEta(v.fEta), fPhi(v.fPhi), fM(v.fM) { }
-
-   /**
-      assignment operator
-    */
-   PtEtaPhiM4D & operator = (const PtEtaPhiM4D & v) {
-      fPt  = v.fPt;
-      fEta = v.fEta;
-      fPhi = v.fPhi;
-      fM   = v.fM;
-      return *this;
-   }
-
 
    /**
       Set internal data based on an array of 4 Scalar numbers

--- a/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
@@ -53,15 +53,12 @@ public :
    /**
       Default constructor  with x=y=z=t=0
    */
-   PxPyPzE4D() : fX(0.0), fY(0.0), fZ(0.0), fT(0.0) { }
-
+   constexpr PxPyPzE4D() noexcept = default;
 
    /**
       Constructor  from x, y , z , t values
    */
-   PxPyPzE4D(Scalar px, Scalar py, Scalar pz, Scalar e) :
-      fX(px), fY(py), fZ(pz), fT(e) { }
-
+   constexpr PxPyPzE4D(Scalar px, Scalar py, Scalar pz, Scalar e) noexcept : fX(px), fY(py), fZ(pz), fT(e) {}
 
    /**
       construct from any vector or  coordinate system class
@@ -70,25 +67,6 @@ public :
    template <class CoordSystem>
    explicit constexpr PxPyPzE4D(const CoordSystem & v) :
       fX( v.x() ), fY( v.y() ), fZ( v.z() ), fT( v.t() )  { }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // so we decided to re-implement them ( there is no no need to have them with g++4)
-   /**
-      copy constructor
-    */
-   PxPyPzE4D(const PxPyPzE4D & v) :
-      fX(v.fX), fY(v.fY), fZ(v.fZ), fT(v.fT) { }
-
-   /**
-      assignment operator
-    */
-   PxPyPzE4D & operator = (const PxPyPzE4D & v) {
-      fX = v.fX;
-      fY = v.fY;
-      fZ = v.fZ;
-      fT = v.fT;
-      return *this;
-   }
 
    /**
       Set internal data based on an array of 4 Scalar numbers
@@ -344,11 +322,10 @@ private:
       (contiguous) data containing the coordinate values x,y,z,t
    */
 
-   ScalarType fX;
-   ScalarType fY;
-   ScalarType fZ;
-   ScalarType fT;
-
+   ScalarType fX = 0;
+   ScalarType fY = 0;
+   ScalarType fZ = 0;
+   ScalarType fT = 0;
 };
 
 } // end namespace Math

--- a/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
@@ -58,8 +58,7 @@ public :
    /**
       Default constructor  with x=y=z=m=0
    */
-   PxPyPzM4D() : fX(0.0), fY(0.0), fZ(0.0), fM(0.0) { }
-
+   constexpr PxPyPzM4D() noexcept = default;
 
    /**
       Constructor  from x, y , z , m values
@@ -78,26 +77,6 @@ public :
    explicit constexpr PxPyPzM4D(const CoordSystem & v) :
       fX( v.X() ), fY( v.Y() ), fZ( v.Z() ), fM( v.M() )
    { }
-
-   // for g++  3.2 and 3.4 on 32 bits found that the compiler generated copy ctor and assignment are much slower
-   // so we decided to re-implement them ( there is no no need to have them with g++4)
-   /**
-      copy constructor
-    */
-   PxPyPzM4D(const PxPyPzM4D & v) :
-      fX(v.fX), fY(v.fY), fZ(v.fZ), fM(v.fM) { }
-
-   /**
-      assignment operator
-    */
-   PxPyPzM4D & operator = (const PxPyPzM4D & v) {
-      fX = v.fX;
-      fY = v.fY;
-      fZ = v.fZ;
-      fM = v.fM;
-      return *this;
-   }
-
 
    /**
       construct from any 4D  coordinate system class
@@ -372,11 +351,10 @@ private:
       (contiguous) data containing the coordinate values x,y,z,t
    */
 
-   ScalarType fX;
-   ScalarType fY;
-   ScalarType fZ;
-   ScalarType fM;
-
+   ScalarType fX = 0;
+   ScalarType fY = 0;
+   ScalarType fZ = 0;
+   ScalarType fM = 0;
 };
 
 } // end namespace Math

--- a/math/genvector/test/CMakeLists.txt
+++ b/math/genvector/test/CMakeLists.txt
@@ -24,3 +24,6 @@ ROOT_ADD_TEST(test-genvector-coordinates3D COMMAND coordinates3D)
 
 ROOT_EXECUTABLE(coordinates4D coordinates4D.cxx LIBRARIES GenVector)
 ROOT_ADD_TEST(test-genvector-coordinates4D COMMAND coordinates4D)
+
+add_library(staticTests OBJECT staticTests.cxx)
+target_link_libraries(staticTests PRIVATE GenVector)

--- a/math/genvector/test/staticTests.cxx
+++ b/math/genvector/test/staticTests.cxx
@@ -1,0 +1,38 @@
+#include <type_traits>
+
+// Test that all vectors and coordinate systems are trivially copyable and move constructible
+template <class T>
+struct TypeTests {
+   static_assert(std::is_nothrow_move_constructible_v<T>);
+   static_assert(std::is_trivially_move_constructible_v<T>);
+   static_assert(std::is_nothrow_move_assignable_v<T>);
+   static_assert(std::is_trivially_move_assignable_v<T>);
+   static_assert(std::is_trivially_copyable_v<T>);
+   static_assert(std::is_trivially_destructible_v<T>);
+};
+
+#include "Math/Point2D.h"
+template struct TypeTests<ROOT::Math::XYPoint>;
+template struct TypeTests<ROOT::Math::Polar2DPoint>;
+
+#include "Math/Point3D.h"
+template struct TypeTests<ROOT::Math::XYZPoint>;
+template struct TypeTests<ROOT::Math::Polar3DPoint>;
+template struct TypeTests<ROOT::Math::RhoZPhiPoint>;
+template struct TypeTests<ROOT::Math::RhoEtaPhiPoint>;
+
+#include "Math/Vector2D.h"
+template struct TypeTests<ROOT::Math::XYVector>;
+template struct TypeTests<ROOT::Math::Polar2DVector>;
+
+#include "Math/Vector3D.h"
+template struct TypeTests<ROOT::Math::XYZVector>;
+template struct TypeTests<ROOT::Math::Polar3DVector>;
+template struct TypeTests<ROOT::Math::RhoZPhiVector>;
+template struct TypeTests<ROOT::Math::RhoEtaPhiVector>;
+
+#include "Math/Vector4D.h"
+template struct TypeTests<ROOT::Math::PxPyPzEVector>;
+template struct TypeTests<ROOT::Math::PxPyPzMVector>;
+template struct TypeTests<ROOT::Math::PtEtaPhiEVector>;
+template struct TypeTests<ROOT::Math::PtEtaPhiMVector>;


### PR DESCRIPTION
- Make genvector classes nothrow move constructible. Old user-defined copy constructors and assignment operators were preventing the auto-generated ones.
- Add a test that statically asserts their moveability / trivially copyable
- ~~Fix a doxygen link [here](https://root.cern.ch/doc/master/classROOT_1_1Math_1_1Cartesian2D.html) The "see also" generates a dead link because doxygen tries to link to "Overview" and "the".~~

Fixes #19042