### PR TITLE
[roottest] Fix warnings in AliAOD tests

### DIFF
--- a/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.cxx
+++ b/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.cxx
@@ -21,7 +21,7 @@
 #include <TObjString.h>
 #include <TObjArray.h>
 // #include "AliLog.h"
-#define AliWarningGeneral(X,Y) do { ::Warning((X), (Y)); } while(false)
+#define AliWarningGeneral(X, fmt, Y) do { ::Warning((X), (fmt), (Y)); } while(false)
 ClassImp(AliAODForwardMult)
 #ifdef DOXY_INPUT
 ; // For Emacs
@@ -320,8 +320,7 @@ AliAODForwardMult::MakeTriggerMask(const char* what)
     else if (s.CompareTo("E")          == 0) trgMask |= kE;
     else if (s.CompareTo("NCLUSTER>0") == 0) trgMask |= kNClusterGt0;
     else
-      AliWarningGeneral("MakeTriggerMask",
-			Form("Unknown trigger %s", s.Data()));
+      AliWarningGeneral("MakeTriggerMask", "Unknown trigger %s", s.Data());
   }
   delete parts;
   return trgMask;

--- a/roottest/root/io/evolution/pragma_read/v2/AliAODForwardHeader.cxx
+++ b/roottest/root/io/evolution/pragma_read/v2/AliAODForwardHeader.cxx
@@ -11,7 +11,7 @@
 #include <TObjArray.h>
 #include <TH1.h>
 // #include "AliLog.h"
-#define AliWarningGeneral(X,Y) do { ::Warning((X), (Y)); } while(false)
+#define AliWarningGeneral(X, fmt, Y) do { ::Warning((X), (fmt), (Y)); } while(false)
 ClassImp(AliAODForwardHeader)
 #ifdef DOXY_INPUT
 ; // For Emacs
@@ -209,8 +209,7 @@ AliAODForwardHeader::MakeTriggerMask(const char* what)
     else if (s.CompareTo("E")          == 0) trgMask |= kE;
     else if (s.CompareTo("NCLUSTER>0") == 0) trgMask |= kNClusterGt0;
     else
-      AliWarningGeneral("MakeTriggerMask",
-			Form("Unknown trigger %s", s.Data()));
+      AliWarningGeneral("MakeTriggerMask", "Unknown trigger %s", s.Data());
   }
   delete parts;
   return trgMask;


### PR DESCRIPTION
On my machine, the AliAOD tests fail with the following warning:
```txt
  99/1338 Test  #373: roottest-root-io-evolution-pragma_read-libRoottestIoEvolutionPragmaV1-build .......................***Failed   18.22 sec
Generating libRoottestIoEvolutionPragmaV1.cxx, libRoottestIoEvolutionPragmaV1_rdict.pcm
Building CXX object roottest/root/io/evolution/pragma_read/CMakeFiles/libRoottestIoEvolutionPragmaV1libgen.dir/libRoottestIoEvolutionPragmaV1.cxx.o
Building CXX object roottest/root/io/evolution/pragma_read/CMakeFiles/libRoottestIoEvolutionPragmaV1libgen.dir/v1/AliAODForwardMult.cxx.o
/home/rembserj/code/root/root_src/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.cxx: In static member function ‘static UInt_t AliAODForwardMult::MakeTriggerMask(const char*)’:
/home/rembserj/code/root/root_src/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.cxx:24:46: error: format not a string literal and no format arguments [-Werror=format-security]
   24 | #define AliWarningGeneral(X,Y) do { ::Warning((X), (Y)); } while(false)
      |                                     ~~~~~~~~~^~~~~~~~~~
/home/rembserj/code/root/root_src/roottest/root/io/evolution/pragma_read/v1/AliAODForwardMult.cxx:323:7: note: in expansion of macro ‘AliWarningGeneral’
  323 |       AliWarningGeneral("MakeTriggerMask",
      |       ^~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
make[1]: *** [roottest/root/io/evolution/pragma_read/CMakeFiles/libRoottestIoEvolutionPragmaV1libgen.dir/build.make:93: roottest/root/io/evolution/pragma_read/CMakeFiles/libRoottestIoEvolutionPragmaV1libgen.dir/v1/AliAODForwardMult.cxx.o] Error 1
make: *** [Makefile:13451: libRoottestIoEvolutionPragmaV1libgen/fast] Error 2
```

The warning is fixed by adding a format argument to the macro.