### PR TITLE
[CMake] Deduplicate static libraries if supported by linker.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT ALLOW_IN_SOURCE)
     " Please see README/INSTALL for more information.")
 endif()
 
-set(policy_new CMP0072 CMP0076 CMP0077 CMP0079)
+set(policy_new CMP0072 CMP0076 CMP0077 CMP0079
+    CMP0156 CMP0179 #deduplicate static libraries when linker supports it
+)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)


### PR DESCRIPTION
With linkers that rescan libraries, link recipes can be shortened. On Mac, the linker even emits a warning when `libgtest.a` is linked to twice. By moving to modern policies, CMake is allowed to deduplicate link recipes (if the linker supports it).

The first policy enables this feature on Windows, LLVM LD and Mac linkers. The second just means to keep the first occurrence.

This should fix the warning @dpiparo 
`ld: warning: ignoring duplicate libraries: '../../../googletest-prefix/src/googletest-build/lib//libgtest.a'`