### PR TITLE
[ci] Add Fedora Rawhide special build with Python debug interpreter

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/rawhide.txt
+++ b/.github/workflows/root-ci-config/buildconfig/rawhide.txt
@@ -1,0 +1,6 @@
+builtin_zlib=ON
+builtin_zstd=ON
+ccache=ON
+test_distrdf_dask=OFF
+test_distrdf_pyspark=OFF
+vdt=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -398,6 +398,11 @@ jobs:
             property: "clang Ninja"
             overrides: ["CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
             cmake_generator: Ninja
+          # Fedora Rawhide with Python debug build
+          - image: rawhide
+            is_special: true
+            property: "Fedora pydebug"
+            overrides: ["CMAKE_CXX_STANDARD=23"]
           # Disable GPU builds until the DNS problem is solved  
           # - image: ubuntu2404-cuda
           #   is_special: true

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -884,7 +884,11 @@ static Py_ssize_t mp_hash(CPPOverload* pymeth)
 {
 // Hash of method proxy object for insertion into dictionaries; with actual
 // method (fMethodInfo) shared, its address is best suited.
+#if PY_VERSION_HEX >= 0x030d0000
+    return Py_HashPointer(pymeth->fMethodInfo);
+#else
     return _Py_HashPointer(pymeth->fMethodInfo);
+#endif
 }
 
 //----------------------------------------------------------------------------

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -146,7 +146,11 @@ static PyTypeObject PyNullPtr_t_Type = {
     nullptr_repr,        // tp_repr
     &nullptr_as_number,  // tp_as_number
     0, 0,
+#if PY_VERSION_HEX >= 0x030d0000
+    (hashfunc)Py_HashPointer, // tp_hash
+#else
     (hashfunc)_Py_HashPointer, // tp_hash
+#endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #if PY_VERSION_HEX >= 0x02030000
@@ -189,7 +193,11 @@ static PyTypeObject PyDefault_t_Type = {
     0, 0, 0, 0,
     default_repr,        // tp_repr
     0, 0, 0,
+#if PY_VERSION_HEX >= 0x030d0000
+    (hashfunc)Py_HashPointer, // tp_hash
+#else
     (hashfunc)_Py_HashPointer, // tp_hash
+#endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #if PY_VERSION_HEX >= 0x02030000

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -1649,8 +1649,12 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
     }
 
 // for STL containers, and user classes modeled after them
-    if (HasAttrDirect(pyclass, PyStrings::gSize))
+// the attribute must be a CPyCppyy overload, otherwise the check gives false
+// positives in the case where the class has a non-function attribute that is
+// called "size".
+    if (HasAttrDirect(pyclass, PyStrings::gSize, /*mustBeCPyCppyy=*/ true)) {
         Utility::AddToClass(pyclass, "__len__", "size");
+    }
 
     if (!IsTemplatedSTLClass(name, "vector")  &&      // vector is dealt with below
            !((PyTypeObject*)pyclass)->tp_iter) {

--- a/bindings/tpython/src/TPyClassGenerator.cxx
+++ b/bindings/tpython/src/TPyClassGenerator.cxx
@@ -207,12 +207,7 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             continue; // skip all other python special funcs
 
 // figure out number of variables required
-#if PY_VERSION_HEX < 0x03000000
-         PyObject *im_func = PyObject_GetAttrString(attr, (char *)"im_func");
-         PyObject *func_code = im_func ? PyObject_GetAttrString(im_func, (char *)"func_code") : NULL;
-#else
          PyObject *func_code = PyObject_GetAttrString(attr, "__code__");
-#endif
          PyObject *var_names = func_code ? PyObject_GetAttrString(func_code, (char *)"co_varnames") : NULL;
          if (PyErr_Occurred())
             PyErr_Clear(); // happens for slots; default to 0 arguments
@@ -223,9 +218,6 @@ TClass *TPyClassGenerator::GetClass(const char *name, Bool_t load, Bool_t silent
             nVars = 0;
          Py_DecRef(var_names);
          Py_DecRef(func_code);
-#if PY_VERSION_HEX < 0x03000000
-         Py_DecRef(im_func);
-#endif
 
          // method declaration as appropriate
          if (isConstructor) {

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -135,18 +135,8 @@ Bool_t TPython::Initialize()
       return true;
 
    if (!Py_IsInitialized()) {
-// this happens if Cling comes in first
-#if PY_VERSION_HEX < 0x03020000
-      PyEval_InitThreads();
-#endif
-
-// set the command line arguments on python's sys.argv
-#if PY_VERSION_HEX < 0x03000000
-      char *argv[] = {"root"};
-#else
       wchar_t rootStr[] = L"root";
       wchar_t *argv[] = {rootStr};
-#endif
       int argc = sizeof(argv) / sizeof(argv[0]);
 #if PY_VERSION_HEX < 0x030b0000
       Py_Initialize();
@@ -171,10 +161,8 @@ Bool_t TPython::Initialize()
       }
       PyConfig_Clear(&config);
 #endif
-#if PY_VERSION_HEX >= 0x03020000
 #if PY_VERSION_HEX < 0x03090000
       PyEval_InitThreads();
-#endif
 #endif
 
       // try again to see if the interpreter is initialized
@@ -297,15 +285,11 @@ void TPython::LoadMacro(const char *name)
    PyObjectRef old{PyDict_Values(gMainDict)};
 
 // actual execution
-#if PY_VERSION_HEX < 0x03000000
-   Exec((std::string("execfile(\"") + name + "\")").c_str());
-#else
    Exec((std::string("__pyroot_f = open(\"") + name +
          "\"); "
          "exec(__pyroot_f.read()); "
          "__pyroot_f.close(); del __pyroot_f")
            .c_str());
-#endif
 
    // obtain new __main__ contents
    PyObjectRef current{PyDict_Values(gMainDict)};

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -268,6 +268,8 @@ Bool_t TPython::Import(const char *mod_name)
          // get full class name (including module)
          PyObject *pyClName = PyObject_GetAttr(value, cppNameStr.obj());
          if (!pyClName) {
+            if (PyErr_Occurred())
+                PyErr_Clear();
             pyClName = PyObject_GetAttr(value, nameStr.obj());
          }
 

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -99,24 +99,6 @@ static PyObject *gMainDict = 0;
 
 namespace {
 
-class CachedPyString {
-
-public:
-   CachedPyString(const char *name) : fObj{PyUnicode_FromString(name)} {}
-
-   CachedPyString(CachedPyString const &) = delete;
-   CachedPyString(CachedPyString &&) = delete;
-   CachedPyString &operator=(CachedPyString const &) = delete;
-   CachedPyString &operator=(CachedPyString &&) = delete;
-
-   ~CachedPyString() { Py_DecRef(fObj); }
-
-   PyObject *obj() { return fObj; }
-
-private:
-   PyObject *fObj = nullptr;
-};
-
 PyThreadState *mainThreadState;
 
 // To acquire the GIL as described here:
@@ -129,6 +111,14 @@ public:
    ~PyGILRAII() { PyGILState_Release(m_GILState); }
 };
 
+struct PyObjDeleter {
+    void operator()(PyObject* obj) const {
+        Py_DecRef(obj);
+    }
+};
+
+using PyObjectRef = std::unique_ptr<PyObject, PyObjDeleter>;
+
 } // namespace
 
 //- static public members ----------------------------------------------------
@@ -140,9 +130,9 @@ Bool_t TPython::Initialize()
    static std::mutex initMutex;
    const std::lock_guard<std::mutex> lock(initMutex);
 
-   static Bool_t isInitialized = kFALSE;
+   static Bool_t isInitialized = false;
    if (isInitialized)
-      return kTRUE;
+      return true;
 
    if (!Py_IsInitialized()) {
 // this happens if Cling comes in first
@@ -152,9 +142,10 @@ Bool_t TPython::Initialize()
 
 // set the command line arguments on python's sys.argv
 #if PY_VERSION_HEX < 0x03000000
-      char *argv[] = {const_cast<char *>("root")};
+      char *argv[] = {"root"};
 #else
-      wchar_t *argv[] = {const_cast<wchar_t *>(L"root")};
+      wchar_t rootStr[] = L"root";
+      wchar_t *argv[] = {rootStr};
 #endif
       int argc = sizeof(argv) / sizeof(argv[0]);
 #if PY_VERSION_HEX < 0x030b0000
@@ -169,14 +160,14 @@ Bool_t TPython::Initialize()
       if (PyStatus_Exception(status)) {
          PyConfig_Clear(&config);
          std::cerr << "Error when setting command line arguments." << std::endl;
-         return kFALSE;
+         return false;
       }
 
       status = Py_InitializeFromConfig(&config);
       if (PyStatus_Exception(status)) {
          PyConfig_Clear(&config);
          std::cerr << "Error when initializing Python." << std::endl;
-         return kFALSE;
+         return false;
       }
       PyConfig_Clear(&config);
 #endif
@@ -190,7 +181,7 @@ Bool_t TPython::Initialize()
       if (!Py_IsInitialized()) {
          // give up ...
          std::cerr << "Error: python has not been intialized; returning." << std::endl;
-         return kFALSE;
+         return false;
       }
 
 #if PY_VERSION_HEX < 0x030b0000
@@ -205,16 +196,16 @@ Bool_t TPython::Initialize()
       PyGILRAII gilRaii;
 
       // force loading of the ROOT module
-      const int ret = PyRun_SimpleString(const_cast<char *>("import ROOT"));
+      const int ret = PyRun_SimpleString("import ROOT");
       if (ret != 0) {
          std::cerr << "Error: import ROOT failed, check your PYTHONPATH environmental variable." << std::endl;
-         return kFALSE;
+         return false;
       }
 
       if (!gMainDict) {
 
          // retrieve the main dictionary
-         gMainDict = PyModule_GetDict(PyImport_AddModule(const_cast<char *>("__main__")));
+         gMainDict = PyModule_GetDict(PyImport_AddModule("__main__"));
          // The gMainDict is borrowed, i.e. we are not calling Py_IncRef(gMainDict).
          // Like this, we avoid unexpectedly affecting how long __main__ is kept
          // alive. The gMainDict is only used in Exec(), ExecScript(), and Eval(),
@@ -226,8 +217,8 @@ Bool_t TPython::Initialize()
    gROOT->AddClassGenerator(new TPyClassGenerator);
 
    // declare success ...
-   isInitialized = kTRUE;
-   return kTRUE;
+   isInitialized = true;
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -247,30 +238,30 @@ Bool_t TPython::Import(const char *mod_name)
    }
 
    // force creation of the module as a namespace
-   TClass::GetClass(mod_name, kTRUE);
+   TClass::GetClass(mod_name, true);
 
-   PyObject *modNameObj = PyUnicode_FromString(mod_name);
-   PyObject *mod = PyImport_GetModule(modNameObj);
-   PyObject *dct = PyModule_GetDict(mod);
+   PyObjectRef modNameObj{PyUnicode_FromString(mod_name)};
+   PyObjectRef mod{PyImport_GetModule(modNameObj.get())};
+   PyObject *dct = PyModule_GetDict(mod.get());
 
-   CachedPyString basesStr{"__bases__"};
-   CachedPyString cppNameStr{"__cpp_name__"};
-   CachedPyString nameStr{"__name__"};
+   PyObjectRef basesStr{PyUnicode_FromString("__bases__")};
+   PyObjectRef cppNameStr{PyUnicode_FromString("__cpp_name__")};
+   PyObjectRef nameStr{PyUnicode_FromString("__name__")};
 
    // create Cling classes for all new python classes
-   PyObject *values = PyDict_Values(dct);
-   for (int i = 0; i < PyList_GET_SIZE(values); ++i) {
-      PyObject *value = PyList_GET_ITEM(values, i);
-      Py_IncRef(value);
+   PyObjectRef values{PyDict_Values(dct)};
+   for (int i = 0; i < PyList_Size(values.get()); ++i) {
+      PyObjectRef value{PyList_GetItem(values.get(), i)};
+      Py_IncRef(value.get());
 
       // collect classes
-      if (PyType_Check(value) || PyObject_HasAttr(value, basesStr.obj())) {
+      if (PyType_Check(value.get()) || PyObject_HasAttr(value.get(), basesStr.get())) {
          // get full class name (including module)
-         PyObject *pyClName = PyObject_GetAttr(value, cppNameStr.obj());
+         PyObjectRef pyClName{PyObject_GetAttr(value.get(), cppNameStr.get())};
          if (!pyClName) {
             if (PyErr_Occurred())
                 PyErr_Clear();
-            pyClName = PyObject_GetAttr(value, nameStr.obj());
+            pyClName = PyObjectRef{PyObject_GetAttr(value.get(), nameStr.get())};
          }
 
          if (PyErr_Occurred())
@@ -279,24 +270,14 @@ Bool_t TPython::Import(const char *mod_name)
          // build full, qualified name
          std::string fullname = mod_name;
          fullname += ".";
-         fullname += PyUnicode_AsUTF8(pyClName);
+         fullname += PyUnicode_AsUTF8AndSize(pyClName.get(), nullptr);
 
          // force class creation (this will eventually call TPyClassGenerator)
-         TClass::GetClass(fullname.c_str(), kTRUE);
-
-         Py_DecRef(pyClName);
+         TClass::GetClass(fullname.c_str(), true);
       }
-
-      Py_DecRef(value);
    }
 
-   Py_DecRef(values);
-   Py_DecRef(mod);
-   Py_DecRef(modNameObj);
-
-   if (PyErr_Occurred())
-      return kFALSE;
-   return kTRUE;
+   return !PyErr_Occurred();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -313,7 +294,7 @@ void TPython::LoadMacro(const char *name)
    PyGILRAII gilRaii;
 
    // obtain a reference to look for new classes later
-   PyObject *old = PyDict_Values(gMainDict);
+   PyObjectRef old{PyDict_Values(gMainDict)};
 
 // actual execution
 #if PY_VERSION_HEX < 0x03000000
@@ -327,50 +308,42 @@ void TPython::LoadMacro(const char *name)
 #endif
 
    // obtain new __main__ contents
-   PyObject *current = PyDict_Values(gMainDict);
+   PyObjectRef current{PyDict_Values(gMainDict)};
 
-   CachedPyString basesStr{"__bases__"};
-   CachedPyString moduleStr{"__module__"};
-   CachedPyString nameStr{"__name__"};
+   PyObjectRef basesStr{PyUnicode_FromString("__bases__")};
+   PyObjectRef moduleStr{PyUnicode_FromString("__module__")};
+   PyObjectRef nameStr{PyUnicode_FromString("__name__")};
 
    // create Cling classes for all new python classes
-   for (int i = 0; i < PyList_GET_SIZE(current); ++i) {
-      PyObject *value = PyList_GET_ITEM(current, i);
-      Py_IncRef(value);
+   for (int i = 0; i < PyList_Size(current.get()); ++i) {
+      PyObjectRef value{PyList_GetItem(current.get(), i)};
+      Py_IncRef(value.get());
 
-      if (!PySequence_Contains(old, value)) {
+      if (!PySequence_Contains(old.get(), value.get())) {
          // collect classes
-         if (PyType_Check(value) || PyObject_HasAttr(value, basesStr.obj())) {
+         if (PyType_Check(value.get()) || PyObject_HasAttr(value.get(), basesStr.get())) {
             // get full class name (including module)
-            PyObject *pyModName = PyObject_GetAttr(value, moduleStr.obj());
-            PyObject *pyClName = PyObject_GetAttr(value, nameStr.obj());
+            PyObjectRef pyModName{PyObject_GetAttr(value.get(), moduleStr.get())};
+            PyObjectRef pyClName{PyObject_GetAttr(value.get(), nameStr.get())};
 
             if (PyErr_Occurred())
                PyErr_Clear();
 
             // need to check for both exact and derived (differences exist between older and newer
             // versions of python ... bug?)
-            if ((pyModName && pyClName) && ((PyUnicode_CheckExact(pyModName) && PyUnicode_CheckExact(pyClName)) ||
-                                            (PyUnicode_Check(pyModName) && PyUnicode_Check(pyClName)))) {
+            if ((pyModName && pyClName) && ((PyUnicode_CheckExact(pyModName.get()) && PyUnicode_CheckExact(pyClName.get())) ||
+                                            (PyUnicode_Check(pyModName.get()) && PyUnicode_Check(pyClName.get())))) {
                // build full, qualified name
-               std::string fullname = PyUnicode_AsUTF8(pyModName);
+               std::string fullname = PyUnicode_AsUTF8AndSize(pyModName.get(), nullptr);
                fullname += '.';
-               fullname += PyUnicode_AsUTF8(pyClName);
+               fullname += PyUnicode_AsUTF8AndSize(pyClName.get(), nullptr);
 
                // force class creation (this will eventually call TPyClassGenerator)
-               TClass::GetClass(fullname.c_str(), kTRUE);
+               TClass::GetClass(fullname.c_str(), true);
             }
-
-            Py_DecRef(pyClName);
-            Py_DecRef(pyModName);
          }
       }
-
-      Py_DecRef(value);
    }
-
-   Py_DecRef(current);
-   Py_DecRef(old);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -428,7 +401,7 @@ Bool_t TPython::Exec(const char *cmd, std::any *result, std::string const &resul
 {
    // setup
    if (!Initialize())
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
@@ -442,17 +415,16 @@ Bool_t TPython::Exec(const char *cmd, std::any *result, std::string const &resul
    }
 
    // execute the command
-   PyObject *pyObjectResult =
-      PyRun_String(const_cast<char *>(command.str().c_str()), Py_file_input, gMainDict, gMainDict);
+   PyObjectRef pyObjectResult{
+      PyRun_String(command.str().c_str(), Py_file_input, gMainDict, gMainDict)};
 
    // test for error
    if (pyObjectResult) {
-      Py_DecRef(pyObjectResult);
-      return kTRUE;
+      return true;
    }
 
    PyErr_Print();
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -462,24 +434,23 @@ Bool_t TPython::Bind(TObject *object, const char *label)
 {
    // check given address and setup
    if (!(object && Initialize()))
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
    // bind object in the main namespace
    TClass *klass = object->IsA();
    if (klass != 0) {
-      PyObject *bound = CPyCppyy::Instance_FromVoidPtr((void *)object, klass->GetName());
+      PyObjectRef bound{CPyCppyy::Instance_FromVoidPtr((void *)object, klass->GetName())};
 
       if (bound) {
-         Bool_t bOk = PyDict_SetItemString(gMainDict, const_cast<char *>(label), bound) == 0;
-         Py_DecRef(bound);
+         Bool_t bOk = PyDict_SetItemString(gMainDict, label, bound.get()) == 0;
 
          return bOk;
       }
    }
 
-   return kFALSE;
+   return false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -496,7 +467,7 @@ void TPython::Prompt()
    PyGILRAII gilRaii;
 
    // enter i/o interactive mode
-   PyRun_InteractiveLoop(stdin, const_cast<char *>("\0"));
+   PyRun_InteractiveLoop(stdin, "\0");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -507,7 +478,7 @@ Bool_t TPython::CPPInstance_Check(PyObject *pyobject)
 {
    // setup
    if (!Initialize())
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
@@ -522,7 +493,7 @@ Bool_t TPython::CPPInstance_CheckExact(PyObject *pyobject)
 {
    // setup
    if (!Initialize())
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
@@ -538,7 +509,7 @@ Bool_t TPython::CPPOverload_Check(PyObject *pyobject)
 {
    // setup
    if (!Initialize())
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
@@ -553,7 +524,7 @@ Bool_t TPython::CPPOverload_CheckExact(PyObject *pyobject)
 {
    // setup
    if (!Initialize())
-      return kFALSE;
+      return false;
 
    PyGILRAII gilRaii;
 
@@ -568,7 +539,7 @@ void *TPython::CPPInstance_AsVoidPtr(PyObject *pyobject)
 {
    // setup
    if (!Initialize())
-      return 0;
+      return nullptr;
 
    PyGILRAII gilRaii;
 
@@ -583,7 +554,7 @@ PyObject *TPython::CPPInstance_FromVoidPtr(void *addr, const char *classname, Bo
 {
    // setup
    if (!Initialize())
-      return 0;
+      return nullptr;
 
    PyGILRAII gilRaii;
 

--- a/roottest/python/cling/runPyClassTest.C
+++ b/roottest/python/cling/runPyClassTest.C
@@ -21,6 +21,9 @@ void runPyClassTest() {
    gROOT->ProcessLine( ".x PyClassTest2.C" );
 
 // test derivation of C++ classes from Python classes
+// make sure that MyModule is in the path
+   TPython::Exec("import sys");
+   TPython::Exec("sys.path.append('./')");
    TPython::Import( "MyModule" );
    gROOT->ProcessLine( ".L PyClassTest3.C" );
    gROOT->ProcessLine( ".x PyClassTest4.C" );


### PR DESCRIPTION
Like this, we have a Python debug interpreter run in our CI and also test the cutting edge of Fedora development.

Quoting from the [Python docs](https://devguide.python.org/getting-started/setup-building/index.html):

> You should always develop under a pydebug build of CPython (the only instance of when you shouldn’t is if you are taking performance measurements). Even when working only on pure Python code the pydebug build provides several useful checks that one should not skip.

Closes https://github.com/root-project/root/issues/19224.