### PR TITLE
[pyroot] remove non-existing builtin_afterimage option

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/create_src_directory.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/create_src_directory.py
@@ -284,8 +284,7 @@ inp = os.path.join('cmake', 'modules', 'RootBuildOptions.cmake')
 outp = inp+'.new'
 new_cml = open(outp, 'w')
 for line in open(inp).readlines():
-    if 'ROOT_BUILD_OPTION(builtin_ftgl' in line or\
-       'ROOT_BUILD_OPTION(builtin_afterimage' in line:
+    if 'ROOT_BUILD_OPTION(builtin_ftgl' in line:
         line = '#'+line
     new_cml.write(line)
 new_cml.close()


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Follow-up of https://github.com/root-project/root/commit/0992621c3e8cadc920b9b139fca87261ef11c93b