### PR TITLE
[rdf] Fix dataframe_snapshot tests on Windows

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -48,19 +48,15 @@ if(MSVC)
   set_source_files_properties(dataframe_simple.cxx PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
-if(NOT MSVC OR win_broken_tests)
-  ROOT_ADD_GTEST(dataframe_snapshot dataframe_snapshot.cxx LIBRARIES ROOTDataFrame GenVector)
-  ROOT_GENERATE_DICTIONARY(DataFrameSnapshotUtils ${CMAKE_CURRENT_SOURCE_DIR}/DataFrameSnapshotUtils.hxx
-    MODULE dataframe_snapshot LINKDEF DataFrameSnapshotUtilsLinkDef.hxx OPTIONS -inlineInputHeader)
-endif()
+ROOT_ADD_GTEST(dataframe_snapshot dataframe_snapshot.cxx LIBRARIES ROOTDataFrame GenVector)
+ROOT_GENERATE_DICTIONARY(DataFrameSnapshotUtils ${CMAKE_CURRENT_SOURCE_DIR}/DataFrameSnapshotUtils.hxx
+  MODULE dataframe_snapshot LINKDEF DataFrameSnapshotUtilsLinkDef.hxx OPTIONS -inlineInputHeader)
 
-if(NOT MSVC OR win_broken_tests)
 ROOT_ADD_GTEST(dataframe_snapshot_emptyoutput dataframe_snapshot_emptyoutput.cxx LIBRARIES ROOTDataFrame GenVector)
 ROOT_GENERATE_DICTIONARY(DummyDict ${CMAKE_CURRENT_SOURCE_DIR}/DummyHeader.hxx
                          MODULE dataframe_snapshot_emptyoutput LINKDEF DummyHeaderLinkDef.hxx OPTIONS -inlineInputHeader
                          DEPENDENCIES ROOTVecOps GenVector)
 ROOT_ADD_GTEST(dataframe_snapshot_ntuple dataframe_snapshot_ntuple.cxx LIBRARIES ROOTDataFrame ROOTNTuple NTupleStruct)
-endif()
 
 ROOT_ADD_GTEST(dataframe_datasetspec dataframe_datasetspec.cxx LIBRARIES ROOTDataFrame)
 

--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -843,6 +843,7 @@ TEST(RDFSnapshotMore, Lazy)
    const auto fname1 = "lazy1.root";
    // make sure the file is not here beforehand
    gSystem->Unlink(fname0);
+   gSystem->Unlink(fname1);
    RDataFrame d(1);
    auto v = 0U;
    auto genf = [&v]() {
@@ -997,7 +998,7 @@ TEST(RDFSnapshotMore, CompositeTypeWithNameClash)
 {
    constexpr auto fName{"snap_compositetypewithnameclash.root"};
    struct FileGuard {
-      ~FileGuard() { std::remove(fName); }
+      ~FileGuard() { std::remove("snap_compositetypewithnameclash.root"); }
    } _;
    ROOT::RDataFrame df{3};
    auto snap_df = df.Define("i", [] { return Int{-1}; }).Define("x", [] { return 1; }).Snapshot("t", fName);


### PR DESCRIPTION
`dataframe_snapshot.cxx`: Fix the following compilation error:
```
dataframe_snapshot.cxx(1000,34): error C2326: 'RDFSnapshotMore_CompositeTypeWithNameClash_Test::TestBody::FileGuard::~FileGuard(void)': function cannot access 'fName'
```
and the following run-time error:
```
467: [ RUN      ] RDFSnapshotMore.Lazy
467: C:\root-dev\git\master\tree\dataframe\test\dataframe_snapshot.cxx(860): error: Value of: gSystem->AccessPathName(fname1)
467:   Actual: false
467: Expected: true
```
`dataframe_snapshot_ntuple.cxx`: Fix the following error:
```
469: [ RUN      ] RDFSnapshotRNTupleTest.InnerFields
469: ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'Snapshot':
469: Column electron.pt will be saved as electron_pt
469: ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'Snapshot':
469: Column jets.electrons will be saved as jets_electrons
469: C:\root-dev\git\master\core\testsupport\src\TestSupport.cxx(81): error: Failed
469: Received unexpected diagnostic of severity 5000 at 'TFile::TFile' reading 'could not delete C:\root-dev\build\x64\relwithdebinfo\tree\dataframe\test\RDFSnapshotRNTuple_inner_fields.root (errno: 13) Permission denied'.
469: Suppress those using ROOT/TestSupport.hxx
469: unknown file: error: C++ exception with description "Snapshot: could not create output file RDFSnapshotRNTuple_inner_fields.root" thrown in the test body.
469: [  FAILED  ] RDFSnapshotRNTupleTest.InnerFields (110 ms)
```
