### PR TITLE
[cling] Handle unloading unnamed `VarDecl`s in catch statements

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.cpp
@@ -603,6 +603,15 @@ namespace cling {
     // * variables and parameters with dependent context;
     // * mangled names for parameters;
     if (!isa<ParmVarDecl>(VD) && !VD->getDeclContext()->isDependentContext()) {
+      // Exception variables without identifiers are not added to scope and will
+      // fail in the steps after the `if` block.
+      // Assuming this rule extends to non-exception variables too.
+      if (!VD->getIdentifier()) {
+        DeclContext* DC = VD->getLexicalDeclContext();
+        if (DC->containsDecl(VD))
+          DC->removeDecl(VD);
+        return true;
+      }
       // Cleanup the module if the transaction was committed and code was
       // generated. This has to go first, because it may need the AST
       // information which we will remove soon. (Eg. mangleDeclName iterates the

--- a/interpreter/cling/test/CodeUnloading/Exception.C
+++ b/interpreter/cling/test/CodeUnloading/Exception.C
@@ -1,0 +1,15 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling 2>&1 | FileCheck %s
+try {} catch (int &) {}
+.undo 1
+
+// Check if interpreter is still functional
+int g = 42
+//CHECK: (int) 42


### PR DESCRIPTION
Fixes the assertion error with the following:

```
[cling]$ #include <exception>
[cling]$ try {} catch (std::exception &) {}
[cling]$ .undo 1
```

# This Pull request:

## Changes or fixes: 


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/14012

