### PR TITLE
Mitigate TChain with no files and SetBranchAddress call 

### DIFF
--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2703,11 +2703,6 @@ Int_t TChain::SetBranchAddress(const char* bname, void* add, TBranch** ptr, TCla
    element->SetBaddressIsPtr(isptr);
    element->SetBranchPtr(ptr);
 
-   if (!fTree && fReadEntry == -1 && fTreeNumber == -1) {
-      // Try to load the first tree to retrieve the dataset schema
-      LoadTree(0);
-   }
-
    return SetBranchAddress(bname, add, ptr);
 }
 
@@ -3212,11 +3207,6 @@ Int_t TChain::SetBranchAddress(const char *bname, void *addr, TBranch **ptr, TCl
       auto *element = new TChainElement(bname, "");
       element->IsDelayed(suppressMissingBranchError);
       fStatus->Add(element);
-   }
-
-   if (!fTree && fReadEntry == -1 && fTreeNumber == -1) {
-      // Try to load the first tree to retrieve the dataset schema
-      LoadTree(0);
    }
 
    return SetBranchAddress(bname, addr, ptr, ptrClass, datatype, isptr);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -2625,6 +2625,15 @@ Int_t TChain::SetBranchAddress(const char *bname, void* add, TBranch** ptr)
    if (!fTree && fReadEntry == -1 && fTreeNumber == -1) {
       // Try to load the first tree to retrieve the dataset schema
       LoadTree(0);
+      // Something went wrong when loading the first tree (possibly there are no
+      // files connected to this chain), let the user know.
+      if (!fTree && fReadEntry == -1 && fTreeNumber == -1)
+         Warning("SetBranchAddress",
+                 "Could not load the first tree in chain \"%s\", no dataset schema available. Thus, it is not possible "
+                 "to know whether the branch name \"%s\" corresponds to an available branch or not. This could happen "
+                 "if the chain has no files connected yet, make sure to add files to the chain before calling "
+                 "'TChain::SetBranchAddress'.",
+                 GetName(), bname);
    }
 
    // Also set address in current tree.


### PR DESCRIPTION
Followup to https://github.com/root-project/root/pull/18871.

When calling TChain::SetBranchAddress, the dataset schema is loaded in case it
hasn't been done yet. This happens so that we can actually check whether the
input branch name can be found in the TChain or not. When this in turn happens
as part of a previous call to SetBranchAddress which is querying all the friends
of a main tree to understand in which friend the branch might be, then we just
can't print an error in case of a seemingly missing branch name in any single
friend.

It can happen that any, or all, the friend TChains have no files. One simple
scenario to imagine is a user calling `TChain::Add` later than
`TChain::SetBranchAddress`. In this situation, we can't tell whether the input
branch name will exist at a later point in the application or it's just wrong.

Thus, this commit adds a warning that is printed when SetBranchAddress tries to
load the dataset schema via LoadTree and if that fails, it informs the user that
it cannot detect whether the given branch name is good or bad.


FYI @lmoureaux 