### PR TITLE
[python] Ensure ctest sees results of pytest

### DIFF
--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -330,4 +330,4 @@ class TestTH1Indexing:
 
 
 if __name__ == "__main__":
-    pytest.main(args=[__file__])
+    raise SystemExit(pytest.main(args=[__file__]))

--- a/bindings/pyroot/pythonizations/test/uhi_plotting.py
+++ b/bindings/pyroot/pythonizations/test/uhi_plotting.py
@@ -28,4 +28,4 @@ class TestTH1Plotting:
 
 
 if __name__ == "__main__":
-    pytest.main(args=[__file__])
+    raise SystemExit(pytest.main(args=[__file__]))


### PR DESCRIPTION
Without the Python script returning the pytest.main result as an exit code, it might happen that ctest thinks that the pytest suite was successfull. Instead, `raise SystemExit` ensures whatever result of pytest is also seen by ctest
