### PR TITLE
[ntuple] Add support for emulating user collections with unknown collection proxies

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
@@ -34,17 +34,17 @@ class RFieldVisitor;
 } // namespace Detail
 
 namespace Internal {
-std::unique_ptr<RFieldBase> CreateEmulatedField(std::string_view fieldName,
-                                                std::vector<std::unique_ptr<RFieldBase>> itemFields,
-                                                std::string_view emulatedFromType);
-}
+std::unique_ptr<RFieldBase> CreateEmulatedRecordField(std::string_view fieldName,
+                                                      std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                                      std::string_view emulatedFromType);
+} // namespace Internal
 
 /// The field for an untyped record. The subfields are stored consecutively in a memory block, i.e.
 /// the memory layout is identical to one that a C++ struct would have
 class RRecordField : public RFieldBase {
-   friend std::unique_ptr<RFieldBase> Internal::CreateEmulatedField(std::string_view fieldName,
-                                                                    std::vector<std::unique_ptr<RFieldBase>> itemFields,
-                                                                    std::string_view emulatedFromType);
+   friend std::unique_ptr<RFieldBase>
+   Internal::CreateEmulatedRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                       std::string_view emulatedFromType);
 
    class RRecordDeleter : public RDeleter {
    private:

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -32,6 +32,11 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+namespace Internal {
+std::unique_ptr<RFieldBase> CreateEmulatedVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
+                                                      std::string_view emulatedFromType);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Template specializations for C++ std::array and C-style arrays
 ////////////////////////////////////////////////////////////////////////////////
@@ -189,7 +194,10 @@ public:
 /// The generic field for a (nested) `std::vector<Type>` except for `std::vector<bool>`
 /// The field can be constructed as untyped collection through CreateUntyped().
 class RVectorField : public RFieldBase {
-private:
+   friend std::unique_ptr<RFieldBase> Internal::CreateEmulatedVectorField(std::string_view fieldName,
+                                                                          std::unique_ptr<RFieldBase> itemField,
+                                                                          std::string_view emulatedFromType);
+
    class RVectorDeleter : public RDeleter {
    private:
       std::size_t fItemSize = 0;
@@ -209,7 +217,11 @@ private:
    std::unique_ptr<RDeleter> fItemDeleter;
 
 protected:
-   RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField, bool isUntyped);
+   /// Creates a possibly-untyped VectorField.
+   /// If `emulatedFromType` is not nullopt, the field is untyped. If the string is empty, it is a "regular"
+   /// untyped vector field; otherwise, it was created as an emulated field from the given type name.
+   RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
+                std::optional<std::string_view> emulatedFromType);
 
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;
 

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -510,10 +510,20 @@ void ROOT::RRecordField::AttachItemFields(std::vector<std::unique_ptr<RFieldBase
 }
 
 std::unique_ptr<ROOT::RFieldBase>
-ROOT::Internal::CreateEmulatedField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,
-                                    std::string_view emulatedFromType)
+ROOT::Internal::CreateEmulatedRecordField(std::string_view fieldName,
+                                          std::vector<std::unique_ptr<RFieldBase>> itemFields,
+                                          std::string_view emulatedFromType)
 {
+   R__ASSERT(!emulatedFromType.empty());
    return std::unique_ptr<RFieldBase>(new RRecordField(fieldName, std::move(itemFields), emulatedFromType));
+}
+
+std::unique_ptr<ROOT::RFieldBase> ROOT::Internal::CreateEmulatedVectorField(std::string_view fieldName,
+                                                                            std::unique_ptr<RFieldBase> itemField,
+                                                                            std::string_view emulatedFromType)
+{
+   R__ASSERT(!emulatedFromType.empty());
+   return std::unique_ptr<RFieldBase>(new RVectorField(fieldName, std::move(itemField), emulatedFromType));
 }
 
 ROOT::RRecordField::RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields,

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -555,7 +555,7 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
       if (!result) {
          auto cl = TClass::GetClass(typeName.c_str());
 
-         if (cl != nullptr) {
+         if (cl && cl->GetState() > TClass::kForwardDeclared) {
             createContextGuard.AddClassToStack(resolvedType);
             if (cl->GetCollectionProxy()) {
                result = std::make_unique<RProxiedCollectionField>(fieldName, typeName);

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -634,10 +634,6 @@ ROOT::RProxiedCollectionField::RProxiedCollectionField(std::string_view fieldNam
    fCollectionType = fProxy->GetCollectionType();
    if (fProxy->HasPointers())
       throw RException(R__FAIL("collection proxies whose value type is a pointer are not supported"));
-   if (!fProxy->GetCollectionClass()->HasDictionary()) {
-      throw RException(R__FAIL("dictionary not available for type " +
-                               GetRenormalizedTypeName(fProxy->GetCollectionClass()->GetName())));
-   }
 
    fIFuncsRead = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), true /* readFromDisk */);
    fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -464,33 +464,38 @@ void ROOT::RRVecField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const
 
 //------------------------------------------------------------------------------
 
-ROOT::RVectorField::RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField, bool isUntyped)
-   : ROOT::RFieldBase(fieldName, isUntyped ? "" : "std::vector<" + itemField->GetTypeName() + ">",
+ROOT::RVectorField::RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
+                                 std::optional<std::string_view> emulatedFromType)
+   : ROOT::RFieldBase(fieldName, emulatedFromType ? *emulatedFromType : "std::vector<" + itemField->GetTypeName() + ">",
                       ROOT::ENTupleStructure::kCollection, false /* isSimple */),
      fItemSize(itemField->GetValueSize()),
      fNWritten(0)
 {
+   if (emulatedFromType && !emulatedFromType->empty())
+      fTraits |= kTraitEmulatedField;
+
    if (!(itemField->GetTraits() & kTraitTriviallyDestructible))
       fItemDeleter = GetDeleterOf(*itemField);
    Attach(std::move(itemField));
 }
 
 ROOT::RVectorField::RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField)
-   : RVectorField(fieldName, std::move(itemField), false)
+   : RVectorField(fieldName, std::move(itemField), {})
 {
 }
 
 std::unique_ptr<ROOT::RVectorField>
 ROOT::RVectorField::CreateUntyped(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField)
 {
-   return std::unique_ptr<ROOT::RVectorField>(new RVectorField(fieldName, std::move(itemField), true));
+   return std::unique_ptr<ROOT::RVectorField>(new RVectorField(fieldName, std::move(itemField), ""));
 }
 
 std::unique_ptr<ROOT::RFieldBase> ROOT::RVectorField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
+   auto isUntyped = GetTypeName().empty();
    return std::unique_ptr<ROOT::RVectorField>(
-      new RVectorField(newName, std::move(newItemField), GetTypeName().empty()));
+      new RVectorField(newName, std::move(newItemField), isUntyped ? std::make_optional("") : std::nullopt));
 }
 
 std::size_t ROOT::RVectorField::AppendImpl(const void *from)

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -493,9 +493,9 @@ ROOT::RVectorField::CreateUntyped(std::string_view fieldName, std::unique_ptr<RF
 std::unique_ptr<ROOT::RFieldBase> ROOT::RVectorField::CloneImpl(std::string_view newName) const
 {
    auto newItemField = fSubfields[0]->Clone(fSubfields[0]->GetFieldName());
-   auto isUntyped = GetTypeName().empty();
-   return std::unique_ptr<ROOT::RVectorField>(
-      new RVectorField(newName, std::move(newItemField), isUntyped ? std::make_optional("") : std::nullopt));
+   auto isUntyped = GetTypeName().empty() || ((fTraits & kTraitEmulatedField) != 0);
+   auto emulatedFromType = isUntyped ? std::make_optional(GetTypeName()) : std::nullopt;
+   return std::unique_ptr<ROOT::RVectorField>(new RVectorField(newName, std::move(newItemField), emulatedFromType));
 }
 
 std::size_t ROOT::RVectorField::AppendImpl(const void *from)

--- a/tree/ntuple/src/RNTupleReader.cxx
+++ b/tree/ntuple/src/RNTupleReader.cxx
@@ -218,8 +218,13 @@ void ROOT::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output
 
 ROOT::RNTupleReader *ROOT::RNTupleReader::GetDisplayReader()
 {
-   if (!fDisplayReader)
-      fDisplayReader = Clone();
+   if (!fDisplayReader) {
+      ROOT::RNTupleDescriptor::RCreateModelOptions opts;
+      opts.SetEmulateUnknownTypes(true);
+      auto fullModel = fSource->GetSharedDescriptorGuard()->CreateModel(opts);
+      fDisplayReader = std::unique_ptr<RNTupleReader>(
+         new RNTupleReader(std::move(fullModel), fSource->Clone(), ROOT::RNTupleReadOptions{}));
+   }
    return fDisplayReader.get();
 }
 

--- a/tree/ntuple/test/ntuple_emulated.cxx
+++ b/tree/ntuple/test/ntuple_emulated.cxx
@@ -1,6 +1,6 @@
 #include "ntuple_test.hxx"
-
 #include "ntuple_fork.hxx"
+#include "TSystem.h"
 
 TEST(RNTupleEmulated, EmulatedFields_Simple)
 {
@@ -492,3 +492,195 @@ TEST(RNTupleEmulated, EmulatedFields_Write)
    }
 }
 
