### PR TITLE
Remove two unused dictionary rules

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/stltypes.xml
+++ b/bindings/pyroot/cppyy/cppyy/test/stltypes.xml
@@ -33,5 +33,4 @@
   <function pattern="ErrorNamespace::*" />
 
   <function name="GetMyErrorCount" />
-  <variable name="N" />
 </lcgdict>

--- a/tree/tree/inc/LinkDef.h
+++ b/tree/tree/inc/LinkDef.h
@@ -66,7 +66,6 @@
 #pragma link C++ class TCollectionPropertyBrowsable+;
 #pragma link C++ class TCollectionMethodBrowsable+;
 #pragma link C++ class TSelectorScalar+;
-#pragma link C++ class TQueryResult+;
 #pragma link C++ class TBranchSTL+;
 #pragma link C++ class TIndArray+;
 


### PR DESCRIPTION
The third warning that I see locally is addressed in https://github.com/root-project/root/pull/19202.