### PR TITLE
Deprecate the `TGLWSIncludes.h` header

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -3,6 +3,7 @@
 * The `RooDataSet` constructors to construct a dataset from a part of an existing dataset were deprecated in ROOT 6.36 and are now removed. This is to avoid interface duplication. Please use `RooAbsData::reduce()` instead, or if you need to change the weight column, use the universal constructor with the `Import()`, `Cut()`, and `WeightVar()` arguments.
 * The `RooStats::HLFactory` class that was deprecated in ROOT 6.36 is now removed. It provided little advantage over using the RooWorkspace directly or any of the other higher-level frameworks that exist in the RooFit ecosystem.
 * The build options `mysql`, `odbc` and `pgsql`, that were deprecated in ROOT 6.36, are now removed.
+* The `TGLWSIncludes.h` header is deprecated and will be removed in ROOT 6.40
 
 ## Core Libraries
 * Behavior change: when selecting a template instantiation for a dictionary, all the template arguments have to be fully defined - the forward declarations are not enough any more. The error prompted by the dictionary generator will be `Warning: Unused class rule: MyTemplate<MyFwdDeclaredClass>`.

--- a/graf3d/gl/CMakeLists.txt
+++ b/graf3d/gl/CMakeLists.txt
@@ -232,6 +232,8 @@ else()
   target_include_directories(RGL PRIVATE ${GL2PS_INCLUDE_DIRS})
 endif()
 
+# Remove when not needed anymore in the ROOT 6.40 development cycle
+target_compile_definitions(RGL PRIVATE _ROOT_GL_BUILDS_ITSELF)
 
 if(MSVC)
   target_compile_definitions (RGL PRIVATE "GLEW_STATIC")

--- a/graf3d/gl/inc/TGLWSIncludes.h
+++ b/graf3d/gl/inc/TGLWSIncludes.h
@@ -14,6 +14,23 @@
 
 #ifndef ROOT_TGLWSIncludes
 
+#include <RVersion.h> // for ROOT_VERSION
+
+// This header is deprecated according to
+// https://its.cern.ch/jira/browse/ROOT-9807
+// In the 6.38 release, our users will get a warning, and then in 6.40 we
+// remove this header. Conditional on the ROOT version, this header will give
+// an error on inclusion to remind us to move it. Remove also the
+// _ROOT_GL_BUILDS_ITSELF definition from the CMakeLists.txt then.
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 38, 00)
+#error "Header should be moved outside of the public ROOT interface now"
+#else
+#ifndef _ROOT_GL_BUILDS_ITSELF
+#warning "The TGLWSIncludes.h header is deprecated and will be removed in ROOT 6.40"
+#endif
+#endif
+
+
 #include "RConfigure.h"
 #include "TGLIncludes.h"
 


### PR DESCRIPTION
Deprecate the `TGLWSIncludes.h` header and add a mechanism that will force us to remove it for ROOT 6.40.

Closes https://its.cern.ch/jira/browse/ROOT-9807.