### PR TITLE
[ntuple] Change GetColumn methods in Inspector

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleInspector.hxx
@@ -277,7 +277,7 @@ public:
    /// \param [in] fieldId The ID of the field for which to collect the columns.
    ///
    /// \return A vector containing the IDs of all columns for the provided field ID.
-   std::vector<ROOT::DescriptorId_t> GetColumnsByFieldId(ROOT::DescriptorId_t fieldId) const;
+   std::vector<ROOT::DescriptorId_t> GetAllColumnsOfField(ROOT::DescriptorId_t fieldId) const;
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get all column types present in the RNTuple being inspected.

--- a/tree/ntupleutil/v7/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleInspector.cxx
@@ -127,7 +127,7 @@ ROOT::Experimental::RNTupleInspector::CollectFieldTreeInfo(ROOT::DescriptorId_t 
 }
 
 std::vector<ROOT::DescriptorId_t>
-ROOT::Experimental::RNTupleInspector::GetColumnsByFieldId(ROOT::DescriptorId_t fieldId) const
+ROOT::Experimental::RNTupleInspector::GetAllColumnsOfField(ROOT::DescriptorId_t fieldId) const
 {
    std::vector<ROOT::DescriptorId_t> colIds;
    std::deque<ROOT::DescriptorId_t> fieldIdQueue{fieldId};

--- a/tree/ntupleutil/v7/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_inspector.cxx
@@ -374,7 +374,6 @@ TEST(RNTupleInspector, ColumnsByType)
    }
 
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
-
    EXPECT_EQ(2U, inspector->GetColumnsByType(ENTupleColumnType::kSplitInt64).size());
    for (const auto colId : inspector->GetColumnsByType(ENTupleColumnType::kSplitInt64)) {
       EXPECT_EQ(ENTupleColumnType::kSplitInt64, inspector->GetColumnInspector(colId).GetType());
@@ -386,12 +385,42 @@ TEST(RNTupleInspector, ColumnsByType)
    }
 
    EXPECT_EQ(1U, inspector->GetColumnsByType(ENTupleColumnType::kSplitIndex64).size());
-   EXPECT_EQ(1U, inspector->GetColumnsByType(ENTupleColumnType::kSplitIndex64).size());
    for (const auto colId : inspector->GetColumnsByType(ENTupleColumnType::kSplitIndex64)) {
       EXPECT_EQ(ENTupleColumnType::kSplitIndex64, inspector->GetColumnInspector(colId).GetType());
    }
 
    EXPECT_EQ(0U, inspector->GetColumnsByType(ENTupleColumnType::kSplitReal64).size());
+}
+
+TEST(RNTupleInspector, AllColumnsOfField)
+{
+   FileRaii fileGuard("test_ntuple_inspector_all_columns_of_field.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto nFldInt1 = model->MakeField<std::int64_t>("int1");
+      auto nFldInt2 = model->MakeField<std::int64_t>("int2");
+      auto nFldFloat = model->MakeField<float>("float");
+      auto nFldFloatVec = model->MakeField<std::vector<float>>("floatVec");
+
+      auto writeOptions = RNTupleWriteOptions();
+      writeOptions.SetCompression(505);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), writeOptions);
+   }
+
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
+
+   EXPECT_EQ(1U, inspector->GetAllColumnsOfField(0).size());
+   EXPECT_EQ(1U, inspector->GetAllColumnsOfField(1).size());
+   for (const auto colId : inspector->GetAllColumnsOfField(0)) {
+      EXPECT_EQ(ENTupleColumnType::kSplitInt64, inspector->GetColumnInspector(colId).GetType());
+   }
+
+   EXPECT_EQ(1U, inspector->GetAllColumnsOfField(2).size());
+   for (const auto colId : inspector->GetAllColumnsOfField(2)) {
+      EXPECT_EQ(ENTupleColumnType::kSplitReal32, inspector->GetColumnInspector(colId).GetType());
+   }
+
+   EXPECT_EQ(2U, inspector->GetAllColumnsOfField(3).size());
 }
 
 TEST(RNTupleInspector, ColumnTypes)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
- Renamed `GetColumnsByFieldId` to `GetAllColumnsOfField`
- Added unit tests for `GetAllColumnsOfField` because it also recently became a public method

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

