### PR TITLE
Add support for Windows in the Jupyter kernel for Cling

### DIFF
--- a/interpreter/cling/tools/Jupyter/CMakeLists.txt
+++ b/interpreter/cling/tools/Jupyter/CMakeLists.txt
@@ -81,6 +81,10 @@ add_cling_library(libclingJupyter ${ENABLE_SHARED} ${ENABLE_STATIC}
 set_target_properties(libclingJupyter
         PROPERTIES ENABLE_EXPORTS 1)
 
+if(MSVC)
+    set_target_properties(libclingJupyter PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+endif()
+
 if(ENABLE_SHARED)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         set(LIBCLINGJUPYTER_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -137,7 +137,7 @@ class ClingKernel(Kernel):
         else:
             raise RuntimeError('cling at ' + clingInPath + ' is unusable. No cling, no fun.')
 
-        for libFolder in ["/lib/libclingJupyter.", "/libexec/lib/libclingJupyter."]:
+        for libFolder in ["/bin/libclingJupyter.", "/lib/libclingJupyter.", "/libexec/lib/libclingJupyter."]:
 
             for ext in ['so', 'dylib', 'dll']:
                 libFilename = clingInstDir + libFolder + ext

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -37,7 +37,10 @@ from jupyter_client.session import Session
 class my_void_p(ctypes.c_void_p):
   pass
 
-libc = ctypes.CDLL(None)
+if sys.platform == 'win32':
+    libc = ctypes.cdll.msvcrt
+else:
+    libc = ctypes.CDLL(None)
 try:
     c_stdout_p = ctypes.c_void_p.in_dll(libc, 'stdout')
     c_stderr_p = ctypes.c_void_p.in_dll(libc, 'stderr')

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -18,8 +18,6 @@ Talks to Cling via ctypes
 __version__ = '0.0.3'
 
 import ctypes
-from contextlib import contextmanager
-from fcntl import fcntl, F_GETFL, F_SETFL
 import os
 import shutil
 import select
@@ -59,8 +57,9 @@ class FdReplacer:
         os.dup2(pipe_in, self.real_fd)
         os.close(pipe_in)
         # make pipe_out non-blocking
-        flags = fcntl(self.pipe_out, F_GETFL)
-        fcntl(self.pipe_out, F_SETFL, flags|os.O_NONBLOCK)
+        # flags = fcntl(self.pipe_out, F_GETFL)
+        # fcntl(self.pipe_out, F_SETFL, flags|os.O_NONBLOCK)
+        os.set_blocking(self.pipe_out, False)
 
     def restore(self):
         os.close(self.real_fd)

--- a/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
+++ b/interpreter/cling/tools/Jupyter/kernel/clingkernel.py
@@ -39,15 +39,30 @@ class my_void_p(ctypes.c_void_p):
 
 if sys.platform == 'win32':
     libc = ctypes.cdll.msvcrt
+
+    class FILE(ctypes.Structure):
+        pass
+
+    FILE_p = ctypes.POINTER(FILE)
+
+    libc._fdopen.argtypes = [ctypes.c_int, ctypes.c_char_p]
+    libc._fdopen.restype = FILE_p
+
+    c_stdout_p = libc._fdopen(sys.stdout.fileno(), b"w")
+    c_stderr_p = libc._fdopen(sys.stderr.fileno(), b"w")
+
+    libc.fflush.argtypes = [FILE_p]
+    libc.fflush.restype = ctypes.c_int
 else:
     libc = ctypes.CDLL(None)
-try:
-    c_stdout_p = ctypes.c_void_p.in_dll(libc, 'stdout')
-    c_stderr_p = ctypes.c_void_p.in_dll(libc, 'stderr')
-except ValueError:
-    # libc.stdout is has a funny name on OS X
-    c_stdout_p = ctypes.c_void_p.in_dll(libc, '__stdoutp')
-    c_stderr_p = ctypes.c_void_p.in_dll(libc, '__stderrp')
+
+    try:
+        c_stdout_p = ctypes.c_void_p.in_dll(libc, 'stdout')
+        c_stderr_p = ctypes.c_void_p.in_dll(libc, 'stderr')
+    except ValueError:
+        # libc.stdout is has a funny name on OS X
+        c_stdout_p = ctypes.c_void_p.in_dll(libc, '__stdoutp')
+        c_stderr_p = ctypes.c_void_p.in_dll(libc, '__stderrp')
 
 
 class FdReplacer:

--- a/interpreter/cling/tools/Jupyter/kernel/setup.py
+++ b/interpreter/cling/tools/Jupyter/kernel/setup.py
@@ -31,7 +31,6 @@ if v[0] >= 3 and v[:2] < (3,3):
 #-----------------------------------------------------------------------------
 
 import os
-from glob import glob
 
 from distutils.core import setup
 
@@ -44,7 +43,11 @@ setup_args = dict(
     name            = name,
     version         = '0.0.2',
     py_modules      = ['clingkernel'],
-    scripts         = glob(pjoin('scripts', '*')),
+    entry_points    = {
+        'console_scripts': [
+            'jupyter-cling-kernel=clingkernel:main'
+        ],
+    },
     description     = "C++ Kernel for Jupyter with Cling",
     author          = 'Min RK, Axel Naumann',
     author_email    = 'cling-dev@cern.ch',


### PR DESCRIPTION
This PR adds support for Windows in the Jupyter kernel. On Windows (MSVCRT), the stdout and stderr file descriptors are not exported as global symbols. To work around this, we now retrieve them using [_fdopen](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen?view=msvc-170). Beginning with Python 3.12, we can utilize the new cross-platform API [os.set_blocking](https://docs.python.org/3.12/library/os.html#os.set_blocking) to configure pipes as non-blocking.

Since Windows does not offer a direct equivalent to the "select" system call for pipes, I replaced it with [PeekNamedPipe](https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-peeknamedpipe) to check for available data in the pipe. Unlike select, PeekNamedPipe does not allow efficient blocking. As a result, we currently poll every 0.25 seconds, aligning with the flush interval to check for new data and act accordingly.

The outcome looks appealing, with the interpreter's output and errors being correctly streamed.
<img width="665" height="335" alt="image" src="https://github.com/user-attachments/assets/cc254987-8955-48a4-b2eb-723a2208fc3a" />

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)