### PR TITLE
[Core] Deprecate `TMath::BinarySearch` overload for iterators

### DIFF
--- a/core/base/inc/TMathBase.h
+++ b/core/base/inc/TMathBase.h
@@ -97,7 +97,8 @@ namespace TMath {
    // Binary search
    template <typename T> Long64_t BinarySearch(Long64_t n, const T  *array, T value);
    template <typename T> Long64_t BinarySearch(Long64_t n, const T **array, T value);
-   template <typename Iterator, typename Element> Iterator BinarySearch(Iterator first, Iterator last, Element value);
+   template <typename Iterator, typename Element> Iterator BinarySearch(Iterator first, Iterator last, Element value)
+       R__DEPRECATED(6,40, "Undefined behavior in case \"value\" is smaller than the first element. Use STL algorithms instead, e.g. std::lower_bound(v.rbegin(), v.rend(), value, std::greater{}).");
 
    // Sorting
    template <typename Element, typename Index>

--- a/tmva/tmva/src/TSpline1.cxx
+++ b/tmva/tmva/src/TSpline1.cxx
@@ -59,7 +59,7 @@ TMVA::TSpline1::~TSpline1( void ) {}
 Double_t TMVA::TSpline1::Eval( Double_t x ) const
 {
    Int_t N = fX.size();
-   Int_t ibin = std::distance(fX.begin(), TMath::BinarySearch(fX.begin(), fX.end(), x));
+   Int_t ibin = std::distance(std::lower_bound(fX.rbegin(), fX.rend(), x, std::greater{}), fX.rend()) - 1;
    // sanity checks
    if (ibin < 0 ) ibin = 0;
    if (ibin >= N) ibin = N - 1;

--- a/tmva/tmva/src/TSpline2.cxx
+++ b/tmva/tmva/src/TSpline2.cxx
@@ -61,7 +61,7 @@ Double_t TMVA::TSpline2::Eval( const Double_t x ) const
 {
    Double_t retval=0;
    Int_t N = fX.size();
-   Int_t ibin = std::distance(fX.begin(), TMath::BinarySearch( fX.begin(), fX.end(), x ));
+   Int_t ibin = std::distance(std::lower_bound(fX.rbegin(), fX.rend(), x, std::greater{}), fX.rend()) - 1;
 
    // sanity checks
    if (ibin < 0 ) ibin = 0;


### PR DESCRIPTION
PR https://github.com/root-project/root/pull/17179 got stuck because there were three different opinions on how to resolve undefined behavior in case the search value is smaller than the smallest element in the collection. In particular, the problem was that in TMVA, the undefined behavior was used, because in practice for a `std::vector()`, the expression `std::distance(v.begin(), v.begin() - 1)` evaluates to -1, even though it's actually UB to take the iterator before the beginning of a vector. So there is no backwards compatible way to resolve the undefined behavior.

The only way out that I see is to deprecate the `TMath::BinarySearch` overload for iterators, and tell people to use the standard library instead. This is implemented in this commit.

Alternative to #17179.

One can use this code snipped to validate that the code changes in TMVA are correct:
```c++
std::vector<double> v{0., 1., 2};

auto check = [&](double x) {
   double r1 = std::distance(v.begin(), TMath::BinarySearch(v.begin(), v.end(), x));
   double r2 = std::distance(std::lower_bound(v.rbegin(), v.rend(), x, std::greater{}), v.rend()) - 1;
   std::cout << "x : " << x << std::endl;
   std::cout << r1 << std::endl;
   std::cout << r2 << std::endl;
   std::cout << std::endl;
};

check(-0.5);
for (double x : v) {
    check(x);
    check(x + 0.5);
}
```