### PR TITLE
[CMake] Also consider fail-on-missing for `fortran` features

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/windows10.txt
+++ b/.github/workflows/root-ci-config/buildconfig/windows10.txt
@@ -18,6 +18,7 @@ builtin_xxhash=ON
 builtin_zlib=ON
 builtin_zstd=ON
 davix=OFF
+fortran=OFF
 llvm13_broken_tests=OFF
 minuit2_mpi=OFF
 minuit2_omp=OFF

--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -23,7 +23,7 @@ endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" _BUILD_TYPE_UPPER)
 
 include(CheckLanguage)
-#---Enable FORTRAN (unfortunatelly is not not possible in all cases)-------------------------------
+#---Enable FORTRAN (unfortunately is not not possible in all cases)-------------------------------
 if(fortran)
   #--Work-around for CMake issue 0009220
   if(DEFINED CMAKE_Fortran_COMPILER AND CMAKE_Fortran_COMPILER MATCHES "^$")
@@ -42,10 +42,13 @@ if(fortran)
       # in a separate process, the result might not be compatible with
       # the C++ compiler, so reset the variable, ...
       unset(CMAKE_Fortran_COMPILER CACHE)
-      # ..., and enable Fortran again, this time prefering compilers
+      # ..., and enable Fortran again, this time preferring compilers
       # compatible to the C++ compiler
       enable_language(Fortran)
     endif()
+  endif()
+  if(NOT CMAKE_Fortran_COMPILER AND fail-on-missing)
+    message(FATAL_ERROR "No Fortran compiler found. Please make sure it's installed, or disable ROOT's Fortran features with '-Dfortran=OFF' (or set '-Dfail-on-missing=OFF' to automatically disable features with missing requirements)")
   endif()
 else()
   set(CMAKE_Fortran_COMPILER CMAKE_Fortran_COMPILER-NOTFOUND)


### PR DESCRIPTION
Motivated by https://github.com/root-project/root/pull/19184

FYI, @ferdymercury.

The first CI run will fail because not all platforms have Fortran installed. In a second pass, `fortran` will then be disabled for all platforms where it failed (probably only Windows).