### PR TITLE
[ntuple] Remove `/bigobj` flag for `RField.cxx`

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -114,7 +114,6 @@ endif()
 
 if(MSVC)
   target_compile_definitions(ROOTNTuple PRIVATE _USE_MATH_DEFINES)
-  set_source_files_properties(src/RField.cxx PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
The file was split some time ago, it should not exceed limits anymore.