### PR TITLE
Properly calculate offset of unsplittable base class of STL collection element type

### DIFF
--- a/roottest/root/tree/gh-18782/CMakeLists.txt
+++ b/roottest/root/tree/gh-18782/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Reproducer of https://github.com/root-project/root/issues/18782
+
+set(MYPARTICLE_DICTNAME MyParticleDict)
+ROOTTEST_GENERATE_DICTIONARY(
+	${MYPARTICLE_DICTNAME}
+	${CMAKE_CURRENT_SOURCE_DIR}/MyParticle.hxx
+    ${CMAKE_CURRENT_SOURCE_DIR}/MyParticle.cxx
+	LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/MyParticleLinkDef.hxx
+    FIXTURES_SETUP myparticle_dict_setup
+)
+
+ROOTTEST_GENERATE_EXECUTABLE(
+    runtest
+    runtest.cxx
+    ${MYPARTICLE_DICTNAME}.cxx
+    LIBRARIES Core RIO Tree GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main
+    FIXTURES_REQUIRED myparticle_dict_setup
+    FIXTURES_SETUP myparticle_runtest_setup)
+
+ROOTTEST_ADD_TEST(runtest
+    EXEC ${CMAKE_CURRENT_BINARY_DIR}/runtest
+    FIXTURES_REQUIRED myparticle_runtest_setup
+    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/MyParticle.hxx)

--- a/roottest/root/tree/gh-18782/MyParticle.cxx
+++ b/roottest/root/tree/gh-18782/MyParticle.cxx
@@ -1,0 +1,11 @@
+#include "MyParticle.hxx"
+#include <TBuffer.h>
+
+void UnsplittableBase::Streamer(TBuffer &R__b)
+{
+   if (R__b.IsReading()) {
+      R__b.ReadClassBuffer(UnsplittableBase::Class(), this);
+   } else {
+      R__b.WriteClassBuffer(UnsplittableBase::Class(), this);
+   }
+}

--- a/roottest/root/tree/gh-18782/MyParticle.hxx
+++ b/roottest/root/tree/gh-18782/MyParticle.hxx
@@ -1,0 +1,33 @@
+#ifndef SHIPDATA_SHIPPARTICLE_H_
+#define SHIPDATA_SHIPPARTICLE_H_
+
+#include <Rtypes.h>
+#include <vector>
+
+class SplittableBase {
+public:
+   int fSplittableBaseInt{101};
+   float fSplittableBaseFloat{102.f};
+
+   SplittableBase() = default;
+};
+
+// Having a base which is not splittable (due to a custom streamer) was
+// making the calculation of the base class offset fail for the case of a
+// std::vector<Derived>
+class UnsplittableBase {
+public:
+   float fUnsplittableBaseFloat{201.f};
+
+   UnsplittableBase() = default;
+   ClassDefNV(UnsplittableBase, 2);
+};
+
+class Derived : public SplittableBase, public UnsplittableBase {
+public:
+   int fDerivedInt{301};
+
+   Derived() = default;
+};
+
+#endif // SHIPDATA_SHIPPARTICLE_H_

--- a/roottest/root/tree/gh-18782/MyParticleLinkDef.hxx
+++ b/roottest/root/tree/gh-18782/MyParticleLinkDef.hxx
@@ -1,0 +1,12 @@
+#ifdef __CLING__
+
+#pragma link C++ class SplittableBase + ;
+#pragma link C++ class std::vector < SplittableBase> + ;
+
+// It is fundamental for the reproducer to have a class with a custom streamer
+// and generate the dictionary with the "-" sign
+#pragma link C++ class UnsplittableBase - ;
+#pragma link C++ class Derived + ;
+#pragma link C++ class std::vector < Derived> + ;
+
+#endif

