### PR TITLE
[Python][RDF] Enable Support for C++ Free Functions in RDF Define and Filter

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -729,6 +729,21 @@ static int tpp_setuseffi(CPPOverload*, PyObject*, void*)
     return 0;                 // dummy (__useffi__ unused)
 }
 
+//-----------------------------------------------------------------------------
+static PyObject* tpp_gettemplateargs(TemplateProxy* self, void*) {
+    if (!self->fTemplateArgs) {
+        Py_RETURN_NONE;
+    }
+
+    Py_INCREF(self->fTemplateArgs);
+    return self->fTemplateArgs;
+}
+
+//-----------------------------------------------------------------------------
+static int tpp_settemplateargs(TemplateProxy*, PyObject*, void*) {
+    PyErr_SetString(PyExc_AttributeError, "__template_args__ is read-only");
+    return -1;
+}
 
 //----------------------------------------------------------------------------
 static PyMappingMethods tpp_as_mapping = {
@@ -739,7 +754,9 @@ static PyGetSetDef tpp_getset[] = {
     {(char*)"__doc__", (getter)tpp_doc, (setter)tpp_doc_set, nullptr, nullptr},
     {(char*)"__useffi__", (getter)tpp_getuseffi, (setter)tpp_setuseffi,
       (char*)"unused", nullptr},
-    {(char*)nullptr,   nullptr,         nullptr, nullptr, nullptr}
+    {(char*)"__template_args__", (getter)tpp_gettemplateargs, (setter)tpp_settemplateargs,
+      (char*)"the template arguments for this method", nullptr},
+    {(char*)nullptr,   nullptr,         nullptr, nullptr, nullptr},
 };
 
 
@@ -770,6 +787,7 @@ static PyObject* tpp_overload(TemplateProxy* pytmpl, PyObject* args)
 {
 // Select and call a specific C++ overload, based on its signature.
     const char* sigarg = nullptr;
+    const char* tmplarg = nullptr;
     PyObject* sigarg_tuple = nullptr;
     int want_const = -1;
 
@@ -795,6 +813,11 @@ static PyObject* tpp_overload(TemplateProxy* pytmpl, PyObject* args)
         scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
         cppmeth = Cppyy::GetMethodTemplate(
             scope, pytmpl->fTI->fCppName, proto.substr(1, proto.size()-2));
+    } else if (PyArg_ParseTuple(args, const_cast<char*>("ss:__overload__"), &sigarg, &tmplarg)) {
+        scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
+        std::string full_name = std::string(pytmpl->fTI->fCppName) + "<" + tmplarg + ">";
+
+        cppmeth = Cppyy::GetMethodTemplate(scope, full_name, sigarg);
     } else if (PyArg_ParseTuple(args, const_cast<char*>("O|i:__overload__"), &sigarg_tuple, &want_const)) {
         PyErr_Clear();
         want_const = PyTuple_GET_SIZE(args) == 1 ? -1 : want_const;

--- a/bindings/pyroot/cppyy/patches/cppyy-Get-overload-from-template-proxy-using-tmpl-args.patch
+++ b/bindings/pyroot/cppyy/patches/cppyy-Get-overload-from-template-proxy-using-tmpl-args.patch
@@ -1,0 +1,70 @@
+From a78169cedc78a7a3787473652e394da3ead5dbdf Mon Sep 17 00:00:00 2001
+From: Silia Taider <siliataider@gmail.com>
+Date: Mon, 14 Jul 2025 11:26:30 +0200
+Subject: [PATCH] [Python][cppyy] Get overload from template proxy using input
+ and template arguments
+
+---
+ .../cppyy/CPyCppyy/src/TemplateProxy.cxx      | 25 ++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+index 20ea4929ad..235a804c37 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+@@ -729,6 +729,21 @@ static int tpp_setuseffi(CPPOverload*, PyObject*, void*)
+     return 0;                 // dummy (__useffi__ unused)
+ }
+ 
++//-----------------------------------------------------------------------------
++static PyObject* tpp_gettemplateargs(TemplateProxy* self, void*) {
++    if (!self->fTemplateArgs) {
++        Py_RETURN_NONE;
++    }
++
++    Py_INCREF(self->fTemplateArgs);
++    return self->fTemplateArgs;
++}
++
++//-----------------------------------------------------------------------------
++static int tpp_settemplateargs(TemplateProxy*, PyObject*, void*) {
++    PyErr_SetString(PyExc_AttributeError, "__template_args__ is read-only");
++    return -1;
++}
+ 
+ //----------------------------------------------------------------------------
+ static PyMappingMethods tpp_as_mapping = {
+@@ -739,7 +754,9 @@ static PyGetSetDef tpp_getset[] = {
+     {(char*)"__doc__", (getter)tpp_doc, (setter)tpp_doc_set, nullptr, nullptr},
+     {(char*)"__useffi__", (getter)tpp_getuseffi, (setter)tpp_setuseffi,
+       (char*)"unused", nullptr},
+-    {(char*)nullptr,   nullptr,         nullptr, nullptr, nullptr}
++    {(char*)"__template_args__", (getter)tpp_gettemplateargs, (setter)tpp_settemplateargs,
++      (char*)"the template arguments for this method", nullptr},
++    {(char*)nullptr,   nullptr,         nullptr, nullptr, nullptr},
+ };
+ 
+ 
+@@ -770,6 +787,7 @@ static PyObject* tpp_overload(TemplateProxy* pytmpl, PyObject* args)
+ {
+ // Select and call a specific C++ overload, based on its signature.
+     const char* sigarg = nullptr;
++    const char* tmplarg = nullptr;
+     PyObject* sigarg_tuple = nullptr;
+     int want_const = -1;
+ 
+@@ -795,6 +813,11 @@ static PyObject* tpp_overload(TemplateProxy* pytmpl, PyObject* args)
+         scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
+         cppmeth = Cppyy::GetMethodTemplate(
+             scope, pytmpl->fTI->fCppName, proto.substr(1, proto.size()-2));
++    } else if (PyArg_ParseTuple(args, const_cast<char*>("ss:__overload__"), &sigarg, &tmplarg)) {
++        scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
++        std::string full_name = std::string(pytmpl->fTI->fCppName) + "<" + tmplarg + ">";
++
++        cppmeth = Cppyy::GetMethodTemplate(scope, full_name, sigarg);
+     } else if (PyArg_ParseTuple(args, const_cast<char*>("O|i:__overload__"), &sigarg_tuple, &want_const)) {
+         PyErr_Clear();
+         want_const = PyTuple_GET_SIZE(args) == 1 ? -1 : want_const;
+-- 
+2.49.0
+

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
@@ -9,7 +9,9 @@
 ################################################################################
 import re
 import typing
+
 from .._numbadeclare import _NumbaDeclareDecorator
+
 
 class FunctionJitter:
     """
@@ -38,11 +40,12 @@ class FunctionJitter:
     fil1 = rdf.Filter( "Numba::" + func_call, "x is greater than 2")
 
     """
+
     # Variable to store previous functions so as to not rejit.
     function_cache = {}
     lambda_function_counter = 0  # Counter to name the lambda functions
 
-    def __init__(self, rdf: 'RDataFrame') -> None:
+    def __init__(self, rdf: "RDataFrame") -> None:
         self.rdf = rdf
         self.col_names: typing.List[str] = rdf.GetColumnNames()
         self.func: typing.Callable
@@ -61,7 +64,7 @@ class FunctionJitter:
         Else it is an a numpy array and maps it to corresponding RVec.
         Otherwise flags a type error
         Args:
-	    `   x: Variable whose type is to be determined
+            `   x: Variable whose type is to be determined
 
         Returns:
             type of the variable x
@@ -69,20 +72,21 @@ class FunctionJitter:
         try:
             import numpy as np
         except:
-            raise ImportError(
-                "Failed to import numpy during call to determine function signature.")
-        from ._rdf_conversion_maps import FUNDAMENTAL_PYTHON_TYPES, TREE_TO_NUMBA, NUMPY_TO_TREE
+            raise ImportError("Failed to import numpy during call to determine function signature.")
+        from ._rdf_conversion_maps import FUNDAMENTAL_PYTHON_TYPES, NUMPY_TO_TREE, TREE_TO_NUMBA
+
         if isinstance(x, str):
             # Can be string constant or can be column name
             if x in self.col_names:  # If x is a column
                 t = self.rdf.GetColumnType(x)
                 if t in TREE_TO_NUMBA:  # The column is a fundamental type from tree
                     return TREE_TO_NUMBA[t]
-                elif '<' in t:  # The column type is a RVec<type>
-                    if '>>' in t:  # It is a RVec<RVec<T>>
+                elif "<" in t:  # The column type is a RVec<type>
+                    if ">>" in t:  # It is a RVec<RVec<T>>
                         raise TypeError(
-                            f"Only columns with 'RVec<T>' where T is is a fundamental type are supported, not '{t}'.")
-                    g = re.match('(.*)<(.*)>', t).groups(0)
+                            f"Only columns with 'RVec<T>' where T is is a fundamental type are supported, not '{t}'."
+                        )
+                    g = re.match("(.*)<(.*)>", t).groups(0)
                     if g[1] in TREE_TO_NUMBA:
                         return "RVec<" + TREE_TO_NUMBA[g[1]] + ">"
                     # There are data type that leak into here. Not sure from where. But need to implement something here such that this condition is never met.
@@ -91,7 +95,7 @@ class FunctionJitter:
                 else:
                     return t
             else:
-                return 'str'
+                return "str"
                 #! Numba Declare does not support "string" type. Check _numbadeclare.Thus, Cannot pass string constants to the filter/Defines..
         elif type(x) in FUNDAMENTAL_PYTHON_TYPES:
             return FUNDAMENTAL_PYTHON_TYPES[type(x)]
@@ -99,12 +103,10 @@ class FunctionJitter:
             if x.dtype.type in NUMPY_TO_TREE:
                 return "RVec<" + NUMPY_TO_TREE[x.dtype.type] + ">"
             else:
-                raise TypeError(
-                    f"Support for {x.dtype.type} arrays is not yet supported.")
+                raise TypeError(f"Support for {x.dtype.type} arrays is not yet supported.")
         #! Need to work out how to map things like tuples, dicts, lists...
         else:
-                raise TypeError(
-                    f"Type of {type(x).__name__}:  {x} cannot be jitted.")
+            raise TypeError(f"Type of {type(x).__name__}:  {x} cannot be jitted.")
 
     def find_function_params(self, func):
         """
@@ -116,6 +118,7 @@ class FunctionJitter:
 
         """
         import inspect
+
         func_sign = inspect.signature(func)
         # Find the Return type
         if func_sign.return_annotation is inspect.Signature.empty:
@@ -145,8 +148,11 @@ class FunctionJitter:
         if n_cols > 0:
             # Check to see if all the parameters have been provided.
             if n_params != n_cols + n_constants:
-                raise ValueError("Not Enough values provided in the column list and extra_args. The function required {} parameters only {} provided.".format(
-                    n_params, n_cols+n_constants))
+                raise ValueError(
+                    "Not Enough values provided in the column list and extra_args. The function required {} parameters only {} provided.".format(
+                        n_params, n_cols + n_constants
+                    )
+                )
 
         # Mapping the column list to the first input parameters of the function.
         for idx, p in enumerate(self.params):
@@ -168,12 +174,15 @@ class FunctionJitter:
                 type_of_p = self.find_type(value_of_p)
                 # Bool(s) in python are represented as True/False but in C++ are true/false. The following if statements are to account for that
                 if type(value_of_p) == bool:
-                    if value_of_p: value_of_p = 'true'
-                    else: value_of_p = 'false'
+                    if value_of_p:
+                        value_of_p = "true"
+                    else:
+                        value_of_p = "false"
             else:  # the parameter was not in func_args. Thus this parameter has to be mapped to a column of rdf
                 if p not in self.col_names:
                     raise Exception(
-                        f"Unable to map function argument {p} to a column.\nUse correct name of column or pass a list of column names.")
+                        f"Unable to map function argument {p} to a column.\nUse correct name of column or pass a list of column names."
+                    )
                 value_of_p = p
                 type_of_p = self.find_type(p)
             self.args_info[p] = (type_of_p, value_of_p)
@@ -184,7 +193,7 @@ class FunctionJitter:
         Updates the class with new attributes func_call and func_sign to hold them,
         """
         func = self.func
-        if func.__name__ == '<lambda>':
+        if func.__name__ == "<lambda>":
             func.__name__ = f"_lambda_func_number_{FunctionJitter.lambda_function_counter}"
             FunctionJitter.lambda_function_counter += 1
         self.func_call = f"{func.__name__}({', '.join(str(arg_info[1]) for arg_info in self.args_info.values())})"
@@ -214,14 +223,14 @@ class FunctionJitter:
             func_call, func_sign = FunctionJitter.function_cache[func.__name__]
             self.get_function_params_args_call(func, cols_list, extra_args)
             if self.func_sign != func_sign:
-                raise ValueError(
-                    "Trying to re-use a function. Do not change function signature.".format(func))
+                raise ValueError("Trying to re-use a function. Do not change function signature.")
             return self.func_call
 
         self.get_function_params_args_call(func, cols_list, extra_args)
         _NumbaDeclareDecorator(self.func_sign, self.return_type)(self.func)
         FunctionJitter.function_cache[self.func.__name__] = (self.func_call, self.func_sign)
         return self.func_call
+
 
 def _convert_to_vector(args):
     """
@@ -243,22 +252,23 @@ def _convert_to_vector(args):
         return args
 
     try:
-        v = ROOT.std.vector['std::string'](args[0])
+        v = ROOT.std.vector["std::string"](args[0])
     except TypeError:
-        raise TypeError(
-            f"The list of columns of a Filter operation can only contain strings. Please check: {args[0]}")
+        raise TypeError(f"The list of columns of a Filter operation can only contain strings. Please check: {args[0]}")
 
     return (v, *args[1:])
+
 
 def remove_fn_name_from_signature(signature):
     """
     Removes the function name from a signature string.
     The signature is expected to be in the form of "return_type function_name(type param1, type param2, ...)".
     """
-    if '(' not in signature or ')' not in signature:
+    if "(" not in signature or ")" not in signature:
         raise ValueError(f"Invalid signature format: {signature}")
 
-    return signature[:signature.index(' ')] + signature[signature.index('('):]
+    return signature[: signature.index(" ")] + signature[signature.index("(") :]
+
 
 def get_cpp_overload_from_templ_proxy(func, types=None):
     """
@@ -269,8 +279,10 @@ def get_cpp_overload_from_templ_proxy(func, types=None):
     template_args = func.__template_args__[1:-1] if func.__template_args__ else ""
     return func.__overload__(signature, template_args)
 
+
 def get_column_types(rdf, cols):
     return [rdf.GetColumnType(col) for col in cols]
+
 
 def get_overload_based_on_args(overload_types, types):
     """
@@ -287,7 +299,7 @@ def get_overload_based_on_args(overload_types, types):
         return next(iter(overload_types))
 
     for full_sig, info in overload_types.items():
-        input_types = info.get('input_types', ())
+        input_types = info.get("input_types", ())
 
         if len(input_types) != len(types):
             continue
@@ -302,7 +314,10 @@ def get_overload_based_on_args(overload_types, types):
         if match:
             return full_sig
 
-    raise ValueError(f"No matching overload found for types: {types} in signatures: {overload_types.keys()}. Please check the function overloads.")
+    raise ValueError(
+        f"No matching overload found for types: {types} in signatures: {overload_types.keys()}. Please check the function overloads."
+    )
+
 
 def _get_cpp_signature(func, rdf, cols):
     """
@@ -320,6 +335,7 @@ def _get_cpp_signature(func, rdf, cols):
     matched_overload = get_overload_based_on_args(overload_types, get_column_types(rdf, cols))
     return remove_fn_name_from_signature(matched_overload)
 
+
 def _to_std_function(func, rdf, cols):
     """
     Converts a cppyy callable to std::function.
@@ -331,6 +347,7 @@ def _to_std_function(func, rdf, cols):
 
     signature = _get_cpp_signature(func, rdf, cols)
     return cppyy.gbl.std.function(signature)
+
 
 def _handle_cpp_callables(func, original_template, *args, rdf=None, cols=None):
     """
@@ -360,9 +377,9 @@ def _handle_cpp_callables(func, original_template, *args, rdf=None, cols=None):
 
     import cppyy
 
-    is_cpp_functor  = lambda : isinstance(getattr(func, '__call__', None), cppyy._backend.CPPOverload)
+    is_cpp_functor = lambda: isinstance(getattr(func, "__call__", None), cppyy._backend.CPPOverload)
 
-    is_std_function = lambda : isinstance(getattr(func, 'target_type', None), cppyy._backend.CPPOverload)
+    is_std_function = lambda: isinstance(getattr(func, "target_type", None), cppyy._backend.CPPOverload)
 
     # handle free functions
     if callable(func) and not is_cpp_functor() and not is_std_function():
@@ -370,12 +387,13 @@ def _handle_cpp_callables(func, original_template, *args, rdf=None, cols=None):
             func = _to_std_function(func, rdf, cols)
         except TypeError as e:
             if "Expected a cppyy callable" in str(e):
-                pass # this function is not convertible to std::function, move on to the next check
+                pass  # this function is not convertible to std::function, move on to the next check
             else:
                 raise
 
     if is_cpp_functor() or is_std_function():
         return original_template[type(func)](*args)
+
 
 def _PyFilter(rdf, callable_or_str, *args, extra_args={}):
     """
@@ -418,42 +436,47 @@ def _PyFilter(rdf, callable_or_str, *args, extra_args={}):
     # The 1st argument is either a string or a python callable.
     if not callable(callable_or_str):
         raise TypeError(
-            f"The first argument of a Filter operation should be a callable. {type(callable_or_str).__name__} object is not callable.")
+            f"The first argument of a Filter operation should be a callable. {type(callable_or_str).__name__} object is not callable."
+        )
 
     if len(args) > 2:
-        raise TypeError(
-            f"Filter takes at most 3 positional arguments but {len(args) + 1} were given")
+        raise TypeError(f"Filter takes at most 3 positional arguments but {len(args) + 1} were given")
 
     func = callable_or_str
     col_list = []
-    filter_name  = ""
-    
+    filter_name = ""
+
     if len(args) == 1:
-        if isinstance(args[0], list): 
+        if isinstance(args[0], list):
             col_list = args[0]
         elif isinstance(args[0], str):
             filter_name = args[0]
         else:
             raise ValueError(f"Argument should be either 'list' or 'str', not {type(args[0]).__name__}.")
-    
+
     elif len(args) == 2:
         if isinstance(args[0], list) and isinstance(args[1], str):
             col_list = args[0]
             filter_name = args[1]
         else:
-            raise ValueError(f"Arguments should be ('list', 'str',) not ({type(args[0]).__name__,type(args[1]).__name__}.")
+            raise ValueError(
+                f"Arguments should be ('list', 'str',) not ({type(args[0]).__name__, type(args[1]).__name__}."
+            )
 
     rdf_node = _handle_cpp_callables(func, rdf._OriginalFilter, func, *_convert_to_vector(args), rdf=rdf, cols=col_list)
     if rdf_node is not None:
         return rdf_node
 
     jitter = FunctionJitter(rdf)