+TEST(RNTupleEmulated, CollectionProxy)
+{
+   FileRaii fileGuard("test_ntuple_emulated_collproxy.root");
+
+   // Declare a custom type in a separate process, then write it through a custom collection proxy.
+   // In the main process we load the generated RNTuple without having its dictionary available and we verify
+   // we can read it (only) via field emulation (as an untyped VectorField).
+   ExecInFork([&] {
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+         // Copypasted from StructUsingCollectionProxy in CustomStruct.hxx
+         // Using a separate type because we don't want to have its dictionary loaded in the test.
+         template <typename T>
+         struct StructWithCollectionProxyForEmuTest {
+            using ValueType = T;
+            std::vector<T> v; //! do not accidentally store via RClassField
+         };
+
+         // Copypasted from SimpleCollectionProxy.hxx
+         // Using a separate type because we don't want to have its dictionary loaded in the test.
+         template <typename CollectionT>
+         class SimpleCollectionProxyForEmuTest : public TVirtualCollectionProxy {
+            /// The internal representation of an iterator, which in this simple test only contains a pointer to an element
+            struct IteratorData {
+               typename CollectionT::ValueType *ptr;
+            };
+
+            static void
+            Func_CreateIterators(void *collection, void **begin_arena, void **end_arena, TVirtualCollectionProxy * /*proxy*/)
+            {
+               static_assert(sizeof(IteratorData) <= TVirtualCollectionProxy::fgIteratorArenaSize);
+               auto &vec = static_cast<CollectionT *>(collection)->v;
+               // An iterator on an array-backed container is just a pointer; thus, it can be directly stored in `*xyz_arena`,
+               // saving one dereference (see TVirtualCollectionProxy documentation)
+               *begin_arena = vec.data();
+               *end_arena = vec.data() + vec.size();
+            }
+
+            static void *Func_Next(void *iter, const void *end)
+            {
+               auto _iter = static_cast<IteratorData *>(iter);
+               auto _end = static_cast<const IteratorData *>(end);
+               if (_iter->ptr >= _end->ptr)
+                  return nullptr;
+               return _iter->ptr++;
+            }
+
+            static void Func_DeleteTwoIterators(void * /*begin*/, void * /*end*/) {}
+
+         private:
+            CollectionT *fObject = nullptr;
+
+         public:
+            SimpleCollectionProxyForEmuTest()
+               : TVirtualCollectionProxy(TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(CollectionT)).c_str()))
+            {
+            }
+            SimpleCollectionProxyForEmuTest(const SimpleCollectionProxyForEmuTest<CollectionT> &) : SimpleCollectionProxyForEmuTest() {}
+
+            TVirtualCollectionProxy *Generate() const override
+            {
+               return new SimpleCollectionProxyForEmuTest<CollectionT>(*this);
+            }
+            Int_t GetCollectionType() const override { return ROOT::kSTLvector; }
+            ULong_t GetIncrement() const override { return sizeof(typename CollectionT::ValueType); }
+            UInt_t Sizeof() const override { return sizeof(CollectionT); }
+            bool HasPointers() const override { return false; }
+
+            TClass *GetValueClass() const override
+            {
+               if constexpr (std::is_fundamental<typename CollectionT::ValueType>::value)
+                  return nullptr;
+               return TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(typename CollectionT::ValueType)).c_str());
+            }
+            EDataType GetType() const override
+            {
+               if constexpr (std::is_same<typename CollectionT::ValueType, char>::value)
+                  return EDataType::kChar_t;
+               ;
+               if constexpr (std::is_same<typename CollectionT::ValueType, float>::value)
+                  return EDataType::kFloat_t;
+               ;
+               return EDataType::kOther_t;
+            }
+
+            void PushProxy(void *objectstart) override { fObject = static_cast<CollectionT *>(objectstart); }
+            void PopProxy() override { fObject = nullptr; }
+
+            void *At(UInt_t idx) override { return &fObject->v[idx]; }
+            void Clear(const char * /*opt*/ = "") override { fObject->v.clear(); }
+            UInt_t Size() const override { return fObject->v.size(); }
+            void *Allocate(UInt_t n, bool /*forceDelete*/) override
+            {
+               fObject->v.resize(n);
+               return fObject;
+            }
+            void Commit(void *) override {}
+            void Insert(const void *data, void *container, size_t size) override
+            {
+               auto p = static_cast<const typename CollectionT::ValueType *>(data);
+               for (size_t i = 0; i < size; ++i) {
+                  static_cast<CollectionT *>(container)->v.push_back(p[i]);
+               }
+            }
+
+            TStreamerInfoActions::TActionSequence *
+            GetConversionReadMemberWiseActions(TClass * /*oldClass*/, Int_t /*version*/) override
+            {
+               return nullptr;
+            }
+            TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Int_t /*version*/) override { return nullptr; }
+            TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions() override { return nullptr; }
+
+            CreateIterators_t GetFunctionCreateIterators(bool /*read*/ = true) override { return &Func_CreateIterators; }
+            CopyIterator_t GetFunctionCopyIterator(bool /*read*/ = true) override { return nullptr; }
+            Next_t GetFunctionNext(bool /*read*/ = true) override { return &Func_Next; }
+            DeleteIterator_t GetFunctionDeleteIterator(bool /*read*/ = true) override { return nullptr; }
+            DeleteTwoIterators_t GetFunctionDeleteTwoIterators(bool /*read*/ = true) override
+            {
+               return &Func_DeleteTwoIterators;
+            }
+         };
+
+         namespace ROOT {
+         template <>
+         struct IsCollectionProxy<StructWithCollectionProxyForEmuTest<char>> : std::true_type {
+         };
+         } // namespace ROOT                                       
+
+         SimpleCollectionProxyForEmuTest<StructWithCollectionProxyForEmuTest<char>> proxyC;
+         auto klassC = TClass::GetClass("StructWithCollectionProxyForEmuTest<char>");
+         klassC->CopyCollectionProxy(proxyC);
+      )"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("proxyC", "StructWithCollectionProxyForEmuTest<char>").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+
+      void *ptr = writer->GetModel().GetDefaultEntry().GetPtr<void>("proxyC").get();
+      DeclarePointer("StructWithCollectionProxyForEmuTest<char>", "pProxyC", ptr);
+      ProcessLine("for(int i = 0; i < 100; ++i) pProxyC->v.push_back(0x42);");
+      writer->Fill();
+
+      ProcessLine("pProxyC->v.clear();");
+      writer->Fill();
+
+      // TStreamerInfo::Build will report a warning for interpreted classes (but only for members).
+      // See also https://github.com/root-project/root/issues/9371
+      ROOT::TestSupport::CheckDiagsRAII diagRAII;
+      diagRAII.optionalDiag(kWarning, "TStreamerInfo::Build", "has no streamer or dictionary",
+                            /*matchFullMessage=*/false);
+      writer.reset();
+   });
+
+   try {
+      auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      reader->GetModel();
+      FAIL() << "Reconstructing the model without emulating fields should fail";
+   } catch (const ROOT::RException &ex) {
+      EXPECT_THAT(ex.what(), testing::HasSubstr("unknown type: StructWithCollectionProxyForEmuTest<char>"));
+   }
+
+   auto opts = RNTupleDescriptor::RCreateModelOptions();
+   opts.SetEmulateUnknownTypes(true);
+   auto reader = ROOT::RNTupleReader::Open(opts, "ntpl", fileGuard.GetPath());
+   EXPECT_EQ(reader->GetNEntries(), 2);
+
+   const auto &model = reader->GetModel();
+   const auto &field = model.GetConstField("proxyC");
+   EXPECT_EQ(field.GetTypeName(), "StructWithCollectionProxyForEmuTest<char>");
+   EXPECT_EQ(field.GetStructure(), ROOT::ENTupleStructure::kCollection);
+   EXPECT_EQ(field.GetConstSubfields().size(), 1);
+   EXPECT_NE(field.GetTraits() & RFieldBase::kTraitEmulatedField, 0);
+   EXPECT_EQ(field.GetValueSize(), sizeof(std::vector<char>));
+
+   const auto *vec = dynamic_cast<const ROOT::RVectorField *>(&field);
+   ASSERT_NE(vec, nullptr);
+   RNTupleLocalIndex collectionStart;
+   ROOT::NTupleSize_t size;
+   vec->GetCollectionInfo(0, &collectionStart, &size);
+   EXPECT_EQ(collectionStart.GetClusterId(), 0);
+   EXPECT_EQ(collectionStart.GetIndexInCluster(), 0);
+   EXPECT_EQ(size, 100);
+   vec->GetCollectionInfo(1, &collectionStart, &size);
+   EXPECT_EQ(collectionStart.GetClusterId(), 0);
+   EXPECT_EQ(collectionStart.GetIndexInCluster(), 100);
+   EXPECT_EQ(size, 0);
+
+   reader->LoadEntry(0);
+}

