### PR TITLE
[cling] DlClose what DlLibMan has DlOpened in reverse order

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
+++ b/interpreter/cling/include/cling/Interpreter/DynamicLibraryManager.h
@@ -56,6 +56,7 @@ namespace cling {
     ///\brief DynamicLibraries loaded by this Interpreter.
     ///
     DyLibs m_DyLibs;
+    std::vector<DyLibHandle> m_OpenDyLibs;
     llvm::StringSet<> m_LoadedLibraries;
 
     ///\brief System's include path, get initialized at construction time.

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -393,6 +393,7 @@ namespace cling {
     if (!insRes.second)
       return kLoadLibAlreadyLoaded;
     m_LoadedLibraries.insert(canonicalLoadedLib);
+    m_OpenDyLibs.push_back(dyLibHandle);
     return kLoadLibSuccess;
   }
 
@@ -424,6 +425,9 @@ namespace cling {
 
     m_DyLibs.erase(dyLibHandle);
     m_LoadedLibraries.erase(canonicalLoadedLib);
+    auto it =
+        std::find(m_OpenDyLibs.rbegin(), m_OpenDyLibs.rend(), dyLibHandle);
+    *it = (DyLibHandle)-1; // Invalidate
   }
 
   bool DynamicLibraryManager::isLibraryLoaded(llvm::StringRef fullPath) const {

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -1336,8 +1336,31 @@ namespace cling {
     return ""; // Search found no match.
   }
 
+  namespace {
+    template <class T> struct Reversed {
+      const T& m_orig;
+      auto begin() -> decltype(m_orig.rbegin()) { return m_orig.rbegin(); }
+      auto end() -> decltype(m_orig.rend()) { return m_orig.rend(); }
+    };
+    template <class T> Reversed<T> reverse(const T& orig) { return {orig}; }
+  } // namespace
+
   DynamicLibraryManager::~DynamicLibraryManager() {
     static_assert(sizeof(Dyld) > 0, "Incomplete type");
+
+    // dlclose all libraries.
+    for (auto&& Handle : reverse(m_OpenDyLibs)) {
+      if (Handle == (DyLibHandle)-1)
+        continue; // was already closed previously.
+      std::string errMsg;
+      platform::DLClose(Handle, &errMsg);
+      if (!errMsg.empty()) {
+        cling::errs()
+            << "cling::DynamicLibraryManager::~DynamicLibraryManager(): "
+            << errMsg << '\n';
+      }
+    }
+
     delete m_Dyld;
   }
 


### PR DESCRIPTION
All credit goes to @Axel-Naumann, this is just a rebase of https://github.com/root-project/root/pull/5568/ to see if it still works / makes sense or if it should just be closed.

Not sure if this is exhaustive, there might be other places to take care:

```
core/metacling/src/TClingCallbacks.cxx
core/base/src/TROOT.cxx
core/metacling/src/TCling.cxx
interpreter/cling/lib/Utils/PlatformPosix.cpp
interpreter/cling/lib/Interpreter/IncrementalParser.cpp
interpreter/CppInterOp/lib/CppInterOp/CppInterOpInterpreter.h
interpreter/cling/lib/Utils/PlatformPosix.cpp
bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/cppcompleter.py
```

Related:
https://its.cern.ch/jira/browse/ROOT-10659
https://its.cern.ch/jira/browse/ROOT-6022