### PR TITLE
[main] Rewrite rootls in c++

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WIN32)
   set_property(TARGET rootcling APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
 endif()
 
-ROOT_EXECUTABLE(rootlscxx src/rootls.cxx LIBRARIES RIO Tree Hist Core Rint)
+ROOT_EXECUTABLE(rootlscxx src/rootls.cxx LIBRARIES RIO Tree Core Rint)
 
 # Create aliases: rootcint, genreflex.
 if(WIN32)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -115,6 +115,8 @@ if(WIN32)
   set_property(TARGET rootcling APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
 endif()
 
+ROOT_EXECUTABLE(rootlscxx src/rootls.cxx LIBRARIES RIO Tree Hist Core Rint)
+
 # Create aliases: rootcint, genreflex.
 if(WIN32)
   add_custom_command(TARGET rootcling POST_BUILD

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -1,0 +1,154 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <regex>
+
+#include "wildcards.hpp"
+
+#include <TFile.h>
+#include <TKey.h>
+
+#include <ROOT/StringUtils.hxx>
+
+static const char *const ONE_HELP = "Print content in one column";
+static const char *const LONG_PRINT_HELP = "Use a long listing format.";
+static const char *const TREE_PRINT_HELP = "Print tree recursively and use a long listing format.";
+static const char *const RECURSIVE_PRINT_HELP = "Traverse file recursively entering any TDirectory.";
+static const char *const EPILOG = R"(Examples:
+- rootls example.root
+  Display contents of the ROOT file 'example.root'.
+
+- rootls example.root:dir
+  Display contents of the directory 'dir' from the ROOT file 'example.root'.
+
+- rootls example.root:*
+  Display contents of the ROOT file 'example.root' and his subdirectories.
+
+- rootls file1.root file2.root
+  Display contents of ROOT files 'file1.root' and 'file2.root'.
+
+- rootls *.root
+  Display contents of ROOT files whose name ends with '.root'.
+
+- rootls -1 example.root
+  Display contents of the ROOT file 'example.root' in one column.
+
+- rootls -l example.root
+  Display contents of the ROOT file 'example.root' and use a long listing format.
+
+- rootls -t example.root
+  Display contents of the ROOT file 'example.root', use a long listing format and print trees recursively.
+
+- rootls -r example.root
+  Display contents of the ROOT file 'example.root', traversing recursively any TDirectory.
+)";
+
+
+struct SplitPath {
+  std::vector<std::string> fPathFragments;
+};
+
+struct RootLsSource {
+  std::string fFileName;
+  // List of object paths that match the query
+  std::vector<SplitPath> fObjectPaths;
+};
+
+static void RootLs(const std::vector<RootLsSource> &sourceFiles)
+{
+  int indent = 2 * (sourceFiles.size() > 1);
+  for (const auto &source : sourceFiles) {
+    std::cout << source.fFileName << "\n";
+    for (const auto &path : source.fObjectPaths) {
+      int ind = indent + 2;
+      for (const auto &frag : path.fPathFragments) {
+        for (int i = 0; i < ind; ++i)
+          std::cout << ' ';
+        std::cout << frag << "\n";
+        ind += 2;
+      }
+    }
+  }
+}
+
+static bool MatchesGlob(std::string_view haystack, std::string_view pattern)
+{
+  return wildcards::match(haystack, pattern);
+}
+
+static std::vector<SplitPath> GetMatchingPathsInFile(std::string_view fileName, std::string_view pattern)
+{
+  std::vector<SplitPath> result;
+  
+  auto file = std::unique_ptr<TFile>(TFile::Open(std::string(fileName).c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
+  if (!file)
+    return result;
+
+  // @Speed: avoid allocating
+  const auto patternSplits = ROOT::Split(pattern, "/");
+
+  // Match all objects at all nesting levels
+  struct DirLevel {
+    TDirectory *fDir;
+    // @Speed this is super inefficient!
+    std::vector<std::string> fAncestorPaths;
+  };
+  std::vector<DirLevel> dirsToVisit { {file.get(), {}} };
+  for (const auto &pat : patternSplits) {
+    std::vector<DirLevel> newDirsToVisit;
+    for (const auto &[dir, ancestorPaths] : dirsToVisit) {
+      for (TKey *key : ROOT::Detail::TRangeStaticCast<TKey>(dir->GetListOfKeys())) {
+        // std::cout << "matching pattern fragment " << pat << " against " << key->GetName() << "\n";
+        if (MatchesGlob(key->GetName(), pat)) {
+          const TClass *className = TClass::GetClass(key->GetClassName());
+          std::vector<std::string> newAncestorPaths = ancestorPaths;
+          newAncestorPaths.push_back(key->GetName());
+          // std::cout << "matched. is dir? " << className->InheritsFrom("TDirectory") << " (class: " << key->GetClassName() << ", name: " << key->GetName() << ")\n";
+          if (className && className->InheritsFrom("TDirectory")) {
+            newDirsToVisit.push_back({dir->GetDirectory(key->GetName()), newAncestorPaths});
+          } else {
+            result.push_back(SplitPath { newAncestorPaths });
+          }
+        }
+      }
+    }
+    std::swap(dirsToVisit, newDirsToVisit);
+  }
+
+  return result;
+}
+
+static std::vector<RootLsSource> GetPositionalArguments(const char **args, int nArgs)
+{
+  std::vector<RootLsSource> outArgs;
+  outArgs.reserve(nArgs);
+  
+  for (int i = 0; i < nArgs; ++i) {
+    const char *arg = args[i];
+    if (arg[0] == '-')
+      continue;
+    
+    RootLsSource &newSource = outArgs.emplace_back();
+    auto tokens = ROOT::Split(arg, ":"); 
+    newSource.fFileName = tokens[0];   
+    if (tokens.size() > 1) {
+      newSource.fObjectPaths = GetMatchingPathsInFile(tokens[0], tokens[1]);
+    }
+  }
+
+  return outArgs;
+}
+
+int main(int argc, char **argv)
+{
+  // TODO: parse flags
+  auto sourceFiles = GetPositionalArguments(const_cast<const char **>(argv) + 1, argc - 1);
+
+  // sort by name
+  std::sort(sourceFiles.begin(), sourceFiles.end(), [] (const auto &a, const auto &b) {
+    return a.fFileName < b.fFileName;
+  });
+  
+  RootLs(sourceFiles);
+}

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -179,22 +179,26 @@ struct V2i {
 
 static V2i GetTerminalSize()
 {
+   int rows = 80, columns = 25;
 #if defined(R__UNIX)
-   winsize w;
-   if (::ioctl(STDIN_FILENO, TIOCGWINSZ, &w) == 0 || ::ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0 ||
-       ::ioctl(STDERR_FILENO, TIOCGWINSZ, &w) == 0)
-      return {w.ws_col, w.ws_row};
-#elif defined(R__WINDOWS)
-   int rows = 0, columns = 0;
-   CONSOLE_SCREEN_BUFFER_INFO csbi;
-   if (::GetConsoleScreenBufferInfo(::GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
-      columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
-      rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+   {
+      winsize w;
+      if (::ioctl(STDIN_FILENO, TIOCGWINSZ, &w) == 0 || ::ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0 ||
+          ::ioctl(STDERR_FILENO, TIOCGWINSZ, &w) == 0) {
+         rows = w.ws_row;
+         columns = w.ws_col;
+      }
    }
-   return {columns, rows};
+#elif defined(R__WINDOWS)
+   {
+      CONSOLE_SCREEN_BUFFER_INFO csbi;
+      if (::GetConsoleScreenBufferInfo(::GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+         columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+         rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+      }
+   }
 #endif
-   // Fallback
-   return {80, 25};
+   return {columns, rows};
 }
 
 using Indent = int;

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -1,8 +1,10 @@
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <iomanip>
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
-#include <algorithm>
-#include <regex>
 
 #include "wildcards.hpp"
 
@@ -10,6 +12,16 @@
 #include <TKey.h>
 
 #include <ROOT/StringUtils.hxx>
+#include <ROOT/RError.hxx>
+
+#if defined(R__UNIX)
+#include <sys/ioctl.h>
+#include <unistd.h>
+#elif defined(R__WINDOWS)
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#include <windows.h>
+#endif
 
 static const char *const ONE_HELP = "Print content in one column";
 static const char *const LONG_PRINT_HELP = "Use a long listing format.";
@@ -44,111 +56,329 @@ static const char *const EPILOG = R"(Examples:
   Display contents of the ROOT file 'example.root', traversing recursively any TDirectory.
 )";
 
+static ROOT::RLogChannel &RootLsChannel()
+{
+   static ROOT::RLogChannel sLog("ROOTLS");
+   return sLog;
+}
 
 struct SplitPath {
-  std::vector<std::string> fPathFragments;
+   std::vector<std::string> fPathFragments;
+};
+
+using NodeIdx = std::uint32_t;
+
+struct RootLsNode {
+   std::string fName;
+   TDirectory *fDir = nullptr; // may be null
+   // TODO: this can probably be replaced by `NodeIdx firstChild; NodeIdx nChildren;` since the children
+   // should always be contiguous.
+   std::vector<NodeIdx> fChildren;
+   std::uint32_t fNesting = 0;
+};
+
+struct RootLsTree {
+   // 0th node is the root node
+   std::vector<RootLsNode> fNodes;
 };
 
 struct RootLsSource {
-  std::string fFileName;
-  // List of object paths that match the query
-  std::vector<SplitPath> fObjectPaths;
+   std::string fFileName;
+   // List of object paths that match the query
+   // std::vector<SplitPath> fObjectPaths;
+   RootLsTree fObjectTree;
 };
 
-static void RootLs(const std::vector<RootLsSource> &sourceFiles)
+struct RootLsArgs {
+   enum Flags {
+      kNone = 0,
+      kOneColumn = 1,
+      kLongListing = 2,
+      kTreeListing = 4,
+      kRecursiveListing = 8
+   };
+
+   std::uint32_t fFlags = 0;
+   std::vector<RootLsSource> fSources;
+};
+
+template <typename F>
+static void VisitBreadthFirst(const RootLsTree &tree, const F &func, NodeIdx nodeIdx = 0)
 {
-  int indent = 2 * (sourceFiles.size() > 1);
-  for (const auto &source : sourceFiles) {
-    std::cout << source.fFileName << "\n";
-    for (const auto &path : source.fObjectPaths) {
-      int ind = indent + 2;
-      for (const auto &frag : path.fPathFragments) {
-        for (int i = 0; i < ind; ++i)
-          std::cout << ' ';
-        std::cout << frag << "\n";
-        ind += 2;
+   // TODO: make non-recursive?
+   auto &root = tree.fNodes[nodeIdx];
+   func(root);
+   for (auto childIdx : root.fChildren) {
+      VisitBreadthFirst(tree, func, childIdx);
+   }
+}
+
+struct V2i {
+   int x, y;
+};
+
+static V2i GetTerminalSize()
+{
+#if defined(R__UNIX)
+   winsize w;
+   ::ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+   return {w.ws_col, w.ws_row};
+#elif defined(R__WINDOWS)
+   int rows = 0, columns = 0;
+   CONSOLE_SCREEN_BUFFER_INFO csbi;
+   if (::GetConsoleScreenBufferInfo(::GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+      columns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+      rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+   }
+   return {columns, rows};
+#endif
+   // Fallback
+   return {80, 10};
+}
+
+enum EPrintFlags {
+   kPrintNone = 0,
+   kPrintOneColumn = 1,
+};
+
+enum Indent : int;
+
+static void PrintChildrenInColumns(std::ostream &stream, const RootLsTree &tree, NodeIdx nodeIdx, std::uint32_t flags, Indent indent)
+{
+   const auto &node = tree.fNodes[nodeIdx];
+   if (node.fChildren.empty())
+      return;
+
+   const V2i terminalSize = GetTerminalSize();
+   std::cout << "size: " << terminalSize.x << ", " << terminalSize.y << "\n";
+   const int minCharsBetween = 2;
+   const auto [minElemWidthIt, maxElemWidthIt] =
+      std::minmax_element(node.fChildren.begin(), node.fChildren.end(), [&tree](NodeIdx aIdx, NodeIdx bIdx) {
+         const auto &a = tree.fNodes[aIdx];
+         const auto &b = tree.fNodes[bIdx];
+         return a.fName.length() < b.fName.length();
+      });
+   const auto minElemWidth = tree.fNodes[*minElemWidthIt].fName.length() + minCharsBetween;
+   const auto maxElemWidth = tree.fNodes[*maxElemWidthIt].fName.length() + minCharsBetween;
+
+   // Figure out how many columns do we need
+   int nCols = 0;
+   std::vector<int> colWidths;
+   if (maxElemWidth > terminalSize.x) {
+      nCols = 1;
+      colWidths = {1};
+   } else {
+      bool oneColumn = (flags & kPrintOneColumn);
+      // Start with the max possible number of columns and reduce it until it fits
+      nCols = oneColumn ? 1 : std::min<int>(node.fChildren.size(), terminalSize.x / static_cast<int>(minElemWidth));
+      while (1) {
+         int totWidth = 0;
+
+         // Find maximum width of each column 
+         for (int colIdx = 0; colIdx < nCols; ++colIdx) {
+            int width = 0;
+            for (int j = 0; j < node.fChildren.size(); ++j) {
+               if ((j % nCols) == colIdx) {
+                  NodeIdx childIdx = node.fChildren[j];
+                  const RootLsNode &child = tree.fNodes[childIdx];
+                  width = std::max<int>(width, child.fName.length()) + minCharsBetween;
+               }
+            }
+
+            totWidth += width;
+            if (totWidth > terminalSize.x) {
+               --nCols;
+               colWidths.clear();
+               break;
+            }
+
+            colWidths.push_back(width);
+         }
+
+         if (!colWidths.empty())
+            break;
+
+         // The loop should always end at some point given the check on maxElemWidth <= terminalSize.x
+         assert(nCols > 0);
       }
-    }
-  }
+   }
+
+   for (auto i = 0u; i < node.fChildren.size(); ++i) {
+      NodeIdx childIdx = node.fChildren[i];
+      const auto &child = tree.fNodes[childIdx];
+      if (i % nCols) {
+         std::string indentStr(indent, ' ');
+         stream << indent;
+      }
+      // TODO: colors
+      if (((i + 1) % nCols) != 0 && i != node.fChildren.size() - 1) {
+         stream << std::left << std::setw(colWidths[i % nCols]) << child.fName;
+      } else {
+         stream << child.fName << "\n";
+      }
+   }
+}
+
+static void RootLs(const RootLsArgs &args)
+{
+   int indent = 2 * (args.fSources.size() > 1);
+   for (const auto &source : args.fSources) {
+      // std::cout << source.fFileName << "\n";
+      // VisitBreadthFirst(source.fObjectTree, [](const auto &node) {
+      //    std::string indentStr(std::size_t(node.fNesting * 2), ' ');
+      //    std::cout << indentStr << node.fName << "\n";
+      // });
+      PrintChildrenInColumns(std::cout, source.fObjectTree, NodeIdx(0), kPrintNone, Indent(0));
+
+      auto file = std::unique_ptr<TFile>(TFile::Open(source.fFileName.c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
+      if (!file || file->IsZombie()) {
+         R__LOG_ERROR(RootLsChannel()) << "failed to open file " << source.fFileName;
+         continue;
+      }
+
+      // Print
+      if (args.fSources.size() > 1) {
+         std::cout << source.fFileName << ":\n";
+      }
+   }
 }
 
 static bool MatchesGlob(std::string_view haystack, std::string_view pattern)
 {
-  return wildcards::match(haystack, pattern);
+   return wildcards::match(haystack, pattern);
 }
 
-static std::vector<SplitPath> GetMatchingPathsInFile(std::string_view fileName, std::string_view pattern)
+static RootLsTree GetMatchingPathsInFile(std::string_view fileName, std::string_view pattern)
 {
-  std::vector<SplitPath> result;
-  
-  auto file = std::unique_ptr<TFile>(TFile::Open(std::string(fileName).c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
-  if (!file)
-    return result;
+   // std::vector<SplitPath> result;
 
-  // @Speed: avoid allocating
-  const auto patternSplits = ROOT::Split(pattern, "/");
+   auto file = std::unique_ptr<TFile>(TFile::Open(std::string(fileName).c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
+   if (!file)
+      return {};
 
-  // Match all objects at all nesting levels
-  struct DirLevel {
-    TDirectory *fDir;
-    // @Speed this is super inefficient!
-    std::vector<std::string> fAncestorPaths;
-  };
-  std::vector<DirLevel> dirsToVisit { {file.get(), {}} };
-  for (const auto &pat : patternSplits) {
-    std::vector<DirLevel> newDirsToVisit;
-    for (const auto &[dir, ancestorPaths] : dirsToVisit) {
-      for (TKey *key : ROOT::Detail::TRangeStaticCast<TKey>(dir->GetListOfKeys())) {
-        // std::cout << "matching pattern fragment " << pat << " against " << key->GetName() << "\n";
-        if (MatchesGlob(key->GetName(), pat)) {
-          const TClass *className = TClass::GetClass(key->GetClassName());
-          std::vector<std::string> newAncestorPaths = ancestorPaths;
-          newAncestorPaths.push_back(key->GetName());
-          // std::cout << "matched. is dir? " << className->InheritsFrom("TDirectory") << " (class: " << key->GetClassName() << ", name: " << key->GetName() << ")\n";
-          if (className && className->InheritsFrom("TDirectory")) {
-            newDirsToVisit.push_back({dir->GetDirectory(key->GetName()), newAncestorPaths});
-          } else {
-            result.push_back(SplitPath { newAncestorPaths });
-          }
-        }
+   // @Speed: avoid allocating
+   const auto patternSplits = ROOT::Split(pattern, "/");
+
+   // Match all objects at all nesting levels
+   struct DirLevel {
+      TDirectory *fDir;
+      // @Speed this is super inefficient!
+      std::vector<std::string> fAncestorPaths;
+   };
+
+   RootLsTree nodeTree;
+   auto &rootNode = nodeTree.fNodes.emplace_back(RootLsNode{std::string(fileName), file.get()});
+   std::deque<NodeIdx> nodesToVisit{0};
+
+   do {
+      NodeIdx curIdx = nodesToVisit.front();
+      nodesToVisit.pop_front();
+      RootLsNode *cur = &nodeTree.fNodes[curIdx];
+      assert(cur->fDir);
+      if (cur->fNesting == patternSplits.size())
+         break;
+
+      for (TKey *key : ROOT::Detail::TRangeStaticCast<TKey>(cur->fDir->GetListOfKeys())) {
+         if (!MatchesGlob(key->GetName(), patternSplits[cur->fNesting]))
+            continue;
+
+         RootLsNode &newChild = nodeTree.fNodes.emplace_back();
+         // Need to get back cur since the emplace_back() may have moved it.
+         cur = &nodeTree.fNodes[curIdx];
+         newChild.fName = key->GetName();
+         newChild.fNesting = cur->fNesting + 1;
+         cur->fChildren.push_back(nodeTree.fNodes.size() - 1);
+
+         const TClass *className = TClass::GetClass(key->GetClassName());
+         if (className && className->InheritsFrom("TDirectory")) {
+            newChild.fDir = cur->fDir->GetDirectory(key->GetName());
+         }
       }
-    }
-    std::swap(dirsToVisit, newDirsToVisit);
-  }
 
-  return result;
+      for (auto childIdx : cur->fChildren) {
+         auto &child = nodeTree.fNodes[childIdx];
+         if (child.fDir)
+            nodesToVisit.push_back(childIdx);
+      }
+   } while (!nodesToVisit.empty());
+
+   // std::vector<DirLevel> dirsToVisit { {file.get(), {}} };
+
+   // for (const auto &pat : patternSplits) {
+   //   std::vector<DirLevel> newDirsToVisit;
+   //   for (const auto &[dir, ancestorPaths] : dirsToVisit) {
+   //     for (TKey *key : ROOT::Detail::TRangeStaticCast<TKey>(dir->GetListOfKeys())) {
+   //       // std::cout << "matching pattern fragment " << pat << " against " << key->GetName() << "\n";
+   //       if (!MatchesGlob(key->GetName(), pat))
+   //         continue;
+
+   //       const TClass *className = TClass::GetClass(key->GetClassName());
+   //       std::vector<std::string> newAncestorPaths = ancestorPaths;
+   //       newAncestorPaths.push_back(key->GetName());
+   //       // std::cout << "matched. is dir? " << className->InheritsFrom("TDirectory") << " (class: " <<
+   //       key->GetClassName() << ", name: " << key->GetName() << ")\n"; if (className &&
+   //       className->InheritsFrom("TDirectory")) {
+   //         newDirsToVisit.push_back({dir->GetDirectory(key->GetName()), newAncestorPaths});
+   //       } else {
+   //         result.push_back(SplitPath { newAncestorPaths });
+   //       }
+   //     }
+   //   }
+   //   std::swap(dirsToVisit, newDirsToVisit);
+   // }
+
+   return nodeTree;
 }
 
-static std::vector<RootLsSource> GetPositionalArguments(const char **args, int nArgs)
+static bool
+MatchFlag(const char *flag, char short_, const char *long_, RootLsArgs::Flags flagVal, std::uint32_t &outFlags)
 {
-  std::vector<RootLsSource> outArgs;
-  outArgs.reserve(nArgs);
-  
-  for (int i = 0; i < nArgs; ++i) {
-    const char *arg = args[i];
-    if (arg[0] == '-')
-      continue;
-    
-    RootLsSource &newSource = outArgs.emplace_back();
-    auto tokens = ROOT::Split(arg, ":"); 
-    newSource.fFileName = tokens[0];   
-    if (tokens.size() > 1) {
-      newSource.fObjectPaths = GetMatchingPathsInFile(tokens[0], tokens[1]);
-    }
-  }
+   const int flagLen = strlen(flag);
+   if (flagLen == 1 && *flag == short_) {
+      outFlags |= flagVal;
+      return true;
+   } else {
+      const int longLen = strlen(long_);
+      if (flagLen == longLen + 1 && flag[0] == '-' && strncmp(flag + 1, long_, flagLen) == 0) {
+         outFlags |= flagVal;
+         return true;
+      }
+   }
+   return false;
+}
 
-  return outArgs;
+static RootLsArgs ParseArgs(const char **args, int nArgs)
+{
+   RootLsArgs outArgs;
+
+   for (int i = 0; i < nArgs; ++i) {
+      const char *arg = args[i];
+      if (arg[0] == '-') {
+         ++arg;
+         MatchFlag(arg, '1', "oneColumn", RootLsArgs::kOneColumn, outArgs.fFlags) ||
+            MatchFlag(arg, 'l', "longListing", RootLsArgs::kLongListing, outArgs.fFlags) ||
+            MatchFlag(arg, 't', "treeListing", RootLsArgs::kTreeListing, outArgs.fFlags) ||
+            MatchFlag(arg, 'r', "recursiveListing", RootLsArgs::kRecursiveListing, outArgs.fFlags);
+      } else {
+         RootLsSource &newSource = outArgs.fSources.emplace_back();
+         auto tokens = ROOT::Split(arg, ":");
+         newSource.fFileName = tokens[0];
+         if (tokens.size() > 1) {
+            newSource.fObjectTree = GetMatchingPathsInFile(tokens[0], tokens[1]);
+         }
+      }
+   }
+
+   return outArgs;
 }
 
 int main(int argc, char **argv)
 {
-  // TODO: parse flags
-  auto sourceFiles = GetPositionalArguments(const_cast<const char **>(argv) + 1, argc - 1);
+   auto args = ParseArgs(const_cast<const char **>(argv) + 1, argc - 1);
 
-  // sort by name
-  std::sort(sourceFiles.begin(), sourceFiles.end(), [] (const auto &a, const auto &b) {
-    return a.fFileName < b.fFileName;
-  });
-  
-  RootLs(sourceFiles);
+   // sort by name
+   std::sort(args.fSources.begin(), args.fSources.end(),
+             [](const auto &a, const auto &b) { return a.fFileName < b.fFileName; });
+
+   RootLs(args);
 }

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -542,8 +542,6 @@ static RootLsTree GetMatchingPathsInFile(std::string_view fileName, std::string_
             auto &child = nodeTree.fNodes[childIdx];
             if (child.fDir)
                nodesToVisit.push_back(childIdx);
-            else
-               nodeTree.fLeafList.push_back(childIdx);
          }
       }
       if (cur->fNesting == patternSplits.size()) {

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -520,9 +520,10 @@ static void RootLs(const RootLsArgs &args, std::ostream &stream = std::cout)
          PrintNodesInColumns(stream, source.fObjectTree, source.fObjectTree.fLeafList.begin(),
                              source.fObjectTree.fLeafList.end(), args.fFlags, outerIndent);
 
-      const Indent indent = outerIndent + (source.fObjectTree.fDirList.size() > 1) * 2;
+      const bool manySources = source.fObjectTree.fDirList.size() + source.fObjectTree.fLeafList.size() > 1;
+      const Indent indent = outerIndent + manySources * 2;
       for (NodeIdx rootIdx : source.fObjectTree.fDirList) {
-         if (source.fObjectTree.fDirList.size() > 1) {
+         if (manySources) {
             PrintIndent(stream, outerIndent);
             stream << NodeFullPath(source.fObjectTree, rootIdx) << " :\n";
          }

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -448,27 +448,27 @@ static void PrintChildrenInColumns(std::ostream &stream, const RootLsTree &tree,
    PrintNodesInColumns(stream, tree, children.begin(), children.end(), flags, indent);
 }
 
-static void RootLs(const RootLsArgs &args)
+static void RootLs(const RootLsArgs &args, std::ostream &stream = std::cout)
 {
    const Indent outerIndent = (args.fSources.size() > 1) * 2;
    for (const auto &source : args.fSources) {
       if (args.fSources.size() > 1) {
-         std::cout << source.fFileName << " :\n";
+         stream << source.fFileName << " :\n";
       }
       const Indent indent = outerIndent + (source.fObjectTree.fDirList.size() > 1) * 2;
-      PrintNodesInColumns(std::cout, source.fObjectTree, source.fObjectTree.fLeafList.begin(),
+      PrintNodesInColumns(stream, source.fObjectTree, source.fObjectTree.fLeafList.begin(),
                           source.fObjectTree.fLeafList.end(), args.fFlags, indent);
       for (NodeIdx rootIdx : source.fObjectTree.fDirList) {
          if (source.fObjectTree.fDirList.size() > 1) {
             const auto &node = source.fObjectTree.fNodes[rootIdx];
-            PrintIndent(std::cout, outerIndent);
-            std::cout << node.fName << " :\n";
+            PrintIndent(stream, outerIndent);
+            stream << node.fName << " :\n";
          }
 
          if (args.fFlags & (RootLsArgs::kLongListing | RootLsArgs::kTreeListing))
-            PrintChildrenDetailed(std::cout, source.fObjectTree, rootIdx, args.fFlags, indent);
+            PrintChildrenDetailed(stream, source.fObjectTree, rootIdx, args.fFlags, indent);
          else
-            PrintChildrenInColumns(std::cout, source.fObjectTree, rootIdx, args.fFlags, indent);
+            PrintChildrenInColumns(stream, source.fObjectTree, rootIdx, args.fFlags, indent);
       }
    }
 }

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -180,7 +180,7 @@ struct V2i {
 
 static V2i GetTerminalSize()
 {
-   int rows = 80, columns = 25;
+   int columns = 80, rows = 25;
 #if defined(R__UNIX)
    {
       winsize w;
@@ -246,7 +246,6 @@ static void PrintTTree(std::ostream &stream, T &tree, Indent indent)
       stream << std::setw(maxTitleLen) << titleStr;
       stream << std::setw(1) << branch->GetTotBytes();
       stream << '\n';
-      // @Recursion
       PrintTTree(stream, *branch, Indent(indent + 2));
    }
 }
@@ -339,7 +338,6 @@ static void PrintNodesDetailed(std::ostream &stream, const RootLsTree &tree,
          }
       }
       if ((flags & RootLsArgs::kRecursiveListing) && ClassInheritsFrom(child.fClassName.c_str(), "TDirectory")) {
-         // @Recursion
          PrintChildrenDetailed(stream, tree, childIdx, flags, Indent(indent + 2));
       }
    }
@@ -357,7 +355,6 @@ PrintChildrenDetailed(std::ostream &stream, const RootLsTree &tree, NodeIdx node
 
    std::vector<NodeIdx> children(node.fNChildren);
    std::iota(children.begin(), children.end(), node.fFirstChild);
-   // @Recursion
    PrintNodesDetailed(stream, tree, children.begin(), children.end(), flags, indent);
 }
 
@@ -464,7 +461,6 @@ static void PrintNodesInColumns(std::ostream &stream, const RootLsTree &tree,
       if (isDir && (flags & RootLsArgs::kRecursiveListing)) {
          if (!isExtremal)
             stream << "\n";
-         // @Recursion
          PrintChildrenInColumns(stream, tree, childIdx, flags, Indent(indent + 2));
          mustIndent = true;
       }
@@ -481,7 +477,6 @@ static void PrintChildrenInColumns(std::ostream &stream, const RootLsTree &tree,
 
    std::vector<NodeIdx> children(node.fNChildren);
    std::iota(children.begin(), children.end(), node.fFirstChild);
-   // @Recursion
    PrintNodesInColumns(stream, tree, children.begin(), children.end(), flags, indent);
 }
 

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -24,6 +24,7 @@
 
 #include "wildcards.hpp"
 
+#include <TBranch.h>
 #include <TError.h>
 #include <TFile.h>
 #include <TKey.h>

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -24,10 +24,10 @@
 
 #include "wildcards.hpp"
 
+#include <TError.h>
 #include <TFile.h>
 #include <TKey.h>
 #include <TTree.h>
-#include <THnSparse.h>
 
 #include <ROOT/StringUtils.hxx>
 #include <ROOT/RError.hxx>
@@ -327,12 +327,6 @@ PrintChildrenDetailed(std::ostream &stream, const RootLsTree &tree, NodeIdx node
                PrintTTree(stream, *tree, Indent(indent + 2));
                PrintClusters(stream, *tree, Indent(indent + 2));
             }
-         }
-         // XXX: is this still needed?
-         if (ClassInheritsFrom(child.fClassName.c_str(), "THnSparse")) {
-            THnSparse *hs = child.fKey->ReadObject<THnSparse>();
-            if (hs)
-               hs->Print("all");
          }
       }
       if ((flags & RootLsArgs::kRecursiveListing) && ClassInheritsFrom(child.fClassName.c_str(), "TDirectory")) {

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -40,6 +40,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
 #include <windows.h>
+#undef GetClassName
 #endif
 
 static const char *const kAnsiNone = "\x1B[0m";

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -330,10 +330,10 @@ static void PrintNodesDetailed(std::ostream &stream, const RootLsTree &tree,
 
       if (flags & RootLsArgs::kTreeListing) {
          if (ClassInheritsFrom(child.fClassName.c_str(), "TTree")) {
-            TTree *tree = child.fKey->ReadObject<TTree>();
-            if (tree) {
-               PrintTTree(stream, *tree, Indent(indent + 2));
-               PrintClusters(stream, *tree, Indent(indent + 2));
+            TTree *ttree = child.fKey->ReadObject<TTree>();
+            if (ttree) {
+               PrintTTree(stream, *ttree, Indent(indent + 2));
+               PrintClusters(stream, *ttree, Indent(indent + 2));
             }
          }
       }

--- a/main/src/wildcards.hpp
+++ b/main/src/wildcards.hpp
@@ -1,0 +1,1833 @@
+// THIS FILE HAS BEEN GENERATED AUTOMATICALLY. DO NOT EDIT DIRECTLY.
+// Generated: 2019-03-08 09:59:35.958950200
+// Copyright Tomas Zeman 2018.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#ifndef WILDCARDS_HPP
+#define WILDCARDS_HPP 
+#define WILDCARDS_VERSION_MAJOR 1
+#define WILDCARDS_VERSION_MINOR 5
+#define WILDCARDS_VERSION_PATCH 0
+#ifndef WILDCARDS_CARDS_HPP
+#define WILDCARDS_CARDS_HPP 
+#include <utility>
+namespace wildcards
+{
+template <typename T>
+struct cards
+{
+constexpr cards(T a, T s, T e)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{false},
+alt_enabled{false}
+{
+}
+constexpr cards(T a, T s, T e, T so, T sc, T sn, T ao, T ac, T ar)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{true},
+set_open{std::move(so)},
+set_close{std::move(sc)},
+set_not{std::move(sn)},
+alt_enabled{true},
+alt_open{std::move(ao)},
+alt_close{std::move(ac)},
+alt_or{std::move(ar)}
+{
+}
+T anything;
+T single;
+T escape;
+bool set_enabled;
+T set_open;
+T set_close;
+T set_not;
+bool alt_enabled;
+T alt_open;
+T alt_close;
+T alt_or;
+};
+enum class cards_type
+{
+standard,
+extended
+};
+template <>
+struct cards<char>
+{
+constexpr cards(cards_type type = cards_type::extended)
+: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+{
+}
+constexpr cards(char a, char s, char e)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{false},
+alt_enabled{false}
+{
+}
+constexpr cards(char a, char s, char e, char so, char sc, char sn, char ao, char ac, char ar)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{true},
+set_open{std::move(so)},
+set_close{std::move(sc)},
+set_not{std::move(sn)},
+alt_enabled{true},
+alt_open{std::move(ao)},
+alt_close{std::move(ac)},
+alt_or{std::move(ar)}
+{
+}
+char anything{'*'};
+char single{'?'};
+char escape{'\\'};
+bool set_enabled{true};
+char set_open{'['};
+char set_close{']'};
+char set_not{'!'};
+bool alt_enabled{true};
+char alt_open{'('};
+char alt_close{')'};
+char alt_or{'|'};
+};
+template <>
+struct cards<char16_t>
+{
+constexpr cards(cards_type type = cards_type::extended)
+: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+{
+}
+constexpr cards(char16_t a, char16_t s, char16_t e)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{false},
+alt_enabled{false}
+{
+}
+constexpr cards(char16_t a, char16_t s, char16_t e, char16_t so, char16_t sc, char16_t sn,
+char16_t ao, char16_t ac, char16_t ar)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{true},
+set_open{std::move(so)},
+set_close{std::move(sc)},
+set_not{std::move(sn)},
+alt_enabled{true},
+alt_open{std::move(ao)},
+alt_close{std::move(ac)},
+alt_or{std::move(ar)}
+{
+}
+char16_t anything{u'*'};
+char16_t single{u'?'};
+char16_t escape{u'\\'};
+bool set_enabled{true};
+char16_t set_open{u'['};
+char16_t set_close{u']'};
+char16_t set_not{u'!'};
+bool alt_enabled{true};
+char16_t alt_open{u'('};
+char16_t alt_close{u')'};
+char16_t alt_or{u'|'};
+};
+template <>
+struct cards<char32_t>
+{
+constexpr cards(cards_type type = cards_type::extended)
+: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+{
+}
+constexpr cards(char32_t a, char32_t s, char32_t e)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{false},
+alt_enabled{false}
+{
+}
+constexpr cards(char32_t a, char32_t s, char32_t e, char32_t so, char32_t sc, char32_t sn,
+char32_t ao, char32_t ac, char32_t ar)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{true},
+set_open{std::move(so)},
+set_close{std::move(sc)},
+set_not{std::move(sn)},
+alt_enabled{true},
+alt_open{std::move(ao)},
+alt_close{std::move(ac)},
+alt_or{std::move(ar)}
+{
+}
+char32_t anything{U'*'};
+char32_t single{U'?'};
+char32_t escape{U'\\'};
+bool set_enabled{true};
+char32_t set_open{U'['};
+char32_t set_close{U']'};
+char32_t set_not{U'!'};
+bool alt_enabled{true};
+char32_t alt_open{U'('};
+char32_t alt_close{U')'};
+char32_t alt_or{U'|'};
+};
+template <>
+struct cards<wchar_t>
+{
+constexpr cards(cards_type type = cards_type::extended)
+: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+{
+}
+constexpr cards(wchar_t a, wchar_t s, wchar_t e)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{false},
+alt_enabled{false}
+{
+}
+constexpr cards(wchar_t a, wchar_t s, wchar_t e, wchar_t so, wchar_t sc, wchar_t sn, wchar_t ao,
+wchar_t ac, wchar_t ar)
+: anything{std::move(a)},
+single{std::move(s)},
+escape{std::move(e)},
+set_enabled{true},
+set_open{std::move(so)},
+set_close{std::move(sc)},
+set_not{std::move(sn)},
+alt_enabled{true},
+alt_open{std::move(ao)},
+alt_close{std::move(ac)},
+alt_or{std::move(ar)}
+{
+}
+wchar_t anything{L'*'};
+wchar_t single{L'?'};
+wchar_t escape{L'\\'};
+bool set_enabled{true};
+wchar_t set_open{L'['};
+wchar_t set_close{L']'};
+wchar_t set_not{L'!'};
+bool alt_enabled{true};
+wchar_t alt_open{L'('};
+wchar_t alt_close{L')'};
+wchar_t alt_or{L'|'};
+};
+template <typename T>
+constexpr cards<T> make_cards(T&& a, T&& s, T&& e)
+{
+return {std::forward<T>(a), std::forward<T>(s), std::forward<T>(e)};
+}
+template <typename T>
+constexpr cards<T> make_cards(T&& a, T&& s, T&& e, T&& so, T&& sc, T&& sn, T&& ao, T&& ac, T&& ar)
+{
+return {std::forward<T>(a), std::forward<T>(s), std::forward<T>(e),
+std::forward<T>(so), std::forward<T>(sc), std::forward<T>(sn),
+std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
+}
+}
+#endif
+#ifndef WILDCARDS_MATCH_HPP
+#define WILDCARDS_MATCH_HPP 
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#ifndef CONFIG_HPP
+#define CONFIG_HPP 
+#ifndef QUICKCPPLIB_HAS_FEATURE_H
+#define QUICKCPPLIB_HAS_FEATURE_H 
+#if __cplusplus >= 201103L
+#if !defined(__cpp_alias_templates)
+#define __cpp_alias_templates 190000
+#endif
+#if !defined(__cpp_attributes)
+#define __cpp_attributes 190000
+#endif
+#if !defined(__cpp_constexpr)
+#if __cplusplus >= 201402L
+#define __cpp_constexpr 201304
+#else
+#define __cpp_constexpr 190000
+#endif
+#endif
+#if !defined(__cpp_decltype)
+#define __cpp_decltype 190000
+#endif
+#if !defined(__cpp_delegating_constructors)
+#define __cpp_delegating_constructors 190000
+#endif
+#if !defined(__cpp_explicit_conversion)
+#define __cpp_explicit_conversion 190000
+#endif
+#if !defined(__cpp_inheriting_constructors)
+#define __cpp_inheriting_constructors 190000
+#endif
+#if !defined(__cpp_initializer_lists)
+#define __cpp_initializer_lists 190000
+#endif
+#if !defined(__cpp_lambdas)
+#define __cpp_lambdas 190000
+#endif
+#if !defined(__cpp_nsdmi)
+#define __cpp_nsdmi 190000
+#endif
+#if !defined(__cpp_range_based_for)
+#define __cpp_range_based_for 190000
+#endif
+#if !defined(__cpp_raw_strings)
+#define __cpp_raw_strings 190000
+#endif
+#if !defined(__cpp_ref_qualifiers)
+#define __cpp_ref_qualifiers 190000
+#endif
+#if !defined(__cpp_rvalue_references)
+#define __cpp_rvalue_references 190000
+#endif
+#if !defined(__cpp_static_assert)
+#define __cpp_static_assert 190000
+#endif
+#if !defined(__cpp_unicode_characters)
+#define __cpp_unicode_characters 190000
+#endif
+#if !defined(__cpp_unicode_literals)
+#define __cpp_unicode_literals 190000
+#endif
+#if !defined(__cpp_user_defined_literals)
+#define __cpp_user_defined_literals 190000
+#endif
+#if !defined(__cpp_variadic_templates)
+#define __cpp_variadic_templates 190000
+#endif
+#endif
+#if __cplusplus >= 201402L
+#if !defined(__cpp_aggregate_nsdmi)
+#define __cpp_aggregate_nsdmi 190000
+#endif
+#if !defined(__cpp_binary_literals)
+#define __cpp_binary_literals 190000
+#endif
+#if !defined(__cpp_decltype_auto)
+#define __cpp_decltype_auto 190000
+#endif
+#if !defined(__cpp_generic_lambdas)
+#define __cpp_generic_lambdas 190000
+#endif
+#if !defined(__cpp_init_captures)
+#define __cpp_init_captures 190000
+#endif
+#if !defined(__cpp_return_type_deduction)
+#define __cpp_return_type_deduction 190000
+#endif
+#if !defined(__cpp_sized_deallocation)
+#define __cpp_sized_deallocation 190000
+#endif
+#if !defined(__cpp_variable_templates)
+#define __cpp_variable_templates 190000
+#endif
+#endif
+#if defined(_MSC_VER) && !defined(__clang__)
+#if !defined(__cpp_exceptions) && defined(_CPPUNWIND)
+#define __cpp_exceptions 190000
+#endif
+#if !defined(__cpp_rtti) && defined(_CPPRTTI)
+#define __cpp_rtti 190000
+#endif
+#if !defined(__cpp_alias_templates) && _MSC_VER >= 1800
+#define __cpp_alias_templates 190000
+#endif
+#if !defined(__cpp_attributes)
+#define __cpp_attributes 190000
+#endif
+#if !defined(__cpp_constexpr) && _MSC_FULL_VER >= 190023506
+#define __cpp_constexpr 190000
+#endif
+#if !defined(__cpp_decltype) && _MSC_VER >= 1600
+#define __cpp_decltype 190000
+#endif
+#if !defined(__cpp_delegating_constructors) && _MSC_VER >= 1800
+#define __cpp_delegating_constructors 190000
+#endif
+#if !defined(__cpp_explicit_conversion) && _MSC_VER >= 1800
+#define __cpp_explicit_conversion 190000
+#endif
+#if !defined(__cpp_inheriting_constructors) && _MSC_VER >= 1900
+#define __cpp_inheriting_constructors 190000
+#endif
+#if !defined(__cpp_initializer_lists) && _MSC_VER >= 1900
+#define __cpp_initializer_lists 190000
+#endif
+#if !defined(__cpp_lambdas) && _MSC_VER >= 1600
+#define __cpp_lambdas 190000
+#endif
+#if !defined(__cpp_nsdmi) && _MSC_VER >= 1900
+#define __cpp_nsdmi 190000
+#endif
+#if !defined(__cpp_range_based_for) && _MSC_VER >= 1700
+#define __cpp_range_based_for 190000
+#endif
+#if !defined(__cpp_raw_strings) && _MSC_VER >= 1800
+#define __cpp_raw_strings 190000
+#endif
+#if !defined(__cpp_ref_qualifiers) && _MSC_VER >= 1900
+#define __cpp_ref_qualifiers 190000
+#endif
+#if !defined(__cpp_rvalue_references) && _MSC_VER >= 1600
+#define __cpp_rvalue_references 190000
+#endif
+#if !defined(__cpp_static_assert) && _MSC_VER >= 1600
+#define __cpp_static_assert 190000
+#endif
+#if !defined(__cpp_user_defined_literals) && _MSC_VER >= 1900
+#define __cpp_user_defined_literals 190000
+#endif
+#if !defined(__cpp_variadic_templates) && _MSC_VER >= 1800
+#define __cpp_variadic_templates 190000
+#endif
+#if !defined(__cpp_binary_literals) && _MSC_VER >= 1900
+#define __cpp_binary_literals 190000
+#endif
+#if !defined(__cpp_decltype_auto) && _MSC_VER >= 1900
+#define __cpp_decltype_auto 190000
+#endif
+#if !defined(__cpp_generic_lambdas) && _MSC_VER >= 1900
+#define __cpp_generic_lambdas 190000
+#endif
+#if !defined(__cpp_init_captures) && _MSC_VER >= 1900
+#define __cpp_init_captures 190000
+#endif
+#if !defined(__cpp_return_type_deduction) && _MSC_VER >= 1900
+#define __cpp_return_type_deduction 190000
+#endif
+#if !defined(__cpp_sized_deallocation) && _MSC_VER >= 1900
+#define __cpp_sized_deallocation 190000
+#endif
+#if !defined(__cpp_variable_templates) && _MSC_FULL_VER >= 190023506
+#define __cpp_variable_templates 190000
+#endif
+#endif
+#if(defined(__GNUC__) && !defined(__clang__))
+#define QUICKCPPLIB_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if !defined(__cpp_exceptions) && defined(__EXCEPTIONS)
+#define __cpp_exceptions 190000
+#endif
+#if !defined(__cpp_rtti) && defined(__GXX_RTTI)
+#define __cpp_rtti 190000
+#endif
+#if defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if !defined(__cpp_alias_templates) && (QUICKCPPLIB_GCC >= 40700)
+#define __cpp_alias_templates 190000
+#endif
+#if !defined(__cpp_attributes) && (QUICKCPPLIB_GCC >= 40800)
+#define __cpp_attributes 190000
+#endif
+#if !defined(__cpp_constexpr) && (QUICKCPPLIB_GCC >= 40600)
+#define __cpp_constexpr 190000
+#endif
+#if !defined(__cpp_decltype) && (QUICKCPPLIB_GCC >= 40300)
+#define __cpp_decltype 190000
+#endif
+#if !defined(__cpp_delegating_constructors) && (QUICKCPPLIB_GCC >= 40700)
+#define __cpp_delegating_constructors 190000
+#endif
+#if !defined(__cpp_explicit_conversion) && (QUICKCPPLIB_GCC >= 40500)
+#define __cpp_explicit_conversion 190000
+#endif
+#if !defined(__cpp_inheriting_constructors) && (QUICKCPPLIB_GCC >= 40800)
+#define __cpp_inheriting_constructors 190000
+#endif
+#if !defined(__cpp_initializer_lists) && (QUICKCPPLIB_GCC >= 40800)
+#define __cpp_initializer_lists 190000
+#endif
+#if !defined(__cpp_lambdas) && (QUICKCPPLIB_GCC >= 40500)
+#define __cpp_lambdas 190000
+#endif
+#if !defined(__cpp_nsdmi) && (QUICKCPPLIB_GCC >= 40700)
+#define __cpp_nsdmi 190000
+#endif
+#if !defined(__cpp_range_based_for) && (QUICKCPPLIB_GCC >= 40600)
+#define __cpp_range_based_for 190000
+#endif
+#if !defined(__cpp_raw_strings) && (QUICKCPPLIB_GCC >= 40500)
+#define __cpp_raw_strings 190000
+#endif
+#if !defined(__cpp_ref_qualifiers) && (QUICKCPPLIB_GCC >= 40801)
+#define __cpp_ref_qualifiers 190000
+#endif
+#if !defined(__cpp_rvalue_references) && defined(__cpp_rvalue_reference)
+#define __cpp_rvalue_references __cpp_rvalue_reference
+#endif
+#if !defined(__cpp_static_assert) && (QUICKCPPLIB_GCC >= 40300)
+#define __cpp_static_assert 190000
+#endif
+#if !defined(__cpp_unicode_characters) && (QUICKCPPLIB_GCC >= 40500)
+#define __cpp_unicode_characters 190000
+#endif
+#if !defined(__cpp_unicode_literals) && (QUICKCPPLIB_GCC >= 40500)
+#define __cpp_unicode_literals 190000
+#endif
+#if !defined(__cpp_user_defined_literals) && (QUICKCPPLIB_GCC >= 40700)
+#define __cpp_user_defined_literals 190000
+#endif
+#if !defined(__cpp_variadic_templates) && (QUICKCPPLIB_GCC >= 40400)
+#define __cpp_variadic_templates 190000
+#endif
+#endif
+#endif
+#if defined(__clang__)
+#define QUICKCPPLIB_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+#if !defined(__cpp_exceptions) && (defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#define __cpp_exceptions 190000
+#endif
+#if !defined(__cpp_rtti) && (defined(__GXX_RTTI) || defined(_CPPRTTI))
+#define __cpp_rtti 190000
+#endif
+#if defined(__GXX_EXPERIMENTAL_CXX0X__)
+#if !defined(__cpp_alias_templates) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_alias_templates 190000
+#endif
+#if !defined(__cpp_attributes) && (QUICKCPPLIB_CLANG >= 30300)
+#define __cpp_attributes 190000
+#endif
+#if !defined(__cpp_constexpr) && (QUICKCPPLIB_CLANG >= 30100)
+#define __cpp_constexpr 190000
+#endif
+#if !defined(__cpp_decltype) && (QUICKCPPLIB_CLANG >= 20900)
+#define __cpp_decltype 190000
+#endif
+#if !defined(__cpp_delegating_constructors) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_delegating_constructors 190000
+#endif
+#if !defined(__cpp_explicit_conversion) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_explicit_conversion 190000
+#endif
+#if !defined(__cpp_inheriting_constructors) && (QUICKCPPLIB_CLANG >= 30300)
+#define __cpp_inheriting_constructors 190000
+#endif
+#if !defined(__cpp_initializer_lists) && (QUICKCPPLIB_CLANG >= 30100)
+#define __cpp_initializer_lists 190000
+#endif
+#if !defined(__cpp_lambdas) && (QUICKCPPLIB_CLANG >= 30100)
+#define __cpp_lambdas 190000
+#endif
+#if !defined(__cpp_nsdmi) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_nsdmi 190000
+#endif
+#if !defined(__cpp_range_based_for) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_range_based_for 190000
+#endif
+#if !defined(__cpp_raw_strings) && defined(__cpp_raw_string_literals)
+#define __cpp_raw_strings __cpp_raw_string_literals
+#endif
+#if !defined(__cpp_raw_strings) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_raw_strings 190000
+#endif
+#if !defined(__cpp_ref_qualifiers) && (QUICKCPPLIB_CLANG >= 20900)
+#define __cpp_ref_qualifiers 190000
+#endif
+#if !defined(__cpp_rvalue_references) && defined(__cpp_rvalue_reference)
+#define __cpp_rvalue_references __cpp_rvalue_reference
+#endif
+#if !defined(__cpp_rvalue_references) && (QUICKCPPLIB_CLANG >= 20900)
+#define __cpp_rvalue_references 190000
+#endif
+#if !defined(__cpp_static_assert) && (QUICKCPPLIB_CLANG >= 20900)
+#define __cpp_static_assert 190000
+#endif
+#if !defined(__cpp_unicode_characters) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_unicode_characters 190000
+#endif
+#if !defined(__cpp_unicode_literals) && (QUICKCPPLIB_CLANG >= 30000)
+#define __cpp_unicode_literals 190000
+#endif
+#if !defined(__cpp_user_defined_literals) && defined(__cpp_user_literals)
+#define __cpp_user_defined_literals __cpp_user_literals
+#endif
+#if !defined(__cpp_user_defined_literals) && (QUICKCPPLIB_CLANG >= 30100)
+#define __cpp_user_defined_literals 190000
+#endif
+#if !defined(__cpp_variadic_templates) && (QUICKCPPLIB_CLANG >= 20900)
+#define __cpp_variadic_templates 190000
+#endif
+#endif
+#endif
+#endif
+#define cfg_HAS_CONSTEXPR14 (__cpp_constexpr >= 201304)
+#if cfg_HAS_CONSTEXPR14
+#define cfg_constexpr14 constexpr
+#else
+#define cfg_constexpr14 
+#endif
+#if cfg_HAS_CONSTEXPR14 && defined(__clang__)
+#define cfg_HAS_FULL_FEATURED_CONSTEXPR14 1
+#else
+#define cfg_HAS_FULL_FEATURED_CONSTEXPR14 0
+#endif
+#endif
+#ifndef CX_FUNCTIONAL_HPP
+#define CX_FUNCTIONAL_HPP 
+#include <utility>
+namespace cx
+{
+template <typename T>
+struct less
+{
+constexpr auto operator()(const T& lhs, const T& rhs) const -> decltype(lhs < rhs)
+{
+return lhs < rhs;
+}
+};
+template <>
+struct less<void>
+{
+template <typename T, typename U>
+constexpr auto operator()(T&& lhs, U&& rhs) const
+-> decltype(std::forward<T>(lhs) < std::forward<U>(rhs))
+{
+return std::forward<T>(lhs) < std::forward<U>(rhs);
+}
+};
+template <typename T>
+struct equal_to
+{
+constexpr auto operator()(const T& lhs, const T& rhs) const -> decltype(lhs == rhs)
+{
+return lhs == rhs;
+}
+};
+template <>
+struct equal_to<void>
+{
+template <typename T, typename U>
+constexpr auto operator()(T&& lhs, U&& rhs) const
+-> decltype(std::forward<T>(lhs) == std::forward<U>(rhs))
+{
+return std::forward<T>(lhs) == std::forward<U>(rhs);
+}
+};
+}
+#endif
+#ifndef CX_ITERATOR_HPP
+#define CX_ITERATOR_HPP 
+#include <cstddef>
+#include <initializer_list>
+namespace cx
+{
+template <typename It>
+constexpr It next(It it)
+{
+return it + 1;
+}
+template <typename It>
+constexpr It prev(It it)
+{
+return it - 1;
+}
+template <typename C>
+constexpr auto size(const C& c) -> decltype(c.size())
+{
+return c.size();
+}
+template <typename T, std::size_t N>
+constexpr std::size_t size(const T (&)[N])
+{
+return N;
+}
+template <typename C>
+constexpr auto empty(const C& c) -> decltype(c.empty())
+{
+return c.empty();
+}
+template <typename T, std::size_t N>
+constexpr bool empty(const T (&)[N])
+{
+return false;
+}
+template <typename E>
+constexpr bool empty(std::initializer_list<E> il)
+{
+return il.size() == 0;
+}
+template <typename C>
+constexpr auto begin(const C& c) -> decltype(c.begin())
+{
+return c.begin();
+}
+template <typename C>
+constexpr auto begin(C& c) -> decltype(c.begin())
+{
+return c.begin();
+}
+template <typename T, std::size_t N>
+constexpr T* begin(T (&array)[N])
+{
+return &array[0];
+}
+template <typename E>
+constexpr const E* begin(std::initializer_list<E> il)
+{
+return il.begin();
+}
+template <typename C>
+constexpr auto cbegin(const C& c) -> decltype(cx::begin(c))
+{
+return cx::begin(c);
+}
+template <typename C>
+constexpr auto end(const C& c) -> decltype(c.end())
+{
+return c.end();
+}
+template <typename C>
+constexpr auto end(C& c) -> decltype(c.end())
+{
+return c.end();
+}
+template <typename T, std::size_t N>
+constexpr T* end(T (&array)[N])
+{
+return &array[N];
+}
+template <typename E>
+constexpr const E* end(std::initializer_list<E> il)
+{
+return il.end();
+}
+template <typename C>
+constexpr auto cend(const C& c) -> decltype(cx::end(c))
+{
+return cx::end(c);
+}
+}
+#endif
+#ifndef WILDCARDS_UTILITY_HPP
+#define WILDCARDS_UTILITY_HPP 
+#include <type_traits>
+#include <utility>
+namespace wildcards
+{
+template <typename C>
+struct const_iterator
+{
+using type = typename std::remove_cv<
+typename std::remove_reference<decltype(cx::cbegin(std::declval<C>()))>::type>::type;
+};
+template <typename C>
+using const_iterator_t = typename const_iterator<C>::type;
+template <typename C>
+struct iterator
+{
+using type = typename std::remove_cv<
+typename std::remove_reference<decltype(cx::begin(std::declval<C>()))>::type>::type;
+};
+template <typename C>
+using iterator_t = typename iterator<C>::type;
+template <typename It>
+struct iterated_item
+{
+using type = typename std::remove_cv<
+typename std::remove_reference<decltype(*std::declval<It>())>::type>::type;
+};
+template <typename It>
+using iterated_item_t = typename iterated_item<It>::type;
+template <typename C>
+struct container_item
+{
+using type = typename std::remove_cv<
+typename std::remove_reference<decltype(*cx::begin(std::declval<C>()))>::type>::type;
+};
+template <typename C>
+using container_item_t = typename container_item<C>::type;
+}
+#endif
+namespace wildcards
+{
+template <typename SequenceIterator, typename PatternIterator>
+struct full_match_result
+{
+bool res;
+SequenceIterator s, send, s1;
+PatternIterator p, pend, p1;
+constexpr operator bool() const
+{
+return res;
+}
+};
+namespace detail
+{
+template <typename SequenceIterator, typename PatternIterator>
+struct match_result
+{
+bool res;
+SequenceIterator s;
+PatternIterator p;
+constexpr operator bool() const
+{
+return res;
+}
+};
+template <typename SequenceIterator, typename PatternIterator>
+constexpr match_result<SequenceIterator, PatternIterator> make_match_result(bool res,
+SequenceIterator s,
+PatternIterator p)
+{
+return {std::move(res), std::move(s), std::move(p)};
+}
+template <typename SequenceIterator, typename PatternIterator>
+constexpr full_match_result<SequenceIterator, PatternIterator> make_full_match_result(
+SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+match_result<SequenceIterator, PatternIterator> mr)
+{
+return {std::move(mr.res), std::move(s), std::move(send), std::move(mr.s),
+std::move(p), std::move(pend), std::move(mr.p)};
+}
+#if !cfg_HAS_FULL_FEATURED_CONSTEXPR14
+constexpr bool throw_invalid_argument(const char* what_arg)
+{
+return what_arg == nullptr ? false : throw std::invalid_argument(what_arg);
+}
+template <typename T>
+constexpr T throw_invalid_argument(T t, const char* what_arg)
+{
+return what_arg == nullptr ? t : throw std::invalid_argument(what_arg);
+}
+constexpr bool throw_logic_error(const char* what_arg)
+{
+return what_arg == nullptr ? false : throw std::logic_error(what_arg);
+}
+template <typename T>
+constexpr T throw_logic_error(T t, const char* what_arg)
+{
+return what_arg == nullptr ? t : throw std::logic_error(what_arg);
+}
+#endif
+enum class is_set_state
+{
+open,
+not_or_first,
+first,
+next
+};
+template <typename PatternIterator>
+constexpr bool is_set(
+PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+is_set_state state = is_set_state::open)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.set_enabled)
+{
+return false;
+}
+while (p != pend)
+{
+switch (state)
+{
+case is_set_state::open:
+if (*p != c.set_open)
+{
+return false;
+}
+state = is_set_state::not_or_first;
+break;
+case is_set_state::not_or_first:
+if (*p == c.set_not)
+{
+state = is_set_state::first;
+}
+else
+{
+state = is_set_state::next;
+}
+break;
+case is_set_state::first:
+state = is_set_state::next;
+break;
+case is_set_state::next:
+if (*p == c.set_close)
+{
+return true;
+}
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+"The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+return false;
+#else
+return c.set_enabled && p != pend &&
+(state == is_set_state::open
+? *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+:
+state == is_set_state::not_or_first
+? *p == c.set_not ? is_set(cx::next(p), pend, c, is_set_state::first)
+: is_set(cx::next(p), pend, c, is_set_state::next)
+: state == is_set_state::first
+? is_set(cx::next(p), pend, c, is_set_state::next)
+: state == is_set_state::next
+? *p == c.set_close ||
+is_set(cx::next(p), pend, c, is_set_state::next)
+: throw std::logic_error("The program execution should never end up "
+"here throwing this exception"));
+#endif
+}
+enum class set_end_state
+{
+open,
+not_or_first,
+first,
+next
+};
+template <typename PatternIterator>
+constexpr PatternIterator set_end(
+PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+set_end_state state = set_end_state::open)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.set_enabled)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The use of sets is disabled");
+#else
+return throw_invalid_argument(p, "The use of sets is disabled");
+#endif
+}
+while (p != pend)
+{
+switch (state)
+{
+case set_end_state::open:
+if (*p != c.set_open)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid set");
+#else
+return throw_invalid_argument(p, "The given pattern is not a valid set");
+#endif
+}
+state = set_end_state::not_or_first;
+break;
+case set_end_state::not_or_first:
+if (*p == c.set_not)
+{
+state = set_end_state::first;
+}
+else
+{
+state = set_end_state::next;
+}
+break;
+case set_end_state::first:
+state = set_end_state::next;
+break;
+case set_end_state::next:
+if (*p == c.set_close)
+{
+return cx::next(p);
+}
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+p, "The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid set");
+#else
+return throw_invalid_argument(p, "The given pattern is not a valid set");
+#endif
+#else
+return !c.set_enabled
+? throw std::invalid_argument("The use of sets is disabled")
+: p == pend
+? throw std::invalid_argument("The given pattern is not a valid set")
+:
+state == set_end_state::open
+? *p == c.set_open
+? set_end(cx::next(p), pend, c, set_end_state::not_or_first)
+: throw std::invalid_argument("The given pattern is not a valid set")
+:
+state == set_end_state::not_or_first
+? *p == c.set_not ? set_end(cx::next(p), pend, c, set_end_state::first)
+: set_end(cx::next(p), pend, c, set_end_state::next)
+: state == set_end_state::first
+? set_end(cx::next(p), pend, c, set_end_state::next)
+: state == set_end_state::next
+? *p == c.set_close
+? cx::next(p)
+: set_end(cx::next(p), pend, c, set_end_state::next)
+: throw std::logic_error(
+"The program execution should never end up "
+"here throwing this exception");
+#endif
+}
+enum class match_set_state
+{
+open,
+not_or_first_in,
+first_out,
+next_in,
+next_out
+};
+template <typename SequenceIterator, typename PatternIterator,
+typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator> match_set(
+SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+const EqualTo& equal_to = EqualTo(), match_set_state state = match_set_state::open)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.set_enabled)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The use of sets is disabled");
+#else
+return throw_invalid_argument(make_match_result(false, s, p), "The use of sets is disabled");
+#endif
+}
+while (p != pend)
+{
+switch (state)
+{
+case match_set_state::open:
+if (*p != c.set_open)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid set");
+#else
+return throw_invalid_argument(make_match_result(false, s, p),
+"The given pattern is not a valid set");
+#endif
+}
+state = match_set_state::not_or_first_in;
+break;
+case match_set_state::not_or_first_in:
+if (*p == c.set_not)
+{
+state = match_set_state::first_out;
+}
+else
+{
+if (s == send)
+{
+return make_match_result(false, s, p);
+}
+if (equal_to(*s, *p))
+{
+return make_match_result(true, s, p);
+}
+state = match_set_state::next_in;
+}
+break;
+case match_set_state::first_out:
+if (s == send || equal_to(*s, *p))
+{
+return make_match_result(false, s, p);
+}
+state = match_set_state::next_out;
+break;
+case match_set_state::next_in:
+if (*p == c.set_close || s == send)
+{
+return make_match_result(false, s, p);
+}
+if (equal_to(*s, *p))
+{
+return make_match_result(true, s, p);
+}
+break;
+case match_set_state::next_out:
+if (*p == c.set_close)
+{
+return make_match_result(true, s, p);
+}
+if (s == send || equal_to(*s, *p))
+{
+return make_match_result(false, s, p);
+}
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+make_match_result(false, s, p),
+"The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid set");
+#else
+return throw_invalid_argument(make_match_result(false, s, p),
+"The given pattern is not a valid set");
+#endif
+#else
+return !c.set_enabled
+? throw std::invalid_argument("The use of sets is disabled")
+: p == pend
+? throw std::invalid_argument("The given pattern is not a valid set")
+: state == match_set_state::open
+? *p == c.set_open
+? match_set(s, send, cx::next(p), pend, c, equal_to,
+match_set_state::not_or_first_in)
+:
+throw std::invalid_argument("The given pattern is not a valid set")
+:
+state == match_set_state::not_or_first_in
+? *p == c.set_not
+? match_set(s, send, cx::next(p), pend, c, equal_to,
+match_set_state::first_out)
+:
+s == send ? make_match_result(false, s, p)
+: equal_to(*s, *p)
+? make_match_result(true, s, p)
+: match_set(s, send, cx::next(p), pend, c,
+equal_to, match_set_state::next_in)
+:
+state == match_set_state::first_out
+? s == send || equal_to(*s, *p)
+? make_match_result(false, s, p)
+: match_set(s, send, cx::next(p), pend, c, equal_to,
+match_set_state::next_out)
+:
+state == match_set_state::next_in
+? *p == c.set_close || s == send
+? make_match_result(false, s, p)
+: equal_to(*s, *p) ? make_match_result(true, s, p)
+: match_set(s, send, cx::next(p),
+pend, c, equal_to, state)
+:
+state == match_set_state::next_out
+? *p == c.set_close
+? make_match_result(true, s, p)
+: s == send || equal_to(*s, *p)
+? make_match_result(false, s, p)
+: match_set(s, send, cx::next(p), pend, c,
+equal_to, state)
+: throw std::logic_error(
+"The program execution should never end up "
+"here "
+"throwing this exception");
+#endif
+}
+enum class is_alt_state
+{
+open,
+next,
+escape
+};
+template <typename PatternIterator>
+constexpr bool is_alt(
+PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+is_alt_state state = is_alt_state::open, int depth = 0)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.alt_enabled)
+{
+return false;
+}
+while (p != pend)
+{
+switch (state)
+{
+case is_alt_state::open:
+if (*p != c.alt_open)
+{
+return false;
+}
+state = is_alt_state::next;
+++depth;
+break;
+case is_alt_state::next:
+if (*p == c.escape)
+{
+state = is_alt_state::escape;
+}
+else if (c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c, is_set_state::not_or_first))
+{
+p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+}
+else if (*p == c.alt_open)
+{
+++depth;
+}
+else if (*p == c.alt_close)
+{
+--depth;
+if (depth == 0)
+{
+return true;
+}
+}
+break;
+case is_alt_state::escape:
+state = is_alt_state::next;
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+p, "The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+return false;
+#else
+return c.alt_enabled && p != pend &&
+(state == is_alt_state::open
+? *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, depth + 1)
+: state == is_alt_state::next
+? *p == c.escape
+? is_alt(cx::next(p), pend, c, is_alt_state::escape, depth)
+: c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+? is_alt(set_end(cx::next(p), pend, c, set_end_state::not_or_first),
+pend, c, state, depth)
+: *p == c.alt_open
+? is_alt(cx::next(p), pend, c, state, depth + 1)
+: *p == c.alt_close
+? depth == 1 ||
+is_alt(cx::next(p), pend, c, state, depth - 1)
+: is_alt(cx::next(p), pend, c, state, depth)
+:
+state == is_alt_state::escape
+? is_alt(cx::next(p), pend, c, is_alt_state::next, depth)
+: throw std::logic_error(
+"The program execution should never end up here throwing this "
+"exception"));
+#endif
+}
+enum class alt_end_state
+{
+open,
+next,
+escape
+};
+template <typename PatternIterator>
+constexpr PatternIterator alt_end(
+PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+alt_end_state state = alt_end_state::open, int depth = 0)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.alt_enabled)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The use of alternatives is disabled");
+#else
+return throw_invalid_argument(p, "The use of alternatives is disabled");
+#endif
+}
+while (p != pend)
+{
+switch (state)
+{
+case alt_end_state::open:
+if (*p != c.alt_open)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid alternative");
+#else
+return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+#endif
+}
+state = alt_end_state::next;
+++depth;
+break;
+case alt_end_state::next:
+if (*p == c.escape)
+{
+state = alt_end_state::escape;
+}
+else if (c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c, is_set_state::not_or_first))
+{
+p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+}
+else if (*p == c.alt_open)
+{
+++depth;
+}
+else if (*p == c.alt_close)
+{
+--depth;
+if (depth == 0)
+{
+return cx::next(p);
+}
+}
+break;
+case alt_end_state::escape:
+state = alt_end_state::next;
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+p, "The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid alternative");
+#else
+return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+#endif
+#else
+return !c.alt_enabled
+? throw std::invalid_argument("The use of alternatives is disabled")
+: p == pend
+? throw std::invalid_argument("The given pattern is not a valid alternative")
+: state == alt_end_state::open
+? *p == c.alt_open
+? alt_end(cx::next(p), pend, c, alt_end_state::next, depth + 1)
+: throw std::invalid_argument(
+"The given pattern is not a valid alternative")
+: state == alt_end_state::next
+? *p == c.escape
+? alt_end(cx::next(p), pend, c, alt_end_state::escape, depth)
+: c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c,
+is_set_state::not_or_first)
+? alt_end(set_end(cx::next(p), pend, c,
+set_end_state::not_or_first),
+pend, c, state, depth)
+: *p == c.alt_open
+? alt_end(cx::next(p), pend, c, state, depth + 1)
+: *p == c.alt_close
+? depth == 1 ? cx::next(p)
+: alt_end(cx::next(p), pend, c,
+state, depth - 1)
+: alt_end(cx::next(p), pend, c, state, depth)
+:
+state == alt_end_state::escape
+? alt_end(cx::next(p), pend, c, alt_end_state::next, depth)
+: throw std::logic_error(
+"The program execution should never end up here throwing "
+"this "
+"exception");
+#endif
+}
+enum class alt_sub_end_state
+{
+next,
+escape
+};
+template <typename PatternIterator>
+constexpr PatternIterator alt_sub_end(
+PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+alt_sub_end_state state = alt_sub_end_state::next, int depth = 1)
+{
+#if cfg_HAS_CONSTEXPR14
+if (!c.alt_enabled)
+{
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The use of alternatives is disabled");
+#else
+return throw_invalid_argument(p, "The use of alternatives is disabled");
+#endif
+}
+while (p != pend)
+{
+switch (state)
+{
+case alt_sub_end_state::next:
+if (*p == c.escape)
+{
+state = alt_sub_end_state::escape;
+}
+else if (c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c, is_set_state::not_or_first))
+{
+p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+}
+else if (*p == c.alt_open)
+{
+++depth;
+}
+else if (*p == c.alt_close)
+{
+--depth;
+if (depth == 0)
+{
+return p;
+}
+}
+else if (*p == c.alt_or)
+{
+if (depth == 1)
+{
+return p;
+}
+}
+break;
+case alt_sub_end_state::escape:
+state = alt_sub_end_state::next;
+break;
+default:
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::logic_error(
+"The program execution should never end up here throwing this exception");
+#else
+return throw_logic_error(
+p, "The program execution should never end up here throwing this exception");
+#endif
+}
+p = cx::next(p);
+}
+#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
+throw std::invalid_argument("The given pattern is not a valid alternative");
+#else
+return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+#endif
+#else
+return !c.alt_enabled
+? throw std::invalid_argument("The use of alternatives is disabled")
+: p == pend
+? throw std::invalid_argument("The given pattern is not a valid alternative")
+: state == alt_sub_end_state::next
+? *p == c.escape
+? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::escape, depth)
+: c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+? alt_sub_end(set_end(cx::next(p), pend, c,
+set_end_state::not_or_first),
+pend, c, state, depth)
+: *p == c.alt_open
+? alt_sub_end(cx::next(p), pend, c, state, depth + 1)
+: *p == c.alt_close
+? depth == 1 ? p : alt_sub_end(cx::next(p), pend,
+c, state, depth - 1)
+: *p == c.alt_or
+? depth == 1 ? p
+: alt_sub_end(cx::next(p), pend,
+c, state, depth)
+: alt_sub_end(cx::next(p), pend, c, state,
+depth)
+:
+state == alt_sub_end_state::escape
+? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::next, depth)
+: throw std::logic_error(
+"The program execution should never end up here throwing "
+"this "
+"exception");
+#endif
+}
+template <typename SequenceIterator, typename PatternIterator,
+typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator> match(
+SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+const EqualTo& equal_to = EqualTo(), bool partial = false, bool escape = false);
+template <typename SequenceIterator, typename PatternIterator,
+typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator> match_alt(
+SequenceIterator s, SequenceIterator send, PatternIterator p1, PatternIterator p1end,
+PatternIterator p2, PatternIterator p2end,
+const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
+const EqualTo& equal_to = EqualTo(), bool partial = false)
+{
+#if cfg_HAS_CONSTEXPR14
+auto result1 = match(s, send, p1, p1end, c, equal_to, true);
+if (result1)
+{
+auto result2 = match(result1.s, send, p2, p2end, c, equal_to, partial);
+if (result2)
+{
+return result2;
+}
+}
+p1 = cx::next(p1end);
+if (p1 == p2)
+{
+return make_match_result(false, s, p1end);
+}
+return match_alt(s, send, p1, alt_sub_end(p1, p2, c), p2, p2end, c, equal_to, partial);
+#else
+return match(s, send, p1, p1end, c, equal_to, true) &&
+match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to,
+partial)
+? match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to,
+partial)
+: cx::next(p1end) == p2
+? make_match_result(false, s, p1end)
+: match_alt(s, send, cx::next(p1end), alt_sub_end(cx::next(p1end), p2, c), p2,
+p2end, c, equal_to, partial);
+#endif
+}
+template <typename SequenceIterator, typename PatternIterator, typename EqualTo>
+constexpr match_result<SequenceIterator, PatternIterator> match(
+SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+const cards<iterated_item_t<PatternIterator>>& c, const EqualTo& equal_to, bool partial,
+bool escape)
+{
+#if cfg_HAS_CONSTEXPR14
+if (p == pend)
+{
+return make_match_result(partial || s == send, s, p);
+}
+if (escape)
+{
+if (s == send || !equal_to(*s, *p))
+{
+return make_match_result(false, s, p);
+}
+return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+}
+if (*p == c.anything)
+{
+auto result = match(s, send, cx::next(p), pend, c, equal_to, partial);
+if (result)
+{
+return result;
+}
+if (s == send)
+{
+return make_match_result(false, s, p);
+}
+return match(cx::next(s), send, p, pend, c, equal_to, partial);
+}
+if (*p == c.single)
+{
+if (s == send)
+{
+return make_match_result(false, s, p);
+}
+return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+}
+if (*p == c.escape)
+{
+return match(s, send, cx::next(p), pend, c, equal_to, partial, true);
+}
+if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first))
+{
+auto result =
+match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in);
+if (!result)
+{
+return result;
+}
+return match(cx::next(s), send, set_end(cx::next(p), pend, c, set_end_state::not_or_first),
+pend, c, equal_to, partial);
+}
+if (c.alt_enabled && *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, 1))
+{
+auto p_alt_end = alt_end(cx::next(p), pend, c, alt_end_state::next, 1);
+return match_alt(s, send, cx::next(p), alt_sub_end(cx::next(p), p_alt_end, c), p_alt_end, pend,
+c, equal_to, partial);
+}
+if (s == send || !equal_to(*s, *p))
+{
+return make_match_result(false, s, p);
+}
+return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+#else
+return p == pend
+? make_match_result(partial || s == send, s, p)
+: escape
+? s == send || !equal_to(*s, *p)
+? make_match_result(false, s, p)
+: match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
+: *p == c.anything
+? match(s, send, cx::next(p), pend, c, equal_to, partial)
+? match(s, send, cx::next(p), pend, c, equal_to, partial)
+: s == send ? make_match_result(false, s, p)
+: match(cx::next(s), send, p, pend, c, equal_to, partial)
+: *p == c.single
+? s == send ? make_match_result(false, s, p)
+: match(cx::next(s), send, cx::next(p), pend, c,
+equal_to, partial)
+: *p == c.escape
+? match(s, send, cx::next(p), pend, c, equal_to, partial, true)
+: c.set_enabled && *p == c.set_open &&
+is_set(cx::next(p), pend, c,
+is_set_state::not_or_first)
+? !match_set(s, send, cx::next(p), pend, c, equal_to,
+match_set_state::not_or_first_in)
+? match_set(s, send, cx::next(p), pend, c,
+equal_to,
+match_set_state::not_or_first_in)
+: match(cx::next(s), send,
+set_end(cx::next(p), pend, c,
+set_end_state::not_or_first),
+pend, c, equal_to, partial)
+: c.alt_enabled && *p == c.alt_open &&
+is_alt(cx::next(p), pend, c,
+is_alt_state::next, 1)
+? match_alt(
+s, send, cx::next(p),
+alt_sub_end(cx::next(p),
+alt_end(cx::next(p), pend, c,
+alt_end_state::next, 1),
+c),
+alt_end(cx::next(p), pend, c,
+alt_end_state::next, 1),
+pend, c, equal_to, partial)
+: s == send || !equal_to(*s, *p)
+? make_match_result(false, s, p)
+: match(cx::next(s), send, cx::next(p), pend,
+c, equal_to, partial);
+#endif
+}
+}
+template <typename Sequence, typename Pattern, typename EqualTo = cx::equal_to<void>>
+constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> match(
+Sequence&& sequence, Pattern&& pattern,
+const cards<container_item_t<Pattern>>& c = cards<container_item_t<Pattern>>(),
+const EqualTo& equal_to = EqualTo())
+{
+return detail::make_full_match_result(
+cx::cbegin(sequence), cx::cend(sequence), cx::cbegin(pattern), cx::cend(pattern),
+detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)),
+cx::cbegin(pattern), cx::cend(std::forward<Pattern>(pattern)), c, equal_to));
+}
+template <typename Sequence, typename Pattern, typename EqualTo = cx::equal_to<void>,
+typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
+constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> match(
+Sequence&& sequence, Pattern&& pattern, const EqualTo& equal_to)
+{
+return match(std::forward<Sequence>(sequence), std::forward<Pattern>(pattern),
+cards<container_item_t<Pattern>>(), equal_to);
+}
+}
+#endif
+#ifndef WILDCARDS_MATCHER_HPP
+#define WILDCARDS_MATCHER_HPP 
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#ifndef CX_STRING_VIEW_HPP
+#define CX_STRING_VIEW_HPP 
+#include <cstddef>
+#include <ostream>
+#ifndef CX_ALGORITHM_HPP
+#define CX_ALGORITHM_HPP 
+namespace cx
+{
+template <typename Iterator1, typename Iterator2>
+constexpr bool equal(Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2)
+{
+#if cfg_HAS_CONSTEXPR14
+while (first1 != last1 && first2 != last2 && *first1 == *first2)
+{
+++first1, ++first2;
+}
+return first1 == last1 && first2 == last2;
+#else
+return first1 != last1 && first2 != last2 && *first1 == *first2
+? equal(first1 + 1, last1, first2 + 1, last2)
+: first1 == last1 && first2 == last2;
+#endif
+}
+}
+#endif
+namespace cx
+{
+template <typename T>
+class basic_string_view
+{
+public:
+using value_type = T;
+constexpr basic_string_view() = default;
+template <std::size_t N>
+constexpr basic_string_view(const T (&str)[N]) : data_{&str[0]}, size_{N - 1}
+{
+}
+constexpr basic_string_view(const T* str, std::size_t s) : data_{str}, size_{s}
+{
+}
+constexpr const T* data() const
+{
+return data_;
+}
+constexpr std::size_t size() const
+{
+return size_;
+}
+constexpr bool empty() const
+{
+return size() == 0;
+}
+constexpr const T* begin() const
+{
+return data_;
+}
+constexpr const T* cbegin() const
+{
+return begin();
+}
+constexpr const T* end() const
+{
+return data_ + size_;
+}
+constexpr const T* cend() const
+{
+return end();
+}
+private:
+const T* data_{nullptr};
+std::size_t size_{0};
+};
+template <typename T>
+constexpr bool operator==(const basic_string_view<T>& lhs, const basic_string_view<T>& rhs)
+{
+return equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+template <typename T>
+constexpr bool operator!=(const basic_string_view<T>& lhs, const basic_string_view<T>& rhs)
+{
+return !(lhs == rhs);
+}
+template <typename T>
+std::basic_ostream<T>& operator<<(std::basic_ostream<T>& o, const basic_string_view<T>& s)
+{
+o << s.data();
+return o;
+}
+template <typename T, std::size_t N>
+constexpr basic_string_view<T> make_string_view(const T (&str)[N])
+{
+return {str, N - 1};
+}
+template <typename T>
+constexpr basic_string_view<T> make_string_view(const T* str, std::size_t s)
+{
+return {str, s};
+}
+using string_view = basic_string_view<char>;
+using u16string_view = basic_string_view<char16_t>;
+using u32string_view = basic_string_view<char32_t>;
+using wstring_view = basic_string_view<wchar_t>;
+namespace literals
+{
+constexpr string_view operator"" _sv(const char* str, std::size_t s)
+{
+return {str, s};
+}
+constexpr u16string_view operator"" _sv(const char16_t* str, std::size_t s)
+{
+return {str, s};
+}
+constexpr u32string_view operator"" _sv(const char32_t* str, std::size_t s)
+{
+return {str, s};
+}
+constexpr wstring_view operator"" _sv(const wchar_t* str, std::size_t s)
+{
+return {str, s};
+}
+}
+}
+#endif
+namespace wildcards
+{
+template <typename Pattern, typename EqualTo = cx::equal_to<void>>
+class matcher
+{
+public:
+constexpr explicit matcher(Pattern&& pattern, const cards<container_item_t<Pattern>>& c =
+cards<container_item_t<Pattern>>(),
+const EqualTo& equal_to = EqualTo())
+: p_{cx::cbegin(pattern)},
+pend_{cx::cend(std::forward<Pattern>(pattern))},
+c_{c},
+equal_to_{equal_to}
+{
+}
+constexpr matcher(Pattern&& pattern, const EqualTo& equal_to)
+: p_{cx::cbegin(pattern)},
+pend_{cx::cend(std::forward<Pattern>(pattern))},
+c_{cards<container_item_t<Pattern>>()},
+equal_to_{equal_to}
+{
+}
+template <typename Sequence>
+constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> matches(
+Sequence&& sequence) const
+{
+return detail::make_full_match_result(
+cx::cbegin(sequence), cx::cend(sequence), p_, pend_,
+detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)), p_, pend_,
+c_, equal_to_));
+}
+private:
+const_iterator_t<Pattern> p_;
+const_iterator_t<Pattern> pend_;
+cards<container_item_t<Pattern>> c_;
+EqualTo equal_to_;
+};
+template <typename Pattern, typename EqualTo = cx::equal_to<void>>
+constexpr matcher<Pattern, EqualTo> make_matcher(
+Pattern&& pattern,
+const cards<container_item_t<Pattern>>& c = cards<container_item_t<Pattern>>(),
+const EqualTo& equal_to = EqualTo())
+{
+return matcher<Pattern, EqualTo>{std::forward<Pattern>(pattern), c, equal_to};
+}
+template <typename Pattern, typename EqualTo = cx::equal_to<void>,
+typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
+constexpr matcher<Pattern, EqualTo> make_matcher(Pattern&& pattern, const EqualTo& equal_to)
+{
+return make_matcher(std::forward<Pattern>(pattern), cards<container_item_t<Pattern>>(), equal_to);
+}
+namespace literals
+{
+constexpr auto operator"" _wc(const char* str, std::size_t s)
+-> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+{
+return make_matcher(cx::make_string_view(str, s + 1));
+}
+constexpr auto operator"" _wc(const char16_t* str, std::size_t s)
+-> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+{
+return make_matcher(cx::make_string_view(str, s + 1));
+}
+constexpr auto operator"" _wc(const char32_t* str, std::size_t s)
+-> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+{
+return make_matcher(cx::make_string_view(str, s + 1));
+}
+constexpr auto operator"" _wc(const wchar_t* str, std::size_t s)
+-> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+{
+return make_matcher(cx::make_string_view(str, s + 1));
+}
+}
+}
+#endif
+#endif

