### PR TITLE
[Python][RDF] Add support for std::vector and std::array in numba jitted functions

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -33,9 +33,37 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
     except:
         raise Exception('Failed to import cffi')
     import re, sys
+    from typing import Union
 
     if hasattr(nb, 'version_info') and nb.version_info >= (0, 54):
         import cppyy.numba_ext
+
+    CONTAINER_TYPES = {
+        'RVec': {
+            'match_pattern': r'RVec\w+|RVec<[\w\s]+>',
+            'cpp_name': 'ROOT::RVec',
+        },
+        'std::vector': {
+            'match_pattern': r'std::vector<[\w\s]+>',
+            'cpp_name': 'std::vector',
+        },
+        'std::array': {
+            'match_pattern': r'std::array<[\w\s,<>]+>',
+            'cpp_name': 'std::array',
+        },
+    }
+
+    def get_container_type(cpp_type: str) -> Union[str, None]:
+        return next((name for name in CONTAINER_TYPES if name in cpp_type), None)
+
+    def is_container_type(cpp_type: str) -> bool:
+        return get_container_type(cpp_type) is not None
+
+    def get_container_cpp_name(cpp_type: str) -> Union[str, None]:
+        container_type = get_container_type(cpp_type)
+        if container_type is None:
+            return None
+        return CONTAINER_TYPES[container_type]['cpp_name']
 
     # Normalize input types by stripping ROOT and VecOps namespaces from input types
     def normalize_typename(t):
@@ -48,7 +76,7 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
     return_type = normalize_typename(return_type) if return_type is not None else None
 
     # Helper functions to determine types
-    def get_inner_type(t):
+    def get_inner_type(t: str, with_dims: bool = False) -> str:
         '''
         Get inner typename of a templated C++ typename
         '''
@@ -72,7 +100,11 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
                         'Unrecognized type {}. Valid shorthand aliases of RVec are {}'
                         .format(t, list('RVec' + i for i in typemap.keys())))
             g = re.match('(.*)<(.*)>', t).groups(0)
-            return g[1]
+            inner_type = g[1]
+            # Handle std::array<T, N> by splitting the inner type, if requested
+            if ',' in inner_type and not with_dims:
+                inner_type = inner_type.split(',')[0].strip()
+            return inner_type
         except:
             raise Exception('Failed to extract template argument of type {}'.format(t))
 