--- a/roottest/root/tree/gh-18782/runtest.cxx
+++ b/roottest/root/tree/gh-18782/runtest.cxx
@@ -1,0 +1,53 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <vector>
+
+#include "MyParticle.hxx"
+
+#include <gtest/gtest.h>
+
+struct MyParticleReproducer : public ::testing::Test {
+   constexpr static auto fFileName{"particles.root"};
+   constexpr static auto fTreeName{"Particles"};
+   static void SetUpTestSuite()
+   {
+      auto file = std::make_unique<TFile>(fFileName, "RECREATE");
+      auto tree = std::make_unique<TTree>(fTreeName, fTreeName);
+
+      std::vector<Derived> objects(1);
+
+      // Default splitlevel=99
+      tree->Branch("objects", &objects);
+      tree->Fill();
+
+      file->Write();
+   }
+   static void TearDownTestSuite() { std::remove(fFileName); }
+};
+
+TEST_F(MyParticleReproducer, ClassHierarchy)
+{
+   auto file = std::make_unique<TFile>(fFileName);
+   auto *tree = file->Get<TTree>(fTreeName);
+   auto objectsOwner = std::make_unique<std::vector<Derived>>();
+   auto *objectsPtr = objectsOwner.get();
+   tree->SetBranchAddress("objects", &objectsPtr);
+
+   tree->GetEntry(0);
+
+   const auto &objects = *objectsPtr;
+   ASSERT_EQ(objects.size(), 1);
+
+   const auto &object = objects[0];
+   EXPECT_EQ(object.fSplittableBaseInt, 101);
+   EXPECT_FLOAT_EQ(object.fSplittableBaseFloat, 102);
+   EXPECT_FLOAT_EQ(object.fUnsplittableBaseFloat, 201);
+   EXPECT_EQ(object.fDerivedInt, 301);
+}
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3402,6 +3402,26 @@ void TBranchElement::InitializeOffsets()
                stlParentName.Remove(0, motherName.Length());
                stlParentNameUpdated = true;
             }
+         } else if (fType == 4) {
+            // This is a top-level branch of type STL collection. In this current
+            // iteration, we are trying to calculate the offset of one of the
+            // base classes of the element type of the STL collection. The
+            // dataName string in this case will be akin to
+            // "nameOfBranch.BaseClassName". Later logic in this function will
+            // try to get the TRealData relative to "BaseClassName". But if the
+            // base class is not splittable (i.e. it has a custom streamer), that
+            // will not work anyway. The treatment of base classes follows a
+            // different path: we remove the leading name of the branch, so only
+            // the name of the base class is left. This will be later detected
+            // and dataName will be stripped from the name of the base class,
+            // leaving the string completely empty. Since the dataName string
+            // will be empty, the logic of this function skips the part related
+            // to finding the TRealData and directly computes the base class
+            // offset.
+            // Only perform the modification of the string if it looks as we
+            // expect
+            if (dataName == (motherName + '.' + subBranchElement->GetName()))
+               dataName = subBranchElement->GetName();
          } else if (motherDot) {
             // -- Remove the top-level branch name from our name, folder case.
             //


### PR DESCRIPTION
A call to `TTree::Branch` with the branch type being an STL collection with an element type derived from an unsplittable base class (i.e. with a custom streamer) would fail with the following error message:

```
Fatal in <TBranchElement::InitializeOffsets>: Could not find the real data member 'objects' when constructing the branch 'objects' [Likely an internal error, please report to the developers].
aborting
```

Due to the fact that InitializeOffsets was not able to properly compute the offset of the base class of the element type. Unfortunately the error message itself was obscure, since the repetition of the word 'objects' in this case simply refers to the top-level branch name.

What is really happening is that the function logic mixes the calculation of the offsets of base classes with the calculation of offsets of data members of a class in the same code path. For this reason, the failure should have hinted at this by specifying that the first 'objects' was actually 'base class of the type of the objects branch'.

In the particular configuration of an STL collection type, the function needs to compute the offset of the base class of its element type. The function generally looks for TRealData of each data member and base class. But when the base class is unsplittable, this will not work anyway.

The logic of the function is slightly extended so that if the name of the data member being currently looked at is actually of the type 'nameOfBranch.BaseClassName', i.e. we are not looking for a data member for the base class of the element type of an STL collection, we remove all the leading part of the name until the base class name itself.

This helps because other parts of the function compare the current data member name with the base class name and if they are equal, the data member name is completely removed. When there is no data member name to look at, the function simply skips all the logic related to TRealData and directly computes the offset of the base class, which is the desired behaviour in this case.

A test is added to exemplify the case at hand.


This PR fixes #18782 