-    func.__annotations__['return'] = 'bool' # return type for Filters is bool # Note: You can keep double and Filter still works.
-            
+    func.__annotations__["return"] = (
+        "bool"  # return type for Filters is bool # Note: You can keep double and Filter still works.
+    )
+
     func_call = jitter.jit_function(func, col_list, extra_args)
     return rdf._OriginalFilter("Numba::" + func_call, filter_name)
 
-def _PyDefine(rdf, col_name, callable_or_str, cols = [] , extra_args = {} ):
+
+def _PyDefine(rdf, col_name, callable_or_str, cols=[], extra_args={}):
     """
     Defines a new column in the RDataFrame.
     Arguments:
@@ -465,7 +488,7 @@ def _PyDefine(rdf, col_name, callable_or_str, cols = [] , extra_args = {} ):
     4. extra_args: non-columnar arguments to be passed to the callable.
     Returns:
         RDataFrame: rdf with new column defined
-    
+
     Examples:
     1. rdf.Define("x", lambda: np.random.rand())
         Define using a python lambda
@@ -483,22 +506,26 @@ def _PyDefine(rdf, col_name, callable_or_str, cols = [] , extra_args = {} ):
 
     """
     if not isinstance(col_name, str):
-        raise TypeError(f"First argument of Define must be a valid string for the new column name. {type(col_name).__name__} is not a string.")
+        raise TypeError(
+            f"First argument of Define must be a valid string for the new column name. {type(col_name).__name__} is not a string."
+        )
 
