### PR TITLE
[skip-ci][docu] strip home/github/master from ROOT.tag file

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -26,6 +26,7 @@ export DOXYGEN_NOTEBOOK_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/notebooks
 export DOXYGEN_STRIP_PATH := $(shell cd $(PWD)/../..; pwd)
 export DOXYGEN_INCLUDE_PATH := $(shell find $(DOXYGEN_STRIP_PATH) -type d -name dictpch -prune -o -type d -name inc)
 export DOXYGEN_PYZDOC_PATH := $(DOXYGEN_OUTPUT_DIRECTORY)/pyzdoc
+export DOXYGEN_STRIP_PATH := "$(DOXYGEN_STRIP_PATH) $(DOXYGEN_OUTPUT_DIRECTORY)"
 
 PYZ_DIR = $(DOXYGEN_SOURCE_DIRECTORY)/bindings/pyroot/pythonizations/python/ROOT/_pythonization
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

@couet this is what I meant. I am not sure though if separating by space is correct, in case you could verify this locally. Thanks!

Fixes https://github.com/root-project/root/issues/10059

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

