### PR TITLE
[df] Remove RDatasetSpec header dependency on TTree

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
@@ -11,14 +11,18 @@
 #ifndef ROOT_RDF_RDATASETSPEC
 #define ROOT_RDF_RDATASETSPEC
 
+#include <any>
 #include <limits>
 #include <string>
 #include <utility> // std::pair
 #include <vector>
 
 #include <ROOT/RDF/RSample.hxx>
-#include <ROOT/RFriendInfo.hxx>
 #include <RtypesCore.h> // Long64_t
+
+namespace ROOT::TreeUtils {
+struct RFriendInfo;
+}
 
 namespace ROOT {
 namespace Detail {
@@ -75,12 +79,12 @@ public:
 
 private:
    std::vector<RSample> fSamples;             ///< List of samples
-   ROOT::TreeUtils::RFriendInfo fFriendInfo;  ///< List of friends
+   std::any fFriendInfo;  ///< List of friends
    REntryRange fEntryRange; ///< Start (inclusive) and end (exclusive) entry for the dataset processing
    std::vector<RSample> MoveOutSamples();
 
 public:
-   RDatasetSpec() = default;
+   RDatasetSpec() noexcept;
 
    const std::vector<std::string> GetSampleNames() const;
    const std::vector<std::string> GetTreeNames() const;

--- a/tree/dataframe/src/RDatasetSpec.cxx
+++ b/tree/dataframe/src/RDatasetSpec.cxx
@@ -9,6 +9,7 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RDatasetSpec.hxx"
+#include <ROOT/RFriendInfo.hxx>
 #include <stdexcept> // std::logic_error
 
 namespace ROOT {
@@ -76,7 +77,7 @@ const std::vector<RMetaData> RDatasetSpec::GetMetaData() const
 /// \brief Returns the reference to the friend tree information.
 const ROOT::TreeUtils::RFriendInfo &RDatasetSpec::GetFriendInfo() const
 {
-   return fFriendInfo;
+   return *std::any_cast<ROOT::TreeUtils::RFriendInfo>(&fFriendInfo);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -153,7 +154,7 @@ RDatasetSpec &RDatasetSpec::AddSample(RSample sample)
 RDatasetSpec &
 RDatasetSpec::WithGlobalFriends(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias)
 {
-   fFriendInfo.AddFriend(treeName, fileNameGlob, alias);
+   std::any_cast<ROOT::TreeUtils::RFriendInfo>(fFriendInfo).AddFriend(treeName, fileNameGlob, alias);
    return *this;
 }
 
@@ -166,7 +167,7 @@ RDatasetSpec::WithGlobalFriends(const std::string &treeName, const std::string &
 RDatasetSpec &RDatasetSpec::WithGlobalFriends(const std::string &treeName,
                                               const std::vector<std::string> &fileNameGlobs, const std::string &alias)
 {
-   fFriendInfo.AddFriend(treeName, fileNameGlobs, alias);
+   std::any_cast<ROOT::TreeUtils::RFriendInfo>(fFriendInfo).AddFriend(treeName, fileNameGlobs, alias);
    return *this;
 }
 
@@ -178,7 +179,7 @@ RDatasetSpec &
 RDatasetSpec::WithGlobalFriends(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
                                 const std::string &alias)
 {
-   fFriendInfo.AddFriend(treeAndFileNameGlobs, alias);
+   std::any_cast<ROOT::TreeUtils::RFriendInfo>(fFriendInfo).AddFriend(treeAndFileNameGlobs, alias);
    return *this;
 }
 
@@ -196,7 +197,7 @@ RDatasetSpec &RDatasetSpec::WithGlobalFriends(const std::vector<std::string> &tr
    target.reserve(fileNameGlobs.size());
    for (auto i = 0u; i < fileNameGlobs.size(); ++i)
       target.emplace_back(std::make_pair((treeNames.size() == 1u ? treeNames[0] : treeNames[i]), fileNameGlobs[i]));
-   fFriendInfo.AddFriend(target, alias);
+   std::any_cast<ROOT::TreeUtils::RFriendInfo>(fFriendInfo).AddFriend(target, alias);
    return *this;
 }
 
@@ -222,3 +223,8 @@ RDatasetSpec &RDatasetSpec::WithGlobalRange(const RDatasetSpec::REntryRange &ent
 } // namespace Experimental
 } // namespace RDF
 } // namespace ROOT
+
+ROOT::RDF::Experimental::RDatasetSpec::RDatasetSpec() noexcept
+{
+   fFriendInfo = ROOT::TreeUtils::RFriendInfo{};
+};

--- a/tree/dataframe/test/dataframe_cache.cxx
+++ b/tree/dataframe/test/dataframe_cache.cxx
@@ -11,6 +11,7 @@
 #include <algorithm>
 
 #include <TFile.h>
+#include <TTree.h>
 
 using namespace ROOT::RDF;
 using namespace ROOT::VecOps;

--- a/tree/dataframe/test/dataframe_cloning.cxx
+++ b/tree/dataframe/test/dataframe_cloning.cxx
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <TFile.h>
+#include <TTree.h>
 
 using ROOT::Internal::RDF::ChangeBeginAndEndEntries;
 using ROOT::Internal::RDF::ChangeEmptyEntryRange;

--- a/tree/dataframe/test/dataframe_colnames.cxx
+++ b/tree/dataframe/test/dataframe_colnames.cxx
@@ -1,4 +1,5 @@
 #include "ROOT/RDataFrame.hxx"
+#include <TTree.h>
 
 #include "gtest/gtest.h"
 

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -12,6 +12,7 @@
 #include <thread> // std::thread::hardware_concurrency
 
 #include <TFile.h>
+#include <TTree.h>
 
 using namespace ROOT;
 using namespace ROOT::RDF::Experimental;

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 
 #include <TFile.h>
+#include <TTree.h>
 
 using namespace ROOT;
 using namespace ROOT::RDF;

--- a/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
@@ -14,6 +14,7 @@
 #include "NTupleStruct.hxx"
 
 #include <TFile.h>
+#include <TTree.h>
 
 using ROOT::RNTupleModel;
 using ROOT::RNTupleReader;

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <TFile.h>
+#include <TTree.h>
 
 using ROOT::RDF::Experimental::VariationsFor;
 

--- a/tree/dataframe/test/datasource_more.cxx
+++ b/tree/dataframe/test/datasource_more.cxx
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include <TFile.h>
+#include <TTree.h>
 
 using namespace ROOT::RDF;
 


### PR DESCRIPTION
RDatasetSpec depended on RFriendInfo.hxx which transitively includes TTree.h. This commit proposes to remove this dependency by changing the type of the data member that stores information about friend trees as a std::any and cast it when appropriate. In the future, when introducing support for RNTuple joins, this can be extended, changed to std::variant without the need for the extra dependency on TTree.

