### PR TITLE
[geom] Disable a test when gdml unavailable.

### DIFF
--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -4,8 +4,10 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-configure_file(no_extrusion.gdml no_extrusion.gdml COPYONLY)
-ROOT_ADD_GTEST(geomTests
-  test_material_units.cxx
-  test_boolean_extrusion.cxx
-  LIBRARIES Geom)
+if(gdml)
+  configure_file(no_extrusion.gdml no_extrusion.gdml COPYONLY)
+  ROOT_ADD_GTEST(geomTests
+    test_material_units.cxx
+    test_boolean_extrusion.cxx
+    LIBRARIES Geom)
+endif()


### PR DESCRIPTION
The test fails because it emits warnings that the gdml couldn't be loaded.