### PR TITLE
[ntuple] Prevent creating a RNTupleView of a Streamer field

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -266,6 +266,8 @@ public:
    /// **Note**: if `T = void`, type checks are disabled. This is not really useful for this overload because
    /// RNTupleView<void> does not give access to the pointer. If required, it is possible to provide an `objPtr` of a
    /// dynamic type, for example via GetView(std::string_view, void *, std::string_view).
+   ///
+   /// Note that creating a View for a Streamer field is not supported.
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName)
    {
@@ -295,6 +297,8 @@ public:
    /// object types. It is strongly recommended to use an overload that allows passing the `typeName`, such as
    /// GetView(std::string_view, void *, std::string_view). This allows type checks with the on-disk metadata and
    /// enables automatic schema evolution and conversion rules.
+   ///
+   /// Note that creating a View for a Streamer field is not supported.
    template <typename T>
    ROOT::RNTupleView<T> GetView(std::string_view fieldName, std::shared_ptr<T> objPtr)
    {

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -563,8 +563,13 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
             if (cl->GetCollectionProxy()) {
                result = std::make_unique<RProxiedCollectionField>(fieldName, typeName);
             } else {
-               if (ROOT::Internal::GetRNTupleSerializationMode(cl) ==
-                   ROOT::Internal::ERNTupleSerializationMode::kForceStreamerMode) {
+               bool reconstructAsStreamer = ROOT::Internal::GetRNTupleSerializationMode(cl) ==
+                                            ROOT::Internal::ERNTupleSerializationMode::kForceStreamerMode;
+               if (!reconstructAsStreamer && desc) {
+                  reconstructAsStreamer =
+                     (desc->GetFieldDescriptor(fieldId).GetStructure() == ENTupleStructure::kStreamer);
+               }
+               if (reconstructAsStreamer) {
                   result = std::make_unique<RStreamerField>(fieldName, typeName);
                } else {
                   result = std::make_unique<RClassField>(fieldName, typeName);

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -421,6 +421,9 @@ void ROOT::RClassField::BeforeConnectPageSource(ROOT::Internal::RPageSource &pag
       const ROOT::RNTupleDescriptor &desc = descriptorGuard.GetRef();
       const auto &fieldDesc = desc.GetFieldDescriptor(GetOnDiskId());
 
+      if (fieldDesc.GetStructure() == ENTupleStructure::kStreamer)
+         throw RException(R__FAIL("invalid attempt to reconstruct StreamerField as a ClassField"));
+
       for (auto linkId : fieldDesc.GetLinkIds()) {
          const auto &subFieldDesc = desc.GetFieldDescriptor(linkId);
          regularSubfields.insert(subFieldDesc.GetFieldName());


### PR DESCRIPTION
An RNTupleView created from a Streamer field currently silently reads zeroed values if the dictionary is available, as the View attempts to create a RClassField but fails to find any columns for its subfields. This is not considered an error because of schema evolution, so all fields will be marked as artificial and zero initialized.

To prevent this from happening, explicitly check that the field is not stored as a Streamer field on disk in BeforeConnectPageSource and error out if that's the case.


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


