### PR TITLE
Remove seemingly illogical code in `rootcp`

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -702,16 +702,10 @@ def copyRootObjectRecursive(sourceFile, sourcePathSplit, destFile, destPathSplit
             if replaceOption and isExisting(destFile, destPathSplit + [setName]):
                 changeDirectory(destFile, destPathSplit)
                 otherObj = getFromDirectory(setName)
-                if not otherObj == obj:
-                    retcodeTemp = deleteObject(destFile, destPathSplit + [setName])
-                    if retcodeTemp:
-                        retcode += retcodeTemp
-                        continue
-                    else:
-                        if isinstance(obj, ROOT.TNamed):
-                            obj.SetName(setName)
-                        changeDirectory(destFile, destPathSplit)
-                        obj.Write()
+                retcodeTemp = deleteObject(destFile, destPathSplit + [setName])
+                if retcodeTemp:
+                    retcode += retcodeTemp
+                    continue
                 else:
                     if isinstance(obj, ROOT.TNamed):
                         obj.SetName(setName)


### PR DESCRIPTION
There is this weird check in `rootcp --replace` where a possibly existing object in the destination file is only deleted if it is not equal (`==`) to the object in the source file.

The default equality check for TObjects is to compare by pointer, so this condition can never be false and the existing is always deleted, as one would expect from the `--replace` option.

The object would only *not* be replaced if the class overrides `operator==` and both `otherObj` and `obj` are the same. But why not deleting the existing object if it's the same anyway?

To me, this check doesn't make sense and this commit suggests to always delete the existing object, as the user would expect when passing the `--replace` option to `rootcp`.

Closes #19035.