--- a/tree/ntuple/test/ntuple_emulated.cxx
+++ b/tree/ntuple/test/ntuple_emulated.cxx
@@ -14,20 +14,20 @@ TEST(RNTupleEmulated, EmulatedFields_Simple)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-struct Inner_Simple {
-   int fInt1 = 1;
-   int fInt2 = 2;
+         struct Inner_Simple {
+            int fInt1 = 1;
+            int fInt2 = 2;
 
-   ClassDefNV(Inner_Simple, 2);
-};
+            ClassDefNV(Inner_Simple, 2);
+         };
 
-struct Outer_Simple {
-   int fInt1 = 1;
-   Inner_Simple fInner;
+         struct Outer_Simple {
+            int fInt1 = 1;
+            Inner_Simple fInner;
 
-   ClassDefNV(Outer_Simple, 2);
-};
-)"));
+            ClassDefNV(Outer_Simple, 2);
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("f", "Outer_Simple").Unwrap());
@@ -116,20 +116,20 @@ TEST(RNTupleEmulated, EmulatedFields_Vecs)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-struct Inner_Vecs {
-   float fFlt;
+         struct Inner_Vecs {
+            float fFlt;
 
-   ClassDefNV(Inner_Vecs, 2);
-};
+            ClassDefNV(Inner_Vecs, 2);
+         };
 