@@ -94,7 +126,7 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         if t in typemap:
             return typemap[t]
         raise Exception(
-                'Type {} is not supported for jitting with numba. Valid fundamental types and RVecs thereof are {}'.format(
+                'Type {} is not supported for jitting with numba. Valid fundamental types and container types (RVec, std::vector, std::array) thereof are {}'.format(
                     t, list(typemap.keys())))
 
     def get_c_signature(input_types, return_type):
@@ -105,12 +137,12 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         '''
         c_input_types = []
         for t in input_types:
-            if 'RVec' in t:
+            if is_container_type(t):
                 c_input_types += [nb.types.CPointer(get_numba_type(get_inner_type(t))), nb.int32]
             else:
                 c_input_types.append(get_numba_type(t))
-        if 'RVec' in return_type:
-            # We return an RVec through pointers as part of the input arguments. Note that the
+        if is_container_type(return_type):
+            # We return an container through pointers as part of the input arguments. Note that the
             # pointer type in numba is always an int64 and is later on cast in C++ to the correct type.
             # In addition, we provide the size of the data type of the array for preallocating memory of
             # the returned array.
@@ -129,12 +161,12 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         '''
         nb_input_types = []
         for t in input_types:
-            if 'RVec' in t:
+            if is_container_type(t):
                 nb_input_types.append(get_numba_type(get_inner_type(t))[:])
             else:
                 nb_input_types.append(get_numba_type(t))
         if return_type is not None:
-            if 'RVec' in return_type:
+            if is_container_type(return_type):
                 nb_return_type = get_numba_type(get_inner_type(return_type))[:]
             else:
                 nb_return_type = get_numba_type(return_type)
@@ -142,20 +174,23 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
             nb_return_type = None
         return nb_return_type, nb_input_types
 
-    def add_rvec_input_type_ref(input_types_ref, const_mod, rvect):
+    def add_container_input_type_ref(input_types_ref: list, const_mod: str, container_t: str) -> None:
         '''
-        Construct the type of an RVec input parameter for its use in the C++
+        Construct the type of a container input parameter for its use in the C++
         wrapper function signature.
         '''
-        tref = '{}ROOT::{}&'.format(const_mod, rvect)
+        container_base = get_container_type(container_t)
+        cpp_name = get_container_cpp_name(container_t)
+        full_type = container_t.replace(container_base, cpp_name, 1)
+        tref = f"{const_mod}{full_type}&"
         input_types_ref.append(tref)
 
-    def add_rvec_func_ptr_input_type(func_ptr_input_types, const_mod, rvect):
+    def add_container_func_ptr_input_type(func_ptr_input_types: list, const_mod: str, container_t: str) -> None:
         '''
-        Construct the type of an RVec input parameter for its use in the cast
+        Construct the type of a container input parameter for its use in the cast
         of the function pointer of the jitted Python wrapper.
         '''
-        innert = get_inner_type(rvect)
+        innert = get_inner_type(container_t)
         if innert == 'bool':
             # Special treatment for bool: In numpy, bools have 1 byte
             innert = 'char'
@@ -203,21 +238,21 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
 
         # Define signature
         pywrapper_signature = [
-                'ptr_{0}, size_{0}'.format(i) if 'RVec' in t else 'x_{}'.format(i) \
+                'ptr_{0}, size_{0}'.format(i) if is_container_type(t) else 'x_{}'.format(i) \
                         for i, t in enumerate(input_types)]
-        if 'RVec' in return_type:
-            # If we return an RVec, we return via pointer the pointer of the allocated data,
+        if is_container_type(return_type):
+            # If we return a container, we return via pointer the pointer of the allocated data,
             # the size in elements. In addition, we provide the size of the datatype in bytes.
             pywrapper_signature += ['ptrptr_r, ptrsize_r']
 
         # Define arguments for jit function
         pywrapper_args_def = [
-                'x_{0} = nb.carray(ptr_{0}, (size_{0},))'.format(i) if 'RVec' in t else 'x_{}'.format(i) \
+                'x_{0} = nb.carray(ptr_{0}, (size_{0},))'.format(i) if is_container_type(t) else 'x_{}'.format(i) \
                         for i, t in enumerate(input_types)]
         pywrapper_args = ['x_{}'.format(i) for i in range(len(input_types))]
 
         # Define return operation
-        if 'RVec' in return_type:
+        if is_container_type(return_type):
             innert = get_inner_type(return_type)
             dtypesize = 1 if innert == 'bool' else int(get_numba_type(innert).bitwidth / 8)
             pywrapper_return = '\n    '.join([
@@ -238,7 +273,7 @@ def pywrapper({SIGNATURE}):
     """
     Wrapper function for the jitted Python callable with special treatment of arrays
     """
-    # If an RVec is given, define numba carray wrapper for the input types
+    # If a container is given, define numba carray wrapper for the input types
     {ARGS_DEF}
     # Call the jitted Python function
     r = nbjit({ARGS})
@@ -260,7 +295,7 @@ def pywrapper({SIGNATURE}):
         C = ffi.dlopen(None)
         glob['malloc'] = C.malloc
 
-        if 'RVec' in return_type:
+        if is_container_type(return_type):
             glob['dtype_r'] = get_numba_type(get_inner_type(return_type))
 
         # Execute the pywrapper code and generate the wrapper function
@@ -301,25 +336,26 @@ def pywrapper({SIGNATURE}):
         input_types_ref = []
         func_ptr_input_types = []
         for t in input_types:
-            m = re.match(r'\s*(const\s+)?(RVec\w+|RVec<[\w\s]+>)', t)
+            container_match_group = '|'.join(entry['match_pattern'] for entry in CONTAINER_TYPES.values())
+            m = re.match(rf'\s*(const\s+)?({container_match_group})', t)
             if m:
                 const_mod = '' if m.group(1) is None else 'const '
-                rvect = m.group(2)
+                container_t = m.group(2)
 
-                add_rvec_input_type_ref(input_types_ref, const_mod, rvect)
-                add_rvec_func_ptr_input_type(func_ptr_input_types, const_mod, rvect)
+                add_container_input_type_ref(input_types_ref, const_mod, container_t)
+                add_container_func_ptr_input_type(func_ptr_input_types, const_mod, container_t)
             else:
                 input_types_ref.append(t)
                 func_ptr_input_types.append(t)
 
         input_signature = ', '.join('{} x_{}'.format(t, i) for i, t in enumerate(input_types_ref))
 
-        if 'RVec' in return_type:
+        if is_container_type(return_type):
             # See C++ wrapper code for the reason using these types
             innert = get_inner_type(return_type)
             func_ptr_input_types += ['{}**, long*'.format('char' if innert == 'bool' else innert)]
         func_ptr_type = '{RETURN_TYPE}(*)({INPUT_TYPES})'.format(
-                RETURN_TYPE='void*' if 'RVec' in return_type else return_type,
+                RETURN_TYPE='void*' if is_container_type(return_type) else return_type,
                 INPUT_TYPES=', '.join(func_ptr_input_types)
                 )
 
@@ -327,32 +363,53 @@ def pywrapper({SIGNATURE}):
         vecbool_conversion = []
         func_args = []
         for i, t in enumerate(input_types):
-            if 'RVec' in t:
+            if is_container_type(t):
                 func_args += ['x_{0}.data(), x_{0}.size()'.format(i)]
                 if get_inner_type(t) == 'bool':
-                    # Copy the RVec<bool> to a RVec<char> to match the numpy memory layout
+                    # Copy the container<bool> to a container<char> to match the numpy memory layout
                     func_args[-1] = func_args[-1].replace('x_', 'xb_')
-                    vecbool_conversion += ['ROOT::RVec<char> xb_{0} = x_{0};'.format(i)]
+                    vecbool_conversion += [f'{get_container_cpp_name(t)}<char> xb_{i} = x_{i};']
             else:
                 func_args += ['x_{}'.format(i)]
-        if 'RVec' in return_type:
+        if is_container_type(return_type):
             # See C++ wrapper code for the reason using these arguments
             func_args += ['&ptr, &size']
 
         # Define return operation
-        if 'RVec' in return_type:
+        if is_container_type(return_type):
             innert = get_inner_type(return_type)
-            if innert == 'bool': innert = 'char'
+            container_cpp = get_container_cpp_name(return_type)
+            inner_with_dims = get_inner_type(return_type, with_dims=True)
+
+            if innert == 'bool':
+                innert = 'char'
+                inner_with_dims = 'char' + inner_with_dims[4:]
+
+            # Default case: create container from pointer and size (e.g. std::vector, RVec)
+            copy_lines = [
+                f'{container_cpp}<{innert}> x_r(ptr, ptr + size);'
+            ]
+
+            # Special case: if inner type includes dimensions (e.g. std::array<T, N>)
+            # We construct the array then copy the data manually
+            if innert != inner_with_dims:
+                innert, dims = inner_with_dims.split(',')
+                copy_lines = [
+                    f'{container_cpp}<{innert}, {dims}> x_r;'
+                    f'std::copy(ptr, ptr + size, x_r.begin());'
+                ]
+
             return_op = '\n    '.join([
-                '// Because an RVec cannot take the ownership of external data, we have to copy the returned array',
+                '// Because a container type cannot take the ownership of external data, we have to copy the returned array',
                 'long size; // Size of the returned array',
-                '{}* ptr; // Pointer to the data of the returned array'.format(innert),
-                'funcptr({});'.format(', '.join(func_args)),
-                # TODO: Remove this copy as soon as RVec can adopt the ownership
-                'ROOT::RVec<{}> x_r(ptr, ptr + size);'.format(innert),
+                f'{innert}* ptr; // Pointer to the data of the returned array',
+                f'funcptr({", ".join(func_args)});',
+                # TODO: Remove this copy as soon as the container type can adopt the ownership
+                *copy_lines,
                 'free(ptr);',
-                # If we return a RVec<bool>, we rely here on the automatic conversion of RVec<char> to RVec<bool>
-                'return x_r;'])
+                # If we return a container_type<bool>, we rely here on the automatic conversion of container_type<char> to container_type<bool>
+                'return x_r;'
+            ])
         else:
             return_op = 'return funcptr({});'.format(', '.join(func_args))
 
@@ -365,7 +422,7 @@ namespace Numba {{
 {RETURN_TYPE} {FUNC_NAME}({INPUT_SIGNATURE}) {{
     // Create a function pointer from the jitted Python wrapper
     const auto funcptr = reinterpret_cast<{FUNC_PTR_TYPE}>({FUNC_PTR});
-    // Perform conversion of RVec<bool>
+    // Perform conversion of container_type<bool>
     {VECBOOL_CONVERSION}
     // Return the result
     {RETURN_OP}

--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -1,8 +1,8 @@
 from cppyy import gbl as gbl_namespace
 
 
-def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
-    '''
+def _NumbaDeclareDecorator(input_types, return_type=None, name=None):
+    """
     Decorator for making Python callables accessible in C++ by just-in-time compilation
     with numba and cling
 
@@ -22,34 +22,34 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
     Note that the callable is fully compiled without side-effects. The numba jitting uses the nopython
     option which does not allow interaction with the Python interpreter. This means that you can use
     the resulting function also safely in multi-threaded environments.
-    '''
+    """
     # Make required imports
     try:
         import numba as nb
-    except:
-        raise Exception('Failed to import numba')
+    except ImportError:
+        raise Exception("Failed to import numba")
     try:
         import cffi
-    except:
-        raise Exception('Failed to import cffi')
-    import re, sys
+    except ImportError:
+        raise Exception("Failed to import cffi")
+    import re
     from typing import Union
 
-    if hasattr(nb, 'version_info') and nb.version_info >= (0, 54):
-        import cppyy.numba_ext
+    if hasattr(nb, "version_info") and nb.version_info >= (0, 54):
+        pass
 
     CONTAINER_TYPES = {
-        'RVec': {
-            'match_pattern': r'RVec\w+|RVec<[\w\s]+>',
-            'cpp_name': 'ROOT::RVec',
+        "RVec": {
+            "match_pattern": r"RVec\w+|RVec<[\w\s]+>",
+            "cpp_name": "ROOT::RVec",
         },
-        'std::vector': {
-            'match_pattern': r'std::vector<[\w\s]+>',
-            'cpp_name': 'std::vector',
+        "std::vector": {
+            "match_pattern": r"std::vector<[\w\s]+>",
+            "cpp_name": "std::vector",
         },
-        'std::array': {
-            'match_pattern': r'std::array<[\w\s,<>]+>',
-            'cpp_name': 'std::array',
+        "std::array": {
+            "match_pattern": r"std::array<[\w\s,<>]+>",
+            "cpp_name": "std::array",
         },
     }
 
@@ -63,78 +63,82 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         container_type = get_container_type(cpp_type)
         if container_type is None:
             return None
-        return CONTAINER_TYPES[container_type]['cpp_name']
+        return CONTAINER_TYPES[container_type]["cpp_name"]
 
     # Normalize input types by stripping ROOT and VecOps namespaces from input types
     def normalize_typename(t):
-        '''
+        """
         Remove ROOT:: and VecOps:: namespaces
-        '''
-        return t.replace('ROOT::', '').replace('VecOps::', '')
+        """
+        return t.replace("ROOT::", "").replace("VecOps::", "")
 
     input_types = [normalize_typename(t) for t in input_types]
     return_type = normalize_typename(return_type) if return_type is not None else None
 
     # Helper functions to determine types
     def get_inner_type(t: str, with_dims: bool = False) -> str:
-        '''
+        """
         Get inner typename of a templated C++ typename
-        '''
+        """
         try:
-            if '<' not in t:
+            if "<" not in t:
                 # therefore, type must use a shorthand alias
                 typemap = {
-                        'F': 'float',
-                        'D': 'double',
-                        'I': 'int',
-                        'U': 'unsigned int',
-                        'L': 'long',
-                        'UL': 'unsigned long',
-                        'B': 'bool'
-                        }
-                rvec_start = t.find('RVec') # discard a possible const modifier before "RVec"
+                    "F": "float",
+                    "D": "double",
+                    "I": "int",
+                    "U": "unsigned int",
+                    "L": "long",
+                    "UL": "unsigned long",
+                    "B": "bool",
+                }
+                rvec_start = t.find("RVec")  # discard a possible const modifier before "RVec"
                 try:
-                    return typemap[t[rvec_start+4:]] # alias type characters come after "RVec"
+                    return typemap[t[rvec_start + 4 :]]  # alias type characters come after "RVec"
                 except KeyError:
                     raise Exception(
-                        'Unrecognized type {}. Valid shorthand aliases of RVec are {}'
-                        .format(t, list('RVec' + i for i in typemap.keys())))
-            g = re.match('(.*)<(.*)>', t).groups(0)
+                        "Unrecognized type {}. Valid shorthand aliases of RVec are {}".format(
+                            t, list("RVec" + i for i in typemap.keys())
+                        )
+                    )
+            g = re.match("(.*)<(.*)>", t).groups(0)
             inner_type = g[1]
             # Handle std::array<T, N> by splitting the inner type, if requested
-            if ',' in inner_type and not with_dims:
-                inner_type = inner_type.split(',')[0].strip()
+            if "," in inner_type and not with_dims:
+                inner_type = inner_type.split(",")[0].strip()
             return inner_type
-        except:
-            raise Exception('Failed to extract template argument of type {}'.format(t))
+        except:  # noqa E722
+            raise Exception("Failed to extract template argument of type {}".format(t))
 
     def get_numba_type(t):
-        '''
+        """
         Get numba type object from a C++ fundamental typename
 
         These are the types we use to jit the Python callable.
-        '''
+        """
         typemap = {
-                'float': nb.float32,
-                'double': nb.float64,
-                'int': nb.int32,
-                'unsigned int': nb.uint32,
-                'long': nb.int64,
-                'unsigned long': nb.uint64,
-                'bool': nb.boolean
-                }
+            "float": nb.float32,
+            "double": nb.float64,
+            "int": nb.int32,
+            "unsigned int": nb.uint32,
+            "long": nb.int64,
+            "unsigned long": nb.uint64,
+            "bool": nb.boolean,
+        }
         if t in typemap:
             return typemap[t]
         raise Exception(
-                'Type {} is not supported for jitting with numba. Valid fundamental types and container types (RVec, std::vector, std::array) thereof are {}'.format(
-                    t, list(typemap.keys())))
+            "Type {} is not supported for jitting with numba. Valid fundamental types and container types (RVec, std::vector, std::array) thereof are {}".format(
+                t, list(typemap.keys())
+            )
+        )
 
     def get_c_signature(input_types, return_type):
-        '''
+        """
         Get C friendly signature as numba type objects from C++ typenames
 
         We need the types to jit a Python wrapper, which can be accessed as a function pointer in C++.
-        '''
+        """
         c_input_types = []
         for t in input_types:
             if is_container_type(t):
@@ -149,16 +153,17 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
             # See the Python wrapper for further information why we are using these types.
             c_return_type = nb.void
             c_input_types += [
-                    nb.types.CPointer(nb.int64), # Pointer to the data (the first element of the array)
-                    nb.types.CPointer(nb.int64)] # Size of the array in elements
+                nb.types.CPointer(nb.int64),  # Pointer to the data (the first element of the array)
+                nb.types.CPointer(nb.int64),
+            ]  # Size of the array in elements
         else:
             c_return_type = get_numba_type(return_type)
         return c_return_type, c_input_types
 
     def get_numba_signature(input_types, return_type):
-        '''
+        """
         Get numba signature as numba type objects from C++ typenames
-        '''
+        """
         nb_input_types = []
         for t in input_types:
             if is_container_type(t):
@@ -175,10 +180,10 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         return nb_return_type, nb_input_types
 
     def add_container_input_type_ref(input_types_ref: list, const_mod: str, container_t: str) -> None:
-        '''
+        """
         Construct the type of a container input parameter for its use in the C++
         wrapper function signature.
-        '''
+        """
         container_base = get_container_type(container_t)
         cpp_name = get_container_cpp_name(container_t)
         full_type = container_t.replace(container_base, cpp_name, 1)
@@ -186,48 +191,48 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
         input_types_ref.append(tref)
 
     def add_container_func_ptr_input_type(func_ptr_input_types: list, const_mod: str, container_t: str) -> None:
-        '''
+        """
         Construct the type of a container input parameter for its use in the cast
         of the function pointer of the jitted Python wrapper.
-        '''
+        """
         innert = get_inner_type(container_t)
-        if innert == 'bool':
+        if innert == "bool":
             # Special treatment for bool: In numpy, bools have 1 byte
-            innert = 'char'
+            innert = "char"
 
-        func_ptr_input_types += ['{}{}*, int'.format(const_mod, innert)]
+        func_ptr_input_types += ["{}{}*, int".format(const_mod, innert)]
 
     def inner(func, input_types=input_types, return_type=return_type, name=name):
-        '''
+        """
         Inner decorator without arguments, see outer decorator for documentation
-        '''
+        """
 
         # Jit the given Python callable with numba
         nb_return_type, nb_input_types = get_numba_signature(input_types, return_type)
         try:
             if nb_return_type is not None:
-                nbjit = nb.jit(nb_return_type(*nb_input_types), nopython=True, inline='always')(func)
+                nbjit = nb.jit(nb_return_type(*nb_input_types), nopython=True, inline="always")(func)
             else:
-                nbjit = nb.jit(tuple(nb_input_types), nopython=True, inline='always')(func)
+                nbjit = nb.jit(tuple(nb_input_types), nopython=True, inline="always")(func)
                 nb_return_type = nbjit.nopython_signatures[-1].return_type
-        except:
-            raise Exception('Failed to jit Python callable {} with numba.jit'.format(func))
+        except:  # noqa E722
+            raise Exception("Failed to jit Python callable {} with numba.jit".format(func))
         func.numba_func = nbjit
         # return_type = "int"
         if return_type is None:
             type_map = {
-                nb.types.boolean: 'bool',
-                nb.types.uint8: 'unsigned int',
-                nb.types.uint16: 'unsigned int',
-                nb.types.uint32: 'unsigned int',
-                nb.types.uint64: 'unsigned long',
-                nb.types.char: 'int',
-                nb.types.int8: 'int',
-                nb.types.int16: 'int',
-                nb.types.int32: 'int',
-                nb.types.int64: 'long',
-                nb.types.float32: 'float',
-                nb.types.float64: 'double',
+                nb.types.boolean: "bool",
+                nb.types.uint8: "unsigned int",
+                nb.types.uint16: "unsigned int",
+                nb.types.uint32: "unsigned int",
+                nb.types.uint64: "unsigned long",
+                nb.types.char: "int",
+                nb.types.int8: "int",
+                nb.types.int16: "int",
+                nb.types.int32: "int",
+                nb.types.int64: "long",
+                nb.types.float32: "float",
+                nb.types.float64: "double",
             }
 
             if nb_return_type in type_map:
@@ -238,34 +243,38 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
 
         # Define signature
         pywrapper_signature = [
-                'ptr_{0}, size_{0}'.format(i) if is_container_type(t) else 'x_{}'.format(i) \
-                        for i, t in enumerate(input_types)]
+            "ptr_{0}, size_{0}".format(i) if is_container_type(t) else "x_{}".format(i)
+            for i, t in enumerate(input_types)
+        ]
         if is_container_type(return_type):
             # If we return a container, we return via pointer the pointer of the allocated data,
             # the size in elements. In addition, we provide the size of the datatype in bytes.
-            pywrapper_signature += ['ptrptr_r, ptrsize_r']
+            pywrapper_signature += ["ptrptr_r, ptrsize_r"]
 
         # Define arguments for jit function
         pywrapper_args_def = [
-                'x_{0} = nb.carray(ptr_{0}, (size_{0},))'.format(i) if is_container_type(t) else 'x_{}'.format(i) \
-                        for i, t in enumerate(input_types)]
-        pywrapper_args = ['x_{}'.format(i) for i in range(len(input_types))]
+            "x_{0} = nb.carray(ptr_{0}, (size_{0},))".format(i) if is_container_type(t) else "x_{}".format(i)
+            for i, t in enumerate(input_types)
+        ]
+        pywrapper_args = ["x_{}".format(i) for i in range(len(input_types))]
 
         # Define return operation
         if is_container_type(return_type):
             innert = get_inner_type(return_type)
-            dtypesize = 1 if innert == 'bool' else int(get_numba_type(innert).bitwidth / 8)
-            pywrapper_return = '\n    '.join([
-                '# Because we cannot manipulate the memory management of the numpy array we copy the data',
-                'ptr = malloc(r.size * {})'.format(dtypesize),
-                'cp = nb.carray(ptr, r.size, dtype_r)',
-                'cp[:] = r[:]',
-                '# Return size of the array and the pointer to the copied data',
-                'ptrsize_r[0] = r.size',
-                'ptrptr_r[0] = cp.ctypes.data'
-                ])
+            dtypesize = 1 if innert == "bool" else int(get_numba_type(innert).bitwidth / 8)
+            pywrapper_return = "\n    ".join(
+                [
+                    "# Because we cannot manipulate the memory management of the numpy array we copy the data",
+                    "ptr = malloc(r.size * {})".format(dtypesize),
+                    "cp = nb.carray(ptr, r.size, dtype_r)",
+                    "cp[:] = r[:]",
+                    "# Return size of the array and the pointer to the copied data",
+                    "ptrsize_r[0] = r.size",
+                    "ptrptr_r[0] = cp.ctypes.data",
+                ]
+            )
         else:
-            pywrapper_return = 'return r'
+            pywrapper_return = "return r"
 
         # Build wrapper code
         pywrappercode = '''\
@@ -280,23 +289,23 @@ def pywrapper({SIGNATURE}):
     # Return the result
     {RETURN}
         '''.format(
-                SIGNATURE=', '.join(pywrapper_signature),
-                ARGS_DEF='\n    '.join(pywrapper_args_def),
-                ARGS=', '.join(pywrapper_args),
-                RETURN=pywrapper_return
-                )
+            SIGNATURE=", ".join(pywrapper_signature),
+            ARGS_DEF="\n    ".join(pywrapper_args_def),
+            ARGS=", ".join(pywrapper_args),
+            RETURN=pywrapper_return,
+        )
 
