### PR TITLE
Fix hardware_destructive_interference_size across TUs.

### DIFF
--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -43,7 +43,6 @@
 #@uselibc++@ R__USE_LIBCXX    /**/
 #@has_found_attribute_always_inline@ R__HAS_ATTRIBUTE_ALWAYS_INLINE /**/
 #@has_found_attribute_noinline@ R__HAS_ATTRIBUTE_NOINLINE /**/
-#@hashardwareinterferencesize@ R__HAS_HARDWARE_INTERFERENCE_SIZE /**/
 #@useimt@ R__USE_IMT   /**/
 #@memory_term@ R__COMPLETE_MEM_TERMINATION /**/
 #@hascefweb@ R__HAS_CEFWEB  /**/
@@ -53,6 +52,7 @@
 #@hasroot7@ R__HAS_ROOT7 /**/
 #@use_less_includes@ R__LESS_INCLUDES /**/
 #@hastbb@ R__HAS_TBB /**/
+#define R__HARDWARE_INTERFERENCE_SIZE @hardwareinterferencesize@ /*Determined at CMake configure to be stable across all TUs*/
 
 #if defined(R__HAS_VECCORE) && defined(R__HAS_VC)
 #ifndef VECCORE_ENABLE_VC

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -512,12 +512,9 @@ struct alignas(T) SmallVectorStorage<T, 0> {
 template <typename T>
 struct RVecInlineStorageSize {
 private:
-#ifdef R__HAS_HARDWARE_INTERFERENCE_SIZE
-   static constexpr std::size_t cacheLineSize = std::hardware_destructive_interference_size;
-#else
-   // safe bet: assume the typical 64 bytes
+   // Cannot use R__HARDWARE_INTERFERENCE_SIZE, because RConfigure.h is suppressed when rootcling runs.
+   // We risk breaking the ABI, because rootcling and compiled ROOT might see different values.
    static constexpr std::size_t cacheLineSize = 64;
-#endif
    static constexpr unsigned elementsPerCacheLine = (cacheLineSize - sizeof(SmallVectorBase)) / sizeof(T);
    static constexpr unsigned maxInlineByteSize = 1024;
 

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -160,12 +160,7 @@ std::size_t EvalRVecValueSize(std::size_t alignOfT, std::size_t sizeOfT, std::si
 
    // mimic the logic of RVecInlineStorageSize, but at runtime
    const auto inlineStorageSz = [&] {
-#ifdef R__HAS_HARDWARE_INTERFERENCE_SIZE
-      // hardware_destructive_interference_size is a C++17 feature but many compilers do not implement it yet
-      constexpr unsigned cacheLineSize = std::hardware_destructive_interference_size;
-#else
-      constexpr unsigned cacheLineSize = 64u;
-#endif
+      constexpr unsigned cacheLineSize = R__HARDWARE_INTERFERENCE_SIZE;
       const unsigned elementsPerCacheLine = (cacheLineSize - dataMemberSz) / sizeOfT;
       constexpr unsigned maxInlineByteSize = 1024;
       const unsigned nElements =


### PR DESCRIPTION
ROOT might currently change the layout of classes by making
use of hardware_interference_size in publicly visible types. gcc
rightfully warns about that when the feature is used in a header. ROOT
works around the warning by assigning the value to another variable, but
this doesn't solve the issue.

Since the value of std::hardware_destructive_interference_size can vary
with compiler versions, standard library, or tune settings, it might
change across translation units in ROOT, breaking the ABI of RDF/RVec.
This, for example, happens when building with address sanitizer:
JITted code was trying to use the standard C++ value, whereas precompiled
code didn't even have the feature (it is suppressed when asan is used).
ASAN builds couldn't even be compiled, because ROOT unconditionally
tried to read the interference size for RVec.
Moreover, when users use an installed ROOT, they don't necessarily use
it on the same CPU / with the same tune settings that were used to
compile ROOT, think e.g. of ROOT on cvmfs.

For these reasons, the interference size is determined once at the CMake
configure stage, saved in RConfigure.h, and kept fixed afterwards.