-struct Outer_Vecs {
-   std::vector<Inner_Vecs> fInners;
-   Inner_Vecs fInner;
-   int f;
+         struct Outer_Vecs {
+            std::vector<Inner_Vecs> fInners;
+            Inner_Vecs fInner;
+            int f;
 
-   ClassDefNV(Outer_Vecs, 2);
-};
-)"));
+            ClassDefNV(Outer_Vecs, 2);
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("outers", "std::vector<Outer_Vecs>").Unwrap());
@@ -218,11 +218,11 @@ TEST(RNTupleEmulated, EmulatedFields_VecsTemplatedWrapper)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-template <typename T>
-struct TemplatedWrapper {
-   T fValue;
-};
-)"));
+         template <typename T>
+         struct TemplatedWrapper {
+            T fValue;
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("vec", "std::vector<TemplatedWrapper<float>>").Unwrap());
@@ -294,15 +294,15 @@ TEST(RNTupleEmulated, EmulatedFields_EmptyStruct)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-struct Inner_EmptyStruct {
-   ClassDefNV(Inner_EmptyStruct, 2);
-};
+         struct Inner_EmptyStruct {
+            ClassDefNV(Inner_EmptyStruct, 2);
+         };
 
-struct Outer_EmptyStruct {
-   Inner_EmptyStruct fInner;
-   ClassDefNV(Outer_EmptyStruct, 2);
-};
-)"));
+         struct Outer_EmptyStruct {
+            Inner_EmptyStruct fInner;
+            ClassDefNV(Outer_EmptyStruct, 2);
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("f", "Outer_EmptyStruct").Unwrap());
@@ -370,10 +370,10 @@ TEST(RNTupleEmulated, EmulatedFields_EmptyVec)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-struct Inner_EmptyVec {
-   ClassDefNV(Inner_EmptyVec, 2);
-};
-)"));
+         struct Inner_EmptyVec {
+            ClassDefNV(Inner_EmptyVec, 2);
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("f", "std::vector<Inner_EmptyVec>").Unwrap());
@@ -449,18 +449,18 @@ TEST(RNTupleEmulated, EmulatedFields_Write)
       fileGuard.PreserveFile();
 
       ASSERT_TRUE(gInterpreter->Declare(R"(
-struct Inner_Write {
-   int fFlt = 42;
+         struct Inner_Write {
+            int fFlt = 42;
 
-   ClassDefNV(Inner_Write, 2);
-};
+            ClassDefNV(Inner_Write, 2);
+         };
 
-struct Outer_Write {
-   std::vector<Inner_Write> fInners;
+         struct Outer_Write {
+            std::vector<Inner_Write> fInners;
 
-   ClassDefNV(Outer_Write, 2);
-};
-)"));
+            ClassDefNV(Outer_Write, 2);
+         };
+      )"));
 
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("f", "Outer_Write").Unwrap());
@@ -491,3 +491,4 @@ struct Outer_Write {
       EXPECT_THAT(ex.GetError().GetReport(), testing::HasSubstr("unsupported"));
    }
 }
+


### PR DESCRIPTION
Previously to this PR, if the user tried to load an emulated user-defined class using a custom CollectionProxy, they would get an untyped Record field which doesn't represent the collection properly.
With this change we instead detect if the field with unknown type is a Collection and, if so, we create an untyped Vector field rather than a Record field, allowing for proper inspection of the underlying values.

Another minor related change: in case of non-emulated fields (so if we have a proper TClass backing the user type) we don't require anymore that the class is at least Interpreted in case of collection proxies, as that is not necessary.

TODO: 
- add a test for the case where we have the dictionary for the user defined class but it's not associated to its original collection proxy (reading in this case should fail unless the user enables emulated fields).
- ~~verify that RNTupleReader::Show() works correctly~~ -> with the latest commit, it does

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

