### PR TITLE
[CMake] Standardize Smatrix and GenVector libraries

### DIFF
--- a/math/genvector/CMakeLists.txt
+++ b/math/genvector/CMakeLists.txt
@@ -8,30 +8,8 @@
 # CMakeLists.txt file for building ROOT math/genvector package
 ############################################################################
 
-ROOT_LINKER_LIBRARY(GenVector
-    src/3DConversions.cxx
-    src/3DDistances.cxx
-    src/AxisAngle.cxx
-    src/AxisAngleXother.cxx
-    src/BitReproducible.cxx
-    src/Boost.cxx
-    src/BoostX.cxx
-    src/BoostY.cxx
-    src/BoostZ.cxx
-    src/EulerAngles.cxx
-    src/LorentzRotation.cxx
-    src/Quaternion.cxx
-    src/QuaternionXaxial.cxx
-    src/Rotation3D.cxx
-    src/Rotation3DxAxial.cxx
-    src/RotationZYX.cxx
-    src/VectorUtil.cxx
-  DEPENDENCIES
-    Core
-    MathCore
-)
-
-ROOT_GENERATE_DICTIONARY(G__GenVector
+ROOT_STANDARD_LIBRARY_PACKAGE(GenVector
+  HEADERS
     Math/AxisAngle.h
     Math/Boost.h
     Math/BoostX.h
@@ -142,29 +120,27 @@ ROOT_GENERATE_DICTIONARY(G__GenVector
     Math/Vector4Dfwd.h
     Math/Vector4D.h
     Math/VectorUtil.h
-  MODULE
-    GenVector
+  SOURCES
+    src/3DConversions.cxx
+    src/3DDistances.cxx
+    src/AxisAngle.cxx
+    src/AxisAngleXother.cxx
+    src/BitReproducible.cxx
+    src/Boost.cxx
+    src/BoostX.cxx
+    src/BoostY.cxx
+    src/BoostZ.cxx
+    src/EulerAngles.cxx
+    src/LorentzRotation.cxx
+    src/Quaternion.cxx
+    src/QuaternionXaxial.cxx
+    src/Rotation3D.cxx
+    src/Rotation3DxAxial.cxx
+    src/RotationZYX.cxx
+    src/VectorUtil.cxx
   LINKDEF
-    Math/LinkDef_GenVector.h
-  OPTIONS
-    -writeEmptyRootPCM
-  DEPENDENCIES
-    Core
-    MathCore
-)
-
-ROOT_GENERATE_DICTIONARY(G__GenVector32
-    Math/Point2D.h
-    Math/Point3D.h
-    Math/Vector2D.h
-    Math/Vector3D.h
-    Math/Vector4D.h
-  MODULE
-    GenVector
-  MULTIDICT
-  LINKDEF
-    Math/LinkDef_GenVector32.h
-  OPTIONS
+    Math/LinkDef_GenVectorAll.h
+  DICTIONARY_OPTIONS
     -writeEmptyRootPCM
   DEPENDENCIES
     Core
@@ -172,5 +148,3 @@ ROOT_GENERATE_DICTIONARY(G__GenVector32
 )
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
-
-ROOT_INSTALL_HEADERS()

--- a/math/smatrix/CMakeLists.txt
+++ b/math/smatrix/CMakeLists.txt
@@ -33,25 +33,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Smatrix
     Math/UnaryOperators.h
   NO_SOURCES
   LINKDEF
-    LinkDef.h
+    LinkDefAll.h
   DICTIONARY_OPTIONS
-    -writeEmptyRootPCM
-  DEPENDENCIES
-    Core
-    MathCore
-)
-
-ROOT_GENERATE_DICTIONARY(G__Smatrix32
-    Math/SMatrix.h
-    Math/SMatrixDfwd.h
-    Math/SMatrixFfwd.h
-    Math/SVector.h
-  MULTIDICT
-  MODULE
-    Smatrix
-  LINKDEF
-    LinkDefD32.h
-  OPTIONS
     -writeEmptyRootPCM
   DEPENDENCIES
     Core


### PR DESCRIPTION
It's a bit strange that these two packages separate their dictionaries from the libraries, being the only math libraries that use `ROOT_GENERATE_DICTIONARY` in their CMake code. Especially for modules builds, this is inconsistent, because with that macro you also get `rootmap` files, while we just want `pcm` files. Having both can be problematic in more fragile environments.

It's probably better to use `ROOT_STANDARD_LIBRARY_PACKAGE` all the way.

With this commit, no `rootmap` files from standard ROOT packages remain in the install trees `lib` for modules enabled. Just these files here, where I'm not sure if they are needed:
```txt
libcomplexDict.rootmap
libdequeDict.rootmap
libforward_listDict.rootmap
liblistDict.rootmap
libmap2Dict.rootmap
libmapDict.rootmap
libmultimap2Dict.rootmap
libmultimapDict.rootmap
libmultisetDict.rootmap
libsetDict.rootmap
libunordered_mapDict.rootmap
libunordered_multimapDict.rootmap
libunordered_multisetDict.rootmap
libunordered_setDict.rootmap
libvalarrayDict.rootmap
libvectorDict.rootmap
```