### PR TITLE
[CMake] Remove `ROOTTEST_DIR` variable

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2155,7 +2155,7 @@ endfunction(ROOTTEST_SET_TESTOWNER)
 # Construct a target name for a given file <filename> and store its name into
 # <resultvar>. The target name is of the form:
 #
-#   roottest-<directorypath>-<filename_WE>
+#   <directorypath>-<filename_WE>
 #
 #-------------------------------------------------------------------------------
 function(ROOTTEST_TARGETNAME_FROM_FILE resultvar filename)
@@ -2163,15 +2163,11 @@ function(ROOTTEST_TARGETNAME_FROM_FILE resultvar filename)
   get_filename_component(realfp ${filename} ABSOLUTE)
   get_filename_component(filename_we ${filename} NAME_WE)
 
-  if(DEFINED ROOTTEST_DIR)
-    string(REPLACE "${ROOTTEST_DIR}" "" relativepath ${realfp})
-  else()
-    string(REPLACE "${CMAKE_SOURCE_DIR}" "" relativepath ${realfp})
-  endif()
+  string(REPLACE "${CMAKE_SOURCE_DIR}/" "" relativepath ${realfp})
   string(REPLACE "${filename}"     "" relativepath ${relativepath})
 
   string(REPLACE "/" "-" targetname ${relativepath}${filename_we})
-  set(${resultvar} "roottest${targetname}" PARENT_SCOPE)
+  set(${resultvar} "${targetname}" PARENT_SCOPE)
 
 endfunction(ROOTTEST_TARGETNAME_FROM_FILE)
 
@@ -2305,7 +2301,7 @@ macro(ROOTTEST_COMPILE_MACRO filename)
     string(REPLACE "/" "\\\\" realfp ${realfp})
   endif()
 
-  set(BuildScriptFile ${ROOTTEST_DIR}/scripts/build.C)
+  set(BuildScriptFile ${ROOT_SOURCE_DIR}/roottest/scripts/build.C)
 
   set(BuildScriptArg \(\"${realfp}\",\"${ARG_BUILDLIB}\",\"${ARG_BUILDOBJ}\"\))
 
@@ -3144,7 +3140,7 @@ function(ROOTTEST_ADD_TEST testname)
                         ${outref}
                         ${errref}
                         WORKING_DIR ${test_working_dir}
-                        DIFFCMD ${Python3_EXECUTABLE} ${ROOTTEST_DIR}/scripts/custom_diff.py
+                        DIFFCMD ${Python3_EXECUTABLE} ${ROOT_SOURCE_DIR}/roottest/scripts/custom_diff.py
                         TIMEOUT ${timeout}
                         ${environment}
                         ${build}

--- a/roottest/CMakeLists.txt
+++ b/roottest/CMakeLists.txt
@@ -266,14 +266,11 @@ else()
   endif()
 endif()
 
-# Resolve symbolic links for the ROOTTEST_DIR variable.
-get_filename_component(ROOTTEST_DIR ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
-
 # Set some variables that customizes the behaviour of the ROOT macros
 set(CMAKE_ROOTTEST_DICT ON)
 
 # Set the CMake module path. Here are all the custom CMake modules.
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ROOTTEST_DIR}/cmake/modules")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${ROOT_SOURCE_DIR}/roottest/cmake/modules")
 
 # Find python.
 if(ROOT_pyroot_FOUND)

--- a/roottest/root/tree/fastcloningeventtree/CMakeLists.txt
+++ b/roottest/root/tree/fastcloningeventtree/CMakeLists.txt
@@ -1,8 +1,4 @@
-if(ROOTTEST_DIR)
-      set(ROOT_EVENT_DIR ${ROOTTEST_DIR}/root/treeformula/event/)
-else()
-      set(ROOT_EVENT_DIR ${ROOT_SOURCE_DIR}/roottest/root/treeformula/event/)
-endif()
+set(ROOT_EVENT_DIR ${ROOT_SOURCE_DIR}/roottest/root/treeformula/event/)
 
 # Generating dataset from roottest-treeformula-event-make test
 # FIXME: it will be nice to move roottest-treeformula-event to CMake and add it as dependency


### PR DESCRIPTION
It's not needed anymore now that `roottest` was merged into the main repository.

Follows up on a comment by @pcanal:

  * https://github.com/root-project/root/pull/19370#discussion_r2242930620