### PR TITLE
[io] seek parent should point to mother dir, not to top level dir

### DIFF
--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -153,7 +153,7 @@ void TDirectoryFile::InitDirectoryFile(TClass *cl)
          cl = IsA(); // NOLINT: silence clang-tidy warnings
       }
       TDirectory* motherdir = GetMotherDir();
-      fSeekParent  = f->GetSeekDir();
+      fSeekParent  = motherdir->GetSeekDir();
       Int_t nbytes = TDirectoryFile::Sizeof();
       TKey *key    = new TKey(fName,fTitle,cl,nbytes,motherdir);
       fNbytesName  = key->GetKeylen();

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -7,6 +7,7 @@
 #include "TFile.h"
 #include "TMemFile.h"
 #include "TDirectory.h"
+#include "TDirectoryFile.h"
 #include "TKey.h"
 #include "TNamed.h"
 #include "TPluginManager.h"
@@ -250,4 +251,22 @@ TEST(TFile, WalkTKeys)
    ++it;
    EXPECT_EQ(it->fKeyName, kLongerKey);
    EXPECT_EQ(it->fClassName, "string");
+}
+
+// https://its.cern.ch/jira/browse/ROOT-10352
+TEST(TDirectoryFile, SeekParent)
+{
+   // create test file
+   TMemFile f("subdirTest10352.root", "RECREATE");
+   auto dir1 = f.mkdir("dir-1");
+   dir1->cd();
+   auto dir11 = dir1->mkdir("dir-11");
+   dir11->cd();
+   f.Write();
+   dir1 = static_cast<TDirectory*>(f.Get("dir-1"));
+   EXPECT_EQ(dir1->GetSeekDir(), 239);
+   EXPECT_EQ(dir1->GetSeekParent(), 100);
+   dir11 = static_cast<TDirectory*>(dir1->Get("dir-11"));
+   EXPECT_EQ(dir11->GetSeekDir(), 348);
+   EXPECT_EQ(dir11->GetSeekParent(), 239);
 }

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -7,7 +7,6 @@
 #include "TFile.h"
 #include "TMemFile.h"
 #include "TDirectory.h"
-#include "TDirectoryFile.h"
 #include "TKey.h"
 #include "TNamed.h"
 #include "TPluginManager.h"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes https://its.cern.ch/jira/browse/ROOT-10352

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)