### PR TITLE
[core] fix bug in max uchar and ushort

### DIFF
--- a/core/foundation/inc/RtypesCore.h
+++ b/core/foundation/inc/RtypesCore.h
@@ -93,11 +93,11 @@ typedef float          Size_t;      //Attribute size (float)
 constexpr Bool_t kTRUE = true;
 constexpr Bool_t kFALSE = false;
 
-constexpr Int_t kMaxUChar = 256;
+constexpr Int_t kMaxUChar = UChar_t(~0);
 constexpr Int_t kMaxChar = kMaxUChar >> 1;
 constexpr Int_t kMinChar = -kMaxChar - 1;
 
-constexpr Int_t kMaxUShort = 65534;
+constexpr Int_t kMaxUShort = UShort_t(~0);
 constexpr Int_t kMaxShort = kMaxUShort >> 1;
 constexpr Int_t kMinShort = -kMaxShort - 1;
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The max unsigned limits were off by one since

https://github.com/root-project/root/commit/6f8e7529bf1fc5a7b2ea8a9f969c64991403e587
https://github.com/root-project/root/commit/dcd4a870d454da3628408ed10591cdc53f01ab85

They were wrong for uchar and ushort, and they were right for the rest of data types.

Fixes https://github.com/root-project/root/issues/12208


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
