### PR TITLE
Fix warning in TError.cxx

### DIFF
--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -154,7 +154,7 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_li
 
    // if necessary, write the additional string.
    // NOTE: this will overwrite the null byte written by the previous vsnprintf, extending the string.
-   int nWrittenPost = 0;
+   [[maybe_unused]] int nWrittenPost = 0;
    if (nAdditional > 0) {
       auto sysHandler = GetErrorSystemMsgHandlerRef();
       if (sysHandler) {
@@ -163,6 +163,7 @@ void ErrorHandler(Int_t level, const char *location, const char *fmt, std::va_li
          nWrittenPost = snprintf(buf + nWritten, bufSize - nWritten, " (errno: %d)", errno);
       }
    }
+
    assert(nWrittenPost == nAdditional);
    assert(nWritten + nWrittenPost + 1 <= nRequired);
 


### PR DESCRIPTION
```
core/foundation/src/TError.cxx: In function ‘void ErrorHandler(Int_t, const char*, const char*, __va_list_tag*)’:
core/foundation/src/TError.cxx:157:8: warning: variable ‘nWrittenPost’ set but not used [-Wunused-but-set-variable]
  157 |    int nWrittenPost = 0;
      |        ^~~~~~~~~~~~
```

Seems to be. on some platforms `assert` handled in the way that variable accounted as not used.

