### PR TITLE
[CMake] Append to `CMAKE_INSTALL_RPATH` with `CACHE FORCE`

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -429,10 +429,13 @@ if(rpath)
   if(APPLE)
     set(CMAKE_MACOSX_RPATH TRUE)
     set(CMAKE_INSTALL_NAME_DIR "@rpath")
-    list(APPEND CMAKE_INSTALL_RPATH @loader_path @loader_path/${BINDIR_TO_LIBDIR})
+
+    set(_rpath_values "@loader_path" "@loader_path/${BINDIR_TO_LIBDIR}")
   else()
-    list(APPEND CMAKE_INSTALL_RPATH $ORIGIN $ORIGIN/${BINDIR_TO_LIBDIR})
+    set(_rpath_values "$ORIGIN" "$ORIGIN/${BINDIR_TO_LIBDIR}")
   endif()
+
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH-CACHED};${_rpath_values}" CACHE STRING "Install RPATH" FORCE)
 
   unset(BINDIR_TO_LIBDIR)
 endif()


### PR DESCRIPTION
Correctly append the additional RPATHs set by the ROOT build system to the `CMAKE_INSTALL_RPATH` variable set by the user, which is cached in `CMAKE_INSTALL_RPATH-CACHED` by the ROOT build system.

Follows up on c77bd87.

Closes #19134.

Needs a backport to 6.36.