### PR TITLE
[Python][UHI] Remove __eq__ Pythonization for TH1 Derived Classes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
@@ -379,20 +379,9 @@ def _setitem(self, index, value):
         _slice_set(self, uhi_index, index, value)
 
 
-def _eq(self, other):
-    import numpy as np
-
-    return (
-        isinstance(other, type(self))
-        and _shape(self) == _shape(other)
-        and np.array_equal(_values_default(self), _values_default(other))
-    )
-
-
 def _add_indexing_features(klass: Any) -> None:
     klass.__getitem__ = _getitem
     klass.__setitem__ = _setitem
-    klass.__eq__ = _eq
 
 
 """

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi.py
@@ -548,11 +548,12 @@ def _get_sum_of_weights_squared(self) -> np.typing.NDArray[Any]:  # noqa: F821
     import numpy as np
 
     shape = _shape(self, include_flow_bins=False)
-    return np.frombuffer(
+    sumw2_arr = np.frombuffer(
         self.GetSumw2().GetArray(),
         dtype=self.GetSumw2().GetArray().typecode,
         count=self.GetSumw2().GetSize(),
-    ).reshape(shape, order="F")[tuple([slice(1, -1)] * len(shape))]
+    )
+    return sumw2_arr[tuple([slice(1, -1)] * len(shape))].reshape(shape, order="F") if sumw2_arr.size > 0 else sumw2_arr
 
 
 values_func_dict: dict[str, Callable] = {

--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -315,6 +315,19 @@ class TestTH1Indexing:
         assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), rel=10e-5)
         assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), rel=10e-5)
 
+    def test_equality(self, hist_setup):
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        hist_copy_ptr = hist_setup
+        assert hist_setup == hist_copy_ptr
+
+        hist_copy = hist_setup.Clone()
+        assert hist_setup != hist_copy
+
+        hist_full_slice = hist_setup[...]
+        assert hist_setup != hist_full_slice
+
 
 if __name__ == "__main__":
     pytest.main(args=[__file__])


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR removes the `__eq__` operator pythonization for TH1 and its derived classes, which was introduced as part of the UHI implementation. The operator caused unintended backward-incompatible behavior and potential confusion for python users. Instead of extending the operator to address concerns raised in #19061, this PR reverts it entirely.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #19038

