### PR TITLE
roottest: avoid generated unneeded pcm files

### DIFF
--- a/roottest/cling/parsing/CMakeLists.txt
+++ b/roottest/cling/parsing/CMakeLists.txt
@@ -9,8 +9,8 @@ ROOTTEST_ADD_TEST(runoperatorLessThanTemplate
                   MACRO runoperatorLessThanTemplate.C
                   LABELS roottest regression cling)
 
-ROOTTEST_GENERATE_DICTIONARY(scopeDict  scopeProblem.C LINKDEF linkdef.h)
-ROOTTEST_GENERATE_DICTIONARY(scopeDict2 multiScope.C LINKDEF linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(scopeDict  scopeProblem.C NO_CXXMODULE LINKDEF linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(scopeDict2 multiScope.C NO_CXXMODULE LINKDEF linkdef.h)
 
 ROOTTEST_ADD_TEST(runReadbool
                   MACRO runReadbool.C

--- a/roottest/cling/stl/map/CMakeLists.txt
+++ b/roottest/cling/stl/map/CMakeLists.txt
@@ -1,4 +1,4 @@
-ROOTTEST_GENERATE_DICTIONARY(dict.C testing.C LINKDEF LinkDef.h)
+# ROOTTEST_GENERATE_DICTIONARY(dict.C testing.C NO_CXXMODULE LINKDEF LinkDef.h)
 
 ROOTTEST_COMPILE_MACRO(MyOpClass.C
                        FIXTURES_SETUP cling-stl-map-MyOpClass-fixtures)

--- a/roottest/cling/template/CMakeLists.txt
+++ b/roottest/cling/template/CMakeLists.txt
@@ -19,10 +19,10 @@ ROOTTEST_ADD_TEST(templateSingleton
 if(NOT ROOT_runtime_cxxmodules_FOUND)
   ROOTTEST_GENERATE_DICTIONARY(slaveDict        slave.h        LINKDEF slaveLinkDef.h)
 endif()
-ROOTTEST_GENERATE_DICTIONARY(masterDict       master.h       LINKDEF masterLinkDef.h)
-ROOTTEST_GENERATE_DICTIONARY(forwardDict      forward.C      LINKDEF linkdef.h)
-ROOTTEST_GENERATE_DICTIONARY(constructorDict  constructor.hh LINKDEF linkdef.h)
-ROOTTEST_GENERATE_DICTIONARY(typenameTestDict typenameTest.C LINKDEF linkdef.h
+ROOTTEST_GENERATE_DICTIONARY(masterDict       master.h       NO_CXXMODULE LINKDEF masterLinkDef.h)
+ROOTTEST_GENERATE_DICTIONARY(forwardDict      forward.C      NO_CXXMODULE LINKDEF linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(constructorDict  constructor.hh NO_CXXMODULE LINKDEF linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(typenameTestDict typenameTest.C NO_CXXMODULE LINKDEF linkdef.h
                              FIXTURES_SETUP cling-template-typenameTestDict-fixture)
 
 ROOTTEST_COMPILE_MACRO(usingtemplate.C

--- a/roottest/cling/templateMembers/CMakeLists.txt
+++ b/roottest/cling/templateMembers/CMakeLists.txt
@@ -27,7 +27,7 @@ ROOTTEST_ADD_TEST(runConstructor
                   FIXTURES_REQUIRED cling-templateMembers-constructor-fixture
                   LABELS roottest regression cling)
 
-ROOTTEST_GENERATE_DICTIONARY(opdict operator.C LINKDEF linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(opdict operator.C NO_CXXMODULE LINKDEF linkdef.h)
 
 ROOTTEST_GENERATE_DICTIONARY(libtemplateMembersDict
                              templateMembersClasses.h

--- a/roottest/root/meta/MakeProject/CMakeLists.txt
+++ b/roottest/root/meta/MakeProject/CMakeLists.txt
@@ -1,4 +1,4 @@
-ROOTTEST_GENERATE_DICTIONARY(stl_makeproject_test stl_makeproject_test.h LINKDEF stl_makeproject_test_linkdef.h)
+ROOTTEST_GENERATE_DICTIONARY(stl_makeproject_test stl_makeproject_test.h LINKDEF stl_makeproject_test_linkdef.h NO_ROOTMAP NO_CXXMODULE)
 # If we build roottest in-tree, add a dependecy on Hist because the header
 # includes TH1D.
 if(TARGET Hist)


### PR DESCRIPTION
The tests are checking if the dictionary source files can compile.

Having the pcm files around can affect the other tests in the same directory, for example in case those
other test runs before the pcm has been rebuild (and it depend on something that has already been rebuild).

