### PR TITLE
[cmake] Export root and root.exe

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT WIN32)
   endif()
   ROOT_EXECUTABLE(roots.exe roots.cxx LIBRARIES Core MathCore CMAKENOEXPORT)
 endif()
-ROOT_EXECUTABLE(root.exe rmain.cxx LIBRARIES Core Rint CMAKENOEXPORT)
+ROOT_EXECUTABLE(root.exe rmain.cxx LIBRARIES Core Rint)
 if(MSVC)
   set(root_exports "/EXPORT:_Init_thread_abort /EXPORT:_Init_thread_epoch \
       /EXPORT:_Init_thread_footer /EXPORT:_Init_thread_header /EXPORT:_tls_index \

--- a/rootx/CMakeLists.txt
+++ b/rootx/CMakeLists.txt
@@ -9,7 +9,7 @@
 # @author Pere Mato, CERN
 ############################################################################
 
-ROOT_EXECUTABLE(root src/rootx.cxx CMAKENOEXPORT)
+ROOT_EXECUTABLE(root src/rootx.cxx)
 
 if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
   target_link_libraries(root PRIVATE util procstat)


### PR DESCRIPTION
Export root and root.exe, following [this discussion](https://root-forum.cern.ch/t/removal-of-some-cmake-targets-in-root-6-36/63885)
