### PR TITLE
[v628] Revert "[ci] Turn off mySQL for Alma10"

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma10.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10.txt
@@ -3,5 +3,4 @@ builtin_vdt=ON
 builtin_zlib=ON
 builtin_zstd=ON
 gfal=OFF
-mysql=OFF
 tmva-cpu=OFF


### PR DESCRIPTION
This reverts commit d3860b240871e5694e9b7303f894d50859083730.

I mistakenly believed that mysql-devel was gone from the RHEL 10 repos so I removed it from the CI image, but actually it was just renamed. I brought it back now, so the `mysql` build option should work again on `alma10`.