--- a/main/src/wildcards.hpp
+++ b/main/src/wildcards.hpp
@@ -11,6 +11,11 @@
 #define WILDCARDS_VERSION_PATCH 0
 #ifndef WILDCARDS_CARDS_HPP
 #define WILDCARDS_CARDS_HPP
+#include <cstddef>
+#include <initializer_list>
+#include <ostream>
+#include <stdexcept>
+#include <type_traits>
 #include <utility>
 namespace wildcards {
 template <typename T>
@@ -209,345 +214,6 @@ constexpr cards<T> make_cards(T &&a, T &&s, T &&e, T &&so, T &&sc, T &&sn, T &&a
 }
 } // namespace wildcards
 #endif
-#ifndef WILDCARDS_MATCH_HPP
-#define WILDCARDS_MATCH_HPP
-#include <stdexcept>
-#include <type_traits>
-#include <utility>
-#ifndef CONFIG_HPP
-#define CONFIG_HPP
-#ifndef QUICKCPPLIB_HAS_FEATURE_H
-#define QUICKCPPLIB_HAS_FEATURE_H
-#if __cplusplus >= 201103L
-#if !defined(__cpp_alias_templates)
-#define __cpp_alias_templates 190000
-#endif
-#if !defined(__cpp_attributes)
-#define __cpp_attributes 190000
-#endif
-#if !defined(__cpp_constexpr)
-#if __cplusplus >= 201402L
-#define __cpp_constexpr 201304
-#else
-#define __cpp_constexpr 190000
-#endif
-#endif
-#if !defined(__cpp_decltype)
-#define __cpp_decltype 190000
-#endif
-#if !defined(__cpp_delegating_constructors)
-#define __cpp_delegating_constructors 190000
-#endif
-#if !defined(__cpp_explicit_conversion)
-#define __cpp_explicit_conversion 190000
-#endif
-#if !defined(__cpp_inheriting_constructors)
-#define __cpp_inheriting_constructors 190000
-#endif
-#if !defined(__cpp_initializer_lists)
-#define __cpp_initializer_lists 190000
-#endif
-#if !defined(__cpp_lambdas)
-#define __cpp_lambdas 190000
-#endif
-#if !defined(__cpp_nsdmi)
-#define __cpp_nsdmi 190000
-#endif
-#if !defined(__cpp_range_based_for)
-#define __cpp_range_based_for 190000
-#endif
-#if !defined(__cpp_raw_strings)
-#define __cpp_raw_strings 190000
-#endif
-#if !defined(__cpp_ref_qualifiers)
-#define __cpp_ref_qualifiers 190000
-#endif
-#if !defined(__cpp_rvalue_references)
-#define __cpp_rvalue_references 190000
-#endif
-#if !defined(__cpp_static_assert)
-#define __cpp_static_assert 190000
-#endif
-#if !defined(__cpp_unicode_characters)
-#define __cpp_unicode_characters 190000
-#endif
-#if !defined(__cpp_unicode_literals)
-#define __cpp_unicode_literals 190000
-#endif
-#if !defined(__cpp_user_defined_literals)
-#define __cpp_user_defined_literals 190000
-#endif
-#if !defined(__cpp_variadic_templates)
-#define __cpp_variadic_templates 190000
-#endif
-#endif
-#if __cplusplus >= 201402L
-#if !defined(__cpp_aggregate_nsdmi)
-#define __cpp_aggregate_nsdmi 190000
-#endif
-#if !defined(__cpp_binary_literals)
-#define __cpp_binary_literals 190000
-#endif
-#if !defined(__cpp_decltype_auto)
-#define __cpp_decltype_auto 190000
-#endif
-#if !defined(__cpp_generic_lambdas)
-#define __cpp_generic_lambdas 190000
-#endif
-#if !defined(__cpp_init_captures)
-#define __cpp_init_captures 190000
-#endif
-#if !defined(__cpp_return_type_deduction)
-#define __cpp_return_type_deduction 190000
-#endif
-#if !defined(__cpp_sized_deallocation)
-#define __cpp_sized_deallocation 190000
-#endif
-#if !defined(__cpp_variable_templates)
-#define __cpp_variable_templates 190000
-#endif
-#endif
-#if defined(_MSC_VER) && !defined(__clang__)
-#if !defined(__cpp_exceptions) && defined(_CPPUNWIND)
-#define __cpp_exceptions 190000
-#endif
-#if !defined(__cpp_rtti) && defined(_CPPRTTI)
-#define __cpp_rtti 190000
-#endif
-#if !defined(__cpp_alias_templates) && _MSC_VER >= 1800
-#define __cpp_alias_templates 190000
-#endif
-#if !defined(__cpp_attributes)
-#define __cpp_attributes 190000
-#endif
-#if !defined(__cpp_constexpr) && _MSC_FULL_VER >= 190023506
-#define __cpp_constexpr 190000
-#endif
-#if !defined(__cpp_decltype) && _MSC_VER >= 1600
-#define __cpp_decltype 190000
-#endif
-#if !defined(__cpp_delegating_constructors) && _MSC_VER >= 1800
-#define __cpp_delegating_constructors 190000
-#endif
-#if !defined(__cpp_explicit_conversion) && _MSC_VER >= 1800
-#define __cpp_explicit_conversion 190000
-#endif
-#if !defined(__cpp_inheriting_constructors) && _MSC_VER >= 1900
-#define __cpp_inheriting_constructors 190000
-#endif
-#if !defined(__cpp_initializer_lists) && _MSC_VER >= 1900
-#define __cpp_initializer_lists 190000
-#endif
-#if !defined(__cpp_lambdas) && _MSC_VER >= 1600
-#define __cpp_lambdas 190000
-#endif
-#if !defined(__cpp_nsdmi) && _MSC_VER >= 1900
-#define __cpp_nsdmi 190000
-#endif
-#if !defined(__cpp_range_based_for) && _MSC_VER >= 1700
-#define __cpp_range_based_for 190000
-#endif
-#if !defined(__cpp_raw_strings) && _MSC_VER >= 1800
-#define __cpp_raw_strings 190000
-#endif
-#if !defined(__cpp_ref_qualifiers) && _MSC_VER >= 1900
-#define __cpp_ref_qualifiers 190000
-#endif
-#if !defined(__cpp_rvalue_references) && _MSC_VER >= 1600
-#define __cpp_rvalue_references 190000
-#endif
-#if !defined(__cpp_static_assert) && _MSC_VER >= 1600
-#define __cpp_static_assert 190000
-#endif
-#if !defined(__cpp_user_defined_literals) && _MSC_VER >= 1900
-#define __cpp_user_defined_literals 190000
-#endif
-#if !defined(__cpp_variadic_templates) && _MSC_VER >= 1800
-#define __cpp_variadic_templates 190000
-#endif
-#if !defined(__cpp_binary_literals) && _MSC_VER >= 1900
-#define __cpp_binary_literals 190000
-#endif
-#if !defined(__cpp_decltype_auto) && _MSC_VER >= 1900
-#define __cpp_decltype_auto 190000
-#endif
-#if !defined(__cpp_generic_lambdas) && _MSC_VER >= 1900
-#define __cpp_generic_lambdas 190000
-#endif
-#if !defined(__cpp_init_captures) && _MSC_VER >= 1900
-#define __cpp_init_captures 190000
-#endif
-#if !defined(__cpp_return_type_deduction) && _MSC_VER >= 1900
-#define __cpp_return_type_deduction 190000
-#endif
-#if !defined(__cpp_sized_deallocation) && _MSC_VER >= 1900
-#define __cpp_sized_deallocation 190000
-#endif
-#if !defined(__cpp_variable_templates) && _MSC_FULL_VER >= 190023506
-#define __cpp_variable_templates 190000
-#endif
-#endif
-#if (defined(__GNUC__) && !defined(__clang__))
-#define QUICKCPPLIB_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#if !defined(__cpp_exceptions) && defined(__EXCEPTIONS)
-#define __cpp_exceptions 190000
-#endif
-#if !defined(__cpp_rtti) && defined(__GXX_RTTI)
-#define __cpp_rtti 190000
-#endif
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
-#if !defined(__cpp_alias_templates) && (QUICKCPPLIB_GCC >= 40700)
-#define __cpp_alias_templates 190000
-#endif
-#if !defined(__cpp_attributes) && (QUICKCPPLIB_GCC >= 40800)
-#define __cpp_attributes 190000
-#endif
-#if !defined(__cpp_constexpr) && (QUICKCPPLIB_GCC >= 40600)
-#define __cpp_constexpr 190000
-#endif
-#if !defined(__cpp_decltype) && (QUICKCPPLIB_GCC >= 40300)
-#define __cpp_decltype 190000
-#endif
-#if !defined(__cpp_delegating_constructors) && (QUICKCPPLIB_GCC >= 40700)
-#define __cpp_delegating_constructors 190000
-#endif
-#if !defined(__cpp_explicit_conversion) && (QUICKCPPLIB_GCC >= 40500)
-#define __cpp_explicit_conversion 190000
-#endif
-#if !defined(__cpp_inheriting_constructors) && (QUICKCPPLIB_GCC >= 40800)
-#define __cpp_inheriting_constructors 190000
-#endif
-#if !defined(__cpp_initializer_lists) && (QUICKCPPLIB_GCC >= 40800)
-#define __cpp_initializer_lists 190000
-#endif
-#if !defined(__cpp_lambdas) && (QUICKCPPLIB_GCC >= 40500)
-#define __cpp_lambdas 190000
-#endif
-#if !defined(__cpp_nsdmi) && (QUICKCPPLIB_GCC >= 40700)
-#define __cpp_nsdmi 190000
-#endif
-#if !defined(__cpp_range_based_for) && (QUICKCPPLIB_GCC >= 40600)
-#define __cpp_range_based_for 190000
-#endif
-#if !defined(__cpp_raw_strings) && (QUICKCPPLIB_GCC >= 40500)
-#define __cpp_raw_strings 190000
-#endif
-#if !defined(__cpp_ref_qualifiers) && (QUICKCPPLIB_GCC >= 40801)
-#define __cpp_ref_qualifiers 190000
-#endif
-#if !defined(__cpp_rvalue_references) && defined(__cpp_rvalue_reference)
-#define __cpp_rvalue_references __cpp_rvalue_reference
-#endif
-#if !defined(__cpp_static_assert) && (QUICKCPPLIB_GCC >= 40300)
-#define __cpp_static_assert 190000
-#endif
-#if !defined(__cpp_unicode_characters) && (QUICKCPPLIB_GCC >= 40500)
-#define __cpp_unicode_characters 190000
-#endif
-#if !defined(__cpp_unicode_literals) && (QUICKCPPLIB_GCC >= 40500)
-#define __cpp_unicode_literals 190000
-#endif
-#if !defined(__cpp_user_defined_literals) && (QUICKCPPLIB_GCC >= 40700)
-#define __cpp_user_defined_literals 190000
-#endif
-#if !defined(__cpp_variadic_templates) && (QUICKCPPLIB_GCC >= 40400)
-#define __cpp_variadic_templates 190000
-#endif
-#endif
-#endif
-#if defined(__clang__)
-#define QUICKCPPLIB_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
-#if !defined(__cpp_exceptions) && (defined(__EXCEPTIONS) || defined(_CPPUNWIND))
-#define __cpp_exceptions 190000
-#endif
-#if !defined(__cpp_rtti) && (defined(__GXX_RTTI) || defined(_CPPRTTI))
-#define __cpp_rtti 190000
-#endif
-#if defined(__GXX_EXPERIMENTAL_CXX0X__)
-#if !defined(__cpp_alias_templates) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_alias_templates 190000
-#endif
-#if !defined(__cpp_attributes) && (QUICKCPPLIB_CLANG >= 30300)
-#define __cpp_attributes 190000
-#endif
-#if !defined(__cpp_constexpr) && (QUICKCPPLIB_CLANG >= 30100)
-#define __cpp_constexpr 190000
-#endif
-#if !defined(__cpp_decltype) && (QUICKCPPLIB_CLANG >= 20900)
-#define __cpp_decltype 190000
-#endif
-#if !defined(__cpp_delegating_constructors) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_delegating_constructors 190000
-#endif
-#if !defined(__cpp_explicit_conversion) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_explicit_conversion 190000
-#endif
-#if !defined(__cpp_inheriting_constructors) && (QUICKCPPLIB_CLANG >= 30300)
-#define __cpp_inheriting_constructors 190000
-#endif
-#if !defined(__cpp_initializer_lists) && (QUICKCPPLIB_CLANG >= 30100)
-#define __cpp_initializer_lists 190000
-#endif
-#if !defined(__cpp_lambdas) && (QUICKCPPLIB_CLANG >= 30100)
-#define __cpp_lambdas 190000
-#endif
-#if !defined(__cpp_nsdmi) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_nsdmi 190000
-#endif
-#if !defined(__cpp_range_based_for) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_range_based_for 190000
-#endif
-#if !defined(__cpp_raw_strings) && defined(__cpp_raw_string_literals)
-#define __cpp_raw_strings __cpp_raw_string_literals
-#endif
-#if !defined(__cpp_raw_strings) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_raw_strings 190000
-#endif
-#if !defined(__cpp_ref_qualifiers) && (QUICKCPPLIB_CLANG >= 20900)
-#define __cpp_ref_qualifiers 190000
-#endif
-#if !defined(__cpp_rvalue_references) && defined(__cpp_rvalue_reference)
-#define __cpp_rvalue_references __cpp_rvalue_reference
-#endif
-#if !defined(__cpp_rvalue_references) && (QUICKCPPLIB_CLANG >= 20900)
-#define __cpp_rvalue_references 190000
-#endif
-#if !defined(__cpp_static_assert) && (QUICKCPPLIB_CLANG >= 20900)
-#define __cpp_static_assert 190000
-#endif
-#if !defined(__cpp_unicode_characters) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_unicode_characters 190000
-#endif
-#if !defined(__cpp_unicode_literals) && (QUICKCPPLIB_CLANG >= 30000)
-#define __cpp_unicode_literals 190000
-#endif
-#if !defined(__cpp_user_defined_literals) && defined(__cpp_user_literals)
-#define __cpp_user_defined_literals __cpp_user_literals
-#endif
-#if !defined(__cpp_user_defined_literals) && (QUICKCPPLIB_CLANG >= 30100)
-#define __cpp_user_defined_literals 190000
-#endif
-#if !defined(__cpp_variadic_templates) && (QUICKCPPLIB_CLANG >= 20900)
-#define __cpp_variadic_templates 190000
-#endif
-#endif
-#endif
-#endif
-#define cfg_HAS_CONSTEXPR14 (__cpp_constexpr >= 201304)
-#if cfg_HAS_CONSTEXPR14
-#define cfg_constexpr14 constexpr
-#else
-#define cfg_constexpr14
-#endif
-#if cfg_HAS_CONSTEXPR14 && defined(__clang__)
-#define cfg_HAS_FULL_FEATURED_CONSTEXPR14 1
-#else
-#define cfg_HAS_FULL_FEATURED_CONSTEXPR14 0
-#endif
-#endif
-#ifndef CX_FUNCTIONAL_HPP
-#define CX_FUNCTIONAL_HPP
-#include <utility>
 namespace cx {
 template <typename T>
 struct less {
@@ -574,11 +240,6 @@ struct equal_to<void> {
    }
 };
 } // namespace cx
