### PR TITLE
[build] Enable running wheel workflow on label

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -8,13 +8,14 @@ on:
         type: string
         required: true
         default: "master"
-  push:
-    branches: experimental-pip-install-root
   schedule:
     - cron: '01 1 * * *'
+  pull_request:
+    types: [labeled]
 
 jobs:
   build-wheels:
+    if: contains(github.event.pull_request.labels.*.name, 'build-python-wheels')
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Now that the workflow file is in the master branch, we should be able to run more triggers from PRs. Let's see