### PR TITLE
[cernlib] avoid asan warning / maybe undefined behavior in h2root

### DIFF
--- a/misc/minicern/src/cernlib.c
+++ b/misc/minicern/src/cernlib.c
@@ -72,16 +72,20 @@ unsigned int lshift_(unsigned int *arg, int *len)
 void vxinvb_(int *ixv, int *n)
 {
    int limit, jloop;
-   int in;
+   int out;
+   unsigned char *n1, *n2;
+   n2 = (unsigned char *) &out;
    limit = *n;
    for (jloop = 0; jloop < limit; jloop++) {
-      in = ixv[jloop];
-      ixv[jloop] =
-            ((in >> 24) & 0x000000ff) |
-            ((in >> 8) & 0x0000ff00) |
-            ((in << 8) & 0x00ff0000) |
-            ((in << 24) & 0xff000000);
+      n1 = (unsigned char *) &ixv[jloop];
+      n2[0] = n1[3];
+      n2[1] = n1[2];
+      n2[2] = n1[1];
+      n2[3] = n1[0];
+      ixv[jloop] = out;
+      printf("%04x ", ixv[jloop]);
    }
+   printf("\n");
    return;
 }
 
@@ -90,14 +94,17 @@ void vxinvb_(int *ixv, int *n)
 void vxinvc_ (int *iv, int *ixv, int *n)
 {
    int limit, jloop;
-   int in;
+   int out;
+   unsigned char *n1, *n2;
+   n2 = (unsigned char *) &out;
    limit = *n;
    for (jloop = 0; jloop < limit; jloop++) {
-      in = iv[jloop];
-      ixv[jloop] =
-      ((in >> 24) & 0x000000ff) |
-      ((in >> 8) & 0x0000ff00) |
-      ((in << 8) & 0x00ff0000) | ((in << 24) & 0xff000000);
+      n1 = (unsigned char *) &iv[jloop];
+      n2[0] = n1[3];
+      n2[1] = n1[2];
+      n2[2] = n1[1];
+      n2[3] = n1[0];
+      ixv[jloop] = out;
    }
    return;
 }

--- a/misc/minicern/src/cernlib.c
+++ b/misc/minicern/src/cernlib.c
@@ -83,9 +83,7 @@ void vxinvb_(int *ixv, int *n)
       n2[2] = n1[1];
       n2[3] = n1[0];
       ixv[jloop] = out;
-      printf("%04x ", ixv[jloop]);
    }
-   printf("\n");
    return;
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

reported by asan

```
/opt/root_src/misc/minicern/src/cernlib.c:82:18: runtime error: left shift of negative value -2012982016
/opt/root_src/misc/minicern/src/cernlib.c:83:18: runtime error: left shift of negative value -2012982016
/opt/root_src/misc/minicern/src/cernlib.c:102:12: runtime error: left shift of 1212370737 by 8 places cannot be represented in type 'int'
/opt/root_src/misc/minicern/src/cernlib.c:102:39: runtime error: left shift of 1212370737 by 24 places cannot be represented in type 'int'
```