### PR TITLE
[io] Register TKey after successful Streamer()

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -327,7 +327,6 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
 
    fBufferRef = new TBufferFile(TBuffer::kWrite, bufsize);
    fBufferRef->SetParent(GetFile());
-   fCycle     = fMotherDir->AppendKey(this);
 
    Streamer(*fBufferRef);         //write key itself
    fKeylen    = fBufferRef->Length();
@@ -338,6 +337,10 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
    clActual->Streamer((void*)actualStart, *fBufferRef); //write object
    lbuf       = fBufferRef->Length();
    fObjlen    = lbuf - fKeylen;
+
+   // Append to mother directory only after the call to Streamer() was
+   // successful (and didn't throw).
+   fCycle = fMotherDir->AppendKey(this);
 
    Int_t cxlevel = GetFile() ? GetFile()->GetCompressionLevel() : 0;
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(GetFile() ? GetFile()->GetCompressionAlgorithm() : 0);

--- a/roottest/root/io/customStreamer/CMakeLists.txt
+++ b/roottest/root/io/customStreamer/CMakeLists.txt
@@ -2,3 +2,11 @@ ROOTTEST_ADD_TEST(run
                   MACRO run.C
                   OUTREF customStreamerTest.ref)
 
+ROOTTEST_GENERATE_DICTIONARY(StreamerThrowClass StreamerThrowClass.h
+                             LINKDEF StreamerThrowClass_LinkDef.h
+                             FIXTURES_SETUP root-io-customStreamer-StreamerThrow)
+# ACLiC compiled to work around problems with exceptions in Apple Silicon.
+ROOTTEST_ADD_TEST(StreamerThrow
+                  MACRO StreamerThrow.C+
+                  OUTREF StreamerThrow.ref
+                  FIXTURES_REQUIRED root-io-customStreamer-StreamerThrow)

--- a/roottest/root/io/customStreamer/StreamerThrow.C
+++ b/roottest/root/io/customStreamer/StreamerThrow.C
@@ -1,0 +1,19 @@
+#include "StreamerThrowClass.h"
+
+#include <TMemFile.h>
+
+#include <iostream>
+#include <stdexcept>
+
+void StreamerThrow()
+{
+   StreamerThrowClass c;
+   TMemFile f("mem.root", "RECREATE");
+   try {
+      f.WriteObject(&c, "c");
+   } catch (const std::runtime_error &e) {
+      std::cerr << "std::runtime_error: " << e.what() << "\n";
+   }
+   f.ls();
+   f.Close();
+}

--- a/roottest/root/io/customStreamer/StreamerThrow.ref
+++ b/roottest/root/io/customStreamer/StreamerThrow.ref
@@ -1,0 +1,4 @@
+
+std::runtime_error: streaming not supported
+TMemFile**		mem.root	
+ TMemFile*		mem.root	

--- a/roottest/root/io/customStreamer/StreamerThrowClass.h
+++ b/roottest/root/io/customStreamer/StreamerThrowClass.h
@@ -1,0 +1,12 @@
+#ifndef StreamerThrowClass_h
+#define StreamerThrowClass_h
+
+#include <stdexcept>
+
+class TBuffer;
+
+struct StreamerThrowClass final {
+   void Streamer(TBuffer &) { throw std::runtime_error("streaming not supported"); }
+};
+
+#endif

--- a/roottest/root/io/customStreamer/StreamerThrowClass_LinkDef.h
+++ b/roottest/root/io/customStreamer/StreamerThrowClass_LinkDef.h
@@ -1,0 +1,1 @@
+#pragma link C++ struct StreamerThrowClass-;


### PR DESCRIPTION
This avoids corrupting the in-memory `TFile` structure with throwing `Streamer()` functions.