### PR TITLE
added tutorial for RooMultiPdf

### DIFF
--- a/tutorials/roofit/roofit/RooMultiPdf_tutorial.C
+++ b/tutorials/roofit/roofit/RooMultiPdf_tutorial.C
@@ -1,0 +1,120 @@
+#include <RooRealVar.h>
+#include <RooAbsPdf.h>
+#include <RooCategory.h>
+#include <RooArgList.h>
+#include <RooMultiPdf.h>
+#include <RooDataSet.h>
+#include <RooMinimizer.h>
+#include <RooAbsReal.h>
+#include <RooGaussian.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace RooFit;
+
+void RooMultiPdf_tutorial()
+{
+   RooRealVar x("x", "x", -10, 10);
+
+   RooRealVar true_mean("true_mean", "true mean", 0);
+   RooRealVar true_sigma("true_sigma", "true sigma", 1, 0.01, 5);
+   RooGaussian true_pdf("true_pdf", "True Gaussian", x, true_mean, true_sigma);
+
+   std::unique_ptr<RooDataSet> data(true_pdf.generate(x, 10));
+
+   RooRealVar mean1("mean1", "mean1", 0, -1.5, 1.5);
+   RooRealVar mean2("mean2", "mean2", 0.5, -1.5, 1.5);
+   RooRealVar mean3("mean3", "mean3", 2, -1.5, 1.5);
+
+   RooRealVar sigma1("sigma1", "sigma1", 1.11, 0.1, 5);
+   RooRealVar sigma2("sigma2", "sigma2", 1.10, 0.1, 5);
+   RooRealVar sigma3("sigma3", "sigma3", 1.05, 0.1, 5);
+
+   RooGaussian gauss1("gauss1", "Gaussian 1", x, mean1, sigma1);
+   RooGaussian gauss2("gauss2", "Gaussian 2", x, mean1, sigma2);
+   RooGaussian gauss3("gauss3", "Gaussian 3", x, mean1, sigma3);
+
+   mean1.setConstant(false); // at least one of the parameters should be free in order to minimizer to work
+
+   // mean2.setConstant(true);
+   // mean3.setConstant(true);
+   sigma1.setConstant(true);
+   sigma2.setConstant(true);
+   sigma3.setConstant(true);
+
+   RooCategory indexCat("indexCat", "Model index");
+
+   RooArgList pdfList;
+   pdfList.add(gauss1);
+   pdfList.add(gauss2);
+   pdfList.add(gauss3);
+
+   RooMultiPdf multiPdf("multiPdf", "Multi-model PDF", indexCat, pdfList);
+
+   // Fix the index to 0 (e.g. gauss1) for this example
+   indexCat.setIndex(0);
+   indexCat.setConstant();
+
+   std::unique_ptr<RooAbsReal> nll(multiPdf.createNLL(*data, EvalBackend("codegen")));
+
+   std::unique_ptr<RooAbsReal> nll2(gauss2.createNLL(*data, EvalBackend("codegen")));
+   std::unique_ptr<RooAbsReal> nll3(gauss3.createNLL(*data, EvalBackend("codegen")));
+
+   RooMinimizer minim(*nll);
+   minim.setPrintLevel(1);
+   minim.minimize("Minuit2", "Migrad");
+
+   /* std::cout << "Best model index = " << indexCat.getIndex() << std::endl;
+    std::cout << "Best PDF: " << multiPdf.getCurrentPdf()->GetName() << std::endl; */
+
+   RooPlot *frame1 = mean1.frame(Title("RooMultiPdf fit to toy data"));
+
+   nll->plotOn(frame1, LineColor(kBlack));
+   nll2->plotOn(frame1, LineColor(kRed));
+   nll3->plotOn(frame1, LineColor(kBlue));
+
+   TCanvas *c1 = new TCanvas("c1", "NLL Plot", 800, 600); // NLL plot
+   frame1->Draw();
+   c1->Update();
+   // Minimize over all pdfs
+   double bestNLL = 1e30;
+   int bestIndex = -1;
+   RooAbsReal *bestNLLObj = nullptr;
+
+   int nPdfs = pdfList.getSize();
+   int currentIndex = 0;
+
+   std::vector<std::unique_ptr<RooAbsReal>> nlls;
+
+   while (currentIndex < nPdfs) {
+      std::cout << "Fitting model index " << currentIndex << std::endl;
+
+      indexCat.setIndex(currentIndex);
+      indexCat.setConstant(true);
+
+      auto currentNLL = std::unique_ptr<RooAbsReal>(multiPdf.createNLL(*data, EvalBackend("codegen")));
+
+      RooMinimizer currentMinim(*currentNLL);
+      currentMinim.setPrintLevel(0);
+      currentMinim.minimize("Minuit2", "Migrad");
+
+      double nllVal = currentNLL->getVal();
+      std::cout << "NLL value for index " << currentIndex << " = " << nllVal << std::endl;
+
+      nlls.push_back(std::move(currentNLL));
+
+      if (nllVal < bestNLL) {
+         bestNLL = nllVal;
+         bestIndex = currentIndex;
+         bestNLLObj = nlls.back().get();
+      }
+
+      ++currentIndex;
+   }
+
+   std::cout << "\nBrute-force Best model index = " << bestIndex << std::endl;
+   std::cout << "Brute-force Best NLL value = " << bestNLL << std::endl;
+}


