### PR TITLE
Add auto_ptr schema evolution test

### DIFF
--- a/roottest/root/io/autoptr/CMakeLists.txt
+++ b/roottest/root/io/autoptr/CMakeLists.txt
@@ -1,0 +1,46 @@
+ROOTTEST_GENERATE_DICTIONARY(
+  test_auto_ptr_v2_dict
+  ${CMAKE_CURRENT_SOURCE_DIR}/TestAutoPtr_v2.hxx
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/TestAutoPtr_v2_LinkDef.h
+  NO_ROOTMAP NO_CXXMODULE
+  FIXTURES_SETUP generated_test_auto_ptr_v2_dictionary
+)
+
+ROOTTEST_GENERATE_EXECUTABLE(
+  write_autoptr
+  LIBRARIES Core RIO Tree
+  FIXTURES_REQUIRED generated_test_auto_ptr_v2_dictionary
+  FIXTURES_SETUP write_autoptr_executable)
+
+target_sources(
+  write_autoptr
+  PRIVATE write_autoptr.cxx test_auto_ptr_v2_dict.cxx
+)
+
+ROOTTEST_ADD_TEST(write_autoptr
+                  EXEC ./write_autoptr
+                  FIXTURES_REQUIRED write_autoptr_executable
+                  FIXTURES_SETUP written_autoptr)
+
+ROOTTEST_GENERATE_DICTIONARY(
+  test_auto_ptr_v3_dict
+  ${CMAKE_CURRENT_SOURCE_DIR}/TestAutoPtr_v3.hxx
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/TestAutoPtr_v3_LinkDef.h
+  NO_ROOTMAP NO_CXXMODULE
+  FIXTURES_SETUP generated_test_auto_ptr_v3_dictionary
+)
+
+ROOTTEST_GENERATE_EXECUTABLE(
+  evolve_autoptr
+  LIBRARIES Core RIO Tree
+  FIXTURES_REQUIRED generated_test_auto_ptr_v3_dictionary
+  FIXTURES_SETUP evolve_autoptr_executable)
+
+target_sources(
+  evolve_autoptr
+  PRIVATE evolve_autoptr.cxx test_auto_ptr_v3_dict.cxx
+)
+
+ROOTTEST_ADD_TEST(evolve_autoptr
+                  EXEC ./evolve_autoptr
+                  FIXTURES_REQUIRED evolve_autoptr_executable written_autoptr)

--- a/roottest/root/io/autoptr/TestAutoPtr_v2.hxx
+++ b/roottest/root/io/autoptr/TestAutoPtr_v2.hxx
@@ -1,0 +1,41 @@
+#ifndef TEST_AUTO_PTR_V2_H
+#define TEST_AUTO_PTR_V2_H
+
+#include <RtypesCore.h>
+
+#include <memory>
+
+// Since std::auto_ptr is deprecated and may not exist anymore, we emulate it.
+template <typename T>
+struct EmulatedAutoPtr {
+   T *fRawPtr = nullptr;
+
+   EmulatedAutoPtr() = default;
+   explicit EmulatedAutoPtr(T *rawPtr) : fRawPtr(rawPtr) {}
+   EmulatedAutoPtr &operator=(EmulatedAutoPtr &other)
+   {
+      fRawPtr = other.fRawPtr;
+      other.fRawPtr = nullptr;
+      return *this;
+   }
+   EmulatedAutoPtr &operator=(T *rawPtr)
+   {
+      fRawPtr = rawPtr;
+      return *this;
+   }
+};
+
+struct Track {
+   int fFoo;
+
+   ClassDefNV(Track, 2)
+};
+
+struct TestAutoPtr {
+   EmulatedAutoPtr<Track> fTrack;
+   float fBar = 137.0;
+
+   ClassDefNV(TestAutoPtr, 2)
+};
+
+#endif // TEST_AUTO_PTR_V2_H

--- a/roottest/root/io/autoptr/TestAutoPtr_v2_LinkDef.h
+++ b/roottest/root/io/autoptr/TestAutoPtr_v2_LinkDef.h
@@ -1,0 +1,7 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class EmulatedAutoPtr<Track>+;
+#pragma link C++ class Track+;
+#pragma link C++ class TestAutoPtr+;
+
+#endif