-    if isinstance(callable_or_str, str): # If string argument is passed. Invoke the Original Define.
+    if isinstance(callable_or_str, str):  # If string argument is passed. Invoke the Original Define.
         return rdf._OriginalDefine(col_name, callable_or_str)
 
-    if not callable(callable_or_str): # The 2st argument is either a string or a python callable.
-        raise TypeError(f"The second argument of a Define operation should be a callable. {type(callable_or_str).__name__} object is not callable.")
-    
-    if not isinstance(cols, list):        
+    if not callable(callable_or_str):  # The 2st argument is either a string or a python callable.
+        raise TypeError(
+            f"The second argument of a Define operation should be a callable. {type(callable_or_str).__name__} object is not callable."
+        )
+
+    if not isinstance(cols, list):
         raise TypeError(f"Define takes a column list as third arguments but {type(cols).__name__} was given.")
-    
+
     func = callable_or_str
     rdf_node = _handle_cpp_callables(func, rdf._OriginalDefine, col_name, func, cols, rdf=rdf, cols=cols)
     if rdf_node is not None:
         return rdf_node
 
-    jitter = FunctionJitter(rdf)    
+    jitter = FunctionJitter(rdf)
     func_call = jitter.jit_function(func, cols, extra_args)
     return rdf._OriginalDefine(col_name, "Numba::" + func_call)