-        glob = dict(globals()) # Make a shallow copy of the dictionary so we don't pollute the global scope
-        glob['nb'] = nb
-        glob['nbjit'] = nbjit
+        glob = dict(globals())  # Make a shallow copy of the dictionary so we don't pollute the global scope
+        glob["nb"] = nb
+        glob["nbjit"] = nbjit
 
         ffi = cffi.FFI()
-        ffi.cdef('void* malloc(long size);')
+        ffi.cdef("void* malloc(long size);")
         C = ffi.dlopen(None)
-        glob['malloc'] = C.malloc
+        glob["malloc"] = C.malloc
 
         if is_container_type(return_type):
-            glob['dtype_r'] = get_numba_type(get_inner_type(return_type))
+            glob["dtype_r"] = get_numba_type(get_inner_type(return_type))
 
         # Execute the pywrapper code and generate the wrapper function
         # which calls the jitted C function
@@ -309,15 +318,15 @@ def pywrapper({SIGNATURE}):
         local_objects = locals()
         exec(pywrappercode, glob, local_objects)
 
-        if not 'pywrapper' in local_objects:
-            raise Exception('Failed to create Python wrapper function:\n{}'.format(pywrappercode))
+        if "pywrapper" not in local_objects:
+            raise Exception("Failed to create Python wrapper function:\n{}".format(pywrappercode))
 
         # Jit the Python wrapper code
         c_return_type, c_input_types = get_c_signature(input_types, return_type)
         try:
