### PR TITLE
[Tree] Delete virtual copy and copy assignment methods in TTree

### DIFF
--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -113,8 +113,6 @@ class MemoryStlString(unittest.TestCase):
             "TGraph2D": (100,),
             "TEntryList": ("name", "title"),
             "TEventList": ("name", "title"),
-            "TTree": ("name", "title"),
-            "TNtuple": ("name", "title", "x:y:z"),
         }
         for klass, args in objs.items():
             with self.subTest(klass=klass):

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -536,7 +536,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
                  && !cl->InheritsFrom( TDirectory::Class() )) {
          R__ASSERT(cl->IsTObject());
          TDirectory::TContext ctxt(current_sourcedir);
-         obj = obj->Clone();
+         obj = gDirectory->CloneObject(obj);
          ownobj = kTRUE;
       }
    } else if (key) {

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -369,7 +369,7 @@ void RooTreeDataStore::loadValues(const TTree *t, const RooFormulaVar* select, c
   // We need a custom deleter, because if we don't deregister the Tree from the directory
   // of the original, it tears it down at destruction time!
   auto deleter = [](TTree* tree){tree->SetDirectory(nullptr); delete tree;};
-  std::unique_ptr<TTree, decltype(deleter)> tClone(static_cast<TTree*>(t->Clone()), deleter);
+  std::unique_ptr<TTree, decltype(deleter)> tClone{static_cast<TTree*>(gDirectory->CloneObject(t)), deleter};
   tClone->SetDirectory(t->GetDirectory());
 
   // Clone list of variables

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -362,6 +362,9 @@ public:
    TTree(const TTree& tt) = delete;
    TTree& operator=(const TTree& tt) = delete;
 
+   TObject *Clone(const char *newname="") const override;
+   void     Copy(TObject &object) const override;
+
    virtual Int_t           AddBranchToCache(const char *bname, bool subbranches = false);
    virtual Int_t           AddBranchToCache(TBranch *branch,   bool subbranches = false);
    virtual Int_t           DropBranchFromCache(const char *bname, bool subbranches = false);

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1059,6 +1059,17 @@ TTree::~TTree()
    }
 }
 
+TObject *TTree::Clone(const char *) const
+{
+   Error("Clone", "Not implemented, use TTree::CloneTree instead.");
+   return nullptr;
+}
+
+void TTree::Copy(TObject &) const
+{
+   Error("Copy", "Not implemented, use TTree::CopyTree or TTree::CopyEntries instead.");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Returns the transient buffer currently used by this TTree for reading/writing baskets.
 
@@ -3204,7 +3215,7 @@ TTree* TTree::CloneTree(Long64_t nentries /* = -1 */, Option_t* option /* = "" *
 
    // Note: For a chain, the returned clone will be
    //       a clone of the chain's first tree.
-   TTree* newtree = (TTree*) thistree->Clone();
+   TTree* newtree = (TTree*) thistree->TNamed::Clone();
    if (!newtree) {
       return nullptr;
    }


### PR DESCRIPTION
The `TTree` class already deletes the copy constructor and the copy assignment, but users might still be tempted to use the virtual copy constructor or copy assignment provided by `TObject::Clone()` and `TObject::Copy()`. But these implementations also make no sense to the TTree.

To avoid user confusion, this commit suggests to override these methods in TTree such that they thow an exception and tell you what to use instead.

Prevents reports like this one in the future:

  * https://its.cern.ch/jira/browse/ROOT-9111