### PR TITLE
Avoid including ambiguous TTree branch names

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -170,8 +170,8 @@ void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnNames_t &bN
          InsertBranchName(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName,
                           allowDuplicates);
 
-      if (bNamesReg.find(subBranchName) == bNamesReg.end() && t.GetBranch(subBranchName.c_str()))
-         InsertBranchName(bNamesReg, bNames, subBranchName, friendName, allowDuplicates);
+      // if (bNamesReg.find(subBranchName) == bNamesReg.end() && t.GetBranch(subBranchName.c_str()))
+      //    InsertBranchName(bNamesReg, bNames, subBranchName, friendName, allowDuplicates);
    }
 }
 

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -14,6 +14,8 @@ ROOT_ADD_GTEST(dataframe_callbacks dataframe_callbacks.cxx LIBRARIES ROOTDataFra
 ROOT_ADD_GTEST(dataframe_cloning dataframe_cloning.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_histomodels dataframe_histomodels.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_interface dataframe_interface.cxx LIBRARIES ROOTDataFrame)
+target_include_directories(dataframe_interface PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+ROOT_GENERATE_DICTIONARY(SimpleElectronDict ${CMAKE_CURRENT_SOURCE_DIR}/SimpleElectron.hxx MODULE dataframe_interface LINKDEF SimpleElectronLinkDef.hxx OPTIONS -inlineInputHeader DEPENDENCIES RIO)
 ROOT_ADD_GTEST(dataframe_nodes dataframe_nodes.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics ROOTDataFrame GenVector)
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/SimpleElectron.hxx
+++ b/tree/dataframe/test/SimpleElectron.hxx
@@ -1,0 +1,8 @@
+#ifndef ROOT_DATAFRAME_TEST_SIMPLE_JET
+#define ROOT_DATAFRAME_TEST_SIMPLE_JET
+
+struct SimpleElectron {
+   float electron_pt;
+};
+
+#endif

--- a/tree/dataframe/test/SimpleElectronLinkDef.hxx
+++ b/tree/dataframe/test/SimpleElectronLinkDef.hxx
@@ -1,0 +1,5 @@
+#ifdef __CLING__
+
+#pragma link C++ class SimpleElectron + ;
+
+#endif

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -13,6 +13,8 @@
 
 #include "gtest/gtest.h"
 
+#include "SimpleElectron.hxx"
+
 #include <thread>
 
 using namespace ROOT;
@@ -993,4 +995,49 @@ TEST(RDataFrameInterface, GetNFilesFromMoreFiles)
    TreeInFileRAII r3{filenames[2]};
    ROOT::RDataFrame df{"t", filenames};
    EXPECT_EQ(df.GetNFiles(), 3);
+}
+
+void expect_colnames_eq(const std::vector<std::string> &v1, const std::vector<std::string> &v2)
+{
+   ASSERT_EQ(v1.size(), v2.size()) << "Vectors 'v1' and 'v2' are of unequal length";
+   for (std::size_t i = 0ull; i < v1.size(); ++i) {
+      EXPECT_EQ(v1[i], v2[i]) << "Vectors 'v1' and 'v2' differ at index " << i;
+   }
+}
+
+// https://github.com/root-project/root/issues/19392
+TEST(RDataFrameInterface, GH19392)
+{
+   class FileRAII {
+   private:
+      std::string fPath;
+
+   public:
+      explicit FileRAII(const std::string &path) : fPath(path) {}
+      ~FileRAII() { std::remove(fPath.c_str()); }
+      auto GetPath() const { return fPath.c_str(); }
+   };
+
+   FileRAII fileraii{"dataframe_interface_gh19392.root"};
+   const auto treeName{"tree"};
+
+   {
+      auto file = std::make_unique<TFile>(fileraii.GetPath(), "RECREATE");
+      auto tree = std::make_unique<TTree>(treeName, treeName);
+
+      SimpleElectron el1;
+      el1.electron_pt = 10.f;
+
+      SimpleElectron el2;
+      el2.electron_pt = 20.f;
+
+      tree->Branch("el1", &el1);
+      tree->Branch("el2", &el2);
+      tree->Fill();
+      tree->Write();
+   }
+   ROOT::RDataFrame df(treeName, fileraii.GetPath());
+   const auto columns = df.GetColumnNames();
+   const std::vector<std::string> expectedCols{"el1", "el1.electron_pt", "el2", "el2.electron_pt"};
+   expect_colnames_eq(columns, expectedCols);
 }


### PR DESCRIPTION
When the input data source is a TTree, GetColumnNames gathers the list of all the available TTree branches. In case there are two branches in the tree (e.g. `el1` and `el2`), each of them has a sub-branch with the same name (e.g. `electron_pt`), TTree allows calling `GetBranch("electron_pt")` and returns the pointer to the sub-branch of the first main branch (i.e. `el1.electron_pt`). This behaviour can lead to ambiguities, thus avoid exposing the ambiguous column name via RDF.

A test is added to exemplify this case.

This PR fixes #19392 

Note that it is a draft PR as the fix is fairly obvious but I am not sure that it won't break other tests