-            nbcfunc = nb.cfunc(c_return_type(*c_input_types), nopython=True)(local_objects['pywrapper'])
-        except:
-            raise Exception('Failed to jit Python wrapper with numba.cfunc')
+            nbcfunc = nb.cfunc(c_return_type(*c_input_types), nopython=True)(local_objects["pywrapper"])
+        except:  # noqa E722
+            raise Exception("Failed to jit Python wrapper with numba.cfunc")
         func.__py_wrapper__ = pywrappercode
         func.__numba_cfunc__ = nbcfunc
 
@@ -336,10 +345,10 @@ def pywrapper({SIGNATURE}):
         input_types_ref = []
         func_ptr_input_types = []
         for t in input_types:
-            container_match_group = '|'.join(entry['match_pattern'] for entry in CONTAINER_TYPES.values())
-            m = re.match(rf'\s*(const\s+)?({container_match_group})', t)
+            container_match_group = "|".join(entry["match_pattern"] for entry in CONTAINER_TYPES.values())
+            m = re.match(rf"\s*(const\s+)?({container_match_group})", t)
             if m:
-                const_mod = '' if m.group(1) is None else 'const '
+                const_mod = "" if m.group(1) is None else "const "
                 container_t = m.group(2)
 
                 add_container_input_type_ref(input_types_ref, const_mod, container_t)
