### PR TITLE
[Python][UHI] Fix entry count after slicing operations

### DIFF
--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -300,6 +300,7 @@ class TestTH1Indexing:
         sliced_hist_full = hist_setup[...]
 
         assert hist_setup.GetEffectiveEntries() == sliced_hist_full.GetEffectiveEntries()
+        assert sliced_hist_full.GetEntries() == sliced_hist_full.GetEffectiveEntries()
         assert hist_setup.Integral() == sliced_hist_full.Integral()
 
         # Check if slicing over a range updates the statistics
@@ -310,6 +311,7 @@ class TestTH1Indexing:
 
         assert hist_setup.Integral() == sliced_hist.Integral()
         assert hist_setup.GetEffectiveEntries() == sliced_hist.GetEffectiveEntries()
+        assert sliced_hist.GetEntries() == sliced_hist.GetEffectiveEntries()
         assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), rel=10e-5)
         assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), rel=10e-5)
 

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -281,7 +281,6 @@ private:
 
       // Update the statistics
       ResetStats();
-      fEntries = std::accumulate(dataArray, dataArray + newSize, 0.0);
    }
 
    template <typename T>
@@ -359,7 +358,6 @@ private:
 
       // Update the statistics
       ResetStats();
-      fEntries += std::accumulate(values.begin(), values.end(), 0.0);
    }
 
    template <typename T>


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
When using UHI for slicing, `GetEntries()` value of a histogram did not correctly reflect the state after the operation.

Note that after this fix, calling `GetEntries()` on a sliced histogram will reflect the effective total count (the same value returned by `GetEffectiveEntries()`). 

The following:
```python
import ROOT

h = ROOT.TH1D("h", "h", 10, 0, 10)
h.SetBinContent(1, 5)

h_slice = h[...]

h.Print()
h_slice.Print()
```

Will output:
```
TH1.Print Name  = h, Entries= 1, Total sum= 5
TH1.Print Name  = h, Entries= 5, Total sum= 5
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #19113

