### PR TITLE
[CMake] Set `CMAKE_OSX_SYSROOT` only if CMake generator is Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(WIN32)
   cmake_policy(SET CMP0091 OLD)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
 endif()
-if(APPLE AND (NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL ""))
+if((CMAKE_GENERATOR MATCHES Xcode) AND (NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL ""))
   # The SYSROOT *must* be set before the project() call
   execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
     OUTPUT_VARIABLE SDK_PATH


### PR DESCRIPTION
Set `CMAKE_OSX_SYSROOT` only if CMake generator is Xcode, because otherwise we don't need it. Also, if not using Xcode ,the `xcrun` executable that is used to figure out this variable is also not available, leading to configuration failures when building ROOT on macOS without Xcode installed.

Follows up on 6bd0dba and ebc38bd.