@@ -348,32 +357,32 @@ def pywrapper({SIGNATURE}):
                 input_types_ref.append(t)
                 func_ptr_input_types.append(t)
 
-        input_signature = ', '.join('{} x_{}'.format(t, i) for i, t in enumerate(input_types_ref))
+        input_signature = ", ".join("{} x_{}".format(t, i) for i, t in enumerate(input_types_ref))
 
         if is_container_type(return_type):
             # See C++ wrapper code for the reason using these types
             innert = get_inner_type(return_type)
-            func_ptr_input_types += ['{}**, long*'.format('char' if innert == 'bool' else innert)]
-        func_ptr_type = '{RETURN_TYPE}(*)({INPUT_TYPES})'.format(
-                RETURN_TYPE='void*' if is_container_type(return_type) else return_type,
-                INPUT_TYPES=', '.join(func_ptr_input_types)
-                )
+            func_ptr_input_types += ["{}**, long*".format("char" if innert == "bool" else innert)]
+        func_ptr_type = "{RETURN_TYPE}(*)({INPUT_TYPES})".format(
+            RETURN_TYPE="void*" if is_container_type(return_type) else return_type,
+            INPUT_TYPES=", ".join(func_ptr_input_types),
+        )
 
         # Define function call
         vecbool_conversion = []
         func_args = []
         for i, t in enumerate(input_types):
             if is_container_type(t):
