### PR TITLE
Revert "[CI] Remove the "upload event payload" step."

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -583,3 +583,19 @@ jobs:
       - name: ccache info (post)
         run: |
           ccache -s || true
+
+  event_file:
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
+    if: |
+        (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
+
+    name: "Upload Event Payload"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}


### PR DESCRIPTION
It is required to post "Test Resuls" as a PR comment, for example.

This reverts commit 445de95697f759b80d7f74efca9d92119912e8a7.