### PR TITLE
[CMake] Also print version of found Python module

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2065,8 +2065,11 @@ function(ROOT_FIND_PYTHON_MODULE module)
   set(CACHE_VAR ROOT_TEST_${module_upper})
 
   if(NOT DEFINED ${CACHE_VAR})
-    execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "import ${module}"
+    execute_process(COMMAND "${Python3_EXECUTABLE}" "-c"
+                            "import ${module}; print(getattr(${module}, '__version__', 'unknown'))"
       RESULT_VARIABLE status
+      OUTPUT_VARIABLE module_version
+      OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET)
 
     if(${status} EQUAL 0)
@@ -2077,7 +2080,7 @@ function(ROOT_FIND_PYTHON_MODULE module)
 
     if(NOT ARG_QUIET)
       if(${CACHE_VAR})
-        message(STATUS "Found Python module ${module}")
+        message(STATUS "Found Python module ${module} (found version \"${module_version}\")")
       else()
         message(STATUS "Could NOT find Python module ${module}. Corresponding tests will be disabled.")
       endif()


### PR DESCRIPTION
This does the same thing as CMakes find package now, printing the version of the Python module in the same style if available.

This will make it easier to debug compatibility problems from the build logs.