### PR TITLE
[RF] Avoid error in `getVal()` in RooFit Python tutorials

### DIFF
--- a/tutorials/roofit/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/roofit/rf110_normintegration.py
@@ -29,7 +29,7 @@ gx = ROOT.RooGaussian("gx", "gx", x, -2, 3)
 print("gx = ", gx.getVal())
 
 # Return value of gx normalized over x in range [-10,10]
-nset = {x}
+nset = ROOT.RooArgSet(x)
 print("gx_Norm[x] = ", gx.getVal(nset))
 
 # Create object representing integral over gx

--- a/tutorials/roofit/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/roofit/rf308_normintegration2d.py
@@ -34,7 +34,7 @@ gxy = ROOT.RooProdPdf("gxy", "gxy", [gx, gy])
 print("gxy = ", gxy.getVal())
 
 # Return value of gxy normalized over x _and_ y in range [-10,10]
-nset_xy = {x, y}
+nset_xy = ROOT.RooArgSet(x, y)
 print("gx_Norm[x,y] = ", gxy.getVal(nset_xy))
 
 # Create object representing integral over gx
@@ -47,12 +47,12 @@ print("gx_Int[x,y] = ", igxy.getVal())
 
 # Return value of gxy normalized over x in range [-10,10] (i.e. treating y
 # as parameter)
-nset_x = {x}
+nset_x = ROOT.RooArgSet(x)
 print("gx_Norm[x] = ", gxy.getVal(nset_x))
 
 # Return value of gxy normalized over y in range [-10,10] (i.e. treating x
 # as parameter)
-nset_y = {y}
+nset_y = ROOT.RooArgSet(y)
 print("gx_Norm[y] = ", gxy.getVal(nset_y))
 
 # Integrate normalized pdf over subrange


### PR DESCRIPTION
In some tutorials, `getVal()` is not called with a not explicitly created RooArgSet, which can result in the following error:

```txt
[#0] FATAL:Eval -- calling RooAbsReal::getVal() with r-value references
to the normalization set is not allowed, because it breaks RooFits
caching logic and potentially introduces significant overhead. Please
explicitly create the RooArgSet outside the call to getVal().
``