### PR TITLE
Revert "[cppyy test] Do not generate rootmap file."

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -22,7 +22,6 @@ std_streams
 templates
 stltypes)
 
-set(CMAKE_ROOTTEST_NOROOTMAP ON)
 foreach(DICT ${CPPYY_TEST_DICTS})
     # Generate dictionary for the tests
     ROOT_GENERATE_DICTIONARY(G__${DICT}Dict ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.h LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/${DICT}.xml)
@@ -32,7 +31,6 @@ foreach(DICT ${CPPYY_TEST_DICTS})
     target_link_libraries(${DICT}Dict PUBLIC Python3::Python ROOT::Core)
     target_compile_options(${DICT}Dict PRIVATE "-w")
 endforeach()
-unset(CMAKE_ROOTTEST_NOROOTMAP)
 
 # Tests list
 set(CPPYY_TESTS


### PR DESCRIPTION
This reverts commit 4c75176418f905473edaef152ed3bb7dc2218ddb.

#19091 was run without the `clean_build` label. Thus, the CI runs were still finding the rootmaps from the cached artifacts.

This commit has broken the following tests

* pyunittests-bindings-pyroot-cppyy-cppyy-test-aclassloader
* pyunittests-bindings-pyroot-cppyy-cppyy-test-stltypes

As seen e.g. https://github.com/root-project/root/actions/runs/15756850240/job/44414087738?pr=19087 and https://github.com/root-project/root/actions/runs/15758350264/job/44418789010?pr=19098

It is visible at least in the `aclassloader` test that the rootmap is indeed required:
https://github.com/root-project/root/blob/8815e18d937d186e3131b08520f1d35fff77a75f/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py#L16
