### PR TITLE
Fixing issues in RooSimultaneous with ConditionalObservables

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -459,7 +459,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RIO
     MathCore
     Foam
-    Smatrix
     ${EXTRA_DEPENDENCIES}
   LINKDEF
     inc/LinkDef.h
@@ -489,6 +488,13 @@ if(fftw3)
 endif()
 
 target_include_directories(RooFitCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
+
+# The SMatrix package is header-only, but it's only exposed via the Smatrix
+# target, which is a shared library that also includes the dictionaries. For
+# RooFit, we are not interested in them, and want to avoid a dependency of the
+# RooFitCore library on the Smatrix dictionary library. Therefore, we just add
+# the include path.
+target_include_directories(RooFitCore PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/math/smatrix/inc>)
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -745,7 +745,17 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, const Ro
 
       RooArgSet normSet;
       pdf.getObservables(data.get(), normSet);
-      normSet.remove(projDeps, true, true);
+
+      if (dynamic_cast<RooSimultaneous const*>(&pdf)) {
+         for (auto i : projDeps) {
+            auto res = normSet.find(i->GetName());
+            if (res != nullptr) {
+               res->setAttribute("__conditional__");
+            }
+         }
+      } else {
+         normSet.remove(projDeps);
+      }
 
       pdf.setAttribute("SplitRange", splitRange);
       pdf.setStringAttribute("RangeName", rangeName);

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1217,6 +1217,10 @@ RooSimultaneous::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
 
       std::unique_ptr<RooArgSet> pdfNormSet{
          std::unique_ptr<RooArgSet>(pdfClone->getVariables())->selectByAttrib("__obs__", true)};
+      std::unique_ptr<RooArgSet> condVarSet{
+         std::unique_ptr<RooArgSet>(pdfClone->getVariables())->selectByAttrib("__conditional__", true)};
+
+      pdfNormSet->remove(*condVarSet, true, true);
 
       if (rangeName) {
          pdfClone->setNormRange(RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, catName).c_str());


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`RooSimultaneous` is a PDF class that performs the simultaneous fitting of multiple pairs of a PDF and a dataset.

`RooFit::ConditionalObservables(RooAbsArgs...)` is a command argument to the `fitTo()` method of the `RooAbsPdf` classes, which specifies variables that should be excluded from the normalization set of a PDF when fitting.

If I use the command argument for fitting using the class, the class does not deal with the conditional variable well, and the conditional variables become floating parameters. This should be fixed.



## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR addresses the bug. Please see the details of the issue in the link: https://github.com/root-project/root/issues/19166