### PR TITLE
[cmake][skip-ci] disable ROOT_8197 if no PyROOT

### DIFF
--- a/roottest/main/CMakeLists.txt
+++ b/roottest/main/CMakeLists.txt
@@ -98,12 +98,12 @@ ROOTTEST_ADD_TEST(RootlsRNTuple
 
 #########################################################################
 
+if(ROOT_pyroot_FOUND)
+
 ROOTTEST_ADD_TEST(ROOT_8197
                   MACRO ROOT_8197.C
                   OUTREF ROOT_8197.ref
                   ENVIRONMENT ${test_env})
-
-if(ROOT_pyroot_FOUND)
 
 # We compare the output of some tests against ref. files, and we don't want to
 # get noise for Python warnings (for example the warning that the GIL is


### PR DESCRIPTION
ROOT_8197.C calls gSystem->Exec("rootcp --recreate ...
