### PR TITLE
[Python][UHI] Add implementation of __iter__ to fix list(h)

### DIFF
--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -315,6 +315,16 @@ class TestTH1Indexing:
         assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), rel=10e-5)
         assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), rel=10e-5)
 
+    def test_list_iter(self, hist_setup):
+        import numpy as np
+
+        if _special_setting(hist_setup):
+            pytest.skip("Setting cannot be tested here")
+
+        expected = np.full(_shape(hist_setup), 3, dtype=np.int64)
+        hist_setup[...] = expected
+        assert list(hist_setup) == expected.flatten().tolist()
+
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main(args=[__file__]))


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Implemented `__iter__` to return an immutable copy of bin contents, including flow bins.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #19311

