### PR TITLE
Make CppInterOp work with new gtest target names.

### DIFF
--- a/interpreter/CppInterOp/unittests/CMakeLists.txt
+++ b/interpreter/CppInterOp/unittests/CMakeLists.txt
@@ -3,16 +3,23 @@ set(CTEST_BUILD_NAME
 enable_testing()
 
 # LLVM builds (not installed llvm) provides gtest.
-if (NOT TARGET gtest)
+if (NOT TARGET GTest::gtest AND NOT TARGET gtest)
   include(GoogleTest)
 endif()
 
 if(EMSCRIPTEN)
-  set(gtest_libs gtest gmock)
+  if (TARGET GTest::gtest)
+    # Target names in CMake >= v3.23
+    set(gtest_libs GTest::gtest GTest::gmock)
+  else()
+    set(gtest_libs gtest gmock)
+  endif()
 else()
-  set(gtest_libs gtest gtest_main)
-  if (TARGET gmock)
-    list(APPEND gtest_libs gmock gmock_main)
+  if (TARGET GTest::gtest)
+    # Target names in CMake >= v3.23
+    set(gtest_libs GTest::gtest GTest::gmock GTest::gtest_main)
+  else()
+    set(gtest_libs gtest gtest_main gmock)
   endif()
   set(link_pthreads_lib pthread)
 endif()


### PR DESCRIPTION
Starting from CMake v3.23, one can use GTest::gtest and similar in CMake. Since the root-project wants to move to these targets, Interop should work with both the new or the old target names in order not to start building its own gtest.

This is a replay of the same commit added to interop [here](https://github.com/compiler-research/CppInterOp/pull/643).