-                func_args += ['x_{0}.data(), x_{0}.size()'.format(i)]
-                if get_inner_type(t) == 'bool':
+                func_args += ["x_{0}.data(), x_{0}.size()".format(i)]
+                if get_inner_type(t) == "bool":
                     # Copy the container<bool> to a container<char> to match the numpy memory layout
-                    func_args[-1] = func_args[-1].replace('x_', 'xb_')
-                    vecbool_conversion += [f'{get_container_cpp_name(t)}<char> xb_{i} = x_{i};']
+                    func_args[-1] = func_args[-1].replace("x_", "xb_")
+                    vecbool_conversion += [f"{get_container_cpp_name(t)}<char> xb_{i} = x_{i};"]
             else:
-                func_args += ['x_{}'.format(i)]
+                func_args += ["x_{}".format(i)]
         if is_container_type(return_type):
             # See C++ wrapper code for the reason using these arguments
-            func_args += ['&ptr, &size']
+            func_args += ["&ptr, &size"]
 
         # Define return operation
         if is_container_type(return_type):
@@ -381,37 +390,34 @@ def pywrapper({SIGNATURE}):
             container_cpp = get_container_cpp_name(return_type)
             inner_with_dims = get_inner_type(return_type, with_dims=True)
 
-            if innert == 'bool':
-                innert = 'char'
-                inner_with_dims = 'char' + inner_with_dims[4:]
+            if innert == "bool":
+                innert = "char"
+                inner_with_dims = "char" + inner_with_dims[4:]
 
             # Default case: create container from pointer and size (e.g. std::vector, RVec)