### PR DESCRIPTION
In this pull request I present a tutorial showcasing the usage of RooMultiPdf with its full implementation.The NLL value is poroduced with  codegen in order to show how the RooMultiPdf object acts under the implementation of AD.The output of the code is the following:Processing RooMultiPdf_tutorial.C...
[#1] INFO:Fitting -- RooAbsPdf::fitTo(multiPdf) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 3.38277 ms
[#1] INFO:Fitting -- using generic CPU library compiled with no vectorizations
MathFunc call used
[#1] INFO:Fitting -- Function JIT time: 59.1723 ms
[#1] INFO:Fitting -- Gradient generation time: 19.3769 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 28.6284 ms
[#1] INFO:Fitting -- [FitHelpers] Detected correction term from RooAbsPdf::getCorrection(). Adding penalty to NLL.
[#1] INFO:Fitting -- RooAbsPdf::fitTo(gauss2_over_gauss2_Int[x]) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 119.719 μs
[#1] INFO:Fitting -- Function JIT time: 5.04805 ms
[#1] INFO:Fitting -- Gradient generation time: 5.68462 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 6.00547 ms
[#1] INFO:Fitting -- RooAbsPdf::fitTo(gauss3_over_gauss3_Int[x]) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 98.145 μs
[#1] INFO:Fitting -- Function JIT time: 3.95232 ms
[#1] INFO:Fitting -- Gradient generation time: 5.44243 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 5.60852 ms
[#1] INFO:Fitting -- RooAddition::defaultErrorLevel(nll_multiPdf_true_pdfData_corrected) WARNING: Summation contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0
Minuit2Minimizer: Minimize with max-calls 500 convergence for edm < 1 strategy 1
Info in <Minuit2>: MnSeedGenerator Computing seed using NumericalGradient calculator
Info in <Minuit2>: MnSeedGenerator Evaluated function and gradient in 116.115 μs
Info in <Minuit2>: MnSeedGenerator Initial state: FCN =       12.64016428 Edm =     0.02017136278 NCalls =      5
Info in <Minuit2>: MnSeedGenerator Initial state  
  Minimum value : 12.64016428
  Edm           : 0.02017136278
  Internal parameters:	[                0]	
  Internal gradient  :	[    -0.8583232415]	
  Internal covariance matrix:
[[     0.10952001]]]
Info in <Minuit2>: VariableMetricBuilder Start iterating until Edm is < 0.002 with call limit = 500
Info in <Minuit2>: VariableMetricBuilder    0 - FCN =       12.64016428 Edm =     0.02017136278 NCalls =      5
Info in <Minuit2>: VariableMetricBuilder    1 - FCN =       12.61999292 Edm =   2.729690095e-09 NCalls =      8
Info in <Minuit2>: MnHesse Done after 19.482 μs
Info in <Minuit2>: VariableMetricBuilder After Hessian
Info in <Minuit2>: VariableMetricBuilder    2 - FCN =       12.61999292 Edm =   2.733192651e-09 NCalls =     13
Info in <Minuit2>: VariableMetricBuilder Stop iterating after 68.252 μs
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 12.6199929169252236
Edm   = 2.73319265141214306e-09
Nfcn  = 13
mean1	  = 0.0704767	 +/-  0.487376	(limited)

ROOT comes with a web-based canvas, which is now being started. 
Revert to the legacy canvas by setting "Canvas.Name: TRootCanvas" in rootrc file or
by starting "root --web=off".
Find more info on https://root.cern/for_developers/root7/#twebcanvas
Info in <THttpEngine::Create>: Starting HTTP server on port 127.0.0.1:9016
Fitting model index 0
[#1] INFO:Fitting -- RooAbsPdf::fitTo(multiPdf) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 390.083 μs
MathFunc call used
[#1] INFO:Fitting -- Function JIT time: 7.12597 ms
[#1] INFO:Fitting -- Gradient generation time: 11.4141 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 10.8609 ms
[#1] INFO:Fitting -- [FitHelpers] Detected correction term from RooAbsPdf::getCorrection(). Adding penalty to NLL.
[#1] INFO:Fitting -- RooAddition::defaultErrorLevel(nll_multiPdf_true_pdfData_corrected) WARNING: Summation contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0
Minuit2Minimizer: Minimize with max-calls 500 convergence for edm < 1 strategy 1
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 12.6199929141921352
Edm   = 6.34967010218829214e-16
Nfcn  = 15
mean1	  = 0.0705027	 +/-  0.487376	(limited)
NLL value for index 0 = 12.62
Fitting model index 1
[#1] INFO:Fitting -- RooAbsPdf::fitTo(multiPdf) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 110.883 μs
MathFunc call used
[#1] INFO:Fitting -- Function JIT time: 4.99575 ms
[#1] INFO:Fitting -- Gradient generation time: 10.9593 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 10.6752 ms
[#1] INFO:Fitting -- [FitHelpers] Detected correction term from RooAbsPdf::getCorrection(). Adding penalty to NLL.
[#1] INFO:Fitting -- RooAddition::defaultErrorLevel(nll_multiPdf_true_pdfData_corrected) WARNING: Summation contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0
Minuit2Minimizer: Minimize with max-calls 500 convergence for edm < 1 strategy 1
Warning in <Minuit2>: VariableMetricBuilder No improvement in line search
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 12.5548275045952344
Edm   = 6.46781407352796359e-16
Nfcn  = 13
mean1	  = 0.0705027	 +/-  0.483145	(limited)
NLL value for index 1 = 12.5548
Fitting model index 2
[#1] INFO:Fitting -- RooAbsPdf::fitTo(multiPdf) fixing normalization set for coefficient determination to observables in data
[#1] INFO:Fitting -- Creation of NLL object took 113.9 μs
MathFunc call used
[#1] INFO:Fitting -- Function JIT time: 4.94741 ms
[#1] INFO:Fitting -- Gradient generation time: 11.3563 ms
[#1] INFO:Fitting -- Gradient IR to machine code time: 10.7763 ms
[#1] INFO:Fitting -- [FitHelpers] Detected correction term from RooAbsPdf::getCorrection(). Adding penalty to NLL.
[#1] INFO:Fitting -- RooAddition::defaultErrorLevel(nll_multiPdf_true_pdfData_corrected) WARNING: Summation contains neither RooNLLVar nor RooChi2Var server, using default level of 1.0
Minuit2Minimizer: Minimize with max-calls 500 convergence for edm < 1 strategy 1
Warning in <Minuit2>: VariableMetricBuilder No improvement in line search
Minuit2Minimizer : Valid minimum - status = 0
FVAL  = 12.2273385412252757
Edm   = 7.09959020188141533e-16
Nfcn  = 13
mean1	  = 0.0705027	 +/-  0.461925	(limited)
NLL value for index 2 = 12.2273

Brute-force Best model index = 2
Brute-force Best NLL value = 12.2273
.
Along with this output a plot showing the values of the NLL with respect to the mean variable, which is left floating , is shown.Also in the end of the code there is a procedure created in order to determine the best value of the NLL when one of the parameters is left floating.This peace of code will be replaced when discrete profiling is added as a minimization method in RooMinimizer.
