### PR TITLE
[jsroot] 7.9.x 26/06/2025

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,5 +1,11 @@
 # JSROOT changelog
 
+## Changes in 7.9.x
+1. Fix - reading TLeafC leafs
+2. Fix - support BigInt in object inspector
+3. Fix - svg2pdf.js URL bounding box
+
+
 ## Changes in 7.9.1
 1. Fix - colz handling on `THStack`, avoid multiple palette drawings
 2. Fix - bug in pad.Divide context menu command

--- a/js/modules/base/svg2pdf.mjs
+++ b/js/modules/base/svg2pdf.mjs
@@ -2415,7 +2415,7 @@ var GeometryNode = /** @class */ (function (_super) {
                 if (prev instanceof MoveTo || prev instanceof LineTo || prev instanceof CurveTo) {
                     if (curr instanceof CurveTo) {
                         hasStartMarker &&
-                            markers.addMarker(new Marker(markerStart, [prev.x, prev.y], 
+                            markers.addMarker(new Marker(markerStart, [prev.x, prev.y],
                             // @ts-ignore
                             getAngle(last_1 ? [last_1.x, last_1.y] : [prev.x, prev.y], [curr.x1, curr.y1]), true));
                         hasEndMarker &&
@@ -3133,7 +3133,7 @@ var TextNode = /** @class */ (function (_super) {
                     textChunks = [];
                     currentTextSegment = new TextChunk(this, context.attributeState.textAnchor, textX + dx, textY + dy);
                     textChunks.push({ type: '', chunk: currentTextSegment });
-                    initialSpace = this.processTSpans(this, this.element, context, textChunks, currentTextSegment, 
+                    initialSpace = this.processTSpans(this, this.element, context, textChunks, currentTextSegment,
                     // Set prevText to ' ' so any spaces on left of <text> are trimmed
                     { prevText: ' ', prevContext: context });
                     lengthAdjustment = initialSpace ? 0 : 1;
@@ -5415,7 +5415,7 @@ var Anchor = /** @class */ (function (_super) {
                             box = this.getBoundingBox(context);
                             scale = context.pdf.internal.scaleFactor;
                             ph = context.pdf.internal.pageSize.getHeight();
-                            context.pdf.link(scale * (box[0] * context.transform.sx + context.transform.tx), ph - scale * (box[1] * context.transform.sy + context.transform.ty), scale * box[2], scale * box[3], { url: href });
+                            context.pdf.link(scale * (box[0] * context.transform.sx + context.transform.tx), scale * (ph - box[1] * context.transform.sy - context.transform.ty), scale * context.transform.sx * box[2], scale * context.transform.sy * box[3], { url: href });
                         }
                         return [2 /*return*/];
                 }

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -1,10 +1,10 @@
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = '7.9.1',
+const version_id = '7.9.x',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '19/05/2025',
+version_date = '26/06/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -500,7 +500,7 @@ function objectHierarchy(top, obj, args = undefined) {
                }
             }
          }
-      } else if ((typeof fld === 'number') || (typeof fld === 'boolean')) {
+      } else if ((typeof fld === 'number') || (typeof fld === 'boolean') || (typeof fld === 'bigint')) {
          simple = true;
          if (key === 'fBits')
             item._value = '0x' + fld.toString(16);

--- a/js/modules/tree.mjs
+++ b/js/modules/tree.mjs
@@ -1696,7 +1696,7 @@ async function treeProcess(tree, selector, args) {
          default: return null;
       }
       const elem = createStreamerElement(name || leaf.fName, datakind);
-      if (leaf.fLen > 1) {
+      if ((leaf.fLen > 1) && (datakind !== kTString)) {
          elem.fType += kOffsetL;
          elem.fArrayLength = leaf.fLen;
       }


### PR DESCRIPTION
1. Fix - reading TLeafC leafs
2. Fix - support BigInt in object inspector
3. Fix - svg2pdf.js URL bounding box
