### PR TITLE
[ntuple] Correct `RValue::GetRef<T>` usage or use `RValue::GetPtr<void>`

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleView.hxx
@@ -345,6 +345,13 @@ private:
       return fieldId;
    }
 
+   std::uint64_t GetCardinalityValue() const
+   {
+      // We created the RValue and know its type, avoid extra checks.
+      void *ptr = fValue.GetPtr<void>().get();
+      return *static_cast<RNTupleCardinality<std::uint64_t> *>(ptr);
+   }
+
 public:
    RNTupleCollectionView(const RNTupleCollectionView &other) = delete;
    RNTupleCollectionView(RNTupleCollectionView &&other) = default;
@@ -413,14 +420,14 @@ public:
    std::uint64_t operator()(ROOT::NTupleSize_t globalIndex)
    {
       fValue.Read(globalIndex);
-      return fValue.GetRef<std::uint64_t>();
+      return GetCardinalityValue();
    }
 
    /// \see RNTupleView::operator()(RNTupleLocalIndex)
    std::uint64_t operator()(RNTupleLocalIndex localIndex)
    {
       fValue.Read(localIndex);
-      return fValue.GetRef<std::uint64_t>();
+      return GetCardinalityValue();
    }
 };
 

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -104,12 +104,12 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RArrayField::GetDeleter() cons
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::RArrayField::SplitValue(const RValue &value) const
 {
-   auto arrayPtr = value.GetPtr<unsigned char>().get();
+   auto valuePtr = value.GetPtr<void>();
+   auto arrayPtr = static_cast<unsigned char *>(valuePtr.get());
    std::vector<RValue> result;
    result.reserve(fArrayLength);
    for (unsigned i = 0; i < fArrayLength; ++i) {
-      result.emplace_back(
-         fSubfields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), arrayPtr + (i * fItemSize))));
+      result.emplace_back(fSubfields[0]->BindValue(std::shared_ptr<void>(valuePtr, arrayPtr + (i * fItemSize))));
    }
    return result;
 }
@@ -600,15 +600,15 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RVectorField::GetDeleter() con
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::RVectorField::SplitValue(const RValue &value) const
 {
-   auto vec = value.GetPtr<std::vector<char>>();
+   auto valuePtr = value.GetPtr<void>();
+   auto *vec = static_cast<std::vector<char> *>(valuePtr.get());
    R__ASSERT(fItemSize > 0);
    R__ASSERT((vec->size() % fItemSize) == 0);
    auto nItems = vec->size() / fItemSize;
    std::vector<RValue> result;
    result.reserve(nItems);
    for (unsigned i = 0; i < nItems; ++i) {
-      result.emplace_back(
-         fSubfields[0]->BindValue(std::shared_ptr<void>(value.GetPtr<void>(), vec->data() + (i * fItemSize))));
+      result.emplace_back(fSubfields[0]->BindValue(std::shared_ptr<void>(valuePtr, vec->data() + (i * fItemSize))));
    }
    return result;
 }

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -17,6 +17,7 @@
 #include <ROOT/RNTupleView.hxx>
 
 #include <cassert>
+#include <cstddef>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -202,7 +203,8 @@ void ROOT::Internal::RPrintValueVisitor::VisitByteField(const ROOT::RField<std::
    PrintIndent();
    PrintName(field);
    char prev = std::cout.fill();
-   fOutput << "0x" << std::setw(2) << std::setfill('0') << std::hex << (fValue.GetRef<unsigned char>() & 0xff);
+   auto value = std::to_integer<unsigned int>(fValue.GetRef<std::byte>());
+   fOutput << "0x" << std::setw(2) << std::setfill('0') << std::hex << value;
    fOutput << std::resetiosflags(std::ios_base::basefield);
    std::cout.fill(prev);
 }

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -298,7 +298,7 @@ void ROOT::Internal::RPrintValueVisitor::VisitCardinalityField(const ROOT::RCard
 void ROOT::Internal::RPrintValueVisitor::VisitBitsetField(const ROOT::RBitsetField &field)
 {
    constexpr auto nBitsULong = sizeof(unsigned long) * 8;
-   const auto *asULongArray = fValue.GetPtr<unsigned long>().get();
+   const auto *asULongArray = static_cast<unsigned long *>(fValue.GetPtr<void>().get());
 
    PrintIndent();
    PrintName(field);

--- a/tree/ntuple/test/rfield_vector.cxx
+++ b/tree/ntuple/test/rfield_vector.cxx
@@ -145,11 +145,11 @@ TEST(RNTuple, InsideCollection)
 
    auto valueCardinality64 = fieldCardinality64->CreateValue();
    valueCardinality64.Read(0);
-   EXPECT_EQ(1U, valueCardinality64.GetRef<std::uint64_t>());
+   EXPECT_EQ(1U, valueCardinality64.GetRef<ROOT::RNTupleCardinality<std::uint64_t>>());
 
    auto valueCardinality32 = fieldCardinality32->CreateValue();
    valueCardinality32.Read(0);
-   EXPECT_EQ(1U, valueCardinality32.GetRef<std::uint32_t>());
+   EXPECT_EQ(1U, valueCardinality32.GetRef<ROOT::RNTupleCardinality<std::uint32_t>>());
 
    // TODO: test reading of "klassVec.v1"
 }


### PR DESCRIPTION
See the individual commits for the case-by-case changes and explanations.