### PR TITLE
[hist] Ignore buffer in `TH1::Sumw2`

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -9064,9 +9064,6 @@ void TH1::Sumw2(Bool_t flag)
 
    fSumw2.Set(fNcells);
 
-   // empty the buffer
-   if (fBuffer) BufferEmpty();
-
    if (fEntries > 0)
       for (Int_t i = 0; i < fNcells; ++i)
          fSumw2.fArray[i] = TMath::Abs(RetrieveBinContent(i));

--- a/hist/hist/test/test_TH1.cxx
+++ b/hist/hist/test/test_TH1.cxx
@@ -6,6 +6,8 @@
 #include "TH1F.h"
 #include "THLimitsFinder.h"
 
+#include <cmath>
+#include <cstddef>
 #include <random>
 #include <vector>
 
@@ -278,4 +280,22 @@ TEST(TAxis, FindBinApprox)
       x -= x * std::numeric_limits<double>::epsilon();
       EXPECT_EQ(i, ax.FindBin(x));
    }
+}
+
+// https://github.com/root-project/root/issues/19359
+TEST(TH1, SetBufferedSumw2)
+{
+   // TH1::SetBuffer auto-adjusts small buffer sizes to at least 100 entries...
+   static constexpr std::size_t Entries = 200;
+   static constexpr double Weight = 2.0;
+
+   TH1D h1("name", "title", 1, 0, 1);
+   h1.SetBuffer(Entries);
+   for (std::size_t i = 0; i < Entries; i++) {
+      h1.Fill(0.5, Weight);
+   }
+   h1.Sumw2();
+
+   EXPECT_FLOAT_EQ(h1.GetBinContent(1), Entries * Weight);
+   EXPECT_FLOAT_EQ(h1.GetBinError(1), std::sqrt(Entries * Weight * Weight));
 }


### PR DESCRIPTION
Before, `Sumw2()` would first allocate `fSumw2`, then empty the buffer, and finally compute the weights squared. However, this last step assumed unweighted filling and would override weighted fills that happened as part of the buffering. Instead I believe it's possible to just leave the entries in the buffer and take care of them later.

Fixes #19359