### PR TITLE
[ntuple] Change entry handling in `RNTupleProcessor` to properly handle missing values

### DIFF
--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -34,13 +34,6 @@ namespace ROOT {
 class RNTupleFillContext;
 class RNTupleReader;
 
-namespace Experimental {
-class RNTupleProcessor;
-class RNTupleSingleProcessor;
-class RNTupleChainProcessor;
-class RNTupleJoinProcessor;
-} // namespace Experimental
-
 // clang-format off
 /**
 \class ROOT::REntry
@@ -55,10 +48,6 @@ class REntry {
    friend class RNTupleFillContext;
    friend class RNTupleModel;
    friend class RNTupleReader;
-   friend class Experimental::RNTupleProcessor;
-   friend class Experimental::RNTupleSingleProcessor;
-   friend class Experimental::RNTupleChainProcessor;
-   friend class Experimental::RNTupleJoinProcessor;
 
 private:
    /// The entry must be linked to a specific model, identified by a model ID

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -18,11 +18,11 @@
 
 #include <ROOT/REntry.hxx>
 #include <ROOT/RError.hxx>
-#include <ROOT/RFieldToken.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleJoinTable.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleTypes.hxx>
+#include <ROOT/RNTupleProcessorEntry.hxx>
 #include <ROOT/RPageStorage.hxx>
 
 #include <memory>
@@ -67,11 +67,152 @@ public:
 
 // clang-format off
 /**
+\class ROOT::Experimental::RNTupleProcessorOptionalPtr<T>
+\ingroup NTuple
+\brief The RNTupleProcessorOptionalPtr provides access to values from fields present in an RNTupleProcessor, with support
+and checks for missing values.
+*/
+// clang-format on
+template <typename T>
+class RNTupleProcessorOptionalPtr {
+   friend class RNTupleProcessor;
+
+private:
+   Internal::RNTupleProcessorEntry *fProcessorEntry;
+   Internal::RNTupleProcessorEntry::FieldIndex_t fFieldIndex;
+
+   RNTupleProcessorOptionalPtr(Internal::RNTupleProcessorEntry *processorEntry,
+                               Internal::RNTupleProcessorEntry::FieldIndex_t fieldIdx)
+      : fProcessorEntry(processorEntry), fFieldIndex(fieldIdx)
+   {
+   }
+
+public:
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if the pointer currently holds a valid value.
+   bool HasValue() const { return fProcessorEntry->IsValidField(fFieldIndex); }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a shared pointer to the field value managed by the processor's entry.
+   ///
+   /// \return A `std::shared_ptr<T>` if the field is valid in the current entry, or a `nullptr` otherwise.
+   std::shared_ptr<T> GetPtr() const
+   {
+      if (fProcessorEntry->IsValidField(fFieldIndex))
+         return fProcessorEntry->GetPtr<T>(fFieldIndex);
+
+      return nullptr;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a non-owning pointer to the field value managed by the processor's entry.
+   ///
+   /// \return A `T*` if the field is valid in the current entry, or a `nullptr` otherwise.
+   T *GetRawPtr() const { return GetPtr().get(); }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Bind the value to `valuePtr`.
+   ///
+   /// \param[in] valuePtr Pointer to bind the value to.
+   ///
+   /// \warning Use this function with care! Values may not always be valid for every entry during processing, for
+   /// example when a field is not present in one of the chained processors or when during a join operation, no matching
+   /// entry in the auxiliary processor can be found. Reading `valuePtr` as-is therefore comes with the risk of reading
+   /// invalid data. After binding a pointer to an `RNTupleProcessorOptionalPtr`, we *strongly* recommend only accessing
+   /// its data through this interface, to ensure that only valid data can be read.
+   void BindRawPtr(T *valuePtr) { fProcessorEntry->BindRawPtr(fFieldIndex, valuePtr); }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a reference to the field value managed by the processor's entry.
+   ///
+   /// Throws an exception if the field is invalid in the processor's current entry.
+   const T &operator*() const
+   {
+      if (auto ptr = GetPtr())
+         return *ptr;
+      else
+         throw RException(R__FAIL("cannot read \"" + fProcessorEntry->FindFieldName(fFieldIndex) +
+                                  "\" because it has no value for the current entry"));
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Access the field value managed by the processor's entry.
+   ///
+   /// Throws an exception if the field is invalid in the processor's current entry.
+   const T *operator->() const
+   {
+      if (auto ptr = GetPtr())
+         return ptr.get();
+      else
+         throw RException(R__FAIL("cannot read \"" + fProcessorEntry->FindFieldName(fFieldIndex) +
+                                  "\" because it has no value for the current entry"));
+   }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleProcessorOptionalPtr<void>
+\ingroup NTuple
+\brief Specialization of RNTupleProcessorOptionalPtr<T> for `void`-type pointers.
+*/
+// clang-format on
+template <>
+class RNTupleProcessorOptionalPtr<void> {
+   friend class RNTupleProcessor;
+
+private:
+   Internal::RNTupleProcessorEntry *fProcessorEntry;
+   Internal::RNTupleProcessorEntry::FieldIndex_t fFieldIndex;
+
+   RNTupleProcessorOptionalPtr(Internal::RNTupleProcessorEntry *processorEntry,
+                               Internal::RNTupleProcessorEntry::FieldIndex_t fieldIdx)
+      : fProcessorEntry(processorEntry), fFieldIndex(fieldIdx)
+   {
+   }
+
+public:
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if the pointer currently holds a valid value.
+   bool HasValue() const { return fProcessorEntry->IsValidField(fFieldIndex); }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the pointer to the field value managed by the processor's entry.
+   ///
+   /// \return A `std::shared_ptr<void>` if the field is valid in the current entry, or a `nullptr` otherwise.
+   std::shared_ptr<void> GetPtr() const
+   {
+      if (fProcessorEntry->IsValidField(fFieldIndex))
+         return fProcessorEntry->GetPtr<void>(fFieldIndex);
+
+      return nullptr;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a non-owning pointer to the field value managed by the processor's entry.
+   ///
+   /// \return A `void*` if the field is valid in the current entry, or a `nullptr` otherwise.
+   void *GetRawPtr() const { return GetPtr().get(); }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Bind the value to `valuePtr`.
+   ///
+   /// \param[in] valuePtr Pointer to bind the value to.
+   ///
+   /// \warning Use this function with care! Values may not always be valid for every entry during processing, for
+   /// example when a field is not present in one of the chained processors or when during a join operation, no matching
+   /// entry in the auxiliary processor can be found. Reading `valuePtr` as-is therefore comes with the risk of reading
+   /// invalid data. After binding a pointer to an `RNTupleProcessorOptionalPtr`, we *strongly* recommend only accessing
+   /// its data through this interface, to ensure that only valid data can be read.
+   void BindRawPtr(void *valuePtr) { fProcessorEntry->BindRawPtr(fFieldIndex, valuePtr); }
+};
+
+// clang-format off
+/**
 \class ROOT::Experimental::RNTupleProcessor
 \ingroup NTuple
-\brief Interface for iterating over entries of RNTuples and vertically concatenated RNTuples (chains).
+\brief Interface for iterating over entries of vertically ("chained") and/or horizontally ("joined") combined RNTuples.
 
-Example usage (see ntpl012_processor.C for a full example):
+Example usage (see ntpl012_processor_chain.C and ntpl015_processor_join.C for bigger examples):
 
 ~~~{.cpp}
 #include <ROOT/RNTupleProcessor.hxx>
@@ -81,20 +222,24 @@ using ROOT::Experimental::RNTupleOpenSpec;
 std::vector<RNTupleOpenSpec> ntuples = {{"ntuple1", "ntuple1.root"}, {"ntuple2", "ntuple2.root"}};
 auto processor = RNTupleProcessor::CreateChain(ntuples);
 
-for (const auto &entry : processor) {
-   std::cout << "pt = " << *entry.GetPtr<float>("pt") << std::endl;
+auto pt = processor->RequestField<float>("pt");
+
+for (const auto idx : *processor) {
+   std::cout << "event = " << idx << ", pt = " << *pt << std::endl;
 }
 ~~~
 
-An RNTupleProcessor is created by providing one or more RNTupleOpenSpecs, each of which contains the name and storage
-location of a single RNTuple. The RNTuples are processed in the order in which they were provided.
+An RNTupleProcessor is created either:
+1. By providing one or more RNTupleOpenSpecs, each of which contains the name and storage location of a single RNTuple;
+2. By providing a previously created RNTupleProcessor.
 
-The RNTupleProcessor constructor also (optionally) accepts an RNTupleModel, which determines which fields should be
-read. If no model is provided, a default model based on the descriptor of the first specified RNTuple will be used.
-If a field that was present in the first RNTuple is not found in a subsequent one, an error will be thrown.
+The RNTupleProcessor provides an iterator which gives access to the index of the current *global* entry of the
+processor, i.e. taking into account previously processed RNTuples.
 
-The RNTupleProcessor provides an iterator which gives access to the REntry containing the field data for the current
-entry. Additional bookkeeping information can be obtained through the RNTupleProcessor itself.
+Because the schemas of each RNTuple that are part of an RNTupleProcessor may not necessarily be identical, or because
+it can occur that entries are only partially complete in a join-based processor, field values may be marked as
+"invalid", at which point their data should not be read. This is handled by the RNTupleProcessorOptionalPtr
+that is returned by RequestField().
 */
 // clang-format on
 class RNTupleProcessor {
@@ -105,8 +250,9 @@ class RNTupleProcessor {
 
 protected:
    std::string fProcessorName;
-   std::unique_ptr<ROOT::REntry> fEntry;
-   std::unique_ptr<ROOT::RNTupleModel> fModel;
+   std::unique_ptr<ROOT::RNTupleModel> fProtoModel = nullptr;
+   std::shared_ptr<Internal::RNTupleProcessorEntry> fEntry = nullptr;
+   std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> fFieldIdxs;
 
    /// Total number of entries. Only to be used internally by the processor, not meant to be exposed in the public
    /// interface.
@@ -117,6 +263,24 @@ protected:
    std::size_t fCurrentProcessorNumber = 0;    //< Number of the currently open inner processor
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Initialize the processor, by setting `fProtoModel` and creating an (initially empty) `fEntry`, or setting
+   /// an existing one.
+   virtual void Initialize(std::shared_ptr<Internal::RNTupleProcessorEntry> entry) = 0;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if the processor already has been initialized.
+   bool IsInitialized() const { return fProtoModel && fEntry; }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect fields to the page source of the processor's underlying RNTuple(s).
+   ///
+   /// \param[in] fieldIdxs Indices of the fields to connect.
+   /// \param[in] updateFields Whether the fields in the entry need to be updated, because the current underlying
+   /// RNTuple source changed.
+   virtual void
+   Connect(const std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs, bool updateFields) = 0;
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided entry number.
    ///
    /// \param[in] entryNumber Entry number to load
@@ -125,14 +289,40 @@ protected:
    virtual ROOT::NTupleSize_t LoadEntry(ROOT::NTupleSize_t entryNumber) = 0;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Point the entry's field values of the processor to the pointers from the provided entry.
+   /// \brief Get the proto model used by the processor.
    ///
-   /// \param[in] entry The entry whose field values to use.
-   virtual void SetEntryPointers(const ROOT::REntry &entry, std::string_view fieldNamePrefix = "") = 0;
+   /// A processor's proto model contains all fields that can be accessed and is inferred from the descriptors of the
+   /// underlying RNTuples. It is used in RequestField() to check that the requested field is actually valid.
+   const ROOT::RNTupleModel &GetProtoModel() const
+   {
+      assert(fProtoModel);
+      return *fProtoModel;
+   }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor
    virtual ROOT::NTupleSize_t GetNEntries() = 0;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if a field exists on-disk and can be read by the processor.
+   ///
+   /// \param[in] fieldName Name of the field to check.
+   virtual bool CanReadFieldFromDisk(std::string_view fieldName) = 0;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a field to the entry.
+   ///
+   ///
+   /// \param[in] fieldName Name of the field to add.
+   /// \param[in] valuePtr Pointer to bind to the field's value in the entry. If this is a `nullptr`, a pointer will be
+   /// created.
+   /// \param[in] auxFieldPrefix Prefix used to identify auxiliary fields, if applicable.
+   ///
+   /// \return The index of the newly added field in the entry.
+   ///
+   /// In case the field was already present in the entry, the index of the existing field is returned.
+   virtual ROOT::RResult<Internal::RNTupleProcessorEntry::FieldIndex_t>
+   AddFieldToEntry(std::string_view fieldName, void *valuePtr, std::string_view auxFieldPrefix) = 0;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Add the entry mappings for this processor to the provided join table.
@@ -154,14 +344,7 @@ protected:
    /// \param[in] processorName Name of the processor. By default, this is the name of the underlying RNTuple for
    /// RNTupleSingleProcessor, the name of the first processor for RNTupleChainProcessor, or the name of the primary
    /// RNTuple for RNTupleJoinProcessor.
-   /// \param[in] model The RNTupleModel representing the entries returned by the processor.
-   ///
-   /// \note Before processing, a model *must* exist. However, this is handled downstream by the RNTupleProcessor's
-   /// factory functions (CreateSingle, CreateChain and CreateJoin) and constructors.
-   RNTupleProcessor(std::string_view processorName, std::unique_ptr<ROOT::RNTupleModel> model)
-      : fProcessorName(processorName), fModel(std::move(model))
-   {
-   }
+   RNTupleProcessor(std::string_view processorName) : fProcessorName(processorName) {}
 
 public:
    RNTupleProcessor(const RNTupleProcessor &) = delete;
@@ -193,14 +376,27 @@ public:
    const std::string &GetProcessorName() const { return fProcessorName; }
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get the model used by the processor.
-   const ROOT::RNTupleModel &GetModel() const { return *fModel; }
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get a reference to the entry used by the processor.
+   /// \brief Request access to a field for reading during processing.
    ///
-   /// \return A reference to the entry used by the processor.
-   const ROOT::REntry &GetEntry() const { return *fEntry; }
+   /// \tparam T Type of the requested field.
+   ///
+   /// \param[in] fieldName Name of the requested field.
+   ///
+   /// \return An RNTupleProcessorOptionalPtr, which provides access to the field's value.
+   ///
+   /// \warning Provide a `valuePtr` with care! Values may not always be valid for every entry during processing, for
+   /// example when a field is not present in one of the chained processors or when during a join operation, no matching
+   /// entry in the auxiliary processor can be found. Reading `valuePtr` as-is therefore comes with the risk of reading
+   /// invalid data. After passing a pointer to `RequestField`, we *strongly* recommend only accessing its data through
+   /// the interface of the returned `RNTupleProcessorOptionalPtr`, to ensure that only valid data can be read.
+   template <typename T>
+   RNTupleProcessorOptionalPtr<T> RequestField(std::string_view fieldName, void *valuePtr = nullptr)
+   {
+      Initialize(fEntry);
+      // TODO handle alternative (compatible field types)
+      auto fieldIdx = AddFieldToEntry(fieldName, valuePtr, /*auxFieldPrefix=*/"").Unwrap();
+      return RNTupleProcessorOptionalPtr<T>(fEntry.get(), fieldIdx);
+   }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Print a graphical representation of the processor composition.
@@ -245,9 +441,13 @@ public:
       RIterator(RNTupleProcessor &processor, ROOT::NTupleSize_t entryNumber)
          : fProcessor(processor), fCurrentEntryNumber(entryNumber)
       {
+         if (!fProcessor.fEntry) {
+            fCurrentEntryNumber = ROOT::kInvalidNTupleIndex;
+         }
          // This constructor is called with kInvalidNTupleIndex for RNTupleProcessor::end(). In that case, we already
          // know there is nothing to load.
          if (fCurrentEntryNumber != ROOT::kInvalidNTupleIndex) {
+            fProcessor.Connect(fProcessor.fEntry->GetFieldIndices(), /*updateFields=*/false);
             fCurrentEntryNumber = fProcessor.LoadEntry(fCurrentEntryNumber);
          }
       }
@@ -284,41 +484,31 @@ public:
    /// \brief Create an RNTupleProcessor for a single RNTuple.
    ///
    /// \param[in] ntuple The name and storage location of the RNTuple to process.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the descriptor of the first ntuple specified.
    /// \param[in] processorName The name to give to the processor. If empty, the name of the input RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> Create(RNTupleOpenSpec ntuple,
-                                                   std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
-                                                   std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor> Create(RNTupleOpenSpec ntuple, std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of RNTuples.
    ///
    /// \param[in] ntuples A list specifying the names and locations of the RNTuples to process.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the descriptor of the first RNTuple specified.
    /// \param[in] processorName The name to give to the processor. If empty, the name of the first RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> CreateChain(std::vector<RNTupleOpenSpec> ntuples,
-                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
-                                                        std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor>
+   CreateChain(std::vector<RNTupleOpenSpec> ntuples, std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of other RNTupleProcessors.
    ///
    /// \param[in] innerProcessors A list with the processors to chain.
-   /// \param[in] model An RNTupleModel specifying which fields can be read by the processor. If no model is provided,
-   /// one will be created based on the model used by the first inner processor.
    /// \param[in] processorName The name to give to the processor. If empty, the name of the first inner processor is
    /// used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
-                                                        std::unique_ptr<ROOT::RNTupleModel> model = nullptr,
-                                                        std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor>
+   CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors, std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -330,17 +520,12 @@ public:
    /// \param[in] joinFields The names of the fields on which to join, in case the specified RNTuples are unaligned.
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified RNTuple. If an empty list is provided, it is assumed that the specified ntuple are fully aligned.
-   /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary RNTuple can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the primary RNTuple.
-   /// \param[in] auxModel An RNTupleModel specifying which fields from the auxiliary RNTuple can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the auxiliary RNTuple.
    /// \param[in] processorName The name to give to the processor. If empty, the name of the primary RNTuple is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   CreateJoin(RNTupleOpenSpec primaryNTuple, RNTupleOpenSpec auxNTuple, const std::vector<std::string> &joinFields,
-              std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-              std::unique_ptr<ROOT::RNTupleModel> auxModel = nullptr, std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor> CreateJoin(RNTupleOpenSpec primaryNTuple, RNTupleOpenSpec auxNTuple,
+                                                       const std::vector<std::string> &joinFields,
+                                                       std::string_view processorName = "");
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -352,17 +537,12 @@ public:
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified processors. If an empty list is provided, it is assumed that the specified processors are fully
    /// aligned.
-   /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary processor can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the primary processor.
-   /// \param[in] auxModel An RNTupleModel specifying which fields from the auxiliary processor can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the auxiliary processor.
    /// \param[in] processorName The name to give to the processor. If empty, the name of the primary processor is used.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
    CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor, std::unique_ptr<RNTupleProcessor> auxProcessor,
-              const std::vector<std::string> &joinFields, std::unique_ptr<ROOT::RNTupleModel> primaryModel = nullptr,
-              std::unique_ptr<ROOT::RNTupleModel> auxModel = nullptr, std::string_view processorName = "");
+              const std::vector<std::string> &joinFields, std::string_view processorName = "");
 };
 
 // clang-format off
@@ -380,8 +560,18 @@ private:
    std::unique_ptr<ROOT::Internal::RPageSource> fPageSource;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \brief Connect the page source of the underlying RNTuple.
-   void Connect();
+   /// \brief Initialize the processor, by setting `fProtoModel` and creating an (initially empty) `fEntry`, or setting
+   /// an existing one.
+   ///
+   /// At this point, the page source for the underlying RNTuple of the processor will be created and opened.
+   void Initialize(std::shared_ptr<Internal::RNTupleProcessorEntry> entry = nullptr) final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect fields to the page source of the processor's underlying RNTuple(s).
+   ///
+   /// \sa RNTupleProcessor::Connect()
+   void Connect(const std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+                bool updateFields = false) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided (global) entry number (i.e., considering all RNTuples in this
@@ -391,16 +581,27 @@ private:
    ROOT::NTupleSize_t LoadEntry(ROOT::NTupleSize_t entryNumber) final;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const ROOT::REntry &entry, std::string_view fieldNamePrefix) final;
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
    ROOT::NTupleSize_t GetNEntries() final
    {
-      Connect();
+      Initialize();
+      if (fNEntries == ROOT::kInvalidNTupleIndex)
+         Connect(fFieldIdxs, /*updateFields=*/false);
       return fNEntries;
    }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if a field exists on-disk and can be read by the processor.
+   ///
+   /// \sa RNTupleProcessor::CanReadFieldFromDisk()
+   bool CanReadFieldFromDisk(std::string_view fieldName) final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a field to the entry.
+   ///
+   /// \sa RNTupleProcessor::AddFieldToEntry()
+   ROOT::RResult<Internal::RNTupleProcessorEntry::FieldIndex_t>
+   AddFieldToEntry(std::string_view fieldName, void *valuePtr = nullptr, std::string_view auxFieldPrefix = "") final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Add the entry mappings for this processor to the provided join table.
@@ -418,18 +619,20 @@ private:
    /// \brief Construct a new RNTupleProcessor for processing a single RNTuple.
    ///
    /// \param[in] ntuple The source specification (name and storage location) for the RNTuple to process.
-   /// \param[in] model The model that specifies which fields should be read by the processor.
    /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::Create, this is
    /// the name of the underlying RNTuple.
-   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::unique_ptr<ROOT::RNTupleModel> model,
-                          std::string_view processorName);
+   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::string_view processorName);
 
 public:
    RNTupleSingleProcessor(const RNTupleSingleProcessor &) = delete;
    RNTupleSingleProcessor(RNTupleSingleProcessor &&) = delete;
    RNTupleSingleProcessor &operator=(const RNTupleSingleProcessor &) = delete;
    RNTupleSingleProcessor &operator=(RNTupleSingleProcessor &&) = delete;
-   ~RNTupleSingleProcessor() override { fModel.release(); };
+   ~RNTupleSingleProcessor() override
+   {
+      // The proto model needs to be deleted before fPageSource.
+      fProtoModel.release();
+   };
 };
 
 // clang-format off
@@ -447,6 +650,22 @@ private:
    std::vector<ROOT::NTupleSize_t> fInnerNEntries;
 
    /////////////////////////////////////////////////////////////////////////////
+   /// \brief Initialize the processor, by setting `fProtoModel` and creating an (initially empty) `fEntry`, or setting
+   /// an existing one.
+   void Initialize(std::shared_ptr<Internal::RNTupleProcessorEntry> entry = nullptr) final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect fields to the page source of the processor's underlying RNTuple(s).
+   ///
+   /// \sa RNTupleProcessor::Connect()
+   void Connect(const std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+                bool updateFields = false) final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Update the entry to reflect any missing fields in the current inner processor.
+   void ConnectInnerProcessor(std::size_t processorNumber);
+
+   /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided (global) entry number (i.e., considering all RNTuples in this
    /// processor).
    ///
@@ -454,14 +673,26 @@ private:
    ROOT::NTupleSize_t LoadEntry(ROOT::NTupleSize_t entryNumber) final;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const ROOT::REntry &, std::string_view fieldNamePrefix) final;
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
    ///
    /// \note This requires opening all underlying RNTuples being processed in the chain, and could become costly!
    ROOT::NTupleSize_t GetNEntries() final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if a field exists on-disk and can be read by the processor.
+   ///
+   /// \sa RNTupleProcessor::CanReadFieldFromDisk()
+   bool CanReadFieldFromDisk(std::string_view fieldName) final
+   {
+      return fInnerProcessors[fCurrentProcessorNumber]->CanReadFieldFromDisk(fieldName);
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a field to the entry.
+   ///
+   /// \sa RNTupleProcessor::AddFieldToEntry()
+   ROOT::RResult<Internal::RNTupleProcessorEntry::FieldIndex_t>
+   AddFieldToEntry(std::string_view fieldName, void *valuePtr = nullptr, std::string_view auxFieldPrefix = "") final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Add the entry mappings for this processor to the provided join table.
@@ -479,15 +710,11 @@ private:
    /// \brief Construct a new RNTupleChainProcessor.
    ///
    /// \param[in] ntuples The source specification (name and storage location) for each RNTuple to process.
-   /// \param[in] model The model that specifies which fields should be read by the processor. The pointer returned by
-   /// RNTupleModel::MakeField can be used to access a field's value during the processor iteration. When no model is
-   /// specified, it is created from the descriptor of the first RNTuple specified in `ntuples`.
    /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateChain, this
    /// is the name of the first inner processor.
    ///
    /// RNTuples are processed in the order in which they are specified.
-   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors,
-                         std::unique_ptr<ROOT::RNTupleModel> model, std::string_view processorName);
+   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName);
 
 public:
    RNTupleChainProcessor(const RNTupleChainProcessor &) = delete;
@@ -511,10 +738,24 @@ private:
    std::unique_ptr<RNTupleProcessor> fPrimaryProcessor;
    std::unique_ptr<RNTupleProcessor> fAuxiliaryProcessor;
 
-   /// Tokens representing the join fields present in the primary processor.
-   std::vector<ROOT::RFieldToken> fJoinFieldTokens;
+   std::vector<std::string> fJoinFieldNames;
+   std::set<Internal::RNTupleProcessorEntry::FieldIndex_t> fJoinFieldIdxs;
+
    std::unique_ptr<Internal::RNTupleJoinTable> fJoinTable;
    bool fJoinTableIsBuilt = false;
+
+   std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> fAuxiliaryFieldIdxs;
+
+   /// \brief Initialize the processor, by setting `fProtoModel` and creating an (initially empty) `fEntry`, or setting
+   /// an existing one.
+   void Initialize(std::shared_ptr<Internal::RNTupleProcessorEntry> entry = nullptr) final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Connect fields to the page source of the processor's underlying RNTuple(s).
+   ///
+   /// \sa RNTupleProcessor::Connect()
+   void Connect(const std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+                bool updateFields = false) final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Load the entry identified by the provided entry number of the primary processor.
@@ -523,29 +764,51 @@ private:
    ROOT::NTupleSize_t LoadEntry(ROOT::NTupleSize_t entryNumber) final;
 
    /////////////////////////////////////////////////////////////////////////////
-   /// \sa ROOT::Experimental::RNTupleProcessor::SetEntryPointers.
-   void SetEntryPointers(const ROOT::REntry &, std::string_view fieldNamePrefix) final;
-
-   /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries in this processor.
    ROOT::NTupleSize_t GetNEntries() final;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Set the processor's proto model by combining the primary and auxiliary models.
+   ///
+   /// \param[in] primaryModel The proto model of the primary processor.
+   /// \param[in] auxModel The proto model of the auxiliary processors.
+   ///
+   /// To prevent field name clashes when one or more models have fields with duplicate names, fields from each
+   /// auxiliary model are stored as a anonymous record, and subsequently registered as subfields in the join model.
+   /// This way, they can be accessed from the processor's entry as `auxNTupleName.fieldName`.
+   void SetProtoModel(std::unique_ptr<ROOT::RNTupleModel> primaryModel, std::unique_ptr<ROOT::RNTupleModel> auxModel);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Set the validity for all fields in the auxiliary processor at once.
+   void SetAuxiliaryFieldValidity(bool validity);
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check if a field exists on-disk and can be read by the processor.
+   ///
+   /// \sa RNTupleProcessor::CanReadFieldFromDisk()
+   bool CanReadFieldFromDisk(std::string_view fieldName) final
+   {
+      if (!fPrimaryProcessor->CanReadFieldFromDisk(fieldName)) {
+         if (fieldName.find(fAuxiliaryProcessor->GetProcessorName()) == 0)
+            fieldName = fieldName.substr(fAuxiliaryProcessor->GetProcessorName().size() + 1);
+         return fAuxiliaryProcessor->CanReadFieldFromDisk(fieldName);
+      }
+
+      return true;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a field to the entry.
+   ///
+   /// \sa RNTupleProcessor::AddFieldToEntry()
+   ROOT::RResult<Internal::RNTupleProcessorEntry::FieldIndex_t>
+   AddFieldToEntry(std::string_view fieldName, void *valuePtr = nullptr, std::string_view auxFieldPrefix = "") final;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Add the entry mappings for this processor to the provided join table.
    ///
    /// \sa ROOT::Experimental::RNTupleProcessor::AddEntriesToJoinTable
    void AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable, ROOT::NTupleSize_t entryOffset = 0) final;
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Set fModel by combining the primary and auxiliary models.
-   ///
-   /// \param[in] primaryModel The model of the primary processor.
-   /// \param[in] auxModel Model of the auxiliary processors.
-   ///
-   /// To prevent field name clashes when one or more models have fields with duplicate names, fields from each
-   /// auxiliary model are stored as a anonymous record, and subsequently registered as subfields in the join model.
-   /// This way, they can be accessed from the processor's entry as `auxNTupleName.fieldName`.
-   void SetModel(std::unique_ptr<ROOT::RNTupleModel> primaryModel, std::unique_ptr<ROOT::RNTupleModel> auxModel);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Processor-specific implementation for printing its structure, called by PrintStructure().
@@ -561,15 +824,10 @@ private:
    /// \param[in] joinFields The names of the fields on which to join, in case the specified processors are unaligned.
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified processor. If an empty list is provided, it is assumed that the processors are fully aligned.
-   /// \param[in] primaryModel An RNTupleModel specifying which fields from the primary processor can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the primary processor.
-   /// \param[in] auxModel An RNTupleModel specifying which fields from the auxiliary processor can be read by the
-   /// processor. If no model is provided, one will be created based on the descriptor of the auxiliary processor.
    /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateJoin, this
    /// is the name of the primary processor.
    RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                         std::unique_ptr<RNTupleProcessor> auxProcessor, const std::vector<std::string> &joinFields,
-                        std::unique_ptr<ROOT::RNTupleModel> primaryModel, std::unique_ptr<ROOT::RNTupleModel> auxModel,
                         std::string_view processorName);
 
 public:

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -433,7 +433,7 @@ public:
       ROOT::NTupleSize_t fCurrentEntryNumber;
 
    public:
-      using iterator_category = std::forward_iterator_tag;
+      using iterator_category = std::input_iterator_tag;
       using iterator = RIterator;
       using value_type = ROOT::NTupleSize_t;
       using difference_type = std::ptrdiff_t;

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -237,10 +237,10 @@ public:
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
-      using value_type = ROOT::REntry;
+      using value_type = ROOT::NTupleSize_t;
       using difference_type = std::ptrdiff_t;
-      using pointer = ROOT::REntry *;
-      using reference = const ROOT::REntry &;
+      using pointer = ROOT::NTupleSize_t *;
+      using reference = ROOT::NTupleSize_t &;
 
       RIterator(RNTupleProcessor &processor, ROOT::NTupleSize_t entryNumber)
          : fProcessor(processor), fCurrentEntryNumber(entryNumber)
@@ -265,7 +265,7 @@ public:
          return obj;
       }
 
