### PR TITLE
[skip-ci][hist] Fix file documentation

### DIFF
--- a/hist/histv7/inc/ROOT/RLinearizedIndex.hxx
+++ b/hist/histv7/inc/ROOT/RLinearizedIndex.hxx
@@ -1,3 +1,4 @@
+/// \file
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 

--- a/hist/histv7/inc/ROOT/RRegularAxis.hxx
+++ b/hist/histv7/inc/ROOT/RRegularAxis.hxx
@@ -1,3 +1,4 @@
+/// \file
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 

--- a/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
+++ b/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
@@ -1,3 +1,4 @@
+/// \file
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
 


### PR DESCRIPTION
Otherwise Doxygen will associate to the next declaration, which is `namespace ROOT`.