### PR TITLE
[skip-ci][Docs] Fix a doxygen crosslink in GenVector.

### DIFF
--- a/math/genvector/inc/Math/GenVector/AxisAngle.h
+++ b/math/genvector/inc/Math/GenVector/AxisAngle.h
@@ -37,7 +37,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 class AxisAngle {
 

--- a/math/genvector/inc/Math/GenVector/Boost.h
+++ b/math/genvector/inc/Math/GenVector/Boost.h
@@ -41,7 +41,7 @@ namespace ROOT {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
   */
 
 class Boost {

--- a/math/genvector/inc/Math/GenVector/BoostX.h
+++ b/math/genvector/inc/Math/GenVector/BoostX.h
@@ -33,7 +33,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class BoostX {

--- a/math/genvector/inc/Math/GenVector/BoostY.h
+++ b/math/genvector/inc/Math/GenVector/BoostY.h
@@ -33,7 +33,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class BoostY {

--- a/math/genvector/inc/Math/GenVector/BoostZ.h
+++ b/math/genvector/inc/Math/GenVector/BoostZ.h
@@ -33,7 +33,7 @@ namespace ROOT {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class BoostZ {

--- a/math/genvector/inc/Math/GenVector/Cartesian2D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian2D.h
@@ -32,7 +32,7 @@ namespace Math {
 
        @ingroup GenVector
 
-       @sa Overview of the @ref GenVector "physics vector library"
+       @see GenVector
    */
 
 template <class T = double>

--- a/math/genvector/inc/Math/GenVector/Cartesian3D.h
+++ b/math/genvector/inc/Math/GenVector/Cartesian3D.h
@@ -39,7 +39,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
   */
 
 template <class T = double>

--- a/math/genvector/inc/Math/GenVector/CoordinateSystemTags.h
+++ b/math/genvector/inc/Math/GenVector/CoordinateSystemTags.h
@@ -32,7 +32,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
    class  DefaultCoordinateSystemTag {};
@@ -44,7 +44,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
    class  GlobalCoordinateSystemTag {};
 
@@ -54,7 +54,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
    class   LocalCoordinateSystemTag {};
 

--- a/math/genvector/inc/Math/GenVector/Cylindrical3D.h
+++ b/math/genvector/inc/Math/GenVector/Cylindrical3D.h
@@ -35,7 +35,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
   */
 
 template <class T>

--- a/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
+++ b/math/genvector/inc/Math/GenVector/CylindricalEta3D.h
@@ -41,7 +41,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
   */
 
 template <class T>

--- a/math/genvector/inc/Math/GenVector/DisplacementVector2D.h
+++ b/math/genvector/inc/Math/GenVector/DisplacementVector2D.h
@@ -51,7 +51,7 @@ namespace ROOT {
 
         @ingroup GenVector
 
-        @sa Overview of the @ref GenVector "physics vector library"
+        @see GenVector
      */
 
      template <class CoordSystem, class Tag = DefaultCoordinateSystemTag >

--- a/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
+++ b/math/genvector/inc/Math/GenVector/DisplacementVector3D.h
@@ -51,7 +51,7 @@ namespace ROOT {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
     */
 
     template <class CoordSystem, class Tag = DefaultCoordinateSystemTag >

--- a/math/genvector/inc/Math/GenVector/EulerAngles.h
+++ b/math/genvector/inc/Math/GenVector/EulerAngles.h
@@ -41,7 +41,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 class EulerAngles {
 

--- a/math/genvector/inc/Math/GenVector/LorentzRotation.h
+++ b/math/genvector/inc/Math/GenVector/LorentzRotation.h
@@ -49,7 +49,7 @@ namespace ROOT {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
   */
 
 class LorentzRotation {

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -54,7 +54,7 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
 - ROOT::Math::XYZTVector based on x,y,z,t coordinates (cartesian) in double precision (same as PxPyPzEVector)
 - ROOT::Math::XYZTVectorF based on x,y,z,t coordinates (cartesian) in float precision (same as PxPyPzEVector but float)
 
-@sa Overview of the @ref GenVector "physics vector library"
+@see GenVector
 */
 
     template< class CoordSystem >

--- a/math/genvector/inc/Math/GenVector/Plane3D.h
+++ b/math/genvector/inc/Math/GenVector/Plane3D.h
@@ -46,7 +46,7 @@ namespace Impl {
 
    @ingroup GenVector
 
-   @sa Overview of the @ref GenVector "physics vector library"
+   @see GenVector
 */
 
 template <typename T = double>

--- a/math/genvector/inc/Math/GenVector/Polar2D.h
+++ b/math/genvector/inc/Math/GenVector/Polar2D.h
@@ -38,7 +38,7 @@ namespace Math {
 
        @ingroup GenVector
 
-       @sa Overview of the @ref GenVector "physics vector library"
+       @see GenVector
    */
 
 

--- a/math/genvector/inc/Math/GenVector/Polar3D.h
+++ b/math/genvector/inc/Math/GenVector/Polar3D.h
@@ -38,7 +38,7 @@ namespace Math {
 
        @ingroup GenVector
 
-       @sa Overview of the @ref GenVector "physics vector library"
+       @see GenVector
    */
 
 

--- a/math/genvector/inc/Math/GenVector/PositionVector2D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector2D.h
@@ -43,7 +43,7 @@ namespace ROOT {
 
          @ingroup GenVector
 
-         @sa Overview of the @ref GenVector "physics vector library"
+         @see GenVector
       */
 
     template <class CoordSystem, class Tag = DefaultCoordinateSystemTag >

--- a/math/genvector/inc/Math/GenVector/PositionVector3D.h
+++ b/math/genvector/inc/Math/GenVector/PositionVector3D.h
@@ -48,7 +48,7 @@ namespace ROOT {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
     */
 
     template <class CoordSystem, class Tag = DefaultCoordinateSystemTag >

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -47,7 +47,7 @@ namespace Math {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 */
 
 template <class ScalarType>

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -48,7 +48,7 @@ namespace Math {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 */
 
 template <class ScalarType>

--- a/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
@@ -37,7 +37,7 @@ namespace Math {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 */
 
 template <class ScalarType = double>

--- a/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
@@ -42,7 +42,7 @@ namespace Math {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 */
 
 template <class ScalarType = double>

--- a/math/genvector/inc/Math/GenVector/Quaternion.h
+++ b/math/genvector/inc/Math/GenVector/Quaternion.h
@@ -43,7 +43,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class Quaternion {

--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -62,7 +62,7 @@ namespace Math {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
   */
 
 class Rotation3D {

--- a/math/genvector/inc/Math/GenVector/RotationX.h
+++ b/math/genvector/inc/Math/GenVector/RotationX.h
@@ -40,7 +40,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class RotationX {

--- a/math/genvector/inc/Math/GenVector/RotationY.h
+++ b/math/genvector/inc/Math/GenVector/RotationY.h
@@ -40,7 +40,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class RotationY {

--- a/math/genvector/inc/Math/GenVector/RotationZ.h
+++ b/math/genvector/inc/Math/GenVector/RotationZ.h
@@ -40,7 +40,7 @@ namespace Math {
 
       @ingroup GenVector
 
-      @sa Overview of the @ref GenVector "physics vector library"
+      @see GenVector
    */
 
 class RotationZ {

--- a/math/genvector/inc/Math/GenVector/RotationZYX.h
+++ b/math/genvector/inc/Math/GenVector/RotationZYX.h
@@ -58,7 +58,7 @@ namespace Math {
 
      @ingroup GenVector
 
-     @sa Overview of the @ref GenVector "physics vector library"
+     @see GenVector
   */
 
 class RotationZYX {

--- a/math/genvector/inc/Math/GenVector/Transform3D.h
+++ b/math/genvector/inc/Math/GenVector/Transform3D.h
@@ -72,7 +72,7 @@ namespace Impl {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 
 */
 

--- a/math/genvector/inc/Math/GenVector/Translation3D.h
+++ b/math/genvector/inc/Math/GenVector/Translation3D.h
@@ -45,7 +45,7 @@ namespace Impl {
 
     @ingroup GenVector
 
-    @sa Overview of the @ref GenVector "physics vector library"
+    @see GenVector
 
 */
 

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -39,7 +39,7 @@ namespace ROOT {
 
        @ingroup GenVector
 
-       @sa Overview of the @ref GenVector "physics vector library"
+       @see GenVector
        */
 
 


### PR DESCRIPTION
The \see or \sa commands are supposed to be used with cross-linkeable objects only.

This fixed those dead links:
![image](https://github.com/user-attachments/assets/ace33580-8d5c-4e61-b002-b743183f4b76)

https://root.cern.ch/doc/master/classROOT_1_1Math_1_1PositionVector2D.html