-      reference operator*() { return fProcessor.GetEntry(); }
+      reference operator*() { return fCurrentEntryNumber; }
 
       friend bool operator!=(const iterator &lh, const iterator &rh)
       {

--- a/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
@@ -1,0 +1,236 @@
+/// \file ROOT/RNTupleProcessor.hxx
+/// \ingroup NTuple
+/// \author Florine de Geus <florine.de.geus@cern.ch>
+/// \date 2025-06-25
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2024, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RNTupleProcessorEntry
+#define ROOT_RNTupleProcessorEntry
+
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RFieldBase.hxx>
+
+#include <cassert>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+// clang-format off
+/**
+\class ROOT::Experimental::Internal::RNTupleProcessorEntry
+\ingroup NTuple
+\brief Collection of values in an RNTupleProcessor, analogous to REntry, with checks and support for missing values.
+*/
+// clang-format on
+class RNTupleProcessorEntry {
+public:
+   // We don't use RFieldTokens here, because it (semantically) does not make sense for the entry to be fixed to the
+   // schema ID of a particular model.
+   using FieldIndex_t = std::uint64_t;
+
+private:
+   struct RProcessorValue {
+      ROOT::RFieldBase::RValue fValue;
+      bool fIsValid;
+
+      RProcessorValue(ROOT::RFieldBase::RValue &&value, bool isValid) : fValue(std::move(value)), fIsValid(isValid) {}
+   };
+
+   std::vector<RProcessorValue> fProcessorValues;
+   std::unordered_map<std::string, FieldIndex_t> fFieldName2Index;
+   std::unordered_set<FieldIndex_t> fAuxiliaryFields;
+
+public:
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Set the validity of a field, i.e. whether it is possible to read its value in the current entry.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   /// \param[in] isValid The new validity of the field.
+   void SetFieldValidity(FieldIndex_t fieldIdx, bool isValid)
+   {
+      assert(fieldIdx < fProcessorValues.size());
+      fProcessorValues[fieldIdx].fIsValid = isValid;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check whether a field is valid for reading.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   bool IsValidField(FieldIndex_t fieldIdx) const
+   {
+      assert(fieldIdx < fProcessorValues.size());
+      return fProcessorValues[fieldIdx].fIsValid;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Check whether a field is auxiliary.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   bool FieldIsAuxiliary(FieldIndex_t fieldIdx) const
+   {
+      return fAuxiliaryFields.find(fieldIdx) != fAuxiliaryFields.end();
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Find the name of a field from its field index.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   ///
+   /// \warning This function has linear complexity, only use it for more helpful error messages!
+   const std::string &FindFieldName(FieldIndex_t fieldIdx) const
+   {
+      assert(fieldIdx < fProcessorValues.size());
+
+      for (const auto &[fieldName, index] : fFieldName2Index) {
+         if (index == fieldIdx) {
+            return fieldName;
+         }
+      }
+      // Should never happen, but avoid compiler warning about "returning reference to local temporary object".
+      R__ASSERT(false);
+      static const std::string empty = "";
+      return empty;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Find the field index of the provided field in the entry.
+   ///
+   /// \param[in] fieldName The name of the field in the entry.
+   ///
+   /// \return A `std::optional` containing the field index if it was found.
+   std::optional<FieldIndex_t> FindFieldIndex(std::string_view fieldName) const
+   {
+      auto it = fFieldName2Index.find(std::string(fieldName));
+      if (it == fFieldName2Index.end()) {
+         return std::nullopt;
+      }
+      return it->second;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a new field to the entry.
+   ///
+   /// \param[in] fieldName Name of the field to add.
+   /// \param[in] field Reference to the field to add, used to to create its corresponding RValue.
+   /// \param[in] valuePtr Pointer to an object corresponding to the field's type to bind to its value. If this is a
+   /// `nullptr`, a pointer will be created.
+   /// \param[in] isAuxiliary Whether the field is auxiliary.
+   ///
+   /// \return The field index of the newly added field.
+   FieldIndex_t AddField(std::string_view fieldName, ROOT::RFieldBase &field, void *valuePtr, bool isAuxiliary = false)
+   {
+      if (FindFieldIndex(fieldName))
+         throw ROOT::RException(
+            R__FAIL("field \"" + field.GetQualifiedFieldName() + "\" is already present in the entry"));
+
+      auto value = field.CreateValue();
+      if (valuePtr)
+         value.BindRawPtr(valuePtr);
+      auto fieldIdx = fProcessorValues.size();
+      fFieldName2Index[std::string(fieldName)] = fieldIdx;
+      fProcessorValues.emplace_back(RProcessorValue(std::move(value), true));
+      if (isAuxiliary)
+         fAuxiliaryFields.insert(fieldIdx);
+
+      return fieldIdx;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Update a field in the entry, preserving the value pointer.
+   ///
+   /// \param[in] fieldIdx Index of the field to update.
+   /// \param[in] field The new field to use in the entry.
+   void UpdateField(FieldIndex_t fieldIdx, ROOT::RFieldBase &field)
+   {
+      assert(fieldIdx < fProcessorValues.size());
+
+      auto currValuePtr = fProcessorValues[fieldIdx].fValue.GetPtr<void>();
+      auto value = field.CreateValue();
+      value.Bind(currValuePtr);
+      fProcessorValues[fieldIdx].fValue = value;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Bind a new value pointer to a field in the entry.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   /// \param[in] valuePtr Pointer to the value to bind to the field.
+   void BindRawPtr(FieldIndex_t fieldIdx, void *valuePtr)
+   {
+      assert(fieldIdx < fProcessorValues.size());
+      fProcessorValues[fieldIdx].fValue.BindRawPtr(valuePtr);
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Read the field value corresponding to the given field index for the provided entry index.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   /// \param[in] entryIdx The entry number to read.
+   void ReadValue(FieldIndex_t fieldIdx, ROOT::NTupleSize_t entryIdx)
+   {
+      assert(fieldIdx < fProcessorValues.size());
+
+      if (fProcessorValues[fieldIdx].fIsValid) {
+         fProcessorValues[fieldIdx].fValue.Read(entryIdx);
+      }
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a pointer to the value for the field represented by the provided field index.
+   ///
+   /// \tparam T The type of the pointer.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   ///
+   /// \return A shared pointer of type `T` with the field's value.
+   template <typename T>
+   std::shared_ptr<T> GetPtr(FieldIndex_t fieldIdx) const
+   {
+      assert(fieldIdx < fProcessorValues.size());
+
+      if (fProcessorValues[fieldIdx].fIsValid)
+         return fProcessorValues[fieldIdx].fValue.GetPtr<T>();
+
+      return nullptr;
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get a reference to a field in the entry.
+   ///
+   /// \param[in] fieldIdx The index of the field in the entry.
+   const ROOT::RFieldBase &GetField(FieldIndex_t fieldIdx) const
+   {
+      assert(fieldIdx < fProcessorValues.size());
+      return fProcessorValues[fieldIdx].fValue.GetField();
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get all field indices of this entry.
+   std::unordered_set<FieldIndex_t> GetFieldIndices() const
+   {
+      // Field indices are sequentially assigned, and the entry (currently) offers no way to remove fields, so we can
+      // just generate and return a set {0, ..., |fProcessorValues| - 1}.
+      std::unordered_set<FieldIndex_t> fieldIdxs(fProcessorValues.size());
+      std::generate_n(std::inserter(fieldIdxs, fieldIdxs.begin()), fProcessorValues.size(),
+                      [i = 0]() mutable { return i++; });
+      return fieldIdxs;
+   }
+};
+} // namespace Internal
+} // namespace Experimental
+} // namespace ROOT
+
+#endif // ROOT_RNTupleProcessorEntry

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -35,17 +35,13 @@ std::unique_ptr<ROOT::Internal::RPageSource> ROOT::Experimental::RNTupleOpenSpec
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
-ROOT::Experimental::RNTupleProcessor::Create(RNTupleOpenSpec ntuple, std::unique_ptr<ROOT::RNTupleModel> model,
-                                             std::string_view processorName)
+ROOT::Experimental::RNTupleProcessor::Create(RNTupleOpenSpec ntuple, std::string_view processorName)
 {
-   return std::unique_ptr<RNTupleSingleProcessor>(
-      new RNTupleSingleProcessor(std::move(ntuple), std::move(model), processorName));
+   return std::unique_ptr<RNTupleSingleProcessor>(new RNTupleSingleProcessor(std::move(ntuple), processorName));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
-ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> ntuples,
-                                                  std::unique_ptr<ROOT::RNTupleModel> model,
-                                                  std::string_view processorName)
+ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> ntuples, std::string_view processorName)
 {
    if (ntuples.empty())
       throw RException(R__FAIL("at least one RNTuple must be provided"));
@@ -53,42 +49,26 @@ ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> n
    std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors;
    innerProcessors.reserve(ntuples.size());
 
-   // If no model is provided, infer it from the first ntuple.
-   if (!model) {
-      auto firstPageSource = ntuples[0].CreatePageSource();
-      firstPageSource->Attach();
-      model = firstPageSource->GetSharedDescriptorGuard()->CreateModel();
-   }
-
    for (auto &ntuple : ntuples) {
-      innerProcessors.emplace_back(Create(std::move(ntuple), model->Clone()));
+      innerProcessors.emplace_back(Create(std::move(ntuple)));
    }
 
-   return CreateChain(std::move(innerProcessors), std::move(model), processorName);
+   return CreateChain(std::move(innerProcessors), processorName);
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
-                                                  std::unique_ptr<ROOT::RNTupleModel> model,
                                                   std::string_view processorName)
 {
    if (innerProcessors.empty())
       throw RException(R__FAIL("at least one inner processor must be provided"));
 
-   // If no model is provided, infer it from the first inner processor.
-   if (!model) {
-      model = innerProcessors[0]->GetModel().Clone();
-   }
-
-   return std::unique_ptr<RNTupleChainProcessor>(
-      new RNTupleChainProcessor(std::move(innerProcessors), std::move(model), processorName));
+   return std::unique_ptr<RNTupleChainProcessor>(new RNTupleChainProcessor(std::move(innerProcessors), processorName));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateJoin(RNTupleOpenSpec primaryNTuple, RNTupleOpenSpec auxNTuple,
                                                  const std::vector<std::string> &joinFields,
-                                                 std::unique_ptr<ROOT::RNTupleModel> primaryModel,
-                                                 std::unique_ptr<ROOT::RNTupleModel> auxModel,
                                                  std::string_view processorName)
 {
    if (joinFields.size() > 4) {
@@ -99,26 +79,18 @@ ROOT::Experimental::RNTupleProcessor::CreateJoin(RNTupleOpenSpec primaryNTuple, 
       throw RException(R__FAIL("join fields must be unique"));
    }
 
-   std::unique_ptr<RNTupleProcessor> primaryProcessor;
-   if (primaryModel)
-      primaryProcessor = Create(primaryNTuple, primaryModel->Clone(), processorName);
-   else
-      primaryProcessor = Create(primaryNTuple, nullptr, processorName);
+   std::unique_ptr<RNTupleProcessor> primaryProcessor = Create(primaryNTuple, processorName);
 
-   std::unique_ptr<RNTupleProcessor> auxProcessor;
-   if (auxModel)
-      auxProcessor = Create(auxNTuple, auxModel->Clone());
-   else
-      auxProcessor = Create(auxNTuple);
+   std::unique_ptr<RNTupleProcessor> auxProcessor = Create(auxNTuple);
 
-   return CreateJoin(std::move(primaryProcessor), std::move(auxProcessor), joinFields, std::move(primaryModel),
-                     std::move(auxModel), processorName);
+   return CreateJoin(std::move(primaryProcessor), std::move(auxProcessor), joinFields, processorName);
 }
 
-std::unique_ptr<ROOT::Experimental::RNTupleProcessor> ROOT::Experimental::RNTupleProcessor::CreateJoin(
-   std::unique_ptr<RNTupleProcessor> primaryProcessor, std::unique_ptr<RNTupleProcessor> auxProcessor,
-   const std::vector<std::string> &joinFields, std::unique_ptr<ROOT::RNTupleModel> primaryModel,
-   std::unique_ptr<ROOT::RNTupleModel> auxModel, std::string_view processorName)
+std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
+ROOT::Experimental::RNTupleProcessor::CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor,
+                                                 std::unique_ptr<RNTupleProcessor> auxProcessor,
+                                                 const std::vector<std::string> &joinFields,
+                                                 std::string_view processorName)
 {
    if (joinFields.size() > 4) {
       throw RException(R__FAIL("a maximum of four join fields is allowed"));
@@ -129,100 +101,133 @@ std::unique_ptr<ROOT::Experimental::RNTupleProcessor> ROOT::Experimental::RNTupl
    }
 
    return std::unique_ptr<RNTupleJoinProcessor>(
-      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessor), joinFields,
-                               std::move(primaryModel), std::move(auxModel), processorName));
+      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessor), joinFields, processorName));
 }
 
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(RNTupleOpenSpec ntuple,
-                                                                   std::unique_ptr<ROOT::RNTupleModel> model,
                                                                    std::string_view processorName)
-   : RNTupleProcessor(processorName, std::move(model)), fNTupleSpec(std::move(ntuple))
+   : RNTupleProcessor(processorName), fNTupleSpec(std::move(ntuple))
 {
-   if (!fModel) {
-      fPageSource = fNTupleSpec.CreatePageSource();
-      fPageSource->Attach();
-      fModel = fPageSource->GetSharedDescriptorGuard()->CreateModel();
-   }
-
    if (fProcessorName.empty()) {
       fProcessorName = fNTupleSpec.fNTupleName;
    }
+}
 
-   fModel->Freeze();
-   fEntry = fModel->CreateEntry();
+void ROOT::Experimental::RNTupleSingleProcessor::Initialize(
+   std::shared_ptr<ROOT::Experimental::Internal::RNTupleProcessorEntry> entry)
+{
+   // The processor has already been initialized.
+   if (IsInitialized())
+      return;
 
-   for (const auto &value : *fEntry) {
-      auto &field = value.GetField();
-      auto token = fEntry->GetToken(field.GetFieldName());
+   if (!entry)
+      fEntry = std::make_shared<Internal::RNTupleProcessorEntry>();
+   else
+      fEntry = entry;
 
-      // If the model has a default entry, use the value pointers from the entry in the entry managed by the
-      // processor. This way, the pointers returned by RNTupleModel::MakeField can be used in the processor loop
-      // to access the corresponding field values.
-      if (!fModel->IsBare()) {
-         auto valuePtr = fModel->GetDefaultEntry().GetPtr<void>(token);
-         fEntry->BindValue(token, valuePtr);
+   fPageSource = fNTupleSpec.CreatePageSource();
+   fPageSource->Attach();
+   ROOT::RNTupleDescriptor::RCreateModelOptions opts;
+   opts.SetCreateBare(true);
+   fProtoModel = fPageSource->GetSharedDescriptorGuard()->CreateModel(opts);
+   fProtoModel->Unfreeze();
+}
+
+bool ROOT::Experimental::RNTupleSingleProcessor::CanReadFieldFromDisk(std::string_view fieldName)
+{
+   Initialize();
+   auto desc = fPageSource->GetSharedDescriptorGuard();
+   auto fieldZeroId = desc->GetFieldZeroId();
+
+   // TODO handle subfields
+   return desc->FindFieldId(fieldName, fieldZeroId) != ROOT::kInvalidDescriptorId;
+}
+
+ROOT::RResult<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t>
+ROOT::Experimental::RNTupleSingleProcessor::AddFieldToEntry(std::string_view fieldName, void *valuePtr,
+                                                            std::string_view auxFieldPrefix)
+{
+   auto fieldIdx = fEntry->FindFieldIndex(fieldName);
+   if (!fieldIdx) {
+      try {
+         if (!auxFieldPrefix.empty()) {
+            auto strippedFieldName = fieldName.substr(auxFieldPrefix.size() + 1);
+            auto &field = fProtoModel->GetMutableField(strippedFieldName);
+            fieldIdx = fEntry->AddField(fieldName, field, valuePtr, /*isAuxiliary=*/true);
+            return *fieldIdx;
+         }
+
+         auto &field = fProtoModel->GetMutableField(fieldName);
+         fieldIdx = fEntry->AddField(fieldName, field, valuePtr);
+         return *fieldIdx;
+      } catch (const ROOT::RException &) {
+         return R__FAIL("cannot register field with name \"" + std::string(fieldName) +
+                        "\" because it is not present in the on-disk information of the RNTuple(s) this "
+                        "processor is created from");
       }
+   } else {
+      return *fieldIdx;
    }
 }
 
 ROOT::NTupleSize_t ROOT::Experimental::RNTupleSingleProcessor::LoadEntry(ROOT::NTupleSize_t entryNumber)
 {
-   Connect();
-
-   if (entryNumber >= fNEntries)
+   if (entryNumber >= fNEntries || !fEntry)
       return kInvalidNTupleIndex;
 
-   fEntry->Read(entryNumber);
+   for (auto fieldIdx : fFieldIdxs) {
+      fEntry->ReadValue(fieldIdx, entryNumber);
+   }
 
    fNEntriesProcessed++;
    fCurrentEntryNumber = entryNumber;
    return entryNumber;
 }
 
-void ROOT::Experimental::RNTupleSingleProcessor::SetEntryPointers(const ROOT::REntry &entry,
-                                                                  std::string_view fieldNamePrefix)
+void ROOT::Experimental::RNTupleSingleProcessor::Connect(
+   const std::unordered_set<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+   bool updateFields)
 {
-   for (const auto &value : *fEntry) {
-      std::string fieldName = value.GetField().GetQualifiedFieldName();
-      auto valuePtr = fieldNamePrefix.empty() ? entry.GetPtr<void>(fieldName)
-                                              : entry.GetPtr<void>(std::string(fieldNamePrefix) + "." + fieldName);
+   Initialize();
 
-      fEntry->BindValue(fieldName, valuePtr);
-   }
-}
-
-void ROOT::Experimental::RNTupleSingleProcessor::Connect()
-{
    // The processor has already been connected.
-   if (fNEntries != kInvalidNTupleIndex)
+   if (fNEntries != kInvalidNTupleIndex && !updateFields)
       return;
 
-   if (!fPageSource)
-      fPageSource = fNTupleSpec.CreatePageSource();
-   fPageSource->Attach();
+   fFieldIdxs = fieldIdxs;
    fNEntries = fPageSource->GetNEntries();
 
    auto desc = fPageSource->GetSharedDescriptorGuard();
-   auto &fieldZero = ROOT::Internal::GetFieldZeroOfModel(*fModel);
+   auto &fieldZero = ROOT::Internal::GetFieldZeroOfModel(*fProtoModel);
    auto fieldZeroId = desc->GetFieldZeroId();
    fieldZero.SetOnDiskId(fieldZeroId);
    ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, true);
 
-   for (auto &field : fieldZero.GetMutableSubfields()) {
-      auto onDiskId = desc->FindFieldId(field->GetQualifiedFieldName(), fieldZeroId);
+   for (const auto &fieldIdx : fieldIdxs) {
+      const auto &entryField = fEntry->GetField(fieldIdx);
+
+      // TODO handle subfields
+      auto onDiskId = desc->FindFieldId(entryField.GetQualifiedFieldName(), fieldZeroId);
       // The field we are trying to connect is not present in the ntuple
       if (onDiskId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("field \"" + field->GetQualifiedFieldName() + "\" not found in the current RNTuple"));
+         fEntry->SetFieldValidity(fieldIdx, false);
+         continue;
       }
 
-      // The field will already have an on-disk ID when the model was inferred from the page source because the user
-      // didn't provide a model themselves.
-      if (field->GetOnDiskId() == kInvalidDescriptorId)
-         field->SetOnDiskId(onDiskId);
+      auto &modelField = fProtoModel->GetMutableField(entryField.GetQualifiedFieldName());
 
-      ROOT::Internal::CallConnectPageSourceOnField(*field, *fPageSource);
+      if (entryField.GetState() == RFieldBase::EState::kConnectedToSource && &entryField != &modelField) {
+         fEntry->UpdateField(fieldIdx, modelField);
+      }
+
+      if (modelField.GetState() == RFieldBase::EState::kUnconnected) {
+         modelField.SetOnDiskId(onDiskId);
+         ROOT::Internal::CallConnectPageSourceOnField(modelField, *fPageSource);
+      }
+
+      fEntry->SetFieldValidity(fieldIdx, true);
    }
    ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, false);
 }
@@ -230,7 +235,7 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 void ROOT::Experimental::RNTupleSingleProcessor::AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable,
                                                                        ROOT::NTupleSize_t entryOffset)
 {
-   Connect();
+   Connect(fFieldIdxs);
    joinTable.Add(*fPageSource, Internal::RNTupleJoinTable::kDefaultPartitionKey, entryOffset);
 }
 
@@ -261,9 +266,8 @@ void ROOT::Experimental::RNTupleSingleProcessor::PrintStructureImpl(std::ostream
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
-   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::unique_ptr<ROOT::RNTupleModel> model,
-   std::string_view processorName)
-   : RNTupleProcessor(processorName, std::move(model)), fInnerProcessors(std::move(processors))
+   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName)
+   : RNTupleProcessor(processorName), fInnerProcessors(std::move(processors))
 {
    if (fProcessorName.empty()) {
       // `CreateChain` ensures there is at least one inner processor.
@@ -271,26 +275,21 @@ ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
    }
 
    fInnerNEntries.assign(fInnerProcessors.size(), kInvalidNTupleIndex);
+}
 
-   fModel->Freeze();
-   fEntry = fModel->CreateEntry();
+void ROOT::Experimental::RNTupleChainProcessor::Initialize(
+   std::shared_ptr<ROOT::Experimental::Internal::RNTupleProcessorEntry> entry)
+{
+   if (IsInitialized())
+      return;
 
-   for (const auto &value : *fEntry) {
-      auto &field = value.GetField();
-      auto token = fEntry->GetToken(field.GetQualifiedFieldName());
+   if (!entry)
+      fEntry = std::make_shared<Internal::RNTupleProcessorEntry>();
+   else
+      fEntry = entry;
 
-      // If the model has a default entry, use the value pointers from the entry in the entry managed by the
-      // processor. This way, the pointers returned by RNTupleModel::MakeField can be used in the processor loop
-      // to access the corresponding field values.
-      if (!fModel->IsBare()) {
-         auto valuePtr = fModel->GetDefaultEntry().GetPtr<void>(token);
-         fEntry->BindValue(token, valuePtr);
-      }
-   }
-
-   for (auto &innerProc : fInnerProcessors) {
-      innerProc->SetEntryPointers(*fEntry);
-   }
+   fInnerProcessors[0]->Initialize(fEntry);
+   fProtoModel = fInnerProcessors[0]->GetProtoModel().Clone();
 }
 
 ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::GetNEntries()
@@ -310,44 +309,56 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::GetNEntries()
    return fNEntries;
 }
 
-void ROOT::Experimental::RNTupleChainProcessor::SetEntryPointers(const ROOT::REntry &entry,
-                                                                 std::string_view fieldNamePrefix)
+void ROOT::Experimental::RNTupleChainProcessor::Connect(
+   const std::unordered_set<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+   bool /* updateFields */)
 {
-   for (const auto &value : *fEntry) {
-      std::string fieldName = value.GetField().GetQualifiedFieldName();
-      auto valuePtr = fieldNamePrefix.empty() ? entry.GetPtr<void>(fieldName)
-                                              : entry.GetPtr<void>(std::string(fieldNamePrefix) + "." + fieldName);
+   Initialize();
+   fFieldIdxs = fieldIdxs;
+   ConnectInnerProcessor(fCurrentProcessorNumber);
+}
 
-      fEntry->BindValue(fieldName, valuePtr);
-   }
+void ROOT::Experimental::RNTupleChainProcessor::ConnectInnerProcessor(std::size_t processorNumber)
+{
+   auto &innerProc = fInnerProcessors[processorNumber];
+   innerProc->Initialize(fEntry);
+   innerProc->Connect(fFieldIdxs, /*updateFields=*/true);
+}
 
-   for (auto &innerProc : fInnerProcessors) {
-      innerProc->SetEntryPointers(entry, fieldNamePrefix);
-   }
+ROOT::RResult<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t>
+ROOT::Experimental::RNTupleChainProcessor::AddFieldToEntry(std::string_view fieldName, void *valuePtr,
+                                                           std::string_view auxFieldPrefix)
+{
+   return R__FORWARD_RESULT(
+      fInnerProcessors[fCurrentProcessorNumber]->AddFieldToEntry(fieldName, valuePtr, auxFieldPrefix));
 }
 
 ROOT::NTupleSize_t ROOT::Experimental::RNTupleChainProcessor::LoadEntry(ROOT::NTupleSize_t entryNumber)
 {
    ROOT::NTupleSize_t localEntryNumber = entryNumber;
-   size_t currProcessor = 0;
+   std::size_t currProcessorNumber = 0;
+   if (entryNumber < fCurrentEntryNumber) {
+      fCurrentProcessorNumber = 0;
+      ConnectInnerProcessor(fCurrentProcessorNumber);
+   }
 
    // As long as the entry fails to load from the current processor, we decrement the local entry number with the number
    // of entries in this processor and try with the next processor until we find the correct local entry number.
-   while (fInnerProcessors[currProcessor]->LoadEntry(localEntryNumber) == kInvalidNTupleIndex) {
-      if (fInnerNEntries[currProcessor] == kInvalidNTupleIndex) {
-         fInnerNEntries[currProcessor] = fInnerProcessors[currProcessor]->GetNEntries();
+   while (fInnerProcessors[currProcessorNumber]->LoadEntry(localEntryNumber) == kInvalidNTupleIndex) {
+      if (fInnerNEntries[currProcessorNumber] == kInvalidNTupleIndex) {
+         fInnerNEntries[currProcessorNumber] = fInnerProcessors[currProcessorNumber]->GetNEntries();
       }
 
-      localEntryNumber -= fInnerNEntries[currProcessor];
+      localEntryNumber -= fInnerNEntries[currProcessorNumber];
 
       // The provided global entry number is larger than the number of available entries.
-      if (++currProcessor >= fInnerProcessors.size())
+      if (++currProcessorNumber >= fInnerProcessors.size())
          return kInvalidNTupleIndex;
+
+      ConnectInnerProcessor(currProcessorNumber);
    }
 
-   if (currProcessor != fCurrentProcessorNumber)
-      fCurrentProcessorNumber = currProcessor;
-
+   fCurrentProcessorNumber = currProcessorNumber;
    fNEntriesProcessed++;
    fCurrentEntryNumber = entryNumber;
    return entryNumber;
@@ -358,6 +369,9 @@ void ROOT::Experimental::RNTupleChainProcessor::AddEntriesToJoinTable(Internal::
 {
    for (unsigned i = 0; i < fInnerProcessors.size(); ++i) {
       const auto &innerProc = fInnerProcessors[i];
+      // TODO can this be done (more) lazily? I.e. only when a match cannot be found in the current inner proc?
+      // At this stage, we don't want to fully initialize (i.e. set the entry of) the inner processor yet
+      innerProc->Initialize(nullptr);
       innerProc->AddEntriesToJoinTable(joinTable, entryOffset);
       entryOffset += innerProc->GetNEntries();
    }
@@ -394,80 +408,97 @@ public:
 };
 } // namespace ROOT::Experimental::Internal
 
+namespace {
+bool IsAuxiliaryField(std::string_view fieldName, std::string_view auxProcessorName)
+{
+   return fieldName.find(std::string(auxProcessorName) + ".") == 0;
+}
+} // anonymous namespace
+
 ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                                                                std::unique_ptr<RNTupleProcessor> auxProcessor,
                                                                const std::vector<std::string> &joinFields,
-                                                               std::unique_ptr<ROOT::RNTupleModel> primaryModel,
-                                                               std::unique_ptr<ROOT::RNTupleModel> auxModel,
                                                                std::string_view processorName)
-   : RNTupleProcessor(processorName, nullptr),
+   : RNTupleProcessor(processorName),
      fPrimaryProcessor(std::move(primaryProcessor)),
-     fAuxiliaryProcessor(std::move(auxProcessor))
+     fAuxiliaryProcessor(std::move(auxProcessor)),
+     fJoinFieldNames(joinFields)
 {
    if (fProcessorName.empty()) {
       fProcessorName = fPrimaryProcessor->GetProcessorName();
    }
+}
 
-   if (!primaryModel)
-      primaryModel = fPrimaryProcessor->GetModel().Clone();
-   if (!auxModel) {
-      auxModel = fAuxiliaryProcessor->GetModel().Clone();
-   }
+void ROOT::Experimental::RNTupleJoinProcessor::Initialize(
+   std::shared_ptr<ROOT::Experimental::Internal::RNTupleProcessorEntry> entry)
+{
+   if (IsInitialized())
+      return;
+
+   if (!entry)
+      fEntry = std::make_shared<Internal::RNTupleProcessorEntry>();
+   else
+      fEntry = entry;
+
+   fPrimaryProcessor->Initialize(fEntry);
+   fAuxiliaryProcessor->Initialize(fEntry);
 
    // If the primaryProcessor has a field with the name of the auxProcessor (either as a "proper" field or because the
    // primary processor itself is a join where its auxProcessor bears the same name as the current auxProcessor), there
    // will be name conflicts, so error out.
-   if (primaryModel->GetFieldNames().find(fAuxiliaryProcessor->GetProcessorName()) !=
-       primaryModel->GetFieldNames().end()) {
+   if (auto &primaryModel = fPrimaryProcessor->GetProtoModel();
+       primaryModel.GetFieldNames().find(fAuxiliaryProcessor->GetProcessorName()) !=
+       primaryModel.GetFieldNames().end()) {
       throw RException(R__FAIL("a field or nested auxiliary processor named \"" +
                                fAuxiliaryProcessor->GetProcessorName() +
-                               "\" is already present in the model of the primary processor; rename the auxiliary "
+                               "\" is already present as a field in the primary processor; rename the auxiliary "
                                "processor to avoid conflicts"));
    }
 
-   SetModel(std::move(primaryModel), std::move(auxModel));
+   SetProtoModel(fPrimaryProcessor->GetProtoModel().Clone(), fAuxiliaryProcessor->GetProtoModel().Clone());
 
-   fModel->Freeze();
-   fEntry = fModel->CreateEntry();
-
-   for (const auto &value : *fEntry) {
-      auto &field = value.GetField();
-      const auto &fieldName = field.GetQualifiedFieldName();
-
-      // If the model provided by the user has a default entry, use the value pointers from the default entry of the
-      // model that was passed to this constructor. This way, the pointers returned by RNTupleModel::MakeField can be
-      // used in the processor loop to access the corresponding field values.
-      if (!fModel->IsBare()) {
-         auto valuePtr = fModel->GetDefaultEntry().GetPtr<void>(fieldName);
-         fEntry->BindValue(fieldName, valuePtr);
-      }
-   }
-
-   fPrimaryProcessor->SetEntryPointers(*fEntry);
-   // FIXME(fdegeus): for nested auxiliary processors, simply passing the processor name is not sufficient because we
-   // also need the name(s) of the *inner* processor(s) (e.g., "ntuple0.ntuple1"). This means either (1) recursively
-   // infer this full name or (2) rethink the way fields in auxiliary processors together with how entries are
-   // currently set altogether.
-   fAuxiliaryProcessor->SetEntryPointers(*fEntry, fAuxiliaryProcessor->GetProcessorName());
-
-   if (!joinFields.empty()) {
-      for (const auto &joinField : joinFields) {
-         auto token = fEntry->GetToken(joinField);
-         fJoinFieldTokens.emplace_back(token);
+   if (!fJoinFieldNames.empty()) {
+      for (const auto &joinField : fJoinFieldNames) {
+         if (!fAuxiliaryProcessor->CanReadFieldFromDisk(joinField)) {
+            throw RException(R__FAIL("could not find join field \"" + joinField + "\" in auxiliary processor \"" +
+                                     fAuxiliaryProcessor->GetProcessorName() + "\""));
+         }
+         auto fieldIdx = AddFieldToEntry(joinField);
+         if (!fieldIdx)
+            throw RException(R__FAIL("could not find join field \"" + joinField + "\" in primary processor \"" +
+                                     fPrimaryProcessor->GetProcessorName() + "\""));
+         fJoinFieldIdxs.insert(fieldIdx.Unwrap());
       }
 
-      fJoinTable = Internal::RNTupleJoinTable::Create(joinFields);
+      fJoinTable = Internal::RNTupleJoinTable::Create(fJoinFieldNames);
    }
 }
 
-void ROOT::Experimental::RNTupleJoinProcessor::SetModel(std::unique_ptr<ROOT::RNTupleModel> primaryModel,
-                                                        std::unique_ptr<RNTupleModel> auxModel)
+void ROOT::Experimental::RNTupleJoinProcessor::Connect(
+   const std::unordered_set<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t> &fieldIdxs,
+   bool updateFields)
 {
-   fModel = std::move(primaryModel);
-   fModel->Unfreeze();
+   Initialize();
+
+   for (const auto &fieldIdx : fieldIdxs) {
+      if (fEntry->FieldIsAuxiliary(fieldIdx))
+         fAuxiliaryFieldIdxs.insert(fieldIdx);
+      else
+         fFieldIdxs.insert(fieldIdx);
+   }
+
+   fPrimaryProcessor->Connect(fFieldIdxs, updateFields);
+   fAuxiliaryProcessor->Connect(fAuxiliaryFieldIdxs, updateFields);
+}
+
+void ROOT::Experimental::RNTupleJoinProcessor::SetProtoModel(std::unique_ptr<ROOT::RNTupleModel> primaryModel,
+                                                             std::unique_ptr<RNTupleModel> auxModel)
+{
+   fProtoModel = std::move(primaryModel);
+   fProtoModel->Unfreeze();
 
    // Create an anonymous record field for the auxiliary processor, containing its top-level fields. These original
-   // top-level fields are registered as subfields in the join model, such that they can be accessed as
+   // top-level fields are registered as subfields in this processor's proto-model, such that they can be accessed as
    // `auxNTupleName.fieldName`.
    std::vector<std::unique_ptr<ROOT::RFieldBase>> auxFields;
    auxFields.reserve(auxModel->GetFieldNames().size());
@@ -479,62 +510,65 @@ void ROOT::Experimental::RNTupleJoinProcessor::SetModel(std::unique_ptr<ROOT::RN
    auto auxParentField = std::make_unique<Internal::RAuxiliaryProcessorField>(fAuxiliaryProcessor->GetProcessorName(),
                                                                               std::move(auxFields));
    const auto &subFields = auxParentField->GetConstSubfields();
-   fModel->AddField(std::move(auxParentField));
+   fProtoModel->AddField(std::move(auxParentField));
 
    for (const auto &field : subFields) {
-      fModel->RegisterSubfield(field->GetQualifiedFieldName());
+      fProtoModel->RegisterSubfield(field->GetQualifiedFieldName());
 
       if (field->GetTypeName() == "RAuxiliaryProcessorField") {
          for (const auto &auxSubField : field->GetConstSubfields()) {
-            fModel->RegisterSubfield(auxSubField->GetQualifiedFieldName());
+            fProtoModel->RegisterSubfield(auxSubField->GetQualifiedFieldName());
          }
       }
    }
-
-   // If the model has a default entry, adopt its value pointers. This way, the pointers returned by
-   // RNTupleModel::MakeField can be used in the processor loop to access the corresponding field values.
-   if (!fModel->IsBare() && !auxModel->IsBare()) {
-      const auto &auxDefaultEntry = auxModel->GetDefaultEntry();
-      auto &joinDefaultEntry = fModel->GetDefaultEntry();
-      for (const auto &fieldName : auxModel->GetFieldNames()) {
-         auto valuePtr = auxDefaultEntry.GetPtr<void>(fieldName);
-         joinDefaultEntry.BindValue(fAuxiliaryProcessor->GetProcessorName() + "." + fieldName, valuePtr);
-      }
-   }
-
-   fModel->Freeze();
 }
 
-void ROOT::Experimental::RNTupleJoinProcessor::SetEntryPointers(const ROOT::REntry &entry,
-                                                                std::string_view fieldNamePrefix)
+ROOT::RResult<ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t>
+ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(std::string_view fieldName, void *valuePtr,
+                                                          std::string_view auxFieldPrefix)
 {
-   for (const auto &value : *fEntry) {
-      std::string fieldName = value.GetField().GetQualifiedFieldName();
-      auto valuePtr = fieldNamePrefix.empty() ? entry.GetPtr<void>(fieldName)
-                                              : entry.GetPtr<void>(std::string(fieldNamePrefix) + "." + fieldName);
-
-      fEntry->BindValue(fieldName, valuePtr);
+   std::string updatedPrefix = auxFieldPrefix.empty()
+                                  ? fAuxiliaryProcessor->GetProcessorName()
+                                  : std::string(auxFieldPrefix) + "." + fAuxiliaryProcessor->GetProcessorName();
+   if (IsAuxiliaryField(fieldName, updatedPrefix)) {
+      std::string newPrefix = auxFieldPrefix.empty()
+                                 ? fAuxiliaryProcessor->GetProcessorName()
+                                 : fAuxiliaryProcessor->GetProcessorName() + "." + std::string(auxFieldPrefix);
+      auto fieldIdx = fAuxiliaryProcessor->AddFieldToEntry(fieldName, valuePtr, newPrefix);
+      if (fieldIdx)
+         fAuxiliaryFieldIdxs.insert(fieldIdx.Unwrap());
+      return R__FORWARD_RESULT(fieldIdx);
+   } else {
+      auto fieldIdx = fPrimaryProcessor->AddFieldToEntry(fieldName, valuePtr, auxFieldPrefix);
+      if (fieldIdx)
+         fFieldIdxs.insert(fieldIdx.Unwrap());
+      return R__FORWARD_RESULT(fieldIdx);
    }
+}
 
-   fPrimaryProcessor->SetEntryPointers(*fEntry);
-   fAuxiliaryProcessor->SetEntryPointers(*fEntry, fAuxiliaryProcessor->GetProcessorName());
+void ROOT::Experimental::RNTupleJoinProcessor::SetAuxiliaryFieldValidity(bool isValid)
+{
+   for (const auto &fieldIdx : fAuxiliaryFieldIdxs) {
+      fEntry->SetFieldValidity(fieldIdx, isValid);
+   }
 }
 
 ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTupleSize_t entryNumber)
 {
-   if (fPrimaryProcessor->LoadEntry(entryNumber) == kInvalidNTupleIndex)
+   if (fPrimaryProcessor->LoadEntry(entryNumber) == kInvalidNTupleIndex) {
+      for (auto fieldIdx : fFieldIdxs) {
+         fEntry->SetFieldValidity(fieldIdx, false);
+      }
+      SetAuxiliaryFieldValidity(false);
       return kInvalidNTupleIndex;
+   }
 
    fCurrentEntryNumber = entryNumber;
    fNEntriesProcessed++;
 
    if (!fJoinTable) {
-      if (fAuxiliaryProcessor->LoadEntry(entryNumber) == kInvalidNTupleIndex) {
-         throw RException(R__FAIL("entry " + std::to_string(entryNumber) +
-                                  " in the primary processor has no corresponding entry in auxiliary processor \"" +
-                                  fAuxiliaryProcessor->GetProcessorName() + "\""));
-      }
-
+      // The auxiliary processor's fields are valid if the entry could be loaded.
+      fAuxiliaryProcessor->LoadEntry(entryNumber);
       return entryNumber;
    }
 
@@ -545,9 +579,9 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
 
    // Collect the values of the join fields for this entry.
    std::vector<void *> valPtrs;
-   valPtrs.reserve(fJoinFieldTokens.size());
-   for (const auto &token : fJoinFieldTokens) {
-      auto ptr = fEntry->GetPtr<void>(token);
+   valPtrs.reserve(fJoinFieldIdxs.size());
+   for (const auto &fieldIdx : fJoinFieldIdxs) {
+      auto ptr = fEntry->GetPtr<void>(fieldIdx);
       valPtrs.push_back(ptr.get());
    }
 
@@ -555,12 +589,14 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
    // corresponding entry.
    const auto entryIdx = fJoinTable->GetEntryIndex(valPtrs);
 
-   if (entryIdx == kInvalidNTupleIndex)
-      throw RException(R__FAIL("entry " + std::to_string(entryNumber) +
-                               " in the primary processor has no corresponding entry in auxiliary processor \"" +
-                               fAuxiliaryProcessor->GetProcessorName() + "\""));
-
-   fAuxiliaryProcessor->LoadEntry(entryIdx);
+   if (entryIdx == kInvalidNTupleIndex) {
+      SetAuxiliaryFieldValidity(false);
+   } else {
+      SetAuxiliaryFieldValidity(true);
+      for (const auto &fieldIdx : fAuxiliaryFieldIdxs) {
+         fEntry->ReadValue(fieldIdx, entryIdx);
+      }
+   }
 
    return entryNumber;
 }

--- a/tree/ntuple/test/ntuple_join_table.cxx
+++ b/tree/ntuple/test/ntuple_join_table.cxx
@@ -274,42 +274,43 @@ TEST(RNTupleJoinTable, Partitions)
    }
    auto proc = RNTupleProcessor::CreateChain(openSpec);
 
-   auto i = proc->GetEntry().GetPtr<std::uint32_t>("i");
-   auto run = proc->GetEntry().GetPtr<int16_t>("run");
+   auto run = proc->RequestField<std::int16_t>("run");
+   auto i = proc->RequestField<std::uint32_t>("i");
+
+   std::uint32_t idx = 0;
 
    // When getting the entry indexes for all partitions, we expect multiple resulting entry indexes (i.e., one entry
    // index for each ntuple in the chain).
-   *i = 0;
    std::unordered_map<RNTupleJoinTable::PartitionKey_t, std::vector<ROOT::NTupleSize_t>> expectedEntryIdxMap = {
       {1, {0}},
       {2, {0}},
       {3, {0, 0}},
    };
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 2, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}, {1, 2, 3}));
 
    expectedEntryIdxMap = {
       {1, {0}},
       {3, {0, 0}},
    };
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}, {1, 3}));
 
    // Calling GetEntryIndexes with a partition key not present in the join table shouldn't fail; it should just return
    // an empty vector.
-   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({i.get()}, 4));
+   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({&idx}, 4));
 
    // Similarly, calling GetEntryIndexes with a partition key that is present in the join table but a join value that
    // isn't shouldn't fail; it should just return an empty vector.