-#endif
-#ifndef CX_ITERATOR_HPP
-#define CX_ITERATOR_HPP
-#include <cstddef>
-#include <initializer_list>
 namespace cx {
 template <typename It>
 constexpr It next(It it)
@@ -666,11 +327,6 @@ constexpr auto cend(const C &c) -> decltype(cx::end(c))
    return cx::end(c);
 }
 } // namespace cx
-#endif
-#ifndef WILDCARDS_UTILITY_HPP
-#define WILDCARDS_UTILITY_HPP
-#include <type_traits>
-#include <utility>
 namespace wildcards {
 template <typename C>
 struct const_iterator {
@@ -700,7 +356,6 @@ struct container_item {
 template <typename C>
 using container_item_t = typename container_item<C>::type;
 } // namespace wildcards
-#endif
 namespace wildcards {
 template <typename SequenceIterator, typename PatternIterator>
 struct full_match_result {
@@ -731,26 +386,6 @@ make_full_match_result(SequenceIterator s, SequenceIterator send, PatternIterato
    return {std::move(mr.res), std::move(s),    std::move(send), std::move(mr.s),
            std::move(p),      std::move(pend), std::move(mr.p)};
 }
-#if !cfg_HAS_FULL_FEATURED_CONSTEXPR14
-constexpr bool throw_invalid_argument(const char *what_arg)
-{
-   return what_arg == nullptr ? false : throw std::invalid_argument(what_arg);
-}
-template <typename T>
-constexpr T throw_invalid_argument(T t, const char *what_arg)
-{
-   return what_arg == nullptr ? t : throw std::invalid_argument(what_arg);
-}
-constexpr bool throw_logic_error(const char *what_arg)
-{
-   return what_arg == nullptr ? false : throw std::logic_error(what_arg);
-}
-template <typename T>
-constexpr T throw_logic_error(T t, const char *what_arg)
-{
-   return what_arg == nullptr ? t : throw std::logic_error(what_arg);
-}
-#endif
 enum class is_set_state {
    open,
    not_or_first,
@@ -762,7 +397,6 @@ constexpr bool is_set(PatternIterator p, PatternIterator pend,
                       const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
                       is_set_state state = is_set_state::open)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.set_enabled) {
       return false;
    }
@@ -788,25 +422,11 @@ constexpr bool is_set(PatternIterator p, PatternIterator pend,
          }
          break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error("The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
    return false;
-#else
-   return c.set_enabled && p != pend &&
-          (state == is_set_state::open ? *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-           : state == is_set_state::not_or_first ? *p == c.set_not ? is_set(cx::next(p), pend, c, is_set_state::first)
-                                                                   : is_set(cx::next(p), pend, c, is_set_state::next)
-           : state == is_set_state::first ? is_set(cx::next(p), pend, c, is_set_state::next)
-           : state == is_set_state::next         ? *p == c.set_close || is_set(cx::next(p), pend, c, is_set_state::next)
-                                                 : throw std::logic_error("The program execution should never end up "
-                                                                                  "here throwing this exception"));
-#endif
 }
 enum class set_end_state {
    open,
@@ -820,23 +440,14 @@ set_end(PatternIterator p, PatternIterator pend,
         const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
         set_end_state state = set_end_state::open)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.set_enabled) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
       throw std::invalid_argument("The use of sets is disabled");
-#else
-      return throw_invalid_argument(p, "The use of sets is disabled");
-#endif
    }
    while (p != pend) {
       switch (state) {
       case set_end_state::open:
          if (*p != c.set_open) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
             throw std::invalid_argument("The given pattern is not a valid set");
-#else
-            return throw_invalid_argument(p, "The given pattern is not a valid set");
-#endif
          }
          state = set_end_state::not_or_first;
          break;
@@ -854,33 +465,11 @@ set_end(PatternIterator p, PatternIterator pend,
          }
          break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
    throw std::invalid_argument("The given pattern is not a valid set");
-#else
-   return throw_invalid_argument(p, "The given pattern is not a valid set");
-#endif
-#else
-   return !c.set_enabled                         ? throw std::invalid_argument("The use of sets is disabled")
-          : p == pend                            ? throw std::invalid_argument("The given pattern is not a valid set")
-          : state == set_end_state::open         ? *p == c.set_open
-                                                      ? set_end(cx::next(p), pend, c, set_end_state::not_or_first)
-                                                      : throw std::invalid_argument("The given pattern is not a valid set")
-                  : state == set_end_state::not_or_first ? *p == c.set_not ? set_end(cx::next(p), pend, c, set_end_state::first)
-                                                                           : set_end(cx::next(p), pend, c, set_end_state::next)
-                  : state == set_end_state::first ? set_end(cx::next(p), pend, c, set_end_state::next)
-          : state == set_end_state::next
-             ? *p == c.set_close ? cx::next(p) : set_end(cx::next(p), pend, c, set_end_state::next)
-             : throw std::logic_error("The program execution should never end up "
-                                      "here throwing this exception");
-#endif
 }
 enum class match_set_state {
    open,
@@ -895,23 +484,14 @@ match_set(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternI
           const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
           const EqualTo &equal_to = EqualTo(), match_set_state state = match_set_state::open)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.set_enabled) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
       throw std::invalid_argument("The use of sets is disabled");
-#else
-      return throw_invalid_argument(make_match_result(false, s, p), "The use of sets is disabled");
-#endif
    }
    while (p != pend) {
       switch (state) {
       case match_set_state::open:
          if (*p != c.set_open) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
             throw std::invalid_argument("The given pattern is not a valid set");
-#else
-            return throw_invalid_argument(make_match_result(false, s, p), "The given pattern is not a valid set");
-#endif
          }
          state = match_set_state::not_or_first_in;
          break;
@@ -951,47 +531,11 @@ match_set(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternI
          }
          break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error(make_match_result(false, s, p),
-                                  "The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
    throw std::invalid_argument("The given pattern is not a valid set");
-#else
-   return throw_invalid_argument(make_match_result(false, s, p), "The given pattern is not a valid set");
-#endif
-#else
-   return !c.set_enabled ? throw std::invalid_argument("The use of sets is disabled")
-          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid set")
-          : state == match_set_state::open
-             ? *p == c.set_open ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
-                                : throw std::invalid_argument("The given pattern is not a valid set")
-          : state == match_set_state::not_or_first_in
-             ? *p == c.set_not    ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::first_out)
-               : s == send        ? make_match_result(false, s, p)
-               : equal_to(*s, *p) ? make_match_result(true, s, p)
-                                  : match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::next_in)
-          : state == match_set_state::first_out
-             ? s == send || equal_to(*s, *p)
-                  ? make_match_result(false, s, p)
-                  : match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::next_out)
-          : state == match_set_state::next_in  ? *p == c.set_close || s == send ? make_match_result(false, s, p)
-                                                 : equal_to(*s, *p)
-                                                    ? make_match_result(true, s, p)
-                                                    : match_set(s, send, cx::next(p), pend, c, equal_to, state)
-           : state == match_set_state::next_out ? *p == c.set_close ? make_match_result(true, s, p)
-                                                  : s == send || equal_to(*s, *p)
-                                                     ? make_match_result(false, s, p)
-                                                     : match_set(s, send, cx::next(p), pend, c, equal_to, state)
-                                                : throw std::logic_error("The program execution should never end up "
-                                                                          "here "
-                                                                          "throwing this exception");
-#endif
 }
 enum class is_alt_state {
    open,
@@ -1003,7 +547,6 @@ constexpr bool is_alt(PatternIterator p, PatternIterator pend,
                       const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
                       is_alt_state state = is_alt_state::open, int depth = 0)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.alt_enabled) {
       return false;
    }
