### PR TITLE
[jupyter] Change ROOT to set JUPYTER_CONFIG_PATH not JUPYTER_CONFIG_DIR

### DIFF
--- a/config/thisroot.csh
+++ b/config/thisroot.csh
@@ -154,8 +154,8 @@ if ($?old_rootsys) then
                                  -e "s;^$old_rootsys/etc/notebook:;;g"   \
                                  -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
    endif
-   if ($?JUPYTER_CONFIG_DIR) then
-      setenv JUPYTER_CONFIG_DIR `set DOLLAR='$'; echo $JUPYTER_CONFIG_DIR | \
+   if ($?JUPYTER_CONFIG_PATH) then
+      setenv JUPYTER_CONFIG_PATH `set DOLLAR='$'; echo $JUPYTER_CONFIG_PATH | \
                              sed -e "s;:$old_rootsys/etc/notebook:;:;g" \
                                  -e "s;:$old_rootsys/etc/notebook${DOLLAR};;g"   \
                                  -e "s;^$old_rootsys/etc/notebook:;;g"   \
@@ -226,14 +226,13 @@ else
    setenv JUPYTER_PATH ${ROOTSYS}/etc/notebook
 endif
 
-if ($?JUPYTER_CONFIG_DIR) then
-   setenv JUPYTER_CONFIG_DIR ${ROOTSYS}/etc/notebook:$JUPYTER_CONFIG_DIR
+if ($?JUPYTER_CONFIG_PATH) then
+   setenv JUPYTER_CONFIG_PATH ${ROOTSYS}/etc/notebook:$JUPYTER_CONFIG_PATH
 else
-   setenv JUPYTER_CONFIG_DIR ${ROOTSYS}/etc/notebook
+   setenv JUPYTER_CONFIG_PATH ${ROOTSYS}/etc/notebook
 endif
 
 endif # if ("$thisroot" != "")
 
 set thisroot=
 set old_rootsys=
-

--- a/config/thisroot.fish
+++ b/config/thisroot.fish
@@ -48,7 +48,7 @@ update_path PYTHONPATH "$old_rootsys" "/lib" @libdir@
 update_path MANPATH "$old_rootsys" "/man" @mandir@
 update_path CMAKE_PREFIX_PATH "$old_rootsys" "" $ROOTSYS
 update_path JUPYTER_PATH "$old_rootsys" "/etc/notebook" $ROOTSYS/etc/notebook
-update_path JUPYTER_CONFIG_DIR "$old_rootsys" "/etc/notebook" $ROOTSYS/etc/notebook
+update_path JUPYTER_CONFIG_PATH "$old_rootsys" "/etc/notebook" $ROOTSYS/etc/notebook
 
 functions -e update_path
 set -e old_rootsys

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -74,9 +74,9 @@ clean_environment()
          drop_from_path "$JUPYTER_PATH" "${old_rootsys}/etc/notebook"
          JUPYTER_PATH=$newpath
       fi
-      if [ -n "${JUPYTER_CONFIG_DIR-}" ]; then
-         drop_from_path "$JUPYTER_CONFIG_DIR" "${old_rootsys}/etc/notebook"
-         JUPYTER_CONFIG_DIR=$newpath
+      if [ -n "${JUPYTER_CONFIG_PATH-}" ]; then
+         drop_from_path "$JUPYTER_CONFIG_PATH" "${old_rootsys}/etc/notebook"
+         JUPYTER_CONFIG_PATH=$newpath
       fi
    fi
    if [ -z "${MANPATH-}" ]; then
@@ -157,10 +157,10 @@ set_environment()
       JUPYTER_PATH=$ROOTSYS/etc/notebook:$JUPYTER_PATH; export JUPYTER_PATH
    fi
 
-   if [ -z "${JUPYTER_CONFIG_DIR-}" ]; then
-      JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook; export JUPYTER_CONFIG_DIR # Linux, ELF HP-UX
+   if [ -z "${JUPYTER_CONFIG_PATH-}" ]; then
+      JUPYTER_CONFIG_PATH=$ROOTSYS/etc/notebook; export JUPYTER_CONFIG_PATH # Linux, ELF HP-UX
    else
-      JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook:$JUPYTER_CONFIG_DIR; export JUPYTER_CONFIG_DIR
+      JUPYTER_CONFIG_PATH=$ROOTSYS/etc/notebook:$JUPYTER_CONFIG_PATH; export JUPYTER_CONFIG_PATH
    fi
 }
 

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -32,7 +32,7 @@
 
 #define JUPYTER_CMD        "jupyter"
 #define NB_OPT             "notebook"
-#define JUPYTER_CONF_DIR_V "JUPYTER_CONFIG_DIR"
+#define JUPYTER_CONF_PATH_V "JUPYTER_CONFIG_PATH"
 #define JUPYTER_PATH_V     "JUPYTER_PATH"
 #define NB_CONF_DIR        "notebook"
 #define ROOTNB_DIR         ".rootnb"
@@ -208,9 +208,9 @@ int main(int argc, char **argv)
 
    // Set IPython directory for the ROOT notebook flavour
    string rootnbpath = homedir + pathsep + ROOTNB_DIR;
-   string jupyconfdir(JUPYTER_CONF_DIR_V + ("=" + rootnbpath));
+   string jupyconfpathdir(JUPYTER_CONF_PATH_V + ("=" + rootnbpath));
    string jupypathdir(JUPYTER_PATH_V + ("=" + rootnbpath));
-   putenv((char *)jupyconfdir.c_str());
+   putenv((char *)jupyconfpathdir.c_str());
    putenv((char *)jupypathdir.c_str());
 
    char **jargv = new char* [argc + 2];


### PR DESCRIPTION
# This Pull request:

With the previous version, ROOT explicitely sets the `JUPYTER_CONFIG_DIR` to a folder part of the ROOT installation. In installation, where this folder is not writable by the user, this lead to Jupyter not starting as Jupyter wants to write user settings to files in this folder.

The revised version uses `JUPYTER_CONFIG_PATH` instead of `JUPYTER_CONFIG_DIR`. This has the effect, of adding the ROOT Jupyter config folder as an additional config, but not as the main config folder.

Thus, Jupyter can stil write to the default config folder, but the ROOT provided Jupyter config is still loaded (this is relevant for providing JsROOT locally, instead of loading it from root.cern).

## Changes or fixes:

Closes https://github.com/root-project/root/issues/19320

## Checklist:

- [X ] tested changes locally
- [ X] updated the docs (if necessary)

This PR fixes #19320