-   *i = 99;
-   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({i.get()}, 3));
+   idx = 99;
+   EXPECT_EQ(std::vector<ROOT::NTupleSize_t>{}, joinTable->GetEntryIndexes({&idx}, 3));
 
    expectedEntryIdxMap.clear();
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 2, 3}));
-   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({i.get()}, {1, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}, {1, 2, 3}));
+   EXPECT_EQ(expectedEntryIdxMap, joinTable->GetPartitionedEntryIndexes({&idx}, {1, 3}));
 
    for (auto it = proc->begin(); it != proc->end(); it++) {
-      auto entryIdxs = joinTable->GetEntryIndexes({i.get()}, *run);
+      auto entryIdxs = joinTable->GetEntryIndexes({i.GetRawPtr()}, *run);
 
       // Because two ntuples store their events under run number 3 and their entries for `i` are identical, two entry
       // indexes are expected. For the other case (run == 1 and run == 2), only one entry index is expected.

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -32,7 +32,7 @@ protected:
          auto fldY = model->MakeField<std::vector<float>>("y");
          auto ntuple = RNTupleWriter::Recreate(std::move(model), fNTupleName, fFileNames[1]);
 
-         for (unsigned i = 5; i < 8; i++) {
+         for (unsigned i = 5; i < 10; i++) {
             *fldX = static_cast<float>(i);
             *fldY = {static_cast<float>(i), static_cast<float>(i * 2)};
             ntuple->Fill();
@@ -44,7 +44,7 @@ protected:
          // missing field y
          auto ntuple = RNTupleWriter::Recreate(std::move(model), fNTupleName, fFileNames[2]);
 
-         for (unsigned i = 8; i < 15; i++) {
+         for (unsigned i = 10; i < 15; i++) {
             *fldX = static_cast<float>(i);
             ntuple->Fill();
          }
@@ -120,7 +120,7 @@ TEST_F(RNTupleChainProcessorTest, Basic)
       std::vector<float> yExp = {static_cast<float>(idx), static_cast<float>((idx) * 2)};
       EXPECT_EQ(yExp, *y);
    }
-   EXPECT_EQ(8, proc->GetNEntriesProcessed());
+   EXPECT_EQ(10, proc->GetNEntriesProcessed());
 }
 
 TEST_F(RNTupleChainProcessorTest, WithModel)
@@ -212,7 +212,7 @@ TEST_F(RNTupleChainProcessorTest, EmptyNTuples)
    for (auto idx : *proc) {
       EXPECT_EQ(static_cast<float>(idx), *x);
    }
-   EXPECT_EQ(8, proc->GetNEntriesProcessed());
+   EXPECT_EQ(10, proc->GetNEntriesProcessed());
 }
 
 namespace ROOT::Experimental::Internal {
@@ -235,8 +235,8 @@ TEST_F(RNTupleChainProcessorTest, LoadRandomEntry)
    EXPECT_EQ(3.f, *x);
    EXPECT_EQ(0, proc->GetCurrentProcessorNumber());
 
-   RNTupleProcessorEntryLoader::LoadEntry(*proc, 7);
-   EXPECT_EQ(7.f, *x);
+   RNTupleProcessorEntryLoader::LoadEntry(*proc, 9);
+   EXPECT_EQ(9.f, *x);
    EXPECT_EQ(1, proc->GetCurrentProcessorNumber());
 
    RNTupleProcessorEntryLoader::LoadEntry(*proc, 6);
@@ -247,7 +247,7 @@ TEST_F(RNTupleChainProcessorTest, LoadRandomEntry)
    EXPECT_EQ(2.f, *x);
    EXPECT_EQ(0, proc->GetCurrentProcessorNumber());
 
-   EXPECT_EQ(ROOT::kInvalidNTupleIndex, RNTupleProcessorEntryLoader::LoadEntry(*proc, 8));
+   EXPECT_EQ(ROOT::kInvalidNTupleIndex, RNTupleProcessorEntryLoader::LoadEntry(*proc, 10));
 }
 
 TEST_F(RNTupleChainProcessorTest, TMemFile)

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -173,7 +173,7 @@ namespace ROOT::Experimental::Internal {
 struct RNTupleProcessorEntryLoader {
    static ROOT::NTupleSize_t LoadEntry(RNTupleProcessor &processor, ROOT::NTupleSize_t entryNumber)
    {
-      processor.Connect(processor.fEntry->GetFieldIndices(), /*updateEntry=*/false);
+      processor.Connect(processor.fEntry->GetFieldIndices(), RNTupleProcessorProvenance(), /*updateFields=*/false);
       return processor.LoadEntry(entryNumber);
    }
 


### PR DESCRIPTION
This PR adds a significant change to the way field values can be accessed from an `RNTupleProcessor`, and, under the hood, how the `RNTupleProcessor` handles the entries that manage these values. The motivation behind this change is that the current processor interface has two main shortcomings:
1. It is too flexible, allowing users to call `GetPtr` on the entry *inside* the event loop which is generally considered a bad practice.
2. It cannot properly handle values missing from entries as the result of an incomplete join or missing fields in subsequent chains.

To address these shortcomings, we introduce two new classes, the `RNTupleProcessorEntry` and the `RNTupleProcessorOptionalPtr`, which are described in more detail below. With the introduction of these classes, the use of the `RNTupleModel` is removed from the public interface entirely.

The changes in this PR are also in preparation of the use of the `RNTupleProcessor` as an RDataFrame data source. A minimal working example has been developed to validate that this new `RNTupleProcessor` interface is compatible with the abstract interface of `RDataSource`.

## The RNTupleProcessorEntry

The `RNTupleProcessorEntry` is an internal class that largely mirrors the `REntry` interface, but with additional functionality for the `RNTupleProcessor`. Most notably, fields and their values present in the entry have a notion of *validity*. Only when a field is valid, its value can be read.

In addition, it keeps track of which fields are auxiliary if a join operation is involved. This is needed in order to properly resolve from which underlying RNTuple the field data should be read. Since the RNTupleProcessor is composable, this is also relevant for the chain-based processor.

## The RNTupleProcessorOptionalPtr

The `RNTupleProcessorOptionalPtr` is what the user or upstream application will actually iteract with to read field values from a processor entry. It is obtained when registering a field in the processor through `RegisterField()`, which has to be done *before* and processor iteration starts (because, as stated before, afterwards the entry will be frozen).
The `RNTupleProcessorOptionalPtr` can be used to get a const reference or a pointer to the field's value. If the field is marked invalid in the entry at the time of access, the const reference access method will throw an exception, whereas the pointer access method returns a `nullptr`.

## Code example

### Old interface
```cpp
auto model = RNTupleModel::Create();
auto fldX = model->MakeField<float>("x");

auto proc =
  RNTupleProcessor::CreateChain({{"ntuple", "ntuple1.root"}, {"ntuple", "ntuple1.root"}}, std::move(model));

for (const auto &entry : *proc) {
  // Either (no way to guarantee the validity of `fldX` in this entry):
  std::cout << "x = " << *fldX << std::endl;
  // Or, same issue as above, plus expensive:
  std::cout << "x = " << entry.GetPtr<float>("x") << std::endl;
}
```

### New interface
```cpp
auto proc =
  RNTupleProcessor::CreateChain({{"ntuple", "ntuple1.root"}, {"ntuple", "ntuple1.root"}});

// Returns RNTupleProcessorOptionalPtr
auto x = proc->RequestField<float>("x");

// Instead of the full entry, now only provide the entry number as iterator value
for (const auto &idx : *proc) {
  // Without this check, `*x` will throw for entries where it is invalid.
  if (x.HasValue())
    std::cout << "x = " << *x << std::endl;
}
```

