### PR TITLE
Option Title: with title containing tex

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5123,6 +5123,9 @@ void TPad::Print(const char *filename, Option_t *option)
    TString opt = !option ? opt_default : option;
    Bool_t image = kFALSE;
 
+   Bool_t title = kFALSE;
+   if (strstr(opt,"Title:")) title = kTRUE;
+
    if (!fs1.Length())  {
       psname = GetName();
       psname += opt;
@@ -5140,25 +5143,25 @@ void TPad::Print(const char *filename, Option_t *option)
 
    // Save pad/canvas in alternative formats
    TImage::EImageFileTypes gtype = TImage::kUnknown;
-   if (strstr(opt, "gif+")) {
+   if (!title && strstr(opt, "gif+")) {
       gtype = TImage::kAnimGif;
       image = kTRUE;
-   } else if (strstr(opt, "gif")) {
+   } else if (!title && strstr(opt, "gif")) {
       gtype = TImage::kGif;
       image = kTRUE;
-   } else if (strstr(opt, "png")) {
+   } else if (!title && strstr(opt, "png")) {
       gtype = TImage::kPng;
       image = kTRUE;
-   } else if (strstr(opt, "jpg")) {
+   } else if (!title && strstr(opt, "jpg")) {
       gtype = TImage::kJpeg;
       image = kTRUE;
-   } else if (strstr(opt, "tiff")) {
+   } else if (!title && strstr(opt, "tiff")) {
       gtype = TImage::kTiff;
       image = kTRUE;
-   } else if (strstr(opt, "xpm")) {
+   } else if (!title && strstr(opt, "xpm")) {
       gtype = TImage::kXpm;
       image = kTRUE;
-   } else if (strstr(opt, "bmp")) {
+   } else if (!title && strstr(opt, "bmp")) {
       gtype = TImage::kBmp;
       image = kTRUE;
    }
@@ -5209,32 +5212,32 @@ void TPad::Print(const char *filename, Option_t *option)
    }
 
    //==============Save pad/canvas as a C++ script==============================
-   if (strstr(opt,"cxx")) {
+   if (!title && strstr(opt,"cxx")) {
       GetCanvas()->SaveSource(psname, "");
       return;
    }
 
    //==============Save pad/canvas as a root file===============================
-   if (strstr(opt,"root")) {
+   if (!title && strstr(opt,"root")) {
       if (gDirectory) gDirectory->SaveObjectAs(this,psname.Data(),"");
       return;
    }
 
    //==============Save pad/canvas as a XML file================================
-   if (strstr(opt,"xml")) {
+   if (!title && strstr(opt,"xml")) {
       // Plugin XML driver
       if (gDirectory) gDirectory->SaveObjectAs(this,psname.Data(),"");
       return;
    }
 
    //==============Save pad/canvas as a JSON file================================
-   if (strstr(opt,"json")) {
+   if (!title && strstr(opt,"json")) {
       if (gDirectory) gDirectory->SaveObjectAs(this,psname.Data(),"");
       return;
    }
 
    //==============Save pad/canvas as a SVG file================================
-   if (strstr(opt,"svg")) {
+   if (!title && strstr(opt,"svg")) {
       gVirtualPS = (TVirtualPS*)gROOT->GetListOfSpecials()->FindObject(psname);
 
       Bool_t noScreen = kFALSE;
@@ -5275,7 +5278,7 @@ void TPad::Print(const char *filename, Option_t *option)
    }
 
    //==============Save pad/canvas as a TeX file================================
-   if (strstr(opt,"tex") || strstr(opt,"Standalone")) {
+   if (!title && (strstr(opt,"tex") || strstr(opt,"Standalone"))) {
       gVirtualPS = (TVirtualPS*)gROOT->GetListOfSpecials()->FindObject(psname);
 
       Bool_t noScreen = kFALSE;
@@ -5363,7 +5366,7 @@ void TPad::Print(const char *filename, Option_t *option)
    if (!gVirtualPS || mustOpen) {
 
       const char *pluginName = "ps"; // Plugin Postscript driver
-      if (strstr(opt,"pdf") || strstr(opt,"Title:") || strstr(opt,"EmbedFonts"))
+      if (strstr(opt,"pdf") || title || strstr(opt,"EmbedFonts"))
          pluginName = "pdf";
       else if (image)
          pluginName = "image"; // Plugin TImageDump driver

--- a/graf2d/gpad/test/CMakeLists.txt
+++ b/graf2d/gpad/test/CMakeLists.txt
@@ -5,3 +5,4 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 ROOT_ADD_GTEST(TRatioPlot ratioplot.cxx LIBRARIES Gpad)
+ROOT_ADD_GTEST(TPad pdftitle.cxx LIBRARIES Gpad)

--- a/graf2d/gpad/test/pdftitle.cxx
+++ b/graf2d/gpad/test/pdftitle.cxx
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+#include "TSystem.h"
+#include "TCanvas.h"
+#include "TString.h"
+
+TEST(TPad, PDFTitle)
+{
+    const TString pdfFile = "output.pdf";
+
+    // Generate a multi-page PDF with a title
+    TCanvas c;
+    c.Print(pdfFile + "(");                  // Start multi-page PDF
+    c.Print(pdfFile, "Title:Vertex");        // Add page with title
+    c.Print(pdfFile + ")");                  // Close multi-page PDF
+
+    // Check if the file was created successfully
+    FileStat_t fileStat;
+    int statCode = gSystem->GetPathInfo(pdfFile, fileStat);
+    ASSERT_EQ(statCode, 0) << "PDF file was not created.";
+
+    // Get the actual size of the generated file
+    Long64_t actualSize = fileStat.fSize;
+
+    // Reference file size in bytes (adjust to match your expected output)
+    const Long64_t referenceSize = 13601;
+    const double tolerance = 0.01; // Allow 1% deviation
+
+    // Compute acceptable size range
+    Long64_t minSize = referenceSize * (1.0 - tolerance);
+    Long64_t maxSize = referenceSize * (1.0 + tolerance);
+
+    // Assert that the actual size is within acceptable range
+    EXPECT_GE(actualSize, minSize) << "PDF file is smaller than expected.";
+    EXPECT_LE(actualSize, maxSize) << "PDF file is larger than expected.";
+
+    // Cleanup: delete the test file
+    gSystem->Unlink(pdfFile);
+}


### PR DESCRIPTION
With pdf output it is possible to define a table of content of a multi-pages file. Each page has its name specified using the option "Titlle:" followed by the title of the page. If the title contains a string matching a possible file extension like, for instance, "tex"o r "png", then the pdf generation went wrong and might crash. This PR fixes the problem.

Fixes https://github.com/root-project/root/issues/19390