--- a/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
@@ -15,65 +15,71 @@ class PyDefine(unittest.TestCase):
 
     def test_with_dtypes(self):
         """
-        Tests the pythonized define with all the numba declare datatypes and 
+        Tests the pythonized define with all the numba declare datatypes and
         """
-        numba_declare_dtypes = ['float', 'double', 'int', 'unsigned int', 'long', 'unsigned long', 'bool']
+        numba_declare_dtypes = ["float", "double", "int", "unsigned int", "long", "unsigned long", "bool"]
         rdf = ROOT.RDataFrame(10)
         for type in numba_declare_dtypes:
-            col_name = "col_" + type.replace(" ","") 
+            col_name = "col_" + type.replace(" ", "")
             rdf = rdf.Define(col_name, f"({type}) rdfentry_")
-            rdf = rdf.Define(col_name + "_arr", lambda col: np.array([col,col]), [col_name])
+            rdf = rdf.Define(col_name + "_arr", lambda col: np.array([col, col]), [col_name])
             arr = np.arange(0, 10)
-            if type == 'bool':
-                arr = np.array(arr, dtype='bool')
+            if type == "bool":
+                arr = np.array(arr, dtype="bool")
             flag1 = np.array_equal(rdf.AsNumpy()[col_name], arr)
             flag2 = True
             for idx, entry in enumerate(rdf.AsNumpy()[col_name + "_arr"]):
                 if not (entry[0] == arr[idx] and entry[1] == arr[idx]):
                     flag2 = False
             self.assertTrue(flag1 and flag2)
