### PR TITLE
[RF] Make `RooAbsReal` and `RooAbsPdf` instantiable

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -36,8 +36,11 @@ public:
   RooAbsPdf() ;
   RooAbsPdf(const char *name, const char *title=nullptr) ;
   RooAbsPdf(const char *name, const char *title, double minVal, double maxVal) ;
-  // RooAbsPdf(const RooAbsPdf& other, const char* name=nullptr);
   ~RooAbsPdf() override;
+
+  TObject* clone(const char* newname=nullptr) const override {
+    return new RooAbsPdf(*this,newname);
+  }
 
   // Toy MC generation
 
@@ -285,6 +288,8 @@ private:
   }
 
 protected:
+
+  double evaluate() const override;
 
   virtual std::unique_ptr<RooAbsReal> createNLLImpl(RooAbsData& data, const RooLinkedList& cmdList);
   virtual std::unique_ptr<RooFitResult> fitToImpl(RooAbsData& data, const RooLinkedList& cmdList);

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -87,7 +87,9 @@ public:
   RooAbsReal(const RooAbsReal& other, const char* name=nullptr);
   ~RooAbsReal() override;
 
-
+  TObject* clone(const char* newname=nullptr) const override {
+    return new RooAbsReal(*this,newname);
+  }
 
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -453,7 +455,7 @@ protected:
   double traceEval(const RooArgSet* set) const ;
 
   /// Evaluate this PDF / function / constant. Needs to be overridden by all derived classes.
-  virtual double evaluate() const = 0;
+  virtual double evaluate() const;
 
   // Hooks for RooDataSet interface
   void syncCache(const RooArgSet* set=nullptr) override { getVal(set) ; }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -351,6 +351,12 @@ double RooAbsPdf::getValV(const RooArgSet* nset) const
   return _value ;
 }
 
+double RooAbsPdf::evaluate() const
+{
+   throw std::runtime_error(
+      "RooAbsPdf::evaluate() should not be called! Please implement in the RooAbsPdf-derived class.");
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Analytical integral with normalization (see RooAbsReal::analyticalIntegralWN() for further information).

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4367,3 +4367,9 @@ double RooAbsReal::getVal(RooArgSet &&) const
    coutF(Eval) << errMsg.str() << std::endl;
    throw std::runtime_error(errMsg.str());
 }
+
+double RooAbsReal::evaluate() const
+{
+   throw std::runtime_error(
+      "RooAbsReal::evaluate() should not be called! Please implement in the RooAbsReal-derived class.");
+}


### PR DESCRIPTION
In some cases, it might happen that a CallFunc wrapper for the `RooAbsReal` or `RooAbsPdf` classes is created, which gives compile errors because these classes are virtual.

It is however not a big deal to make these classes non-virtual and avoid these errors. The `RooAbsArg::clone()` method should have been overridden anyway since `RooAbsReal` and `RooAbsPdf` already have copy constructors. The only other method that needs to be implemented is `RooAbsReal::evaluate()`, which is done as well. The implementation throws an exception, because `evaluate()` should always be called from derived classes.

This is a bit of a hotfix and one can argue that it would be nicer to first understand why these CallFunc wrappers are even created, but this issue needs to be resolved quickly and with minimal changes: the fix also needs to be backported to older ROOT versions and is crucial for the ATLAS Run 2 Higgs combination analysis.

Issue reported on the ROOT forum:
https://root-forum.cern.ch/t/cannot-open-a-rooworkspace-once-it-is-saved-allocating-an-object-of-class-type-error/63954