### PR TITLE
[tree] raise error if entry not properly loaded in EvalInstance

### DIFF
--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -96,12 +96,17 @@ The following method are available from the TFormLeafInfo interface:
 ClassImp(TTreeFormula);
 
 ////////////////////////////////////////////////////////////////////////////////
-
-inline static void R__LoadBranch(TBranch* br, Long64_t entry, bool quickLoad)
+/// The function returns the number of bytes read from the input buffer.
+/// If entry does not exist or (entry!=readEntry && quickload), the function returns 0.
+/// If an I/O error occurs, the function returns -1.
+///
+inline static Int_t R__LoadBranch(TBranch* br, Long64_t entry, bool quickLoad)
 {
    if (!quickLoad || (br->GetReadEntry() != entry)) {
-      br->GetEntry(entry);
+      auto res = br->GetEntry(entry);
+      return res;
    }
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3773,7 +3778,10 @@ const char* TTreeFormula::EvalStringInstance(Int_t instance)
       TBranch *br = leaf->GetBranch();                                                          \
       if (br && br->GetTree()) {                                                                \
          Long64_t tentry = br->GetTree()->GetReadEntry();                                       \
-         R__LoadBranch(br,tentry,fQuickLoad);                                                   \
+         auto loadBranchRes = R__LoadBranch(br,tentry,fQuickLoad);                              \
+         if (loadBranchRes < 0)                                                                 \
+            Error("TTreeFormula::TT_EVAL_INIT",                                                 \
+             "Could not read entry (%lld) of leaf (%s).", tentry, leaf->GetName());             \
       } else {                                                                                  \
         Error("TTreeFormula::TT_EVAL_INIT",                                                     \
           "Could not init branch associated to this leaf (%s).", leaf->GetName());              \


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

See https://root-forum.cern.ch/t/ntuples-unable-to-read/63847/7

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)