### PR TITLE
[Python] Update reference refcount values for Python 3.14 compatibility

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -90,7 +90,7 @@ class DataFrameFromNumpy(unittest.TestCase):
 
         df = ROOT.RDF.FromNumpy(data)
         gc.collect()
-        self.assertEqual(sys.getrefcount(df), 2)
+        self.assertEqual(sys.getrefcount(df), 1 + int(sys.version_info < (3, 14)))
 
         self.assertEqual(sys.getrefcount(data["x"]), 3)
 

--- a/bindings/pyroot/pythonizations/test/rvec_asrvec.py
+++ b/bindings/pyroot/pythonizations/test/rvec_asrvec.py
@@ -137,10 +137,10 @@ class AsRVec(unittest.TestCase):
         rvec = ROOT.VecOps.AsRVec(np_obj)
         gc.collect()
         self.assertEqual(sys.getrefcount(rvec), 1 + int(sys.version_info < (3, 14)))
-        self.assertEqual(sys.getrefcount(np_obj), 3)
+        self.assertEqual(sys.getrefcount(np_obj), 2 + int(sys.version_info < (3, 14)))
         del rvec
         gc.collect()
-        self.assertEqual(sys.getrefcount(np_obj), 2)
+        self.assertEqual(sys.getrefcount(np_obj), 1 + int(sys.version_info < (3, 14)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# This Pull request:

The fix for #18988 in #19014 is incomplete.

## Changes or fixes:

After fixing the first failing assert in the failing tests the tests then fail on a subsequent assert instead. This commit fixes the following asserts using the same pattern.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #18988.
