### PR TITLE
[skip-ci] ci: Checkout explicit branch in root-docs

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -60,6 +60,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        ref: ${{ env.BASE_REF }}
         fetch-depth: 0
 
     - name: Set up Python Virtual Env


### PR DESCRIPTION
This is most relevant for scheduled builds of branches.