### PR TITLE
[DF] Add `signed char` to `TypeID2TypeName`

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -178,12 +178,19 @@ const std::type_info &TypeName2TypeID(const std::string &name)
 std::string TypeID2TypeName(const std::type_info &id)
 {
    const static std::unordered_map<TypeInfoRef, std::string, TypeInfoRefHash, TypeInfoRefEqualComp> typeID2TypeNameMap{
-      {typeid(char), "char"},         {typeid(unsigned char), "unsigned char"},
-      {typeid(int), "int"},           {typeid(unsigned int), "unsigned int"},
-      {typeid(short), "short"},       {typeid(unsigned short), "unsigned short"},
-      {typeid(long), "long"},         {typeid(unsigned long), "unsigned long"},
-      {typeid(double), "double"},     {typeid(float), "float"},
-      {typeid(Long64_t), "Long64_t"}, {typeid(ULong64_t), "ULong64_t"},
+      {typeid(char), "char"},
+      {typeid(unsigned char), "unsigned char"},
+      {typeid(signed char), "signed char"},
+      {typeid(int), "int"},
+      {typeid(unsigned int), "unsigned int"},
+      {typeid(short), "short"},
+      {typeid(unsigned short), "unsigned short"},
+      {typeid(long), "long"},
+      {typeid(unsigned long), "unsigned long"},
+      {typeid(double), "double"},
+      {typeid(float), "float"},
+      {typeid(Long64_t), "Long64_t"},
+      {typeid(ULong64_t), "ULong64_t"},
       {typeid(bool), "bool"}};
 
    if (auto it = typeID2TypeNameMap.find(id); it != typeID2TypeNameMap.end())

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -464,7 +464,7 @@ ROOT::RFieldBase *ROOT::RDF::RNTupleDS::GetFieldWithTypeChecks(std::string_view 
       auto newAltProtoFieldOrException = ROOT::RFieldBase::Create(std::string(fieldName), requestedType);
       if (!newAltProtoFieldOrException) {
          throw std::runtime_error("RNTupleDS: Could not create field with type \"" + requestedType +
-                                  "\" for column \"" + std::string(fieldName));
+                                  "\" for column \"" + std::string(fieldName) + "\"");
       }
       auto newAltProtoField = newAltProtoFieldOrException.Unwrap();
       newAltProtoField->SetOnDiskId(fProtoFields[index]->GetOnDiskId());

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -809,3 +809,22 @@ TEST(RNTupleDS, TDirectory)
    EXPECT_EQ(1ull, ds.GetNFiles());
    EXPECT_EQ(std::vector<std::string>{"x"}, ds.GetColumnNames());
 }
+
+TEST(RNTupleDS, Int8)
+{
+   FileRAII fileGuard("test_rntupleds_int8.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fldX = model->MakeField<std::int8_t>("x");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (unsigned i = 0; i < 5; ++i) {
+         *fldX = i;
+         ntuple->Fill();
+      }
+   }
+
+   ROOT::RDataFrame df("ntuple", fileGuard.GetPath());
+   std::vector<std::int8_t> expected{0, 1, 2, 3, 4};
+   EXPECT_EQ(expected, df.Take<std::int8_t>("x").GetValue());
+}


### PR DESCRIPTION
Discovered when trying to read an RNTuple `std::int8_t`-type field, which is typedeffed as a `signed char`. 