@@ -1032,30 +575,11 @@ constexpr bool is_alt(PatternIterator p, PatternIterator pend,
          break;
       case is_alt_state::escape: state = is_alt_state::next; break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
    return false;
-#else
-   return c.alt_enabled && p != pend &&
-          (state == is_alt_state::open ? *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, depth + 1)
-           : state == is_alt_state::next
-              ? *p == c.escape ? is_alt(cx::next(p), pend, c, is_alt_state::escape, depth)
-                : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-                   ? is_alt(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
-                : *p == c.alt_open  ? is_alt(cx::next(p), pend, c, state, depth + 1)
-                : *p == c.alt_close ? depth == 1 || is_alt(cx::next(p), pend, c, state, depth - 1)
-                                    : is_alt(cx::next(p), pend, c, state, depth)
-           : state == is_alt_state::escape
-              ? is_alt(cx::next(p), pend, c, is_alt_state::next, depth)
-              : throw std::logic_error("The program execution should never end up here throwing this "
-                                       "exception"));
-#endif
 }
 enum class alt_end_state {
    open,
@@ -1068,23 +592,14 @@ alt_end(PatternIterator p, PatternIterator pend,
         const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
         alt_end_state state = alt_end_state::open, int depth = 0)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.alt_enabled) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
       throw std::invalid_argument("The use of alternatives is disabled");