-    
+
     def test_define_overload1(self):
         rdf = ROOT.RDataFrame(10).Define("x", "rdfentry_")
-        rdf = rdf.Define("x2", lambda y: y*y, ["x"])
+        rdf = rdf.Define("x2", lambda y: y * y, ["x"])
         arr = np.arange(0, 10)
-        flag = np.array_equal(rdf.AsNumpy()["x2"], arr*arr)
+        flag = np.array_equal(rdf.AsNumpy()["x2"], arr * arr)
         self.assertTrue(flag)
 
     def test_define_overload2(self):
         rdf = ROOT.RDataFrame(10).Define("x", "rdfentry_")
-        rdf = rdf.Define("x2", lambda x: x*x)
+        rdf = rdf.Define("x2", lambda x: x * x)
         arr = np.arange(0, 10)
-        flag = np.array_equal(rdf.AsNumpy()["x2"], arr*arr)
+        flag = np.array_equal(rdf.AsNumpy()["x2"], arr * arr)
         self.assertTrue(flag)
 
     def test_define_extra_args(self):
         rdf = ROOT.RDataFrame(10).Define("x", "rdfentry_")
+
         def x_y(x, y):
-            return x*y
-        rdf = rdf.Define("x_y", x_y , extra_args = {"y": 0.5})
+            return x * y
+
+        rdf = rdf.Define("x_y", x_y, extra_args={"y": 0.5})
         arr = np.arange(0, 10)
