### PR TITLE
[root.exe] Use non-zero exit status when invalid arguments are passed

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -181,7 +181,7 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options, 
          std::cerr << "root: unrecognized option '" << argv[n] << "'\n";
       }
       std::cerr << "Try 'root --help' for more information.\n";
-      TApplication::Terminate(0);
+      TApplication::Terminate(2);
    }
 
    fNcmd          = 0;

--- a/core/rint/test/TRintTests.cxx
+++ b/core/rint/test/TRintTests.cxx
@@ -8,34 +8,6 @@
 using testing::internal::CaptureStderr;
 using testing::internal::GetCapturedStderr;
 
-TEST(TRint, ExitOnUnknownArgs)
-{
-   // Create array of options.
-   // We need to create it as a dynamic array for the following reasons:
-   // - TRint constructor accepts a char** so we construct directly that type
-   // - TRint will modify this array, removing recognized options and leaving
-   //   only unrecognized ones, so we can't create an std::vector and pass its
-   //   data to TRint directly.
-   int argc{4};
-   char e1[]{"-q"};
-   char e2[]{"-z"};
-   char e3[]{"--nonexistingoption"};
-   char e4[]{"-b"};
-   char *argv[]{e1, e2, e3, e4};
-
-   CaptureStderr();
-   // Unrecognized options will be printed to stderr
-   TRint app{"App", &argc, argv, /*options*/ nullptr, /*numOptions*/ 0, /*noLogo*/ kTRUE, /*exitOnUnknownArgs*/
-             kTRUE};
-   std::string trinterr = GetCapturedStderr();
-
-   const std::string expected{"root: unrecognized option '-z'\n"
-                              "root: unrecognized option '--nonexistingoption'\n"
-                              "Try 'root --help' for more information.\n"};
-
-   EXPECT_EQ(trinterr, expected);
-}
-
 TEST(TRint, KeepUnknownArgs)
 {
    // Create array of options.

--- a/roottest/root/core/CMakeLists.txt
+++ b/roottest/root/core/CMakeLists.txt
@@ -40,3 +40,9 @@ ROOTTEST_ADD_TEST(execStatusBitsCheck
                   OUTCNV ../html/MakeIndex_convert.sh
                   OUTREF execStatusBitsCheck.ref
                   )
+
+add_test(NAME root_exe_exitStatus COMMAND $<TARGET_FILE:root.exe> "-e invalid" "--no_exist")
+set_property(TEST root_exe_exitStatus PROPERTY WILL_FAIL True)
+add_test(NAME root_exe_errorMessage COMMAND $<TARGET_FILE:root.exe> "-e invalid" "--no_exist")
+set_property(TEST root_exe_errorMessage PROPERTY
+	PASS_REGULAR_EXPRESSION "root: unrecognized option '-e invalid'.*--no_exist.*Try 'root --help'")


### PR DESCRIPTION
Followup to #19195:
RDF IMT tutorials didn't run since 10 months, since the following passed with a 0 exit status:
```
$ root '-e "ROOT::EnableImplicitMT(4)"' ...
root: unrecognized option '-e "ROOT::EnableImplicitMT(4)"'
Try 'root --help' for more information.
  2965/2993 Test tutorial-analysis-dataframe-df102_NanoAODDimuonAnalysis ............. Passed 0.15 sec
```

To avoid similar problem in the future, I suggest here to exit with a non-zero exit status. I chose 2 because 1 usually means that the script/macro/command that was running *in the interpreter* failed:
```
bin/root -b -q -e "invalid"; echo $?
1
```

Whereas a failure to parse the argument would now be:
```
$ root '-e "ROOT::EnableImplicitMT(4)"'; echo $?
2
```