### PR TITLE
[Python] Remove TObject `__eq__` pythonization

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tobject.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tobject.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT.libROOTPythonizations import AddTObjectEqNePyz
 import cppyy
 
 # Searching
@@ -56,7 +55,6 @@ def pythonize_tobject():
     klass.__contains__ = _contains
 
     # Inject comparison operators
-    AddTObjectEqNePyz(klass)
     klass.__lt__ = _lt
     klass.__le__ = _le
     klass.__gt__ = _gt


### PR DESCRIPTION
The TObject `__eq__` pythonization calls `TObject::Equals()`, which by default does a pointer comparison. That can be very confusing for Python users.