### PR TITLE
[RF] Avoid expensive double loop in `setData()` for likelihooods

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Evaluator.h
+++ b/roofit/roofitcore/inc/RooFit/Evaluator.h
@@ -64,7 +64,8 @@ private:
    bool _needToUpdateOutputSizes = false;
    RooFit::EvalContext _evalContextCPU;
    RooFit::EvalContext _evalContextCUDA;
-   std::vector<NodeInfo> _nodes; // the ordered computation graph
+   std::vector<NodeInfo> _nodes;                             // the ordered computation graph
+   std::unordered_map<TNamed const *, NodeInfo *> _nodesMap; // for quick lookup of nodes
    std::stack<std::unique_ptr<ChangeOperModeRAII>> _changeOperModeRAIIs;
 };
 


### PR DESCRIPTION
About 2 years ago in 85c5cb4, I made the mistake of introducing a potentially expensive double loop when setting the data for a likelihood: the `RooEvaluatorWapper` iterates over all data variables to set, and for each of them it calls `RooFit::Evaluator::setInput()`, which has a loop over all nodes in the computation graph to identify for which one the data is set.

This caused a big performance hit when instantiating likelihoods with the new vectorizing CPU backend, manifesting in 10 minutes for `createNLL` for the big ATLAS Higgs combination benchmark instead of 1 min.

This commit fixes the problem by caching all nodes in the compute graph in a hash map for fast lookup.