### PR TITLE
[CI] Fix PR label string for skip code analysis

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -18,7 +18,7 @@ jobs:
         (github.event_name == 'pull_request' && !(
           contains(github.event.pull_request.title, '[skip-ci]') ||
           contains(github.event.pull_request.labels.*.name, 'skip ci') ||
-          contains(github.event.pull_request.labels.*.name, 'skip style checks')
+          contains(github.event.pull_request.labels.*.name, 'skip code analysis')
         ))
 
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
         (github.event_name == 'pull_request' && !(
           contains(github.event.pull_request.title, '[skip-ci]') ||
           contains(github.event.pull_request.labels.*.name, 'skip ci') ||
-          contains(github.event.pull_request.labels.*.name, 'skip style checks')
+          contains(github.event.pull_request.labels.*.name, 'skip code analysis')
         ))
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes a mistake the PR https://github.com/root-project/root/pull/19397, where `skip style checks` was mistakenly committed instead of `skip code analysis`

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
Resolves the issue in: https://github.com/root-project/root/pull/19397
