### PR TITLE
[ntuple] Merger: fix bugs in GenerateZeroPagesForColumns

### DIFF
--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -696,6 +696,7 @@ static void GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<con
       const auto colElement = RColumnElementBase::Generate(columnDesc.GetType());
       const auto nElements = nEntriesToGenerate * nRepetitions;
       const auto nBytesOnStorage = colElement->GetPackedSize(nElements);
+      // TODO(gparolini): make this configurable
       constexpr auto kPageSizeLimit = 256 * 1024;
       // TODO(gparolini): consider coalescing the last page if its size is less than some threshold
       const size_t nPages = nBytesOnStorage / kPageSizeLimit + !!(nBytesOnStorage % kPageSizeLimit);
@@ -706,7 +707,7 @@ static void GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<con
          assert(pageSize % colElement->GetSize() == 0);
          const auto nElementsPerPage = pageSize / colElement->GetSize();
          auto page = pageAlloc.NewPage(colElement->GetSize(), nElementsPerPage);
-         page.GrowUnchecked(nElements);
+         page.GrowUnchecked(nElementsPerPage);
          memset(page.GetBuffer(), 0, page.GetNBytes());
 
          auto &buffer = sealedPageData.fBuffers.emplace_back(new unsigned char[bufSize]);
@@ -719,10 +720,9 @@ static void GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<con
          auto sealedPage = RPageSink::SealPage(sealConf);
 
          sealedPageData.fPagesV.push_back({sealedPage});
+         sealedPageData.fGroups.emplace_back(column.fOutputId, sealedPageData.fPagesV.back().cbegin(),
+                                             sealedPageData.fPagesV.back().cend());
       }
-
-      sealedPageData.fGroups.emplace_back(column.fOutputId, sealedPageData.fPagesV.back().cbegin(),
-                                          sealedPageData.fPagesV.back().cend());
    }
 }
 


### PR DESCRIPTION
- nElements was used to grow each zero page instead of nElementsPerPage
- only the last zero page was added to the page groups

This bug manifested as a crash when Union-merging big-enough RNTuples, so that GenerateZeroPagesForColumns actually generates more than 1 page.

This fix will be backported to 6.36.

cc @amete

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


