### PR TITLE
[doc] don't abort building the documentation if roofit isn't found

### DIFF
--- a/documentation/doxygen/print_roofit_pyz_doctrings.py
+++ b/documentation/doxygen/print_roofit_pyz_doctrings.py
@@ -193,8 +193,12 @@ def print_pyroot_blocks_for_cpp_docs():
 
 if __name__ == "__main__":
 
-    print("/**")
-    print_roofit_pythonization_page()
-    print("")
-    print_pyroot_blocks_for_cpp_docs()
-    print("*/")
+    try:
+        print("/**")
+        print_roofit_pythonization_page()
+        print("")
+        print_pyroot_blocks_for_cpp_docs()
+        print("*/")
+    except ImportError:
+        # roofit was probably not built
+        pass


### PR DESCRIPTION
One should be able to build the documentation even with a ROOT build that had -Droofit=off
