### PR TITLE
fix: fix progress bar for RDataFrame with Range limits

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -17,6 +17,7 @@
 #include <ROOT/RDF/RActionBase.hxx>
 #include <ROOT/RDF/RResultMap.hxx>
 #include <ROOT/RResultHandle.hxx> // users of RunGraphs might rely on this transitive include
+#include <ROOT/RResultPtr.hxx>
 #include <ROOT/TypeTraits.hxx>
 
 #include <array>
@@ -276,8 +277,9 @@ SnapshotPtr_t VariationsFor(SnapshotPtr_t resPtr);
 /// \brief Add ProgressBar to a ROOT::RDF::RNode
 /// \param[in] df RDataFrame node at which ProgressBar is called.
 ///
-/// The ProgressBar can be added not only at the RDataFrame head node, but also at any any computational node,
-/// such as Filter or Define.
+/// The ProgressBar can be added not only at the RDataFrame head node, but also at any computational node,
+/// such as Filter or Define. To correctly account for the entries processed, place the progress bar
+/// after transformations that reduce the number of events (e.g. `Range`).
 /// ###Example usage:
 /// ~~~{.cpp}
 /// ROOT::RDataFrame df("tree", "file.root");
@@ -360,6 +362,8 @@ private:
    bool fUseShellColours;
 
    std::shared_ptr<TTree> fTree{nullptr};
+   ROOT::RDF::RResultPtr<ULong64_t> fTotalEntries{};
+
 
 public:
    /// Create a progress helper.
@@ -370,7 +374,8 @@ public:
    /// \param useColors Use shell colour codes to colour the output. Automatically disabled when
    /// we are not writing to a tty.
    ProgressHelper(std::size_t increment, unsigned int totalFiles = 1, unsigned int progressBarWidth = 40,
-                  unsigned int printInterval = 1, bool useColors = true);
+                  unsigned int printInterval = 1, bool useColors = true,
+                  ROOT::RDF::RResultPtr<ULong64_t> totalEntries = {});
 
    ~ProgressHelper() = default;
 

--- a/tutorials/analysis/dataframe/df108_ProgressRange.C
+++ b/tutorials/analysis/dataframe/df108_ProgressRange.C
@@ -1,0 +1,15 @@
+/// Minimal example showing how a progress bar interacts with `Range`.
+///
+/// The progress bar must be attached to the node *after* the range is applied
+/// so the total number of entries displayed corresponds to the ranged dataset
+/// and not the original input.
+///
+/// \macro_code
+void df108_ProgressRange()
+{
+   ROOT::RDataFrame df(100);
+   auto ranged = df.Range(0, 10);
+   ROOT::RDF::Experimental::AddProgressBar(ranged);
+   auto h = ranged.Define("x", []() { return gRandom->Rndm(); }).Histo1D("x");
+   std::cout << h->GetEntries() << std::endl;
+}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR fixes the progress bar display for RDataFrame when using `Range()` transformations. Previously, the progress bar would always show the total entries from the original dataset, even when using `Range()` to limit the number of processed entries. Now the progress bar correctly shows the actual number of entries being processed.

 Also this PR adds new tutorial `df108_ProgressRange.C` demonstrating the correct usage with `Range()` 

I need to write a unit test but still trying to figure this out so this is a work in progress PR. I 

## Checklist:

- [x] tested changes locally - Everything works!
- [x] updated the docs (if necessary) - If adding new tutorial counts but can work on updating to ROOT docs itself. 

This PR fixes #15323