### PR TITLE
[cling] Check if `LLVM_SUBMIT_VERSION` is defined, not its value

### DIFF
--- a/interpreter/cling/tools/Jupyter/CMakeLists.txt
+++ b/interpreter/cling/tools/Jupyter/CMakeLists.txt
@@ -84,7 +84,7 @@ set_target_properties(libclingJupyter
 if(ENABLE_SHARED)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         set(LIBCLINGJUPYTER_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
-        if (DEFINED ${LLVM_SUBMIT_VERSION})
+        if (DEFINED LLVM_SUBMIT_VERSION)
             set(LIBCLINGJUPYTER_LINK_FLAGS
                     "${LIBCLINGJUPYTER_LINK_FLAGS} -Wl,-current_version -Wl,${LLVM_SUBMIT_VERSION}.${LLVM_SUBMIT_SUBVERSION}")
         endif()

--- a/interpreter/cling/tools/libcling/CMakeLists.txt
+++ b/interpreter/cling/tools/libcling/CMakeLists.txt
@@ -97,7 +97,7 @@ set_target_properties(libcling
 if(ENABLE_SHARED)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(LIBCLING_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
-    if (DEFINED ${LLVM_SUBMIT_VERSION})
+    if (DEFINED LLVM_SUBMIT_VERSION)
       set(LIBCLING_LINK_FLAGS
         "${LIBCLING_LINK_FLAGS} -Wl,-current_version -Wl,${LLVM_SUBMIT_VERSION}.${LLVM_SUBMIT_SUBVERSION}")
     endif()


### PR DESCRIPTION
Reported here: https://github.com/root-project/cling/issues/551
We check if a variable exists named with the value of LLVM_SUBMIT_VERSION instead of checking if it is defined.