### PR TITLE
[CMake] Mark `RBatchGenerator_TensorFlow.py` tutorial as multithreaded

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -639,6 +639,7 @@ set (multithreaded
      machine_learning/TMVA_CNN_Classification.py
      machine_learning/TMVA_Higgs_Classification.py
      machine_learning/TMVA_RNN_Classification.py
+     machine_learning/RBatchGenerator_TensorFlow.py
      )
 file(GLOB multithreaded_all_cores RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${multithreaded_all_cores})
 file(GLOB multithreaded RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${multithreaded})


### PR DESCRIPTION
Mark `RBatchGenerator_TensorFlow.py` tutorial as multithreaded so it is not schedeuled at the same time with other tutorials, risking to use more memory than available on the CI.

Hopefully fixes #19125, after I have seen this happen twice in the same CI run again:
https://github.com/root-project/root/pull/19482