--- a/roottest/root/io/autoptr/TestAutoPtr_v3.hxx
+++ b/roottest/root/io/autoptr/TestAutoPtr_v3.hxx
@@ -1,0 +1,36 @@
+#ifndef TEST_AUTO_PTR_V3_H
+#define TEST_AUTO_PTR_V3_H
+
+#include <RtypesCore.h>
+
+#include <memory>
+
+namespace Compat {
+
+template <typename T>
+struct DeprecatedAutoPtr {
+   // We use Compat::DeprecatedAutoPtr only to assign the wrapped raw pointer to a unique pointer
+   // in an I/O customization rule.
+   // However, since the DeprecatedAutoPtr object can be reused, it is essential to always reset the
+   // value after using it, so we can safely delete it (it should always be nullptr)
+   ~DeprecatedAutoPtr() { delete fRawPtr; }
+
+   T *fRawPtr = nullptr;
+};
+
+} // namespace Compat
+
+struct Track {
+   int fFoo;
+
+   ClassDefNV(Track, 2)
+};
+
+struct TestAutoPtr {
+   std::unique_ptr<Track> fTrack;
+   float fBar = 137.0;
+
+   ClassDefNV(TestAutoPtr, 3)
+};
+
+#endif // TEST_AUTO_PTR_V3_H

--- a/roottest/root/io/autoptr/TestAutoPtr_v3_LinkDef.h
+++ b/roottest/root/io/autoptr/TestAutoPtr_v3_LinkDef.h
@@ -1,0 +1,16 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class Compat::DeprecatedAutoPtr<Track>+;
+#pragma link C++ class Track+;
+#pragma link C++ class TestAutoPtr+;
+
+// In practice, we would have:
+// #pragma read sourceClass="std::auto_ptr<Track>" targetClass="Compat::DeprecatedAutoPtr<Track>"
+// but in this example the writing code had to use EmulatedAutoPtr, so we need this:
+#pragma read sourceClass="EmulatedAutoPtr<Track>" targetClass="Compat::DeprecatedAutoPtr<Track>"
+
+#pragma read sourceClass="TestAutoPtr" targetClass="TestAutoPtr" version="[2]" \
+  source="Compat::DeprecatedAutoPtr<Track> fTrack" target="fTrack" \
+  code="{ fTrack.reset(onfile.fTrack.fRawPtr); onfile.fTrack.fRawPtr = nullptr; }"
+
+#endif

--- a/roottest/root/io/autoptr/evolve_autoptr.cxx
+++ b/roottest/root/io/autoptr/evolve_autoptr.cxx
@@ -1,0 +1,34 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <memory>
+
+#include "TestAutoPtr_v3.hxx"
+
+int main()
+{
+   auto f = std::unique_ptr<TFile>(TFile::Open("root_test_autoptr.root"));
+   auto t = (TTree *)f->Get("t");
+
+   int i = 1;
+   for (const auto branchname : {"e_nodot", "e.", "e_split0_nodot", "e_split0."}) {
+      TestAutoPtr *entry = nullptr;
+      t->SetBranchAddress(branchname, &entry);
+
+      t->GetEntry(0);
+      if (!entry->fTrack || entry->fTrack->fFoo != 1)
+         return i * 1;
+
+      t->GetEntry(1);
+      if (entry->fTrack)
+         return i * 2;
+
+      t->GetEntry(2);
+      if (!entry->fTrack || entry->fTrack->fFoo != 3)
+         return i * 3;
+
+      i += 10;
+   }
+
+   return 0;
+}

--- a/roottest/root/io/autoptr/write_autoptr.cxx
+++ b/roottest/root/io/autoptr/write_autoptr.cxx
@@ -1,0 +1,35 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <memory>
+
+#include "TestAutoPtr_v2.hxx"
+
+int main()
+{
+   auto f = std::unique_ptr<TFile>(TFile::Open("root_test_autoptr.root", "RECREATE"));
+   auto t = new TTree("t", "");
+
+   TestAutoPtr entry;
+   t->Branch("e_nodot", &entry);
+   t->Branch("e.", &entry);
+   t->Branch("e_split0_nodot", &entry, 32000, 0);
+   t->Branch("e_split0.", &entry, 32000, 0);
+
+   entry.fTrack = new Track{1};
+   t->Fill();
+   delete entry.fTrack.fRawPtr;
+
+   entry.fTrack = nullptr;
+   t->Fill();
+   delete entry.fTrack.fRawPtr;
+
+   entry.fTrack = new Track{3};
+   t->Fill();
+   delete entry.fTrack.fRawPtr;
+
+   t->Write();
+   f->Close();
+
+   return 0;
+}


### PR DESCRIPTION
Test evolution of auto_ptr into unique_ptr both as a split and unsplit member. Uses an emulated auto_ptr class instead of the real std::auto_ptr because the actual one may have been removed.

Tests the fix of PR #18320

Moved from https://github.com/root-project/roottest/pull/1306, including initial set of review comments.