-            copy_lines = [
-                f'{container_cpp}<{innert}> x_r(ptr, ptr + size);'
-            ]
+            copy_lines = [f"{container_cpp}<{innert}> x_r(ptr, ptr + size);"]
 
             # Special case: if inner type includes dimensions (e.g. std::array<T, N>)
             # We construct the array then copy the data manually
             if innert != inner_with_dims:
-                innert, dims = inner_with_dims.split(',')
-                copy_lines = [
-                    f'{container_cpp}<{innert}, {dims}> x_r;'
-                    f'std::copy(ptr, ptr + size, x_r.begin());'
-                ]
+                innert, dims = inner_with_dims.split(",")
+                copy_lines = [f"{container_cpp}<{innert}, {dims}> x_r;std::copy(ptr, ptr + size, x_r.begin());"]
 
-            return_op = '\n    '.join([
-                '// Because a container type cannot take the ownership of external data, we have to copy the returned array',
-                'long size; // Size of the returned array',
-                f'{innert}* ptr; // Pointer to the data of the returned array',
-                f'funcptr({", ".join(func_args)});',
-                # TODO: Remove this copy as soon as the container type can adopt the ownership
-                *copy_lines,
-                'free(ptr);',
-                # If we return a container_type<bool>, we rely here on the automatic conversion of container_type<char> to container_type<bool>
-                'return x_r;'
-            ])
+            return_op = "\n    ".join(
+                [
+                    "// Because a container type cannot take the ownership of external data, we have to copy the returned array",
+                    "long size; // Size of the returned array",
+                    f"{innert}* ptr; // Pointer to the data of the returned array",
+                    f"funcptr({', '.join(func_args)});",
+                    # TODO: Remove this copy as soon as the container type can adopt the ownership
+                    *copy_lines,
+                    "free(ptr);",
+                    # If we return a container_type<bool>, we rely here on the automatic conversion of container_type<char> to container_type<bool>
+                    "return x_r;",
+                ]
+            )
         else:
-            return_op = 'return funcptr({});'.format(', '.join(func_args))
+            return_op = "return funcptr({});".format(", ".join(func_args))
 
         # Build wrapper code
         cppwrappercode = """\
@@ -428,18 +434,19 @@ namespace Numba {{
     {RETURN_OP}
 }}
 }}""".format(
-                RETURN_TYPE='ROOT::' + return_type if 'RVec' in return_type else return_type,
-                FUNC_NAME=name,
-                INPUT_SIGNATURE=input_signature,
-                FUNC_PTR=address,
-                FUNC_PTR_TYPE=func_ptr_type,
-                VECBOOL_CONVERSION='\n    '.join(vecbool_conversion),
-                RETURN_OP=return_op)
+            RETURN_TYPE="ROOT::" + return_type if "RVec" in return_type else return_type,
+            FUNC_NAME=name,
+            INPUT_SIGNATURE=input_signature,
+            FUNC_PTR=address,
+            FUNC_PTR_TYPE=func_ptr_type,
+            VECBOOL_CONVERSION="\n    ".join(vecbool_conversion),
+            RETURN_OP=return_op,
+        )
 
         # Jit wrapper C++ code
         err = gbl_namespace.gInterpreter.Declare(cppwrappercode)
         if not err:
-            raise Exception('Failed to jit C++ wrapper code with cling:\n{}'.format(cppwrappercode))
+            raise Exception("Failed to jit C++ wrapper code with cling:\n{}".format(cppwrappercode))
         func.__cpp_wrapper__ = cppwrappercode
 
         return func

--- a/bindings/pyroot/pythonizations/test/numbadeclare.py
+++ b/bindings/pyroot/pythonizations/test/numbadeclare.py
@@ -113,6 +113,31 @@ class NumbaDeclareSimple(unittest.TestCase):
 
         self.assertTrue(np.array_equal(rvecf, np.array([4.])))
 
+    def test_rdataframe_std_vector(self):
+        """
+        Test function call as part of RDataFrame
+        """
+        @ROOT.Numba.Declare(["std::vector<int>"], "std::vector<int>")
+        def square_vec(x):
+            return x * x
+        df = ROOT.RDataFrame(4).Define("x", "std::vector{1, 2, 3}").Define("x_sq", "Numba::square_vec(x)")
+        df.Display().Print()
+        self.assertEqual(df.Sum("x").GetValue(), 24)
+        self.assertEqual(df.Sum("x_sq").GetValue(), 56)
+
+    def test_rdataframe_std_array(self):
+        """
+        Test function call as part of RDataFrame with std::array
+        """
+        @ROOT.Numba.Declare(["std::array<int, 3>"], "std::array<int, 3>")
+        def square_array(x):
+            return x * x
+
+        df = ROOT.RDataFrame(4).Define("x", "std::array{1, 2, 3}").Define("x_sq", "Numba::square_array(x)")
+        df.Display().Print()
+        self.assertEqual(df.Sum("x").GetValue(), 24)
+        self.assertEqual(df.Sum("x_sq").GetValue(), 56)
+
     # Test wrappings
     def test_wrapper_in_void(self):
         """


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR adds support for using `std::vector<T>` and `std::array<T>` as input and return types in functions declared with `ROOT.Numba.Declare` used in RDataFrame `.Define` operations.

This makes it possible to define and use functions like:
```python
@ROOT.Numba.Declare(["std::array<int, 3>"], "std::vector<int>")
def square_vec(x):
    return x * x

rdf = ROOT.RDataFrame(3) \
        .Define("xvec", "std::array{(int)rdfentry_, (int)rdfentry_ + 1, (int)rdfentry_ + 2}") \
        .Define("xvec_square", "Numba::square_vec(xvec)")
```

The implementation reuses the logic for handling RVecs.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