-#else
-      return throw_invalid_argument(p, "The use of alternatives is disabled");
-#endif
    }
    while (p != pend) {
       switch (state) {
       case alt_end_state::open:
          if (*p != c.alt_open) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
             throw std::invalid_argument("The given pattern is not a valid alternative");
-#else
-            return throw_invalid_argument(p, "The given pattern is not a valid alternative");
-#endif
          }
          state = alt_end_state::next;
          ++depth;
@@ -1105,38 +620,11 @@ alt_end(PatternIterator p, PatternIterator pend,
          break;
       case alt_end_state::escape: state = alt_end_state::next; break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
    throw std::invalid_argument("The given pattern is not a valid alternative");
-#else
-   return throw_invalid_argument(p, "The given pattern is not a valid alternative");
-#endif
-#else
-   return !c.alt_enabled ? throw std::invalid_argument("The use of alternatives is disabled")
-          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid alternative")
-          : state == alt_end_state::open
-             ? *p == c.alt_open ? alt_end(cx::next(p), pend, c, alt_end_state::next, depth + 1)
-                                : throw std::invalid_argument("The given pattern is not a valid alternative")
-          : state == alt_end_state::next
-             ? *p == c.escape ? alt_end(cx::next(p), pend, c, alt_end_state::escape, depth)
-               : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-                  ? alt_end(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
-               : *p == c.alt_open  ? alt_end(cx::next(p), pend, c, state, depth + 1)
-               : *p == c.alt_close ? depth == 1 ? cx::next(p) : alt_end(cx::next(p), pend, c, state, depth - 1)
-                                   : alt_end(cx::next(p), pend, c, state, depth)
-          : state == alt_end_state::escape
-             ? alt_end(cx::next(p), pend, c, alt_end_state::next, depth)
-             : throw std::logic_error("The program execution should never end up here throwing "
-                                      "this "
-                                      "exception");
-#endif
 }
 enum class alt_sub_end_state {
    next,
@@ -1148,13 +636,8 @@ alt_sub_end(PatternIterator p, PatternIterator pend,
             const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
             alt_sub_end_state state = alt_sub_end_state::next, int depth = 1)
 {
-#if cfg_HAS_CONSTEXPR14
    if (!c.alt_enabled) {
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
       throw std::invalid_argument("The use of alternatives is disabled");
-#else
-      return throw_invalid_argument(p, "The use of alternatives is disabled");
-#endif
    }
    while (p != pend) {
       switch (state) {
@@ -1178,36 +661,11 @@ alt_sub_end(PatternIterator p, PatternIterator pend,
          break;
       case alt_sub_end_state::escape: state = alt_sub_end_state::next; break;
       default:
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
          throw std::logic_error("The program execution should never end up here throwing this exception");
-#else
-         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
-#endif
       }
       p = cx::next(p);
    }
-#if cfg_HAS_FULL_FEATURED_CONSTEXPR14
    throw std::invalid_argument("The given pattern is not a valid alternative");
-#else
-   return throw_invalid_argument(p, "The given pattern is not a valid alternative");
-#endif
-#else
-   return !c.alt_enabled ? throw std::invalid_argument("The use of alternatives is disabled")
-          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid alternative")
-          : state == alt_sub_end_state::next
-             ? *p == c.escape ? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::escape, depth)
-               : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-                  ? alt_sub_end(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
-               : *p == c.alt_open  ? alt_sub_end(cx::next(p), pend, c, state, depth + 1)
-               : *p == c.alt_close ? depth == 1 ? p : alt_sub_end(cx::next(p), pend, c, state, depth - 1)
-               : *p == c.alt_or ? depth == 1 ? p : alt_sub_end(cx::next(p), pend, c, state, depth)
-                                : alt_sub_end(cx::next(p), pend, c, state, depth)
-          : state == alt_sub_end_state::escape
-             ? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::next, depth)
-             : throw std::logic_error("The program execution should never end up here throwing "
-                                      "this "
-                                      "exception");
-#endif
 }
 template <typename SequenceIterator, typename PatternIterator, typename EqualTo = cx::equal_to<void>>
 constexpr match_result<SequenceIterator, PatternIterator>
@@ -1221,7 +679,6 @@ match_alt(SequenceIterator s, SequenceIterator send, PatternIterator p1, Pattern
           const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
           const EqualTo &equal_to = EqualTo(), bool partial = false)
 {
-#if cfg_HAS_CONSTEXPR14
    auto result1 = match(s, send, p1, p1end, c, equal_to, true);
    if (result1) {
       auto result2 = match(result1.s, send, p2, p2end, c, equal_to, partial);
@@ -1234,21 +691,12 @@ match_alt(SequenceIterator s, SequenceIterator send, PatternIterator p1, Pattern
       return make_match_result(false, s, p1end);
    }
    return match_alt(s, send, p1, alt_sub_end(p1, p2, c), p2, p2end, c, equal_to, partial);
-#else
-   return match(s, send, p1, p1end, c, equal_to, true) &&
-                match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to, partial)
-             ? match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to, partial)
-          : cx::next(p1end) == p2 ? make_match_result(false, s, p1end)
-                                  : match_alt(s, send, cx::next(p1end), alt_sub_end(cx::next(p1end), p2, c), p2, p2end,
-                                              c, equal_to, partial);
-#endif
 }
 template <typename SequenceIterator, typename PatternIterator, typename EqualTo>
 constexpr match_result<SequenceIterator, PatternIterator>
 match(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
       const cards<iterated_item_t<PatternIterator>> &c, const EqualTo &equal_to, bool partial, bool escape)
 {
-#if cfg_HAS_CONSTEXPR14
    if (p == pend) {
       return make_match_result(partial || s == send, s, p);
    }
@@ -1294,29 +742,6 @@ match(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternItera
       return make_match_result(false, s, p);
    }
    return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
-#else
-   return p == pend          ? make_match_result(partial || s == send, s, p)
-          : escape           ? s == send || !equal_to(*s, *p) ? make_match_result(false, s, p)
-                                                              : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
-                    : *p == c.anything ? match(s, send, cx::next(p), pend, c, equal_to, partial)
-                                            ? match(s, send, cx::next(p), pend, c, equal_to, partial)
-                                         : s == send ? make_match_result(false, s, p)
-                                                     : match(cx::next(s), send, p, pend, c, equal_to, partial)
-                    : *p == c.single ? s == send ? make_match_result(false, s, p)
-                                                 : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
-                    : *p == c.escape ? match(s, send, cx::next(p), pend, c, equal_to, partial, true)
-          : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-             ? !match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
-                  ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
-                  : match(cx::next(s), send, set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c,
-                          equal_to, partial)
-          : c.alt_enabled && *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, 1)
-             ? match_alt(s, send, cx::next(p),
-                         alt_sub_end(cx::next(p), alt_end(cx::next(p), pend, c, alt_end_state::next, 1), c),
-                         alt_end(cx::next(p), pend, c, alt_end_state::next, 1), pend, c, equal_to, partial)
-          : s == send || !equal_to(*s, *p) ? make_match_result(false, s, p)
-                                           : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
-#endif
 }
 } // namespace detail
 template <typename Sequence, typename Pattern, typename EqualTo = cx::equal_to<void>>
@@ -1339,34 +764,16 @@ match(Sequence &&sequence, Pattern &&pattern, const EqualTo &equal_to)
                 equal_to);
 }
 } // namespace wildcards
-#endif
-#ifndef WILDCARDS_MATCHER_HPP
-#define WILDCARDS_MATCHER_HPP
-#include <cstddef>
-#include <type_traits>
-#include <utility>
-#ifndef CX_STRING_VIEW_HPP
-#define CX_STRING_VIEW_HPP
-#include <cstddef>
-#include <ostream>
-#ifndef CX_ALGORITHM_HPP
-#define CX_ALGORITHM_HPP
 namespace cx {
 template <typename Iterator1, typename Iterator2>
 constexpr bool equal(Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2)
 {
-#if cfg_HAS_CONSTEXPR14
    while (first1 != last1 && first2 != last2 && *first1 == *first2) {
       ++first1, ++first2;
    }
    return first1 == last1 && first2 == last2;
-#else
-   return first1 != last1 && first2 != last2 && *first1 == *first2 ? equal(first1 + 1, last1, first2 + 1, last2)
-                                                                   : first1 == last1 && first2 == last2;
-#endif
 }
 } // namespace cx
-#endif
 namespace cx {
 template <typename T>
 class basic_string_view {
@@ -1439,7 +846,6 @@ constexpr wstring_view operator""_sv(const wchar_t *str, std::size_t s)
 }
 } // namespace literals
 } // namespace cx
-#endif
 namespace wildcards {
 template <typename Pattern, typename EqualTo = cx::equal_to<void>>
 class matcher {
@@ -1506,5 +912,4 @@ constexpr auto operator""_wc(const wchar_t *str, std::size_t s)
 }
 } // namespace literals
 } // namespace wildcards
-#endif
 #endif

--- a/main/src/wildcards.hpp
+++ b/main/src/wildcards.hpp
@@ -5,247 +5,219 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 #ifndef WILDCARDS_HPP
-#define WILDCARDS_HPP 
+#define WILDCARDS_HPP
 #define WILDCARDS_VERSION_MAJOR 1
 #define WILDCARDS_VERSION_MINOR 5
 #define WILDCARDS_VERSION_PATCH 0
 #ifndef WILDCARDS_CARDS_HPP
-#define WILDCARDS_CARDS_HPP 
+#define WILDCARDS_CARDS_HPP
 #include <utility>
