### PR TITLE
[skip-ci][Ruff] Only include files that are added, copied, modified.

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -51,7 +51,7 @@ jobs:
       id: diff
       run: |
         git fetch --depth=1 origin $GITHUB_BASE_REF 
-        git diff --name-only origin/$GITHUB_BASE_REF > changed_files.txt
+        git diff --diff-filter=AMR --name-only origin/$GITHUB_BASE_REF > changed_files.txt
 
     - name: Install ruff
       uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
Ruff currently fails to lint when a python file is deleted from the project. To fix this, I added a status filter to `git diff` which masks all files except for ones that have been **A**dded **M**odified **R**enamed

An example of this failure is in #19196.
In #19195, I already pushed the commit from this PR, and Ruff passes there.
So I think we can "smuggle" this fix in here, bypassing the full CI run and reducing the pressure on our builders.