-        flag = np.array_equal(rdf.AsNumpy()["x_y"], arr*0.5)
+        flag = np.array_equal(rdf.AsNumpy()["x_y"], arr * 0.5)
         self.assertTrue(flag)
 
     def test_capture_from_scope(self):
         rdf = ROOT.RDataFrame(10).Define("x", "rdfentry_")
         y = 0.5
+
         def x_times_y(x):
-            return x*y
-        rdf = rdf.Define("x_y", x_times_y )
+            return x * y
+
+        rdf = rdf.Define("x_y", x_times_y)
         arr = np.arange(0, 10)
-        flag = np.array_equal(rdf.AsNumpy()["x_y"], arr*0.5)
+        flag = np.array_equal(rdf.AsNumpy()["x_y"], arr * 0.5)
         self.assertTrue(flag)
-        
+
     def test_arrays(self):
         rdf = ROOT.RDataFrame(5).Define("x", "rdfentry_")
-        rdf = rdf.Define("x_arr", lambda x:  np.array([x, x]))
+        rdf = rdf.Define("x_arr", lambda x: np.array([x, x]))
+
         def norm(x_arr):
-            return np.sqrt(x_arr[0]**2 + x_arr[1]**2)
+            return np.sqrt(x_arr[0] ** 2 + x_arr[1] ** 2)
+
         rdf = rdf.Define("mag", norm)
         arr = np.arange(0, 5)
-        arr = np.sqrt(arr*arr + arr*arr )
+        arr = np.sqrt(arr * arr + arr * arr)
         flag = np.array_equal(rdf.AsNumpy()["mag"], arr)
         self.assertTrue(flag)
 
@@ -94,8 +100,8 @@ class PyDefine(unittest.TestCase):
         rdf = ROOT.RDataFrame(5)
         rdf2 = rdf.Define("x", f, ["rdfentry_"])
 
-        for x,y in zip(rdf2.Take['ULong64_t']("rdfentry_"), rdf2.Take['ULong64_t']("x")):
-           self.assertEqual(x*x, y)
+        for x, y in zip(rdf2.Take["ULong64_t"]("rdfentry_"), rdf2.Take["ULong64_t"]("x")):
+            self.assertEqual(x * x, y)
 
     def test_std_function(self):
         """
@@ -110,8 +116,8 @@ class PyDefine(unittest.TestCase):
         rdf = ROOT.RDataFrame(5)
         rdf2 = rdf.Define("x", ROOT.myfun, ["rdfentry_"])
 
-        for x,y in zip(rdf2.Take['ULong64_t']("rdfentry_"), rdf2.Take['ULong64_t']("x")):
-           self.assertEqual(x*x, y)
+        for x, y in zip(rdf2.Take["ULong64_t"]("rdfentry_"), rdf2.Take["ULong64_t"]("x")):
+            self.assertEqual(x * x, y)
 
     def test_cpp_free_function(self):
         """