-namespace wildcards
-{
+namespace wildcards {
 template <typename T>
-struct cards
-{
-constexpr cards(T a, T s, T e)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{false},
-alt_enabled{false}
-{
-}
-constexpr cards(T a, T s, T e, T so, T sc, T sn, T ao, T ac, T ar)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{true},
-set_open{std::move(so)},
-set_close{std::move(sc)},
-set_not{std::move(sn)},
-alt_enabled{true},
-alt_open{std::move(ao)},
-alt_close{std::move(ac)},
-alt_or{std::move(ar)}
-{
-}
-T anything;
-T single;
-T escape;
-bool set_enabled;
-T set_open;
-T set_close;
-T set_not;
-bool alt_enabled;
-T alt_open;
-T alt_close;
-T alt_or;
+struct cards {
+   constexpr cards(T a, T s, T e)
+      : anything{std::move(a)}, single{std::move(s)}, escape{std::move(e)}, set_enabled{false}, alt_enabled{false}
+   {
+   }
+   constexpr cards(T a, T s, T e, T so, T sc, T sn, T ao, T ac, T ar)
+      : anything{std::move(a)},
+        single{std::move(s)},
+        escape{std::move(e)},
+        set_enabled{true},
+        set_open{std::move(so)},
+        set_close{std::move(sc)},
+        set_not{std::move(sn)},
+        alt_enabled{true},
+        alt_open{std::move(ao)},
+        alt_close{std::move(ac)},
+        alt_or{std::move(ar)}
+   {
+   }
+   T anything;
+   T single;
+   T escape;
+   bool set_enabled;
+   T set_open;
+   T set_close;
+   T set_not;
+   bool alt_enabled;
+   T alt_open;
+   T alt_close;
+   T alt_or;
 };
-enum class cards_type
-{
-standard,
-extended
+enum class cards_type {
+   standard,
+   extended
 };
 template <>
-struct cards<char>
-{
-constexpr cards(cards_type type = cards_type::extended)
-: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
-{
-}
-constexpr cards(char a, char s, char e)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{false},
-alt_enabled{false}
-{
-}
-constexpr cards(char a, char s, char e, char so, char sc, char sn, char ao, char ac, char ar)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{true},
-set_open{std::move(so)},
-set_close{std::move(sc)},
-set_not{std::move(sn)},
-alt_enabled{true},
-alt_open{std::move(ao)},
-alt_close{std::move(ac)},
-alt_or{std::move(ar)}
-{
-}
-char anything{'*'};
-char single{'?'};
-char escape{'\\'};
-bool set_enabled{true};
-char set_open{'['};
-char set_close{']'};
-char set_not{'!'};
-bool alt_enabled{true};
-char alt_open{'('};
-char alt_close{')'};
-char alt_or{'|'};
+struct cards<char> {
+   constexpr cards(cards_type type = cards_type::extended)
+      : set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+   {
+   }
+   constexpr cards(char a, char s, char e)
+      : anything{std::move(a)}, single{std::move(s)}, escape{std::move(e)}, set_enabled{false}, alt_enabled{false}
+   {
+   }
+   constexpr cards(char a, char s, char e, char so, char sc, char sn, char ao, char ac, char ar)
+      : anything{std::move(a)},
+        single{std::move(s)},
+        escape{std::move(e)},
+        set_enabled{true},
+        set_open{std::move(so)},
+        set_close{std::move(sc)},
+        set_not{std::move(sn)},
+        alt_enabled{true},
+        alt_open{std::move(ao)},
+        alt_close{std::move(ac)},
+        alt_or{std::move(ar)}
+   {
+   }
+   char anything{'*'};
+   char single{'?'};
+   char escape{'\\'};
+   bool set_enabled{true};
+   char set_open{'['};
+   char set_close{']'};
+   char set_not{'!'};
+   bool alt_enabled{true};
+   char alt_open{'('};
+   char alt_close{')'};
+   char alt_or{'|'};
 };
 template <>
-struct cards<char16_t>
-{
-constexpr cards(cards_type type = cards_type::extended)
-: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
-{
-}
-constexpr cards(char16_t a, char16_t s, char16_t e)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{false},
-alt_enabled{false}
-{
-}
-constexpr cards(char16_t a, char16_t s, char16_t e, char16_t so, char16_t sc, char16_t sn,
-char16_t ao, char16_t ac, char16_t ar)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{true},
-set_open{std::move(so)},
-set_close{std::move(sc)},
-set_not{std::move(sn)},
-alt_enabled{true},
-alt_open{std::move(ao)},
-alt_close{std::move(ac)},
-alt_or{std::move(ar)}
-{
-}
-char16_t anything{u'*'};
-char16_t single{u'?'};
-char16_t escape{u'\\'};
-bool set_enabled{true};
-char16_t set_open{u'['};
-char16_t set_close{u']'};
-char16_t set_not{u'!'};
-bool alt_enabled{true};
-char16_t alt_open{u'('};
-char16_t alt_close{u')'};
-char16_t alt_or{u'|'};
+struct cards<char16_t> {
+   constexpr cards(cards_type type = cards_type::extended)
+      : set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+   {
+   }
+   constexpr cards(char16_t a, char16_t s, char16_t e)
+      : anything{std::move(a)}, single{std::move(s)}, escape{std::move(e)}, set_enabled{false}, alt_enabled{false}
+   {
+   }
+   constexpr cards(char16_t a, char16_t s, char16_t e, char16_t so, char16_t sc, char16_t sn, char16_t ao, char16_t ac,
+                   char16_t ar)
+      : anything{std::move(a)},
+        single{std::move(s)},
+        escape{std::move(e)},
+        set_enabled{true},
+        set_open{std::move(so)},
+        set_close{std::move(sc)},
+        set_not{std::move(sn)},
+        alt_enabled{true},
+        alt_open{std::move(ao)},
+        alt_close{std::move(ac)},
+        alt_or{std::move(ar)}
+   {
+   }
+   char16_t anything{u'*'};
+   char16_t single{u'?'};
+   char16_t escape{u'\\'};
+   bool set_enabled{true};
+   char16_t set_open{u'['};
+   char16_t set_close{u']'};
+   char16_t set_not{u'!'};
+   bool alt_enabled{true};
+   char16_t alt_open{u'('};
+   char16_t alt_close{u')'};
+   char16_t alt_or{u'|'};
 };
 template <>
-struct cards<char32_t>
-{
-constexpr cards(cards_type type = cards_type::extended)
-: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
-{
-}
-constexpr cards(char32_t a, char32_t s, char32_t e)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{false},
-alt_enabled{false}
-{
-}
-constexpr cards(char32_t a, char32_t s, char32_t e, char32_t so, char32_t sc, char32_t sn,
-char32_t ao, char32_t ac, char32_t ar)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{true},
-set_open{std::move(so)},
-set_close{std::move(sc)},
-set_not{std::move(sn)},
-alt_enabled{true},
-alt_open{std::move(ao)},
-alt_close{std::move(ac)},
-alt_or{std::move(ar)}
-{
-}
-char32_t anything{U'*'};
-char32_t single{U'?'};
-char32_t escape{U'\\'};
-bool set_enabled{true};
-char32_t set_open{U'['};
-char32_t set_close{U']'};
-char32_t set_not{U'!'};
-bool alt_enabled{true};
-char32_t alt_open{U'('};
-char32_t alt_close{U')'};
-char32_t alt_or{U'|'};
+struct cards<char32_t> {
+   constexpr cards(cards_type type = cards_type::extended)
+      : set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+   {
+   }
+   constexpr cards(char32_t a, char32_t s, char32_t e)
+      : anything{std::move(a)}, single{std::move(s)}, escape{std::move(e)}, set_enabled{false}, alt_enabled{false}
+   {
+   }
+   constexpr cards(char32_t a, char32_t s, char32_t e, char32_t so, char32_t sc, char32_t sn, char32_t ao, char32_t ac,
+                   char32_t ar)
+      : anything{std::move(a)},
+        single{std::move(s)},
+        escape{std::move(e)},
+        set_enabled{true},
+        set_open{std::move(so)},
+        set_close{std::move(sc)},
+        set_not{std::move(sn)},
+        alt_enabled{true},
+        alt_open{std::move(ao)},
+        alt_close{std::move(ac)},
+        alt_or{std::move(ar)}
+   {
+   }
+   char32_t anything{U'*'};
+   char32_t single{U'?'};
+   char32_t escape{U'\\'};
+   bool set_enabled{true};
+   char32_t set_open{U'['};
+   char32_t set_close{U']'};
+   char32_t set_not{U'!'};
+   bool alt_enabled{true};
+   char32_t alt_open{U'('};
+   char32_t alt_close{U')'};
+   char32_t alt_or{U'|'};
 };
 template <>
-struct cards<wchar_t>
-{
-constexpr cards(cards_type type = cards_type::extended)
-: set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
-{
-}
-constexpr cards(wchar_t a, wchar_t s, wchar_t e)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{false},
-alt_enabled{false}
-{
-}
-constexpr cards(wchar_t a, wchar_t s, wchar_t e, wchar_t so, wchar_t sc, wchar_t sn, wchar_t ao,
-wchar_t ac, wchar_t ar)
-: anything{std::move(a)},
-single{std::move(s)},
-escape{std::move(e)},
-set_enabled{true},
-set_open{std::move(so)},
-set_close{std::move(sc)},
-set_not{std::move(sn)},
-alt_enabled{true},
-alt_open{std::move(ao)},
-alt_close{std::move(ac)},
-alt_or{std::move(ar)}
-{
-}
-wchar_t anything{L'*'};
-wchar_t single{L'?'};
-wchar_t escape{L'\\'};
-bool set_enabled{true};
-wchar_t set_open{L'['};
-wchar_t set_close{L']'};
-wchar_t set_not{L'!'};
-bool alt_enabled{true};
-wchar_t alt_open{L'('};
-wchar_t alt_close{L')'};
-wchar_t alt_or{L'|'};
+struct cards<wchar_t> {
+   constexpr cards(cards_type type = cards_type::extended)
+      : set_enabled{type == cards_type::extended}, alt_enabled{type == cards_type::extended}
+   {
+   }
+   constexpr cards(wchar_t a, wchar_t s, wchar_t e)
+      : anything{std::move(a)}, single{std::move(s)}, escape{std::move(e)}, set_enabled{false}, alt_enabled{false}
+   {
+   }
+   constexpr cards(wchar_t a, wchar_t s, wchar_t e, wchar_t so, wchar_t sc, wchar_t sn, wchar_t ao, wchar_t ac,
+                   wchar_t ar)
+      : anything{std::move(a)},
+        single{std::move(s)},
+        escape{std::move(e)},
+        set_enabled{true},
+        set_open{std::move(so)},
+        set_close{std::move(sc)},
+        set_not{std::move(sn)},
+        alt_enabled{true},
+        alt_open{std::move(ao)},
+        alt_close{std::move(ac)},
+        alt_or{std::move(ar)}
+   {
+   }
+   wchar_t anything{L'*'};
+   wchar_t single{L'?'};
+   wchar_t escape{L'\\'};
+   bool set_enabled{true};
+   wchar_t set_open{L'['};
+   wchar_t set_close{L']'};
+   wchar_t set_not{L'!'};
+   bool alt_enabled{true};
+   wchar_t alt_open{L'('};
+   wchar_t alt_close{L')'};
+   wchar_t alt_or{L'|'};
 };
 template <typename T>
-constexpr cards<T> make_cards(T&& a, T&& s, T&& e)
+constexpr cards<T> make_cards(T &&a, T &&s, T &&e)
 {
-return {std::forward<T>(a), std::forward<T>(s), std::forward<T>(e)};
+   return {std::forward<T>(a), std::forward<T>(s), std::forward<T>(e)};
 }
 template <typename T>
-constexpr cards<T> make_cards(T&& a, T&& s, T&& e, T&& so, T&& sc, T&& sn, T&& ao, T&& ac, T&& ar)
+constexpr cards<T> make_cards(T &&a, T &&s, T &&e, T &&so, T &&sc, T &&sn, T &&ao, T &&ac, T &&ar)
 {
-return {std::forward<T>(a), std::forward<T>(s), std::forward<T>(e),
-std::forward<T>(so), std::forward<T>(sc), std::forward<T>(sn),
-std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
+   return {std::forward<T>(a),  std::forward<T>(s),  std::forward<T>(e),  std::forward<T>(so), std::forward<T>(sc),
+           std::forward<T>(sn), std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
 }
-}
+} // namespace wildcards
 #endif
 #ifndef WILDCARDS_MATCH_HPP
-#define WILDCARDS_MATCH_HPP 
+#define WILDCARDS_MATCH_HPP
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
 #ifndef CONFIG_HPP
-#define CONFIG_HPP 
+#define CONFIG_HPP
 #ifndef QUICKCPPLIB_HAS_FEATURE_H
-#define QUICKCPPLIB_HAS_FEATURE_H 
+#define QUICKCPPLIB_HAS_FEATURE_H
 #if __cplusplus >= 201103L
 #if !defined(__cpp_alias_templates)
 #define __cpp_alias_templates 190000
@@ -415,7 +387,7 @@ std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
 #define __cpp_variable_templates 190000
 #endif
 #endif
-#if(defined(__GNUC__) && !defined(__clang__))
+#if (defined(__GNUC__) && !defined(__clang__))
 #define QUICKCPPLIB_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #if !defined(__cpp_exceptions) && defined(__EXCEPTIONS)
 #define __cpp_exceptions 190000
@@ -565,7 +537,7 @@ std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
 #if cfg_HAS_CONSTEXPR14
 #define cfg_constexpr14 constexpr
 #else
-#define cfg_constexpr14 
+#define cfg_constexpr14
 #endif
 #if cfg_HAS_CONSTEXPR14 && defined(__clang__)
 #define cfg_HAS_FULL_FEATURED_CONSTEXPR14 1
@@ -574,1260 +546,965 @@ std::forward<T>(ao), std::forward<T>(ac), std::forward<T>(ar)};
 #endif
 #endif
 #ifndef CX_FUNCTIONAL_HPP
-#define CX_FUNCTIONAL_HPP 
+#define CX_FUNCTIONAL_HPP
 #include <utility>
-namespace cx
-{
+namespace cx {
 template <typename T>
-struct less
-{
-constexpr auto operator()(const T& lhs, const T& rhs) const -> decltype(lhs < rhs)
-{
-return lhs < rhs;
-}
+struct less {
+   constexpr auto operator()(const T &lhs, const T &rhs) const -> decltype(lhs < rhs) { return lhs < rhs; }
 };
 template <>
-struct less<void>
-{
-template <typename T, typename U>
-constexpr auto operator()(T&& lhs, U&& rhs) const
--> decltype(std::forward<T>(lhs) < std::forward<U>(rhs))
-{
-return std::forward<T>(lhs) < std::forward<U>(rhs);
-}
+struct less<void> {
+   template <typename T, typename U>
+   constexpr auto operator()(T &&lhs, U &&rhs) const -> decltype(std::forward<T>(lhs) < std::forward<U>(rhs))
+   {
+      return std::forward<T>(lhs) < std::forward<U>(rhs);
+   }
 };
 template <typename T>
-struct equal_to
-{
-constexpr auto operator()(const T& lhs, const T& rhs) const -> decltype(lhs == rhs)
-{
-return lhs == rhs;
-}
+struct equal_to {
+   constexpr auto operator()(const T &lhs, const T &rhs) const -> decltype(lhs == rhs) { return lhs == rhs; }
 };
 template <>
-struct equal_to<void>
-{
-template <typename T, typename U>
-constexpr auto operator()(T&& lhs, U&& rhs) const
--> decltype(std::forward<T>(lhs) == std::forward<U>(rhs))
-{
-return std::forward<T>(lhs) == std::forward<U>(rhs);
-}
+struct equal_to<void> {
+   template <typename T, typename U>
+   constexpr auto operator()(T &&lhs, U &&rhs) const -> decltype(std::forward<T>(lhs) == std::forward<U>(rhs))
+   {
+      return std::forward<T>(lhs) == std::forward<U>(rhs);
+   }
 };
-}
+} // namespace cx
 #endif
 #ifndef CX_ITERATOR_HPP
-#define CX_ITERATOR_HPP 
+#define CX_ITERATOR_HPP
 #include <cstddef>
 #include <initializer_list>
-namespace cx
-{
+namespace cx {
 template <typename It>
 constexpr It next(It it)
 {
-return it + 1;
+   return it + 1;
 }
 template <typename It>
 constexpr It prev(It it)
 {
-return it - 1;
+   return it - 1;
 }
 template <typename C>
-constexpr auto size(const C& c) -> decltype(c.size())
+constexpr auto size(const C &c) -> decltype(c.size())
 {
-return c.size();
+   return c.size();
 }
 template <typename T, std::size_t N>
 constexpr std::size_t size(const T (&)[N])
 {
-return N;
+   return N;
 }
 template <typename C>
-constexpr auto empty(const C& c) -> decltype(c.empty())
+constexpr auto empty(const C &c) -> decltype(c.empty())
 {
-return c.empty();
+   return c.empty();
 }
 template <typename T, std::size_t N>
 constexpr bool empty(const T (&)[N])
 {
-return false;
+   return false;
 }
 template <typename E>
 constexpr bool empty(std::initializer_list<E> il)
 {
-return il.size() == 0;
+   return il.size() == 0;
 }
 template <typename C>
-constexpr auto begin(const C& c) -> decltype(c.begin())
+constexpr auto begin(const C &c) -> decltype(c.begin())
 {
-return c.begin();
+   return c.begin();
 }
 template <typename C>
-constexpr auto begin(C& c) -> decltype(c.begin())
+constexpr auto begin(C &c) -> decltype(c.begin())
 {
-return c.begin();
+   return c.begin();
 }
 template <typename T, std::size_t N>
-constexpr T* begin(T (&array)[N])
+constexpr T *begin(T (&array)[N])
 {
-return &array[0];
+   return &array[0];
 }
 template <typename E>
-constexpr const E* begin(std::initializer_list<E> il)
+constexpr const E *begin(std::initializer_list<E> il)
 {
-return il.begin();
+   return il.begin();
 }
 template <typename C>
-constexpr auto cbegin(const C& c) -> decltype(cx::begin(c))
+constexpr auto cbegin(const C &c) -> decltype(cx::begin(c))
 {
-return cx::begin(c);
+   return cx::begin(c);
 }
 template <typename C>
-constexpr auto end(const C& c) -> decltype(c.end())
+constexpr auto end(const C &c) -> decltype(c.end())
 {
-return c.end();
+   return c.end();
 }
 template <typename C>
-constexpr auto end(C& c) -> decltype(c.end())
+constexpr auto end(C &c) -> decltype(c.end())
 {
-return c.end();
+   return c.end();
 }
 template <typename T, std::size_t N>
-constexpr T* end(T (&array)[N])
+constexpr T *end(T (&array)[N])
 {
-return &array[N];
+   return &array[N];
 }
 template <typename E>
-constexpr const E* end(std::initializer_list<E> il)
+constexpr const E *end(std::initializer_list<E> il)
 {
-return il.end();
+   return il.end();
 }
 template <typename C>
-constexpr auto cend(const C& c) -> decltype(cx::end(c))
+constexpr auto cend(const C &c) -> decltype(cx::end(c))
 {
-return cx::end(c);
+   return cx::end(c);
 }
-}
+} // namespace cx
 #endif
 #ifndef WILDCARDS_UTILITY_HPP
-#define WILDCARDS_UTILITY_HPP 
+#define WILDCARDS_UTILITY_HPP
 #include <type_traits>
 #include <utility>
-namespace wildcards
-{
+namespace wildcards {
 template <typename C>
-struct const_iterator
-{
-using type = typename std::remove_cv<
-typename std::remove_reference<decltype(cx::cbegin(std::declval<C>()))>::type>::type;
+struct const_iterator {
+   using type =
+      typename std::remove_cv<typename std::remove_reference<decltype(cx::cbegin(std::declval<C>()))>::type>::type;
 };
 template <typename C>
 using const_iterator_t = typename const_iterator<C>::type;
 template <typename C>
-struct iterator
-{
-using type = typename std::remove_cv<
-typename std::remove_reference<decltype(cx::begin(std::declval<C>()))>::type>::type;
+struct iterator {
+   using type =
+      typename std::remove_cv<typename std::remove_reference<decltype(cx::begin(std::declval<C>()))>::type>::type;
 };
 template <typename C>
 using iterator_t = typename iterator<C>::type;
 template <typename It>
-struct iterated_item
-{
-using type = typename std::remove_cv<
-typename std::remove_reference<decltype(*std::declval<It>())>::type>::type;
+struct iterated_item {
+   using type = typename std::remove_cv<typename std::remove_reference<decltype(*std::declval<It>())>::type>::type;
 };
 template <typename It>
 using iterated_item_t = typename iterated_item<It>::type;
 template <typename C>
-struct container_item
-{
-using type = typename std::remove_cv<
-typename std::remove_reference<decltype(*cx::begin(std::declval<C>()))>::type>::type;
+struct container_item {
+   using type =
+      typename std::remove_cv<typename std::remove_reference<decltype(*cx::begin(std::declval<C>()))>::type>::type;
 };
 template <typename C>
 using container_item_t = typename container_item<C>::type;
-}
+} // namespace wildcards
 #endif
-namespace wildcards
-{
+namespace wildcards {
 template <typename SequenceIterator, typename PatternIterator>
-struct full_match_result
-{
-bool res;
-SequenceIterator s, send, s1;
-PatternIterator p, pend, p1;
-constexpr operator bool() const
-{
-return res;
-}
+struct full_match_result {
+   bool res;
+   SequenceIterator s, send, s1;
+   PatternIterator p, pend, p1;
+   constexpr operator bool() const { return res; }
 };
-namespace detail
-{
+namespace detail {
 template <typename SequenceIterator, typename PatternIterator>
-struct match_result
-{
-bool res;
-SequenceIterator s;
-PatternIterator p;
-constexpr operator bool() const
-{
-return res;
-}
+struct match_result {
+   bool res;
+   SequenceIterator s;
+   PatternIterator p;
+   constexpr operator bool() const { return res; }
 };
 template <typename SequenceIterator, typename PatternIterator>
-constexpr match_result<SequenceIterator, PatternIterator> make_match_result(bool res,
-SequenceIterator s,
-PatternIterator p)
+constexpr match_result<SequenceIterator, PatternIterator>
+make_match_result(bool res, SequenceIterator s, PatternIterator p)
 {
-return {std::move(res), std::move(s), std::move(p)};
+   return {std::move(res), std::move(s), std::move(p)};
 }
 template <typename SequenceIterator, typename PatternIterator>
-constexpr full_match_result<SequenceIterator, PatternIterator> make_full_match_result(
-SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
-match_result<SequenceIterator, PatternIterator> mr)
+constexpr full_match_result<SequenceIterator, PatternIterator>
+make_full_match_result(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+                       match_result<SequenceIterator, PatternIterator> mr)
 {
-return {std::move(mr.res), std::move(s), std::move(send), std::move(mr.s),
-std::move(p), std::move(pend), std::move(mr.p)};
+   return {std::move(mr.res), std::move(s),    std::move(send), std::move(mr.s),
+           std::move(p),      std::move(pend), std::move(mr.p)};
 }
 #if !cfg_HAS_FULL_FEATURED_CONSTEXPR14
-constexpr bool throw_invalid_argument(const char* what_arg)
+constexpr bool throw_invalid_argument(const char *what_arg)
 {
-return what_arg == nullptr ? false : throw std::invalid_argument(what_arg);
+   return what_arg == nullptr ? false : throw std::invalid_argument(what_arg);
 }
 template <typename T>
-constexpr T throw_invalid_argument(T t, const char* what_arg)
+constexpr T throw_invalid_argument(T t, const char *what_arg)
 {
-return what_arg == nullptr ? t : throw std::invalid_argument(what_arg);
+   return what_arg == nullptr ? t : throw std::invalid_argument(what_arg);
 }
-constexpr bool throw_logic_error(const char* what_arg)
+constexpr bool throw_logic_error(const char *what_arg)
 {
-return what_arg == nullptr ? false : throw std::logic_error(what_arg);
+   return what_arg == nullptr ? false : throw std::logic_error(what_arg);
 }
 template <typename T>
-constexpr T throw_logic_error(T t, const char* what_arg)
+constexpr T throw_logic_error(T t, const char *what_arg)
 {
-return what_arg == nullptr ? t : throw std::logic_error(what_arg);
+   return what_arg == nullptr ? t : throw std::logic_error(what_arg);
 }
 #endif
-enum class is_set_state
-{
-open,
-not_or_first,
-first,
-next
+enum class is_set_state {
+   open,
+   not_or_first,
+   first,
+   next
 };
 template <typename PatternIterator>
-constexpr bool is_set(
-PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-is_set_state state = is_set_state::open)
+constexpr bool is_set(PatternIterator p, PatternIterator pend,
+                      const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+                      is_set_state state = is_set_state::open)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.set_enabled)
-{
-return false;
-}
-while (p != pend)
-{
-switch (state)
-{
-case is_set_state::open:
-if (*p != c.set_open)
-{
-return false;
-}
-state = is_set_state::not_or_first;
-break;
-case is_set_state::not_or_first:
-if (*p == c.set_not)
-{
-state = is_set_state::first;
-}
-else
-{
-state = is_set_state::next;
-}
-break;
-case is_set_state::first:
-state = is_set_state::next;
-break;
-case is_set_state::next:
-if (*p == c.set_close)
-{
-return true;
-}
-break;
-default:
+   if (!c.set_enabled) {
+      return false;
+   }
+   while (p != pend) {
+      switch (state) {
+      case is_set_state::open:
+         if (*p != c.set_open) {
+            return false;
+         }
+         state = is_set_state::not_or_first;
+         break;
+      case is_set_state::not_or_first:
+         if (*p == c.set_not) {
+            state = is_set_state::first;
+         } else {
+            state = is_set_state::next;
+         }
+         break;
+      case is_set_state::first: state = is_set_state::next; break;
+      case is_set_state::next:
+         if (*p == c.set_close) {
+            return true;
+         }
+         break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-"The program execution should never end up here throwing this exception");
+         return throw_logic_error("The program execution should never end up here throwing this exception");
+#endif
+      }
+      p = cx::next(p);
+   }
+   return false;
+#else
+   return c.set_enabled && p != pend &&
+          (state == is_set_state::open ? *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+           : state == is_set_state::not_or_first ? *p == c.set_not ? is_set(cx::next(p), pend, c, is_set_state::first)
+                                                                   : is_set(cx::next(p), pend, c, is_set_state::next)
+           : state == is_set_state::first ? is_set(cx::next(p), pend, c, is_set_state::next)
+           : state == is_set_state::next         ? *p == c.set_close || is_set(cx::next(p), pend, c, is_set_state::next)
+                                                 : throw std::logic_error("The program execution should never end up "
+                                                                                  "here throwing this exception"));
 #endif
 }
-p = cx::next(p);
-}
-return false;
-#else
-return c.set_enabled && p != pend &&
-(state == is_set_state::open
-? *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-:
-state == is_set_state::not_or_first
-? *p == c.set_not ? is_set(cx::next(p), pend, c, is_set_state::first)
-: is_set(cx::next(p), pend, c, is_set_state::next)
-: state == is_set_state::first
-? is_set(cx::next(p), pend, c, is_set_state::next)
-: state == is_set_state::next
-? *p == c.set_close ||
-is_set(cx::next(p), pend, c, is_set_state::next)
-: throw std::logic_error("The program execution should never end up "
-"here throwing this exception"));
-#endif
-}
-enum class set_end_state
-{
-open,
-not_or_first,
-first,
-next
+enum class set_end_state {
+   open,
+   not_or_first,
+   first,
+   next
 };
 template <typename PatternIterator>
-constexpr PatternIterator set_end(
-PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-set_end_state state = set_end_state::open)
+constexpr PatternIterator
+set_end(PatternIterator p, PatternIterator pend,
+        const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+        set_end_state state = set_end_state::open)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.set_enabled)
-{
+   if (!c.set_enabled) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The use of sets is disabled");
+      throw std::invalid_argument("The use of sets is disabled");
 #else
-return throw_invalid_argument(p, "The use of sets is disabled");
+      return throw_invalid_argument(p, "The use of sets is disabled");
 #endif
-}
-while (p != pend)
-{
-switch (state)
-{
-case set_end_state::open:
-if (*p != c.set_open)
-{
+   }
+   while (p != pend) {
+      switch (state) {
+      case set_end_state::open:
+         if (*p != c.set_open) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid set");
+            throw std::invalid_argument("The given pattern is not a valid set");
 #else
-return throw_invalid_argument(p, "The given pattern is not a valid set");
+            return throw_invalid_argument(p, "The given pattern is not a valid set");
 #endif
-}
-state = set_end_state::not_or_first;
-break;
-case set_end_state::not_or_first:
-if (*p == c.set_not)
-{
-state = set_end_state::first;
-}
-else
-{
-state = set_end_state::next;
-}
-break;
-case set_end_state::first:
-state = set_end_state::next;
-break;
-case set_end_state::next:
-if (*p == c.set_close)
-{
-return cx::next(p);
-}
-break;
-default:
+         }
+         state = set_end_state::not_or_first;
+         break;
+      case set_end_state::not_or_first:
+         if (*p == c.set_not) {
+            state = set_end_state::first;
+         } else {
+            state = set_end_state::next;
+         }
+         break;
+      case set_end_state::first: state = set_end_state::next; break;
+      case set_end_state::next:
+         if (*p == c.set_close) {
+            return cx::next(p);
+         }
+         break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-p, "The program execution should never end up here throwing this exception");
+         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
 #endif
-}
-p = cx::next(p);
-}
+      }
+      p = cx::next(p);
+   }
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid set");
+   throw std::invalid_argument("The given pattern is not a valid set");
 #else
-return throw_invalid_argument(p, "The given pattern is not a valid set");
+   return throw_invalid_argument(p, "The given pattern is not a valid set");
 #endif
 #else
-return !c.set_enabled
-? throw std::invalid_argument("The use of sets is disabled")
-: p == pend
-? throw std::invalid_argument("The given pattern is not a valid set")
-:
-state == set_end_state::open
-? *p == c.set_open
-? set_end(cx::next(p), pend, c, set_end_state::not_or_first)
-: throw std::invalid_argument("The given pattern is not a valid set")
-:
-state == set_end_state::not_or_first
-? *p == c.set_not ? set_end(cx::next(p), pend, c, set_end_state::first)
-: set_end(cx::next(p), pend, c, set_end_state::next)
-: state == set_end_state::first
-? set_end(cx::next(p), pend, c, set_end_state::next)
-: state == set_end_state::next
-? *p == c.set_close
-? cx::next(p)
-: set_end(cx::next(p), pend, c, set_end_state::next)
-: throw std::logic_error(
-"The program execution should never end up "
-"here throwing this exception");
+   return !c.set_enabled                         ? throw std::invalid_argument("The use of sets is disabled")
+          : p == pend                            ? throw std::invalid_argument("The given pattern is not a valid set")
+          : state == set_end_state::open         ? *p == c.set_open
+                                                      ? set_end(cx::next(p), pend, c, set_end_state::not_or_first)
+                                                      : throw std::invalid_argument("The given pattern is not a valid set")
+                  : state == set_end_state::not_or_first ? *p == c.set_not ? set_end(cx::next(p), pend, c, set_end_state::first)
+                                                                           : set_end(cx::next(p), pend, c, set_end_state::next)
+                  : state == set_end_state::first ? set_end(cx::next(p), pend, c, set_end_state::next)
+          : state == set_end_state::next
+             ? *p == c.set_close ? cx::next(p) : set_end(cx::next(p), pend, c, set_end_state::next)
+             : throw std::logic_error("The program execution should never end up "
+                                      "here throwing this exception");
 #endif
 }
-enum class match_set_state
-{
-open,
-not_or_first_in,
-first_out,
-next_in,
-next_out
+enum class match_set_state {
+   open,
+   not_or_first_in,
+   first_out,
+   next_in,
+   next_out
 };
-template <typename SequenceIterator, typename PatternIterator,
-typename EqualTo = cx::equal_to<void>>
-constexpr match_result<SequenceIterator, PatternIterator> match_set(
-SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-const EqualTo& equal_to = EqualTo(), match_set_state state = match_set_state::open)
+template <typename SequenceIterator, typename PatternIterator, typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator>
+match_set(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+          const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+          const EqualTo &equal_to = EqualTo(), match_set_state state = match_set_state::open)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.set_enabled)
-{
+   if (!c.set_enabled) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The use of sets is disabled");
+      throw std::invalid_argument("The use of sets is disabled");
 #else
-return throw_invalid_argument(make_match_result(false, s, p), "The use of sets is disabled");
+      return throw_invalid_argument(make_match_result(false, s, p), "The use of sets is disabled");
 #endif
-}
-while (p != pend)
-{
-switch (state)
-{
-case match_set_state::open:
-if (*p != c.set_open)
-{
+   }
+   while (p != pend) {
+      switch (state) {
+      case match_set_state::open:
+         if (*p != c.set_open) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid set");
+            throw std::invalid_argument("The given pattern is not a valid set");
 #else
-return throw_invalid_argument(make_match_result(false, s, p),
-"The given pattern is not a valid set");
+            return throw_invalid_argument(make_match_result(false, s, p), "The given pattern is not a valid set");
 #endif
-}
-state = match_set_state::not_or_first_in;
-break;
-case match_set_state::not_or_first_in:
-if (*p == c.set_not)
-{
-state = match_set_state::first_out;
-}
-else
-{
-if (s == send)
-{
-return make_match_result(false, s, p);
-}
-if (equal_to(*s, *p))
-{
-return make_match_result(true, s, p);
-}
-state = match_set_state::next_in;
-}
-break;
-case match_set_state::first_out:
-if (s == send || equal_to(*s, *p))
-{
-return make_match_result(false, s, p);
-}
-state = match_set_state::next_out;
-break;
-case match_set_state::next_in:
-if (*p == c.set_close || s == send)
-{
-return make_match_result(false, s, p);
-}
-if (equal_to(*s, *p))
-{
-return make_match_result(true, s, p);
-}
-break;
-case match_set_state::next_out:
-if (*p == c.set_close)
-{
-return make_match_result(true, s, p);
-}
-if (s == send || equal_to(*s, *p))
-{
-return make_match_result(false, s, p);
-}
-break;
-default:
+         }
+         state = match_set_state::not_or_first_in;
+         break;
+      case match_set_state::not_or_first_in:
+         if (*p == c.set_not) {
+            state = match_set_state::first_out;
+         } else {
+            if (s == send) {
+               return make_match_result(false, s, p);
+            }
+            if (equal_to(*s, *p)) {
+               return make_match_result(true, s, p);
+            }
+            state = match_set_state::next_in;
+         }
+         break;
+      case match_set_state::first_out:
+         if (s == send || equal_to(*s, *p)) {
+            return make_match_result(false, s, p);
+         }
+         state = match_set_state::next_out;
+         break;
+      case match_set_state::next_in:
+         if (*p == c.set_close || s == send) {
+            return make_match_result(false, s, p);
+         }
+         if (equal_to(*s, *p)) {
+            return make_match_result(true, s, p);
+         }
+         break;
+      case match_set_state::next_out:
+         if (*p == c.set_close) {
+            return make_match_result(true, s, p);
+         }
+         if (s == send || equal_to(*s, *p)) {
+            return make_match_result(false, s, p);
+         }
+         break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-make_match_result(false, s, p),
-"The program execution should never end up here throwing this exception");
+         return throw_logic_error(make_match_result(false, s, p),
+                                  "The program execution should never end up here throwing this exception");
 #endif
-}
-p = cx::next(p);
-}
+      }
+      p = cx::next(p);
+   }
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid set");
+   throw std::invalid_argument("The given pattern is not a valid set");
 #else
-return throw_invalid_argument(make_match_result(false, s, p),
-"The given pattern is not a valid set");
+   return throw_invalid_argument(make_match_result(false, s, p), "The given pattern is not a valid set");
 #endif
 #else
-return !c.set_enabled
-? throw std::invalid_argument("The use of sets is disabled")
-: p == pend
-? throw std::invalid_argument("The given pattern is not a valid set")
-: state == match_set_state::open
-? *p == c.set_open
-? match_set(s, send, cx::next(p), pend, c, equal_to,
-match_set_state::not_or_first_in)
-:
-throw std::invalid_argument("The given pattern is not a valid set")
-:
-state == match_set_state::not_or_first_in
-? *p == c.set_not
-? match_set(s, send, cx::next(p), pend, c, equal_to,
-match_set_state::first_out)
-:
-s == send ? make_match_result(false, s, p)
-: equal_to(*s, *p)
-? make_match_result(true, s, p)
-: match_set(s, send, cx::next(p), pend, c,
-equal_to, match_set_state::next_in)
-:
-state == match_set_state::first_out
-? s == send || equal_to(*s, *p)
-? make_match_result(false, s, p)
-: match_set(s, send, cx::next(p), pend, c, equal_to,
-match_set_state::next_out)
-:
-state == match_set_state::next_in
-? *p == c.set_close || s == send
-? make_match_result(false, s, p)
-: equal_to(*s, *p) ? make_match_result(true, s, p)
-: match_set(s, send, cx::next(p),
-pend, c, equal_to, state)
-:
-state == match_set_state::next_out
-? *p == c.set_close
-? make_match_result(true, s, p)
-: s == send || equal_to(*s, *p)
-? make_match_result(false, s, p)
-: match_set(s, send, cx::next(p), pend, c,
-equal_to, state)
-: throw std::logic_error(
-"The program execution should never end up "
-"here "
-"throwing this exception");
+   return !c.set_enabled ? throw std::invalid_argument("The use of sets is disabled")
+          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid set")
+          : state == match_set_state::open
+             ? *p == c.set_open ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
+                                : throw std::invalid_argument("The given pattern is not a valid set")
+          : state == match_set_state::not_or_first_in
+             ? *p == c.set_not    ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::first_out)
+               : s == send        ? make_match_result(false, s, p)
+               : equal_to(*s, *p) ? make_match_result(true, s, p)
+                                  : match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::next_in)
+          : state == match_set_state::first_out
+             ? s == send || equal_to(*s, *p)
+                  ? make_match_result(false, s, p)
+                  : match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::next_out)
+          : state == match_set_state::next_in  ? *p == c.set_close || s == send ? make_match_result(false, s, p)
+                                                 : equal_to(*s, *p)
+                                                    ? make_match_result(true, s, p)
+                                                    : match_set(s, send, cx::next(p), pend, c, equal_to, state)
+           : state == match_set_state::next_out ? *p == c.set_close ? make_match_result(true, s, p)
+                                                  : s == send || equal_to(*s, *p)
+                                                     ? make_match_result(false, s, p)
+                                                     : match_set(s, send, cx::next(p), pend, c, equal_to, state)
+                                                : throw std::logic_error("The program execution should never end up "
+                                                                          "here "
+                                                                          "throwing this exception");
 #endif
 }
-enum class is_alt_state
-{
-open,
-next,
-escape
+enum class is_alt_state {
+   open,
+   next,
+   escape
 };
 template <typename PatternIterator>
-constexpr bool is_alt(
-PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-is_alt_state state = is_alt_state::open, int depth = 0)
+constexpr bool is_alt(PatternIterator p, PatternIterator pend,
+                      const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+                      is_alt_state state = is_alt_state::open, int depth = 0)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.alt_enabled)
-{
-return false;
-}
-while (p != pend)
-{
-switch (state)
-{
-case is_alt_state::open:
-if (*p != c.alt_open)
-{
-return false;
-}
-state = is_alt_state::next;
-++depth;
-break;
-case is_alt_state::next:
-if (*p == c.escape)
-{
-state = is_alt_state::escape;
-}
-else if (c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c, is_set_state::not_or_first))
-{
-p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
-}
-else if (*p == c.alt_open)
-{
-++depth;
-}
-else if (*p == c.alt_close)
-{
---depth;
-if (depth == 0)
-{
-return true;
-}
-}
-break;
-case is_alt_state::escape:
-state = is_alt_state::next;
-break;
-default:
+   if (!c.alt_enabled) {
+      return false;
+   }
+   while (p != pend) {
+      switch (state) {
+      case is_alt_state::open:
+         if (*p != c.alt_open) {
+            return false;
+         }
+         state = is_alt_state::next;
+         ++depth;
+         break;
+      case is_alt_state::next:
+         if (*p == c.escape) {
+            state = is_alt_state::escape;
+         } else if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)) {
+            p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+         } else if (*p == c.alt_open) {
+            ++depth;
+         } else if (*p == c.alt_close) {
+            --depth;
+            if (depth == 0) {
+               return true;
+            }
+         }
+         break;
+      case is_alt_state::escape: state = is_alt_state::next; break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-p, "The program execution should never end up here throwing this exception");
+         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
+#endif
+      }
+      p = cx::next(p);
+   }
+   return false;
+#else
+   return c.alt_enabled && p != pend &&
+          (state == is_alt_state::open ? *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, depth + 1)
+           : state == is_alt_state::next
+              ? *p == c.escape ? is_alt(cx::next(p), pend, c, is_alt_state::escape, depth)
+                : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+                   ? is_alt(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
+                : *p == c.alt_open  ? is_alt(cx::next(p), pend, c, state, depth + 1)
+                : *p == c.alt_close ? depth == 1 || is_alt(cx::next(p), pend, c, state, depth - 1)
+                                    : is_alt(cx::next(p), pend, c, state, depth)
+           : state == is_alt_state::escape
+              ? is_alt(cx::next(p), pend, c, is_alt_state::next, depth)
+              : throw std::logic_error("The program execution should never end up here throwing this "
+                                       "exception"));
 #endif
 }
-p = cx::next(p);
-}
-return false;
-#else
-return c.alt_enabled && p != pend &&
-(state == is_alt_state::open
-? *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, depth + 1)
-: state == is_alt_state::next
-? *p == c.escape
-? is_alt(cx::next(p), pend, c, is_alt_state::escape, depth)
-: c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-? is_alt(set_end(cx::next(p), pend, c, set_end_state::not_or_first),
-pend, c, state, depth)
-: *p == c.alt_open
-? is_alt(cx::next(p), pend, c, state, depth + 1)
-: *p == c.alt_close
-? depth == 1 ||
-is_alt(cx::next(p), pend, c, state, depth - 1)
-: is_alt(cx::next(p), pend, c, state, depth)
-:
-state == is_alt_state::escape
-? is_alt(cx::next(p), pend, c, is_alt_state::next, depth)
-: throw std::logic_error(
-"The program execution should never end up here throwing this "
-"exception"));
-#endif
-}
-enum class alt_end_state
-{
-open,
-next,
-escape
+enum class alt_end_state {
+   open,
+   next,
+   escape
 };
 template <typename PatternIterator>
-constexpr PatternIterator alt_end(
-PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-alt_end_state state = alt_end_state::open, int depth = 0)
+constexpr PatternIterator
+alt_end(PatternIterator p, PatternIterator pend,
+        const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+        alt_end_state state = alt_end_state::open, int depth = 0)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.alt_enabled)
-{
+   if (!c.alt_enabled) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The use of alternatives is disabled");
+      throw std::invalid_argument("The use of alternatives is disabled");
 #else
-return throw_invalid_argument(p, "The use of alternatives is disabled");
+      return throw_invalid_argument(p, "The use of alternatives is disabled");
 #endif
-}
-while (p != pend)
-{
-switch (state)
-{
-case alt_end_state::open:
-if (*p != c.alt_open)
-{
+   }
+   while (p != pend) {
+      switch (state) {
+      case alt_end_state::open:
+         if (*p != c.alt_open) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid alternative");
+            throw std::invalid_argument("The given pattern is not a valid alternative");
 #else
-return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+            return throw_invalid_argument(p, "The given pattern is not a valid alternative");
 #endif
-}
-state = alt_end_state::next;
-++depth;
-break;
-case alt_end_state::next:
-if (*p == c.escape)
-{
-state = alt_end_state::escape;
-}
-else if (c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c, is_set_state::not_or_first))
-{
-p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
-}
-else if (*p == c.alt_open)
-{
-++depth;
-}
-else if (*p == c.alt_close)
-{
---depth;
-if (depth == 0)
-{
-return cx::next(p);
-}
-}
-break;
-case alt_end_state::escape:
-state = alt_end_state::next;
-break;
-default:
+         }
+         state = alt_end_state::next;
+         ++depth;
+         break;
+      case alt_end_state::next:
+         if (*p == c.escape) {
+            state = alt_end_state::escape;
+         } else if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)) {
+            p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+         } else if (*p == c.alt_open) {
+            ++depth;
+         } else if (*p == c.alt_close) {
+            --depth;
+            if (depth == 0) {
+               return cx::next(p);
+            }
+         }
+         break;
+      case alt_end_state::escape: state = alt_end_state::next; break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-p, "The program execution should never end up here throwing this exception");
+         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
 #endif
