### PR TITLE
[cppyy] disable C++11 tests on mac-beta

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/test/CMakeLists.txt
@@ -59,7 +59,19 @@ test_concurrent)
 
 if(NOT CMAKE_CXX_STANDARD EQUAL 23)
     # test_cpp11features crashes when run with C++23
-    list(APPEND CPPYY_TESTS test_cpp11features)
+    if(APPLE)
+        execute_process(
+            COMMAND sw_vers -productVersion
+            OUTPUT_VARIABLE MACOS_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(MACOS_VERSION VERSION_LESS "26.0")
+            # Parts of this test suite fail with std::make_unique 
+            list(APPEND CPPYY_TEST_DICTS test_cpp11features)
+        endif()
+    else()
+        list(APPEND CPPYY_TESTS test_cpp11features)
+    endif()
 endif()
 
 if(NOT APPLE)


### PR DESCRIPTION
A subset of these tests fail when calling `std::make_unique` (`test15_unique_ptr_template_deduction ` and `test16_unique_ptr_moves `). This stems from incorrect type info collected in TClingCallFunc, that goes through `cling::utils::Transform::GetPartiallyDesugaredType`, which explicitly adds a 0 to the arg pack of `make_unique` during codegen, which is illegal:

```
2025-06-21T02:05:14.3073430Z ../../../../../../src/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py::TestCPP11FEATURES::test15_unique_ptr_template_deduction input_line_132:7:124: error: address of overloaded function 'make_unique' does not match required type 'std::unique_ptr<int, std::default_delete<int> > ()'
2025-06-21T02:05:14.3074880Z       new (ret) (std::unique_ptr<int, std::default_delete<int> >) (((std::unique_ptr<int, std::default_delete<int> > (&)())std::__1::make_unique<int, 0>)());
2025-06-21T02:05:14.3075500Z                                                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2025-06-21T02:05:14.3076450Z /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/unique_ptr.h:766:76: note: candidate template ignored: invalid explicitly-specified argument for template parameter '_Args'
2025-06-21T02:05:14.3077580Z inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 unique_ptr<_Tp> make_unique(_Args&&... __args) {

2025-06-21T02:05:14.3096070Z ../../../../../../src/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py::TestCPP11FEATURES::test16_unique_ptr_moves input_line_134:7:130: error: address of overloaded function 'make_unique' does not match required type 'std::unique_ptr<int, std::default_delete<int> > (int &&)'
2025-06-21T02:05:14.3097560Z       new (ret) (std::unique_ptr<int, std::default_delete<int> >) (((std::unique_ptr<int, std::default_delete<int> > (&)(int &&))std::__1::make_unique<int, int, 0>)((int&&)*(int*)args[0]));

2025-06-21T02:05:14.3109120Z input_line_134:11:76: error: address of overloaded function 'make_unique' does not match required type 'std::unique_ptr<int, std::default_delete<int> > (int &&)'
2025-06-21T02:05:14.3113010Z       (void)(((std::unique_ptr<int, std::default_delete<int> > (&)(int &&))std::__1::make_unique<int, int, 0>)((int&&)*(int*)args[0]));
```

We should possibly disable this test while the underlying issue is being investigated