@@ -170,14 +176,11 @@ class PyDefine(unittest.TestCase):
                 """,
                 "coltype": "MyStruct2",
                 "define_args": ["s_col", "int_col"],
-                "setup_columns": {
-                    "s_col": "MyStruct2()",
-                    "int_col": "(int)rdfentry_"
-                },
+                "setup_columns": {"s_col": "MyStruct2()", "int_col": "(int)rdfentry_"},
                 "callable": lambda: ROOT.my_free_function_two_args,
                 "extract_fn": lambda s: s.value,
                 "expected_fn": lambda i: i,
-            }
+            },
         ]
 
         for case in test_cases:
@@ -236,5 +239,5 @@ class PyDefine(unittest.TestCase):
             self.assertEqual(x, y)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
@@ -188,8 +188,7 @@ class PyFilter(unittest.TestCase):
         )
 
         rdf2 = ROOT.RDataFrame(5)
-        c = rdf2.Define("x", "(int) rdfentry_") \
-                .Filter(ROOT.myfun_t[int], ["x"]).Count().GetValue()
+        c = rdf2.Define("x", "(int) rdfentry_").Filter(ROOT.myfun_t[int], ["x"]).Count().GetValue()
 
         self.assertEqual(c, 1)
 

--- a/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
@@ -139,6 +139,60 @@ class PyFilter(unittest.TestCase):
 
         self.assertEqual(c, 1)
 
+    def test_cpp_free_function(self):
+        """
+        Test that a C++ free function can be passed as a callable argument of a
+        Filter operation.
+        """
+
+        ROOT.gInterpreter.Declare(
+            """
+        bool myfun(ULong64_t l) { return l == 0; }
+        """
+        )
+
+        rdf = ROOT.RDataFrame(5)
+        c = rdf.Filter(ROOT.myfun, ["rdfentry_"]).Count().GetValue()
+
+        self.assertEqual(c, 1)
+
+    def test_cpp_free_function_overload(self):
+        """
+        Test that an overload of a C++ free function can be passed as a callable argument of a
+        Filter operation with overloads.
+        """
+
+        ROOT.gInterpreter.Declare(
+            """
+        bool myfun(ULong64_t l) { return l == 0; }
+        bool myfun(int l) { return true; }
+        """
+        )
+
+        rdf = ROOT.RDataFrame(5)
+        c = rdf.Filter(ROOT.myfun, ["rdfentry_"]).Count().GetValue()
+
+        self.assertEqual(c, 1)
+
+    def test_cpp_free_function_template(self):
+        """
+        Test that a C++ free function template can be passed as a callable argument of a
+        Filter operation.
+        """
+
+        ROOT.gInterpreter.Declare(
+            """
+        template <typename T>
+        bool myfun_t(T l) { return l == 0; }
+        """
+        )
+
+        rdf2 = ROOT.RDataFrame(5)
+        c = rdf2.Define("x", "(int) rdfentry_") \
+                .Filter(ROOT.myfun_t[int], ["x"]).Count().GetValue()
+
+        self.assertEqual(c, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# This Pull request:

This PR extends the `RDataFrame` pythonizations by adding support for passing C++ free functions to `.Define()` and `Filter` operations, with support for:
- Templated functions
- Overloaded functions
- Functions taking any input/output combination  of
    - Fundamental types
    - ROOT types (e.g. TObject-derived classes)
    - User-defined C++ classes

The implementation works by converting the free function to `std::function` using the function's signature.

> [!warning]
> This currently doesn't work if the function takes templated types as input arguments like STL containers (e.g. `std::vector<T>`) because of #19358
> Concretely, this doesn't work:
> ```cpp
> bool has_even_sum(const RVec<int>& v) {
>    return Sum(v) % 2 == 0;
> } 
> ```

> [!important]
> Prerequisites / TODO:
> - [x] Bring #9138 up to date and merge it: this implementation relies on the API provided by this PR for selecting the proper overload.
> - [ ] #19358: this would unlock a wide range of use-cases, like the example mentioned above.
>        - This should not block this PR though
> - [x] Update documentation / examples

**Quick demo:**
```python
import ROOT

ROOT.gInterpreter.Declare(""" 
struct MyStruct {
    int a;
    MyStruct() : a(0) {}
    MyStruct(int a_) : a(a_) {}
};
                          
float struct_a(const MyStruct& s) {
    return s.a;
}                          

bool is_even(int x) {
    return x % 2 == 0;
}
                          
bool is_even(int x, float y) {
    return x % 2 == 0 && x == y;
}                                                 

template <typename T>
bool is_even_t(const T x, const float y) {
    return x % 2 == 0 && x == y;
}
""")

rdf = ROOT.RDataFrame(3) \
         .Define("x", "(int)rdfentry_") \
         .Define("y", "(float)rdfentry_") \
         .Define("is_even_x", ROOT.is_even, ["x"]) \
         .Define("is_even_x_y", ROOT.is_even, ["x", "y"]) \
         .Define("is_even_t", ROOT.is_even_t[int], ["x", "y"]) \
         .Define("my_struct", "MyStruct((int)rdfentry_)") \
         .Define("struct_a", ROOT.struct_a, ["my_struct"]) 
         
rdf.Display().Print()
```