-}
-p = cx::next(p);
-}
+      }
+      p = cx::next(p);
+   }
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid alternative");
+   throw std::invalid_argument("The given pattern is not a valid alternative");
 #else
-return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+   return throw_invalid_argument(p, "The given pattern is not a valid alternative");
 #endif
 #else
-return !c.alt_enabled
-? throw std::invalid_argument("The use of alternatives is disabled")
-: p == pend
-? throw std::invalid_argument("The given pattern is not a valid alternative")
-: state == alt_end_state::open
-? *p == c.alt_open
-? alt_end(cx::next(p), pend, c, alt_end_state::next, depth + 1)
-: throw std::invalid_argument(
-"The given pattern is not a valid alternative")
-: state == alt_end_state::next
-? *p == c.escape
-? alt_end(cx::next(p), pend, c, alt_end_state::escape, depth)
-: c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c,
-is_set_state::not_or_first)
-? alt_end(set_end(cx::next(p), pend, c,
-set_end_state::not_or_first),
-pend, c, state, depth)
-: *p == c.alt_open
-? alt_end(cx::next(p), pend, c, state, depth + 1)
-: *p == c.alt_close
-? depth == 1 ? cx::next(p)
-: alt_end(cx::next(p), pend, c,
-state, depth - 1)
-: alt_end(cx::next(p), pend, c, state, depth)
-:
-state == alt_end_state::escape
-? alt_end(cx::next(p), pend, c, alt_end_state::next, depth)
-: throw std::logic_error(
-"The program execution should never end up here throwing "
-"this "
-"exception");
+   return !c.alt_enabled ? throw std::invalid_argument("The use of alternatives is disabled")
+          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid alternative")
+          : state == alt_end_state::open
+             ? *p == c.alt_open ? alt_end(cx::next(p), pend, c, alt_end_state::next, depth + 1)
+                                : throw std::invalid_argument("The given pattern is not a valid alternative")
+          : state == alt_end_state::next
+             ? *p == c.escape ? alt_end(cx::next(p), pend, c, alt_end_state::escape, depth)
+               : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+                  ? alt_end(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
+               : *p == c.alt_open  ? alt_end(cx::next(p), pend, c, state, depth + 1)
+               : *p == c.alt_close ? depth == 1 ? cx::next(p) : alt_end(cx::next(p), pend, c, state, depth - 1)
+                                   : alt_end(cx::next(p), pend, c, state, depth)
+          : state == alt_end_state::escape
+             ? alt_end(cx::next(p), pend, c, alt_end_state::next, depth)
+             : throw std::logic_error("The program execution should never end up here throwing "
+                                      "this "
+                                      "exception");
 #endif
 }
-enum class alt_sub_end_state
-{
-next,
-escape
+enum class alt_sub_end_state {
+   next,
+   escape
 };
 template <typename PatternIterator>
-constexpr PatternIterator alt_sub_end(
-PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-alt_sub_end_state state = alt_sub_end_state::next, int depth = 1)
+constexpr PatternIterator
+alt_sub_end(PatternIterator p, PatternIterator pend,
+            const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+            alt_sub_end_state state = alt_sub_end_state::next, int depth = 1)
 {
 #if cfg_HAS_CONSTEXPR14
-if (!c.alt_enabled)
-{
+   if (!c.alt_enabled) {
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The use of alternatives is disabled");
+      throw std::invalid_argument("The use of alternatives is disabled");
 #else
-return throw_invalid_argument(p, "The use of alternatives is disabled");
+      return throw_invalid_argument(p, "The use of alternatives is disabled");
 #endif
-}
-while (p != pend)
-{
-switch (state)
-{
-case alt_sub_end_state::next:
-if (*p == c.escape)
-{
-state = alt_sub_end_state::escape;
-}
-else if (c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c, is_set_state::not_or_first))
-{
-p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
-}
-else if (*p == c.alt_open)
-{
-++depth;
-}
-else if (*p == c.alt_close)
-{
---depth;
-if (depth == 0)
-{
-return p;
-}
-}
-else if (*p == c.alt_or)
-{
-if (depth == 1)
-{
-return p;
-}
-}
-break;
-case alt_sub_end_state::escape:
-state = alt_sub_end_state::next;
-break;
-default:
+   }
+   while (p != pend) {
+      switch (state) {
+      case alt_sub_end_state::next:
+         if (*p == c.escape) {
+            state = alt_sub_end_state::escape;
+         } else if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)) {
+            p = cx::prev(set_end(cx::next(p), pend, c, set_end_state::not_or_first));
+         } else if (*p == c.alt_open) {
+            ++depth;
+         } else if (*p == c.alt_close) {
+            --depth;
+            if (depth == 0) {
+               return p;
+            }
+         } else if (*p == c.alt_or) {
+            if (depth == 1) {
+               return p;
+            }
+         }
+         break;
+      case alt_sub_end_state::escape: state = alt_sub_end_state::next; break;
+      default:
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::logic_error(
-"The program execution should never end up here throwing this exception");
+         throw std::logic_error("The program execution should never end up here throwing this exception");
 #else
-return throw_logic_error(
-p, "The program execution should never end up here throwing this exception");
+         return throw_logic_error(p, "The program execution should never end up here throwing this exception");
 #endif
-}
-p = cx::next(p);
-}
+      }
+      p = cx::next(p);
+   }
 #if cfg_HAS_FULL_FEATURED_CONSTEXPR14
-throw std::invalid_argument("The given pattern is not a valid alternative");
+   throw std::invalid_argument("The given pattern is not a valid alternative");
 #else
-return throw_invalid_argument(p, "The given pattern is not a valid alternative");
+   return throw_invalid_argument(p, "The given pattern is not a valid alternative");
 #endif
 #else
-return !c.alt_enabled
-? throw std::invalid_argument("The use of alternatives is disabled")
-: p == pend
-? throw std::invalid_argument("The given pattern is not a valid alternative")
-: state == alt_sub_end_state::next
-? *p == c.escape
-? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::escape, depth)
-: c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c, is_set_state::not_or_first)
-? alt_sub_end(set_end(cx::next(p), pend, c,
-set_end_state::not_or_first),
-pend, c, state, depth)
-: *p == c.alt_open
-? alt_sub_end(cx::next(p), pend, c, state, depth + 1)
-: *p == c.alt_close
-? depth == 1 ? p : alt_sub_end(cx::next(p), pend,
-c, state, depth - 1)
-: *p == c.alt_or
-? depth == 1 ? p
-: alt_sub_end(cx::next(p), pend,
-c, state, depth)
-: alt_sub_end(cx::next(p), pend, c, state,
-depth)
-:
-state == alt_sub_end_state::escape
-? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::next, depth)
-: throw std::logic_error(
-"The program execution should never end up here throwing "
-"this "
-"exception");
+   return !c.alt_enabled ? throw std::invalid_argument("The use of alternatives is disabled")
+          : p == pend    ? throw std::invalid_argument("The given pattern is not a valid alternative")
+          : state == alt_sub_end_state::next
+             ? *p == c.escape ? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::escape, depth)
+               : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+                  ? alt_sub_end(set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, state, depth)
+               : *p == c.alt_open  ? alt_sub_end(cx::next(p), pend, c, state, depth + 1)
+               : *p == c.alt_close ? depth == 1 ? p : alt_sub_end(cx::next(p), pend, c, state, depth - 1)
+               : *p == c.alt_or ? depth == 1 ? p : alt_sub_end(cx::next(p), pend, c, state, depth)
+                                : alt_sub_end(cx::next(p), pend, c, state, depth)
+          : state == alt_sub_end_state::escape
+             ? alt_sub_end(cx::next(p), pend, c, alt_sub_end_state::next, depth)
+             : throw std::logic_error("The program execution should never end up here throwing "
+                                      "this "
+                                      "exception");
 #endif
 }
-template <typename SequenceIterator, typename PatternIterator,
-typename EqualTo = cx::equal_to<void>>
-constexpr match_result<SequenceIterator, PatternIterator> match(
-SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-const EqualTo& equal_to = EqualTo(), bool partial = false, bool escape = false);
-template <typename SequenceIterator, typename PatternIterator,
-typename EqualTo = cx::equal_to<void>>
-constexpr match_result<SequenceIterator, PatternIterator> match_alt(
-SequenceIterator s, SequenceIterator send, PatternIterator p1, PatternIterator p1end,
-PatternIterator p2, PatternIterator p2end,
-const cards<iterated_item_t<PatternIterator>>& c = cards<iterated_item_t<PatternIterator>>(),
-const EqualTo& equal_to = EqualTo(), bool partial = false)
+template <typename SequenceIterator, typename PatternIterator, typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator>
+match(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+      const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+      const EqualTo &equal_to = EqualTo(), bool partial = false, bool escape = false);
+template <typename SequenceIterator, typename PatternIterator, typename EqualTo = cx::equal_to<void>>
+constexpr match_result<SequenceIterator, PatternIterator>
+match_alt(SequenceIterator s, SequenceIterator send, PatternIterator p1, PatternIterator p1end, PatternIterator p2,
+          PatternIterator p2end,
+          const cards<iterated_item_t<PatternIterator>> &c = cards<iterated_item_t<PatternIterator>>(),
+          const EqualTo &equal_to = EqualTo(), bool partial = false)
 {
 #if cfg_HAS_CONSTEXPR14
-auto result1 = match(s, send, p1, p1end, c, equal_to, true);
-if (result1)
-{
-auto result2 = match(result1.s, send, p2, p2end, c, equal_to, partial);
-if (result2)
-{
-return result2;
-}
-}
-p1 = cx::next(p1end);
-if (p1 == p2)
-{
-return make_match_result(false, s, p1end);
-}
-return match_alt(s, send, p1, alt_sub_end(p1, p2, c), p2, p2end, c, equal_to, partial);
+   auto result1 = match(s, send, p1, p1end, c, equal_to, true);
+   if (result1) {
+      auto result2 = match(result1.s, send, p2, p2end, c, equal_to, partial);
+      if (result2) {
+         return result2;
+      }
+   }
+   p1 = cx::next(p1end);
+   if (p1 == p2) {
+      return make_match_result(false, s, p1end);
+   }
+   return match_alt(s, send, p1, alt_sub_end(p1, p2, c), p2, p2end, c, equal_to, partial);
 #else
-return match(s, send, p1, p1end, c, equal_to, true) &&
-match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to,
-partial)
-? match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to,
-partial)
-: cx::next(p1end) == p2
-? make_match_result(false, s, p1end)
-: match_alt(s, send, cx::next(p1end), alt_sub_end(cx::next(p1end), p2, c), p2,
-p2end, c, equal_to, partial);
+   return match(s, send, p1, p1end, c, equal_to, true) &&
+                match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to, partial)
+             ? match(match(s, send, p1, p1end, c, equal_to, true).s, send, p2, p2end, c, equal_to, partial)
+          : cx::next(p1end) == p2 ? make_match_result(false, s, p1end)
+                                  : match_alt(s, send, cx::next(p1end), alt_sub_end(cx::next(p1end), p2, c), p2, p2end,
+                                              c, equal_to, partial);
 #endif
 }
 template <typename SequenceIterator, typename PatternIterator, typename EqualTo>
-constexpr match_result<SequenceIterator, PatternIterator> match(
-SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
-const cards<iterated_item_t<PatternIterator>>& c, const EqualTo& equal_to, bool partial,
-bool escape)
+constexpr match_result<SequenceIterator, PatternIterator>
+match(SequenceIterator s, SequenceIterator send, PatternIterator p, PatternIterator pend,
+      const cards<iterated_item_t<PatternIterator>> &c, const EqualTo &equal_to, bool partial, bool escape)
 {
 #if cfg_HAS_CONSTEXPR14
-if (p == pend)
-{
-return make_match_result(partial || s == send, s, p);
-}
-if (escape)
-{
-if (s == send || !equal_to(*s, *p))
-{
-return make_match_result(false, s, p);
-}
-return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
-}
-if (*p == c.anything)
-{
-auto result = match(s, send, cx::next(p), pend, c, equal_to, partial);
-if (result)
-{
-return result;
-}
-if (s == send)
-{
-return make_match_result(false, s, p);
-}
-return match(cx::next(s), send, p, pend, c, equal_to, partial);
-}
-if (*p == c.single)
-{
-if (s == send)
-{
-return make_match_result(false, s, p);
-}
-return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
-}
-if (*p == c.escape)
-{
-return match(s, send, cx::next(p), pend, c, equal_to, partial, true);
-}
-if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first))
-{
-auto result =
-match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in);
-if (!result)
-{
-return result;
-}
-return match(cx::next(s), send, set_end(cx::next(p), pend, c, set_end_state::not_or_first),
-pend, c, equal_to, partial);
-}
-if (c.alt_enabled && *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, 1))
-{
-auto p_alt_end = alt_end(cx::next(p), pend, c, alt_end_state::next, 1);
-return match_alt(s, send, cx::next(p), alt_sub_end(cx::next(p), p_alt_end, c), p_alt_end, pend,
-c, equal_to, partial);
-}
-if (s == send || !equal_to(*s, *p))
-{
-return make_match_result(false, s, p);
-}
-return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+   if (p == pend) {
+      return make_match_result(partial || s == send, s, p);
+   }
+   if (escape) {
+      if (s == send || !equal_to(*s, *p)) {
+         return make_match_result(false, s, p);
+      }
+      return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+   }
+   if (*p == c.anything) {
+      auto result = match(s, send, cx::next(p), pend, c, equal_to, partial);
+      if (result) {
+         return result;
+      }
+      if (s == send) {
+         return make_match_result(false, s, p);
+      }
+      return match(cx::next(s), send, p, pend, c, equal_to, partial);
+   }
+   if (*p == c.single) {
+      if (s == send) {
+         return make_match_result(false, s, p);
+      }
+      return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
+   }
+   if (*p == c.escape) {
+      return match(s, send, cx::next(p), pend, c, equal_to, partial, true);
+   }
+   if (c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)) {
+      auto result = match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in);
+      if (!result) {
+         return result;
+      }
+      return match(cx::next(s), send, set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c, equal_to,
+                   partial);
+   }
+   if (c.alt_enabled && *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, 1)) {
+      auto p_alt_end = alt_end(cx::next(p), pend, c, alt_end_state::next, 1);
+      return match_alt(s, send, cx::next(p), alt_sub_end(cx::next(p), p_alt_end, c), p_alt_end, pend, c, equal_to,
+                       partial);
+   }
+   if (s == send || !equal_to(*s, *p)) {
+      return make_match_result(false, s, p);
+   }
+   return match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
 #else
-return p == pend
-? make_match_result(partial || s == send, s, p)
-: escape
-? s == send || !equal_to(*s, *p)
-? make_match_result(false, s, p)
-: match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
-: *p == c.anything
-? match(s, send, cx::next(p), pend, c, equal_to, partial)
-? match(s, send, cx::next(p), pend, c, equal_to, partial)
-: s == send ? make_match_result(false, s, p)
-: match(cx::next(s), send, p, pend, c, equal_to, partial)
-: *p == c.single
-? s == send ? make_match_result(false, s, p)
-: match(cx::next(s), send, cx::next(p), pend, c,
-equal_to, partial)
-: *p == c.escape
-? match(s, send, cx::next(p), pend, c, equal_to, partial, true)
-: c.set_enabled && *p == c.set_open &&
-is_set(cx::next(p), pend, c,
-is_set_state::not_or_first)
-? !match_set(s, send, cx::next(p), pend, c, equal_to,
-match_set_state::not_or_first_in)
-? match_set(s, send, cx::next(p), pend, c,
-equal_to,
-match_set_state::not_or_first_in)
-: match(cx::next(s), send,
-set_end(cx::next(p), pend, c,
-set_end_state::not_or_first),
-pend, c, equal_to, partial)
-: c.alt_enabled && *p == c.alt_open &&
-is_alt(cx::next(p), pend, c,
-is_alt_state::next, 1)
-? match_alt(
-s, send, cx::next(p),
-alt_sub_end(cx::next(p),
-alt_end(cx::next(p), pend, c,
-alt_end_state::next, 1),
-c),
-alt_end(cx::next(p), pend, c,
-alt_end_state::next, 1),
-pend, c, equal_to, partial)
-: s == send || !equal_to(*s, *p)
-? make_match_result(false, s, p)
-: match(cx::next(s), send, cx::next(p), pend,
-c, equal_to, partial);
+   return p == pend          ? make_match_result(partial || s == send, s, p)
+          : escape           ? s == send || !equal_to(*s, *p) ? make_match_result(false, s, p)
+                                                              : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
+                    : *p == c.anything ? match(s, send, cx::next(p), pend, c, equal_to, partial)
+                                            ? match(s, send, cx::next(p), pend, c, equal_to, partial)
+                                         : s == send ? make_match_result(false, s, p)
+                                                     : match(cx::next(s), send, p, pend, c, equal_to, partial)
+                    : *p == c.single ? s == send ? make_match_result(false, s, p)
+                                                 : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial)
+                    : *p == c.escape ? match(s, send, cx::next(p), pend, c, equal_to, partial, true)
+          : c.set_enabled && *p == c.set_open && is_set(cx::next(p), pend, c, is_set_state::not_or_first)
+             ? !match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
+                  ? match_set(s, send, cx::next(p), pend, c, equal_to, match_set_state::not_or_first_in)
+                  : match(cx::next(s), send, set_end(cx::next(p), pend, c, set_end_state::not_or_first), pend, c,
+                          equal_to, partial)
+          : c.alt_enabled && *p == c.alt_open && is_alt(cx::next(p), pend, c, is_alt_state::next, 1)
+             ? match_alt(s, send, cx::next(p),
+                         alt_sub_end(cx::next(p), alt_end(cx::next(p), pend, c, alt_end_state::next, 1), c),
+                         alt_end(cx::next(p), pend, c, alt_end_state::next, 1), pend, c, equal_to, partial)
+          : s == send || !equal_to(*s, *p) ? make_match_result(false, s, p)
+                                           : match(cx::next(s), send, cx::next(p), pend, c, equal_to, partial);
 #endif
 }
-}
+} // namespace detail
 template <typename Sequence, typename Pattern, typename EqualTo = cx::equal_to<void>>
-constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> match(
-Sequence&& sequence, Pattern&& pattern,
-const cards<container_item_t<Pattern>>& c = cards<container_item_t<Pattern>>(),
-const EqualTo& equal_to = EqualTo())
+constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>>
+match(Sequence &&sequence, Pattern &&pattern,
+      const cards<container_item_t<Pattern>> &c = cards<container_item_t<Pattern>>(),
+      const EqualTo &equal_to = EqualTo())
 {
-return detail::make_full_match_result(
-cx::cbegin(sequence), cx::cend(sequence), cx::cbegin(pattern), cx::cend(pattern),
-detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)),
-cx::cbegin(pattern), cx::cend(std::forward<Pattern>(pattern)), c, equal_to));
+   return detail::make_full_match_result(
+      cx::cbegin(sequence), cx::cend(sequence), cx::cbegin(pattern), cx::cend(pattern),
+      detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)), cx::cbegin(pattern),
+                    cx::cend(std::forward<Pattern>(pattern)), c, equal_to));
 }
 template <typename Sequence, typename Pattern, typename EqualTo = cx::equal_to<void>,
-typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
-constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> match(
-Sequence&& sequence, Pattern&& pattern, const EqualTo& equal_to)
+          typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
+constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>>
+match(Sequence &&sequence, Pattern &&pattern, const EqualTo &equal_to)
 {
-return match(std::forward<Sequence>(sequence), std::forward<Pattern>(pattern),
-cards<container_item_t<Pattern>>(), equal_to);
+   return match(std::forward<Sequence>(sequence), std::forward<Pattern>(pattern), cards<container_item_t<Pattern>>(),
+                equal_to);
 }
-}
+} // namespace wildcards
 #endif
 #ifndef WILDCARDS_MATCHER_HPP
-#define WILDCARDS_MATCHER_HPP 
+#define WILDCARDS_MATCHER_HPP
 #include <cstddef>
 #include <type_traits>
 #include <utility>
 #ifndef CX_STRING_VIEW_HPP
-#define CX_STRING_VIEW_HPP 
+#define CX_STRING_VIEW_HPP
 #include <cstddef>
 #include <ostream>
 #ifndef CX_ALGORITHM_HPP
-#define CX_ALGORITHM_HPP 
-namespace cx
-{
+#define CX_ALGORITHM_HPP
+namespace cx {
 template <typename Iterator1, typename Iterator2>
 constexpr bool equal(Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2)
 {
 #if cfg_HAS_CONSTEXPR14
-while (first1 != last1 && first2 != last2 && *first1 == *first2)
-{
-++first1, ++first2;
-}
-return first1 == last1 && first2 == last2;
+   while (first1 != last1 && first2 != last2 && *first1 == *first2) {
+      ++first1, ++first2;
+   }
+   return first1 == last1 && first2 == last2;
 #else
-return first1 != last1 && first2 != last2 && *first1 == *first2
-? equal(first1 + 1, last1, first2 + 1, last2)
-: first1 == last1 && first2 == last2;
+   return first1 != last1 && first2 != last2 && *first1 == *first2 ? equal(first1 + 1, last1, first2 + 1, last2)
+                                                                   : first1 == last1 && first2 == last2;
 #endif
 }
-}
+} // namespace cx
 #endif
-namespace cx
-{
+namespace cx {
 template <typename T>
-class basic_string_view
-{
+class basic_string_view {
 public:
-using value_type = T;
-constexpr basic_string_view() = default;
-template <std::size_t N>
-constexpr basic_string_view(const T (&str)[N]) : data_{&str[0]}, size_{N - 1}
-{
-}
-constexpr basic_string_view(const T* str, std::size_t s) : data_{str}, size_{s}
-{
-}
-constexpr const T* data() const
-{
-return data_;
-}
-constexpr std::size_t size() const
-{
-return size_;
-}
-constexpr bool empty() const
-{
-return size() == 0;
-}
-constexpr const T* begin() const
-{
-return data_;
-}
-constexpr const T* cbegin() const
-{
-return begin();
-}
-constexpr const T* end() const
-{
-return data_ + size_;
-}
-constexpr const T* cend() const
-{
-return end();
-}
+   using value_type = T;
+   constexpr basic_string_view() = default;
+   template <std::size_t N>
+   constexpr basic_string_view(const T (&str)[N]) : data_{&str[0]}, size_{N - 1}
+   {
+   }
+   constexpr basic_string_view(const T *str, std::size_t s) : data_{str}, size_{s} {}
+   constexpr const T *data() const { return data_; }
+   constexpr std::size_t size() const { return size_; }
+   constexpr bool empty() const { return size() == 0; }
+   constexpr const T *begin() const { return data_; }
+   constexpr const T *cbegin() const { return begin(); }
+   constexpr const T *end() const { return data_ + size_; }
+   constexpr const T *cend() const { return end(); }
+
 private:
-const T* data_{nullptr};
-std::size_t size_{0};
+   const T *data_{nullptr};
+   std::size_t size_{0};
 };
 template <typename T>
-constexpr bool operator==(const basic_string_view<T>& lhs, const basic_string_view<T>& rhs)
+constexpr bool operator==(const basic_string_view<T> &lhs, const basic_string_view<T> &rhs)
 {
-return equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+   return equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
 }
 template <typename T>
-constexpr bool operator!=(const basic_string_view<T>& lhs, const basic_string_view<T>& rhs)
+constexpr bool operator!=(const basic_string_view<T> &lhs, const basic_string_view<T> &rhs)
 {
-return !(lhs == rhs);
+   return !(lhs == rhs);
 }
 template <typename T>
-std::basic_ostream<T>& operator<<(std::basic_ostream<T>& o, const basic_string_view<T>& s)
+std::basic_ostream<T> &operator<<(std::basic_ostream<T> &o, const basic_string_view<T> &s)
 {
-o << s.data();
-return o;
+   o << s.data();
+   return o;
 }
 template <typename T, std::size_t N>
 constexpr basic_string_view<T> make_string_view(const T (&str)[N])
 {
-return {str, N - 1};
+   return {str, N - 1};
 }
 template <typename T>
-constexpr basic_string_view<T> make_string_view(const T* str, std::size_t s)
+constexpr basic_string_view<T> make_string_view(const T *str, std::size_t s)
 {
-return {str, s};
+   return {str, s};
 }
 using string_view = basic_string_view<char>;
 using u16string_view = basic_string_view<char16_t>;
 using u32string_view = basic_string_view<char32_t>;
 using wstring_view = basic_string_view<wchar_t>;
-namespace literals
+namespace literals {
+constexpr string_view operator""_sv(const char *str, std::size_t s)
 {
-constexpr string_view operator"" _sv(const char* str, std::size_t s)
+   return {str, s};
+}
+constexpr u16string_view operator""_sv(const char16_t *str, std::size_t s)
 {
-return {str, s};
+   return {str, s};
 }
-constexpr u16string_view operator"" _sv(const char16_t* str, std::size_t s)
+constexpr u32string_view operator""_sv(const char32_t *str, std::size_t s)
 {
-return {str, s};
+   return {str, s};
 }
-constexpr u32string_view operator"" _sv(const char32_t* str, std::size_t s)
+constexpr wstring_view operator""_sv(const wchar_t *str, std::size_t s)
 {
-return {str, s};
+   return {str, s};
 }
-constexpr wstring_view operator"" _sv(const wchar_t* str, std::size_t s)
-{
-return {str, s};
-}
-}
-}
+} // namespace literals
+} // namespace cx
 #endif
-namespace wildcards
-{
+namespace wildcards {
 template <typename Pattern, typename EqualTo = cx::equal_to<void>>
-class matcher
-{
+class matcher {
 public:
-constexpr explicit matcher(Pattern&& pattern, const cards<container_item_t<Pattern>>& c =
-cards<container_item_t<Pattern>>(),
-const EqualTo& equal_to = EqualTo())
-: p_{cx::cbegin(pattern)},
-pend_{cx::cend(std::forward<Pattern>(pattern))},
-c_{c},
-equal_to_{equal_to}
-{
-}
-constexpr matcher(Pattern&& pattern, const EqualTo& equal_to)
-: p_{cx::cbegin(pattern)},
-pend_{cx::cend(std::forward<Pattern>(pattern))},
-c_{cards<container_item_t<Pattern>>()},
-equal_to_{equal_to}
-{
-}
-template <typename Sequence>
-constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> matches(
-Sequence&& sequence) const
-{
-return detail::make_full_match_result(
-cx::cbegin(sequence), cx::cend(sequence), p_, pend_,
-detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)), p_, pend_,
-c_, equal_to_));
-}
+   constexpr explicit matcher(Pattern &&pattern,
+                              const cards<container_item_t<Pattern>> &c = cards<container_item_t<Pattern>>(),
+                              const EqualTo &equal_to = EqualTo())
+      : p_{cx::cbegin(pattern)}, pend_{cx::cend(std::forward<Pattern>(pattern))}, c_{c}, equal_to_{equal_to}
+   {
+   }
+   constexpr matcher(Pattern &&pattern, const EqualTo &equal_to)
+      : p_{cx::cbegin(pattern)},
+        pend_{cx::cend(std::forward<Pattern>(pattern))},
+        c_{cards<container_item_t<Pattern>>()},
+        equal_to_{equal_to}
+   {
+   }
+   template <typename Sequence>
+   constexpr full_match_result<const_iterator_t<Sequence>, const_iterator_t<Pattern>> matches(Sequence &&sequence) const
+   {
+      return detail::make_full_match_result(
+         cx::cbegin(sequence), cx::cend(sequence), p_, pend_,
+         detail::match(cx::cbegin(sequence), cx::cend(std::forward<Sequence>(sequence)), p_, pend_, c_, equal_to_));
+   }
+
 private:
-const_iterator_t<Pattern> p_;
-const_iterator_t<Pattern> pend_;
-cards<container_item_t<Pattern>> c_;
-EqualTo equal_to_;
+   const_iterator_t<Pattern> p_;
+   const_iterator_t<Pattern> pend_;
+   cards<container_item_t<Pattern>> c_;
+   EqualTo equal_to_;
 };
 template <typename Pattern, typename EqualTo = cx::equal_to<void>>
-constexpr matcher<Pattern, EqualTo> make_matcher(
-Pattern&& pattern,
-const cards<container_item_t<Pattern>>& c = cards<container_item_t<Pattern>>(),
-const EqualTo& equal_to = EqualTo())
+constexpr matcher<Pattern, EqualTo>
+make_matcher(Pattern &&pattern, const cards<container_item_t<Pattern>> &c = cards<container_item_t<Pattern>>(),
+             const EqualTo &equal_to = EqualTo())
 {
-return matcher<Pattern, EqualTo>{std::forward<Pattern>(pattern), c, equal_to};
+   return matcher<Pattern, EqualTo>{std::forward<Pattern>(pattern), c, equal_to};
 }
 template <typename Pattern, typename EqualTo = cx::equal_to<void>,
-typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
-constexpr matcher<Pattern, EqualTo> make_matcher(Pattern&& pattern, const EqualTo& equal_to)
+          typename = typename std::enable_if<!std::is_same<EqualTo, cards_type>::value>::type>
+constexpr matcher<Pattern, EqualTo> make_matcher(Pattern &&pattern, const EqualTo &equal_to)
 {
-return make_matcher(std::forward<Pattern>(pattern), cards<container_item_t<Pattern>>(), equal_to);
+   return make_matcher(std::forward<Pattern>(pattern), cards<container_item_t<Pattern>>(), equal_to);
 }
-namespace literals
+namespace literals {
+constexpr auto operator""_wc(const char *str, std::size_t s) -> decltype(make_matcher(cx::make_string_view(str, s + 1)))
 {
-constexpr auto operator"" _wc(const char* str, std::size_t s)
--> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+   return make_matcher(cx::make_string_view(str, s + 1));
+}
+constexpr auto operator""_wc(const char16_t *str, std::size_t s)
+   -> decltype(make_matcher(cx::make_string_view(str, s + 1)))
 {
-return make_matcher(cx::make_string_view(str, s + 1));
+   return make_matcher(cx::make_string_view(str, s + 1));
 }
-constexpr auto operator"" _wc(const char16_t* str, std::size_t s)
--> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+constexpr auto operator""_wc(const char32_t *str, std::size_t s)
+   -> decltype(make_matcher(cx::make_string_view(str, s + 1)))
 {
-return make_matcher(cx::make_string_view(str, s + 1));
+   return make_matcher(cx::make_string_view(str, s + 1));
 }
-constexpr auto operator"" _wc(const char32_t* str, std::size_t s)
--> decltype(make_matcher(cx::make_string_view(str, s + 1)))
+constexpr auto operator""_wc(const wchar_t *str, std::size_t s)
+   -> decltype(make_matcher(cx::make_string_view(str, s + 1)))
 {
-return make_matcher(cx::make_string_view(str, s + 1));
+   return make_matcher(cx::make_string_view(str, s + 1));
 }
-constexpr auto operator"" _wc(const wchar_t* str, std::size_t s)
--> decltype(make_matcher(cx::make_string_view(str, s + 1)))
-{
-return make_matcher(cx::make_string_view(str, s + 1));
-}
-}
-}
+} // namespace literals
+} // namespace wildcards
 #endif
 #endif

--- a/roottest/main/CMakeLists.txt
+++ b/roottest/main/CMakeLists.txt
@@ -392,8 +392,3 @@ ROOTTEST_ADD_TEST(NameCyclesRootmvCheckOutput
                   DEPENDS NameCyclesRootmv
                   ENVIRONMENT ${test_env})
 #########################################################################
-
-ROOTTEST_ADD_TEST(ROOT_8197
-                  MACRO ROOT_8197.C
-                  OUTREF ${ROOTFILES_DIR}/ROOT_8197.ref
-                  ENVIRONMENT ${test_env})

--- a/roottest/main/CMakeLists.txt
+++ b/roottest/main/CMakeLists.txt
@@ -1,0 +1,399 @@
+# For now let's reuse the rootls.py test files.
+set(ROOTFILES_DIR ../python/cmdLineUtils)
+
+configure_file(${ROOTFILES_DIR}/test.root . COPYONLY)
+configure_file(${ROOTFILES_DIR}/simpleTree.root . COPYONLY)
+configure_file(${ROOTFILES_DIR}/multipleNameCycles.root . COPYONLY)
+configure_file(${ROOTFILES_DIR}/MakeNameCyclesRootmvInput.C . COPYONLY)
+configure_file(${ROOTFILES_DIR}/subdirs.root . COPYONLY)
+
+# We compare the output of some tests against ref. files, and we don't want to
+# get noise for Python warnings (for example the warning that the GIL is
+# activated because the ROOT Python bindings don't support free threading yet).
+set(test_env PYTHONWARNINGS=ignore)
+
+if(MSVC)
+    # the command line tools works fine in the Windows command prompt but
+    # not from CTest, so let's add Python.exe and the .py file extension
+    set(PY_TOOLS_PREFIX ${Python3_EXECUTABLE} ${ROOTSYS}/bin)
+    set(TOOLS_PREFIX ${ROOTSYS}/bin)
+    set(pyext .py)
+else()
+    set(PY_TOOLS_PREFIX ${ROOTSYS}/bin)
+    set(TOOLS_PREFIX ${ROOTSYS}/bin)
+endif()
+
+############################## ROOLS TESTS ##############################
+ROOTTEST_ADD_TEST(SimpleRootlsCxx1
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 test.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootls.ref)
+
+ROOTTEST_ADD_TEST(SimpleRootlsCxx2
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 test.root:*
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootls2.ref)
+
+ROOTTEST_ADD_TEST(SimpleRootlsCxx3
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 test.root:tof
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootls3.ref)
+
+ROOTTEST_ADD_TEST(SimpleRootlsCxx4
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 test.root:tof/*
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootls4.ref)
+
+ROOTTEST_ADD_TEST(LongRootlsCxx1
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -l test.root
+                  OUTREF ${ROOTFILES_DIR}/LongRootls.ref)
+
+ROOTTEST_ADD_TEST(LongRootlsCxx2
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -l test.root:*
+                  OUTREF ${ROOTFILES_DIR}/LongRootls2.ref)
+
+ROOTTEST_ADD_TEST(LongRootlsCxx3
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -l test.root:tof
+                  OUTREF ${ROOTFILES_DIR}/LongRootls3.ref)
+
+ROOTTEST_ADD_TEST(LongRootlsCxx4
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -l test.root:tof/*
+                  OUTREF ${ROOTFILES_DIR}/LongRootls4.ref)
+
+if(davix AND NOT MSVC) # davix is optional ; Windows cannot yet read https
+    ROOTTEST_ADD_TEST(WebRootlsCxx1
+                    COMMAND ${TOOLS_PREFIX}/rootlscxx -1 http://root.cern.ch/files/pippa.root
+                    OUTREF ${ROOTFILES_DIR}/WebRootls.ref)
+
+    ROOTTEST_ADD_TEST(WebRootlsCxx2
+                    COMMAND ${TOOLS_PREFIX}/rootlscxx -1 http://root.cern.ch/files/pippa.root:LL
+                    OUTREF ${ROOTFILES_DIR}/WebRootls2.ref)
+endif()
+
+ROOTTEST_ADD_TEST(TreeRootlsCxx1
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -t simpleTree.root
+                  OUTREF ${ROOTFILES_DIR}/TreeRootls.ref)
+
+ROOTTEST_ADD_TEST(NameCyclesRootlsCxx
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -t multipleNameCycles.root:tree
+                  OUTREF ${ROOTFILES_DIR}/MultipleNameCyclesRootls.ref)
+
+ROOTTEST_ADD_TEST(RecursiveRootlsCxx
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -lr subdirs.root
+                  OUTREF ${ROOTFILES_DIR}/RecursiveRootls.ref)
+
+#########################################################################
+
+
+############################## ROORM TESTS ##############################
+ROOTTEST_ADD_TEST(SimpleRootrm1PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root victim1.root)
+
+ROOTTEST_ADD_TEST(SimpleRootrm1
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} victim1.root:hpx
+                  DEPENDS SimpleRootrm1PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootrm1CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 victim1.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootrm.ref
+                  DEPENDS SimpleRootrm1
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootrm1Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r victim1.root
+                  DEPENDS SimpleRootrm1CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootrm2PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root victim2.root)
+
+ROOTTEST_ADD_TEST(SimpleRootrm2
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} victim2.root:hp*
+                  DEPENDS SimpleRootrm2PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootrm2CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 victim2.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootrm2.ref
+                  DEPENDS SimpleRootrm2
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootrm2Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r victim2.root
+                  DEPENDS SimpleRootrm2CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootrm3PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root victim3.root)
+
+ROOTTEST_ADD_TEST(SimpleRootrm3
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r victim3.root:tof/plane0
+                  DEPENDS SimpleRootrm3PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootrm3CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 victim3.root:tof
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootrm3.ref
+                  DEPENDS SimpleRootrm3
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootrm3Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r victim3.root
+                  DEPENDS SimpleRootrm3CheckOutput)
+#########################################################################
+
+############################# ROOMKDIR TESTS ############################
+ROOTTEST_ADD_TEST(SimpleRootmkdir1PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root target1.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir1
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmkdir${pyext} target1.root:new_directory
+                  DEPENDS SimpleRootmkdir1PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir1CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 target1.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmkdir.ref
+                  DEPENDS SimpleRootmkdir1
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir1Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r target1.root
+                  DEPENDS SimpleRootmkdir1CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir2PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root target2.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir2
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmkdir${pyext} target2.root:dir1 target2.root:dir2
+                  DEPENDS SimpleRootmkdir2PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir2CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 target2.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmkdir2.ref
+                  DEPENDS SimpleRootmkdir2
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir2Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r target2.root
+                  DEPENDS SimpleRootmkdir2CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir3PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root target3.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir3
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmkdir${pyext} -p target3.root:aa/bb/cc
+                  DEPENDS SimpleRootmkdir3PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir3CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 target3.root:aa/bb
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmkdir3.ref
+                  DEPENDS SimpleRootmkdir3
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmkdir3Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r target3.root
+                  DEPENDS SimpleRootmkdir3CheckOutput)
+#########################################################################
+
+############################# ROOCP TESTS ############################
+ROOTTEST_ADD_TEST(SimpleRootcp1PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root copy1.root)
+
+ROOTTEST_ADD_TEST(SimpleRootcp1
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} copy1.root:hpx copy1.root:histo
+                  DEPENDS SimpleRootcp1PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp1CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 copy1.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootcp.ref
+                  DEPENDS SimpleRootcp1
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootcp1Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r copy1.root
+                  DEPENDS SimpleRootcp1CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootcp2PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root copy2.root)
+
+ROOTTEST_ADD_TEST(SimpleRootcp2
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} -r copy2.root:tof copy2.root:fot
+                  DEPENDS SimpleRootcp2PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp2CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 copy2.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootcp2.ref
+                  DEPENDS SimpleRootcp2
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootcp2Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r copy2.root
+                  DEPENDS SimpleRootcp2CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootcp3PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root copy3.root)
+
+ROOTTEST_ADD_TEST(SimpleRootcp3
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --replace copy3.root:hpx copy3.root:hpxpy
+                  DEPENDS SimpleRootcp3PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp3CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 copy3.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootcp3.ref
+                  DEPENDS SimpleRootcp3
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootcp3Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r copy3.root
+                  DEPENDS SimpleRootcp3CheckOutput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp4PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root copy4.root)
+
+ROOTTEST_ADD_TEST(SimpleRootcp4
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} copy4.root:hpx copy4.root:dir
+                  DEPENDS SimpleRootcp4PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp4CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 copy4.root:dir
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootcp4.ref
+                  DEPENDS SimpleRootcp4
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootcp4Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r copy4.root
+                  DEPENDS SimpleRootcp4CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootcp5PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root copy5.root)
+
+ROOTTEST_ADD_TEST(SimpleRootcp5
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} -r copy5.root:tof copy5.root:dir
+                  DEPENDS SimpleRootcp5PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootcp5CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 copy5.root:dir
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootcp5.ref
+                  DEPENDS SimpleRootcp5
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootcp5Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r copy5.root
+                  DEPENDS SimpleRootcp5CheckOutput)
+#########################################################################
+
+############################# ROOMV TESTS ############################
+ROOTTEST_ADD_TEST(SimpleRootmv1PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root move1.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmv1
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} move1.root:hpx move1.root:histo
+                  DEPENDS SimpleRootmv1PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv1CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 move1.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmv.ref
+                  DEPENDS SimpleRootmv1
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmv1Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r move1.root
+                  DEPENDS SimpleRootmv1CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootmv2PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root move2.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmv2
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} move2.root:tof move2.root:fot
+                  DEPENDS SimpleRootmv2PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv2CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 move2.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmv2.ref
+                  DEPENDS SimpleRootmv2
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmv2Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r move2.root
+                  DEPENDS SimpleRootmv2CheckOutput)
+
+
+
+ROOTTEST_ADD_TEST(SimpleRootmv3PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root move3.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmv3
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} move3.root:hpx move3.root:hpxpy
+                  DEPENDS SimpleRootmv3PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv3CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 move3.root
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmv3.ref
+                  DEPENDS SimpleRootmv3
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmv3Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r move3.root
+                  DEPENDS SimpleRootmv3CheckOutput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv4PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root move4.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmv4
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} move4.root:hpx move4.root:dir
+                  DEPENDS SimpleRootmv4PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv4CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 move4.root:*
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmv4.ref
+                  DEPENDS SimpleRootmv4
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmv4Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r move4.root
+                  DEPENDS SimpleRootmv4CheckOutput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv5PrepareInput
+                  COMMAND ${PY_TOOLS_PREFIX}/rootcp${pyext} --recreate -r test.root move5.root)
+
+ROOTTEST_ADD_TEST(SimpleRootmv5
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} move5.root:tof move5.root:dir
+                  DEPENDS SimpleRootmv5PrepareInput)
+
+ROOTTEST_ADD_TEST(SimpleRootmv5CheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 move5.root:*
+                  OUTREF ${ROOTFILES_DIR}/SimpleRootmv5.ref
+                  DEPENDS SimpleRootmv5
+                  ENVIRONMENT ${test_env})
+
+ROOTTEST_ADD_TEST(SimpleRootmv5Clean
+                  COMMAND ${PY_TOOLS_PREFIX}/rootrm${pyext} -r move5.root
+                  DEPENDS SimpleRootmv5CheckOutput)
+
+
+ROOTTEST_ADD_TEST(NameCyclesRootmvPrepareInput
+                  COMMAND root.exe -b -q -l MakeNameCyclesRootmvInput.C)
+
+ROOTTEST_ADD_TEST(NameCyclesRootmv
+                  COMMAND ${PY_TOOLS_PREFIX}/rootmv${pyext} nameCyclesRootmvInput.root:tree nameCyclesRootmvOutput.root
+                  DEPENDS NameCyclesRootmvPrepareInput)
+
+ROOTTEST_ADD_TEST(NameCyclesRootmvCheckOutput
+                  COMMAND ${TOOLS_PREFIX}/rootlscxx -1 nameCyclesRootmvOutput.root
+                  OUTREF ${ROOTFILES_DIR}/NameCyclesRootmvCheckOutput.ref
+                  DEPENDS NameCyclesRootmv
+                  ENVIRONMENT ${test_env})
+#########################################################################
+
+ROOTTEST_ADD_TEST(ROOT_8197
+                  MACRO ROOT_8197.C
+                  OUTREF ${ROOTFILES_DIR}/ROOT_8197.ref
+                  ENVIRONMENT ${test_env})


### PR DESCRIPTION
# This Pull request:
Adds a native version of the `rootls` executable. This allows running rootls without Python, meaning one can use it from a ROOT build with pyroot=off.
As a bonus, this version is ~3 to 4x faster than the python version on all the tests I did locally (bringing the "minimal" latency from ~0.5s to ~0.15s).

The output format should be exactly the same, except for some cases I found which rootls.py doesn't handle correctly.

The executable is currently called `rootlscxx` and the original `rootls` is preserved, but ideally it should be phased out after verifying that everything is covered.

I copied the tests for rootls.py and made sure they all pass with rootlscxx as well.

## NOTE
To handle globbing I imported a small header-only library called [wildcards.hpp](https://github.com/zemasoft/wildcards). The license should be compatible with ROOT (boost license).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


