### PR TITLE
[build] Simplify CMake in ATLAS DataVector test directory

### DIFF
--- a/roottest/root/ntuple/atlas-datavector/CMakeLists.txt
+++ b/roottest/root/ntuple/atlas-datavector/CMakeLists.txt
@@ -15,28 +15,13 @@ endif()
 # the ATLAS Athena build. Contributors
 # - It always builds the C++ module from the dictionary (in a module build of ROOT)
 # - It changes names of artifacts (e.g. removes the "lib" prefix from the shared library)
-set(CMAKE_ROOTTEST_DICT OFF)
-set(ATLASLIKEDATAVECTOR_DICTNAME AtlasLikeDataVectorDict)
-ROOT_GENERATE_DICTIONARY(
-	${ATLASLIKEDATAVECTOR_DICTNAME}
-	${CMAKE_CURRENT_SOURCE_DIR}/AtlasLikeDataVector.hxx
-	LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/selection.xml
+ROOTTEST_GENERATE_DICTIONARY(
+    AtlasLikeDataVectorDict
+    NO_CXXMODULE
+    ${CMAKE_CURRENT_SOURCE_DIR}/AtlasLikeDataVector.hxx
+    LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/selection.xml
+    FIXTURES_SETUP atlas_datavector_dict_setup
 )
-ROOTTEST_TARGETNAME_FROM_FILE(GENERATE_DICTIONARY_TEST ${ATLASLIKEDATAVECTOR_DICTNAME})
-set(GENERATE_DICTIONARY_TEST ${GENERATE_DICTIONARY_TEST}-build)
-
-# Generate a shared library from the dictionary sources
-set(ATLASLIKEDATAVECTOR_LIB ${ATLASLIKEDATAVECTOR_DICTNAME}libgen)
-add_library(${ATLASLIKEDATAVECTOR_LIB} SHARED ${ATLASLIKEDATAVECTOR_DICTNAME}.cxx)
-set_target_properties(${ATLASLIKEDATAVECTOR_LIB} PROPERTIES ${ROOT_LIBRARY_PROPERTIES})
-set_target_properties(${ATLASLIKEDATAVECTOR_LIB} PROPERTIES OUTPUT_NAME ${ATLASLIKEDATAVECTOR_DICTNAME})
-target_link_libraries(${ATLASLIKEDATAVECTOR_LIB} Core RIO ROOTNTuple)
-add_dependencies(${ATLASLIKEDATAVECTOR_LIB} ${ATLASLIKEDATAVECTOR_DICTNAME})
-
-add_test(NAME ${GENERATE_DICTIONARY_TEST}
-  COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}
-                           --target ${ATLASLIKEDATAVECTOR_DICTNAME} ${ATLASLIKEDATAVECTOR_LIB})
-set_property(TEST ${GENERATE_DICTIONARY_TEST} PROPERTY FIXTURES_SETUP atlas_datavector_dict_setup)
 
 # Generate an executable to write an RNTuple with a field of type
 # AtlasLikeDataVector<CustomStruct>. Note that we don't link explicitly


### PR DESCRIPTION
Using the `NO_CXXMODULE` option of `ROOTTEST_GENERATE_DICTIONARY` produces dictionary artifacts that correctly reproduce the ATLAS environment (i.e. there are no C++ module neither modulemap produced in the test build directory).