### PR TITLE
[RF] Avoid using out-of-range values in RooDerivative

### DIFF
--- a/tutorials/roofit/roofit/rf111_derivatives.C
+++ b/tutorials/roofit/roofit/rf111_derivatives.C
@@ -35,12 +35,6 @@ void rf111_derivatives()
    RooRealVar mean("mean", "mean of gaussian", 1, -10, 10);
    RooRealVar sigma("sigma", "width of gaussian", 1, 0.1, 10);
 
-   // Ranges for plotting derivatives. They can't be the full range, because
-   // the derivatives is calculated by variation around the central point. We
-   // need to ensure that the varied values are still in the full range.
-   x.setRange("plotrange", -9.95, 9.95);
-   sigma.setRange("plotrange", 0.15, 1.95);
-
    // Build gaussian pdf in terms of x,mean and sigma
    RooGaussian gauss("gauss", "gaussian PDF", x, mean, sigma);
 
@@ -61,9 +55,9 @@ void rf111_derivatives()
    gauss.plotOn(xframe);
 
    // Plot derivatives in same frame
-   dgdx->plotOn(xframe, LineColor(kMagenta), Range("plotrange"));
-   d2gdx2->plotOn(xframe, LineColor(kRed), Range("plotrange"));
-   d3gdx3->plotOn(xframe, LineColor(kOrange), Range("plotrange"));
+   dgdx->plotOn(xframe, LineColor(kMagenta));
+   d2gdx2->plotOn(xframe, LineColor(kRed));
+   d3gdx3->plotOn(xframe, LineColor(kOrange));
 
    // C r e a t e   a n d   p l o t  d e r i v a t i v e s   w . r . t .   s i g m a
    // ------------------------------------------------------------------------------
@@ -82,9 +76,9 @@ void rf111_derivatives()
    gauss.plotOn(sframe);
 
    // Plot derivatives in same frame
-   dgds->plotOn(sframe, LineColor(kMagenta), Range("plotrange"));
-   d2gds2->plotOn(sframe, LineColor(kRed), Range("plotrange"));
-   d3gds3->plotOn(sframe, LineColor(kOrange), Range("plotrange"));
+   dgds->plotOn(sframe, LineColor(kMagenta));
+   d2gds2->plotOn(sframe, LineColor(kRed));
+   d3gds3->plotOn(sframe, LineColor(kOrange));
 
    // Draw all frames on a canvas
    TCanvas *c = new TCanvas("rf111_derivatives", "rf111_derivatives", 800, 400);

--- a/tutorials/roofit/roofit/rf111_derivatives.py
+++ b/tutorials/roofit/roofit/rf111_derivatives.py
@@ -25,12 +25,6 @@ x = ROOT.RooRealVar("x", "x", -10, 10)
 mean = ROOT.RooRealVar("mean", "mean of gaussian", 1, -10, 10)
 sigma = ROOT.RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
 
-# Ranges for plotting derivatives. They can't be the full range, because
-# the derivatives is calculated by variation around the central point. We
-# need to ensure that the varied values are still in the full range.
-x.setRange("plotrange", -9.95, 9.95)
-sigma.setRange("plotrange", 0.15, 1.95)
-
 # Build gaussian pdf in terms of x, and sigma
 gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
 
@@ -51,9 +45,9 @@ xframe = x.frame(Title="d(Gauss)/dx")
 gauss.plotOn(xframe)
 
 # Plot derivatives in same frame
-dgdx.plotOn(xframe, LineColor="m", Range="plotrange")
-d2gdx2.plotOn(xframe, LineColor="r", Range="plotrange")
-d3gdx3.plotOn(xframe, LineColor="kOrange", Range="plotrange")
+dgdx.plotOn(xframe, LineColor="m")
+d2gdx2.plotOn(xframe, LineColor="r")
+d3gdx3.plotOn(xframe, LineColor="kOrange")
 
 # Create and plot derivatives w.r.t. sigma
 # ------------------------------------------------------------------------------
@@ -72,9 +66,9 @@ sframe = sigma.frame(Title="d(Gauss)/d(sigma)", Range=(0.0, 2.0))
 gauss.plotOn(sframe)
 
 # Plot derivatives in same frame
-dgds.plotOn(sframe, LineColor="m", Range="plotrange")
-d2gds2.plotOn(sframe, LineColor="r", Range="plotrange")
-d3gds3.plotOn(sframe, LineColor="kOrange", Range="plotrange")
+dgds.plotOn(sframe, LineColor="m")
+d2gds2.plotOn(sframe, LineColor="r")
+d3gds3.plotOn(sframe, LineColor="kOrange")
 
 # Draw all frames on a canvas
 c = ROOT.TCanvas("rf111_derivatives", "rf111_derivatives", 800, 400)


### PR DESCRIPTION
Avoid using out-of-range values for the numerical differentiation in RooDerivative.

This adds three new special cases:

  * derivative is first order and x-value is close to limit: just use one-directional derivative already implemented in the RichardsonDerivator

  * higher-order derivative but function is constant within floating point precision: just return zero

  * higher-order derivative for non-constant function: throw error, because we don't want to risk wrong derivatives by evaluating outside the range, which will result in x-value-clipping and therefore invalid y value differences

The tutorials fortunately hit the second case with the locally constant function, so we can remove the workaround with the sub-range introduced in #10470.

Closes #18615.

FYI, @VanyaBelyaev