### PR TITLE
[RF] Make RooFit::MsgTopic enum name for numeric integration consistent

### DIFF
--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -86,7 +86,7 @@ TEST(Sample, CopyAssignment)
 
 TEST(HistFactory, Read_ROOT6_16_Model)
 {
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    std::string filename = "./ref_6.16_example_UsingC_channel1_meas_model.root";
    std::unique_ptr<TFile> file(TFile::Open(filename.c_str()));
@@ -115,7 +115,7 @@ TEST(HistFactory, Read_ROOT6_16_Model)
 
 TEST(HistFactory, Read_ROOT6_16_Combined_Model)
 {
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    std::string filename = "./ref_6.16_example_UsingC_combined_meas_model.root";
    std::unique_ptr<TFile> file(TFile::Open(filename.c_str()));

--- a/roofit/roofit/test/testRooCrystalBall.cxx
+++ b/roofit/roofit/test/testRooCrystalBall.cxx
@@ -256,7 +256,7 @@ TEST(RooCrystalBall, FullyParametrized)
 
 TEST(RooCrystalBall, Integral)
 {
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    auto ws = makeWorkspace();
    auto &x = *ws->var("x");

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -63,8 +63,12 @@ enum MsgLevel { DEBUG=0, INFO=1, PROGRESS=2, WARNING=3, ERROR=4, FATAL=5 } ;
 /// Topics for a RooMsgService::StreamConfig in RooMsgService
 enum MsgTopic { Generation=1, Minimization=2, Plotting=4, Fitting=8, Integration=16, LinkStateMgmt=32,
     Eval=64, Caching=128, Optimization=256, ObjectHandling=512, InputArguments=1024, Tracing=2048,
-    Contents=4096, DataHandling=8192, NumIntegration=16384, FastEvaluations=1<<15, HistFactory=1<<16, IO=1<<17 };
+    Contents=4096, DataHandling=8192, NumericIntegration=16384, FastEvaluations=1<<15, HistFactory=1<<16, IO=1<<17 };
 enum MPSplit { BulkPartition=0, Interleave=1, SimComponents=2, Hybrid=3 } ;
+
+/// Alias of MsgLevel::NumericIntegration for backwards compatibility.
+/// \see https://github.com/root-project/root/issues/19422
+constexpr static auto NumIntegration = NumericIntegration;
 
 /// For setting the offset mode with the Offset() command argument to
 /// RooAbsPdf::fitTo()

--- a/roofit/roofitcore/src/RooAbsIntegrator.cxx
+++ b/roofit/roofitcore/src/RooAbsIntegrator.cxx
@@ -54,7 +54,7 @@ double RooAbsIntegrator::calculate(const double *yvec)
   double ret = integral(yvec) ;
   integrand()->restoreXVec() ;
 
-  oocxcoutD(static_cast<TObject*>(nullptr), NumIntegration) << "RooAbsIntegrator::calculate(" << _function->getName() << ") number of function calls = " << integrand()->numCall()<<", result  = "<<ret << std::endl ;
+  oocxcoutD(static_cast<TObject*>(nullptr), NumericIntegration) << "RooAbsIntegrator::calculate(" << _function->getName() << ") number of function calls = " << integrand()->numCall()<<", result  = "<<ret << std::endl ;
   return ret ;
 }
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2536,7 +2536,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createCdf(const RooArgSet& iset, const 
     Int_t isNum= !static_cast<RooRealIntegral&>(*tmp).numIntRealVars().empty();
 
     if (isNum) {
-      coutI(NumIntegration) << "RooAbsPdf::createCdf(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
+      coutI(NumericIntegration) << "RooAbsPdf::createCdf(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
              << "      constructing cdf though numeric integration of sampled pdf in " << numScanBins << " bins and applying order "
              << intOrder << " interpolation on integrated histogram." << std::endl
              << "      To override this choice of technique use argument ScanNone(), to change scan parameters use ScanParameters(nbins,order) argument" << std::endl ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3678,7 +3678,7 @@ RooFit::OwningPtr<RooAbsReal> RooAbsReal::createRunningIntegral(const RooArgSet&
     Int_t isNum= !static_cast<RooRealIntegral&>(*tmp).numIntRealVars().empty();
 
     if (isNum) {
-      coutI(NumIntegration) << "RooAbsPdf::createRunningIntegral(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
+      coutI(NumericIntegration) << "RooAbsPdf::createRunningIntegral(" << GetName() << ") integration over observable(s) " << iset << " involves numeric integration," << std::endl
              << "      constructing cdf though numeric integration of sampled pdf in " << numScanBins << " bins and applying order "
              << intOrder << " interpolation on integrated histogram." << std::endl
              << "      To override this choice of technique use argument ScanNone(), to change scan parameters use ScanParameters(nbins,order) argument" << std::endl ;

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -107,7 +107,7 @@ RooAdaptiveIntegratorND::~RooAdaptiveIntegratorND()
 {
   delete _integrator ;
   if (_nError>_nWarn) {
-    oocoutW(nullptr, NumIntegration) << "RooAdaptiveIntegratorND::dtor(" << _intName
+    oocoutW(nullptr, NumericIntegration) << "RooAdaptiveIntegratorND::dtor(" << _intName
            << ") WARNING: Number of suppressed warningings about integral evaluations where target precision was not reached is " << _nError-_nWarn << std::endl;
   }
 
@@ -168,11 +168,11 @@ double RooAdaptiveIntegratorND::integral(const double* /*yvec*/)
   if (_integrator->Status()==1) {
     _nError++ ;
     if (_nError<=_nWarn) {
-      oocoutW(nullptr, NumIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName() << ") WARNING: target rel. precision not reached due to nEval limit of "
+      oocoutW(nullptr, NumericIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName() << ") WARNING: target rel. precision not reached due to nEval limit of "
              << _nmax << ", estimated rel. precision is " << Form("%3.1e",_integrator->RelError()) << std::endl ;
     }
     if (_nError==_nWarn) {
-      oocoutW(nullptr, NumIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName()
+      oocoutW(nullptr, NumericIntegration) << "RooAdaptiveIntegratorND::integral(" << integrand()->getName()
              << ") Further warnings on target precision are suppressed conform specification in integrator specification" << std::endl ;
     }
   }

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -101,7 +101,7 @@ RooMsgService::RooMsgService()
   _topicNames[Tracing]="Tracing" ;
   _topicNames[Contents]="Contents" ;
   _topicNames[DataHandling]="DataHandling" ;
-  _topicNames[NumIntegration]="NumericIntegration" ;
+  _topicNames[NumericIntegration]="NumericIntegration" ;
   _topicNames[FastEvaluations] = "FastEvaluations";
   _topicNames[HistFactory]="HistFactory";
 
@@ -123,7 +123,7 @@ void RooMsgService::reset() {
   // Old-style streams
   _streams.clear();
   addStream(RooFit::PROGRESS, Topic(RooFit::HistFactory - 1));//All before HistFactory
-  addStream(RooFit::INFO,Topic(RooFit::Eval|RooFit::Plotting|RooFit::Fitting|RooFit::Minimization|RooFit::Caching|RooFit::ObjectHandling|RooFit::NumIntegration|RooFit::InputArguments|RooFit::DataHandling)) ;
+  addStream(RooFit::INFO,Topic(RooFit::Eval|RooFit::Plotting|RooFit::Fitting|RooFit::Minimization|RooFit::Caching|RooFit::ObjectHandling|RooFit::NumericIntegration|RooFit::InputArguments|RooFit::DataHandling)) ;
   addStream(RooFit::INFO, Topic(RooFit::HistFactory));
 }
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -694,11 +694,11 @@ bool RooRealIntegral::initNumIntegrator() const
     return false;
   }
 
-  cxcoutI(NumIntegration) << "RooRealIntegral::init(" << GetName() << ") using numeric integrator "
+  cxcoutI(NumericIntegration) << "RooRealIntegral::init(" << GetName() << ") using numeric integrator "
            << integratorName << " to calculate Int" << _intList << std::endl ;
 
   if (_intList.size()>3) {
-    cxcoutI(NumIntegration) << "RooRealIntegral::init(" << GetName() << ") evaluation requires " << _intList.size() << "-D numeric integration step. Evaluation may be slow, sufficient numeric precision for fitting & minimization is not guaranteed" << std::endl ;
+    cxcoutI(NumericIntegration) << "RooRealIntegral::init(" << GetName() << ") evaluation requires " << _intList.size() << "-D numeric integration step. Evaluation may be slow, sufficient numeric precision for fitting & minimization is not guaranteed" << std::endl ;
   }
 
   _restartNumIntEngine = false ;

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -2191,7 +2191,7 @@ public:
       {
          // To remove the INFO:NumericIntegration output from the stressRooFit output,
          // change the message level locally.
-         RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::INFO, 0u, RooFit::NumIntegration, false};
+         RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::INFO, 0u, RooFit::NumericIntegration, false};
 
          // Create integral over normalized pdf model over x,y,z in "R" region
          std::unique_ptr<RooAbsReal> intPdf{pxyz.createIntegral(RooArgSet(x, y, z), RooArgSet(x, y, z), "R")};

--- a/roofit/roofitcore/test/testRooCurve.cxx
+++ b/roofit/roofitcore/test/testRooCurve.cxx
@@ -24,7 +24,7 @@
 TEST(RooPlot, Average)
 {
    // Silence the info about numeric integration because we don't care about it
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    RooRealVar x("x", "x", 0, 50);
    RooGenericPdf func("func", "Test Function", "x", x);

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -29,7 +29,7 @@ public:
 private:
    void SetUp() override
    {
-      RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+      RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
       datap = std::unique_ptr<RooDataSet>{prod.generate(x, 1000)};
       a.setConstant(true);
@@ -56,7 +56,7 @@ protected:
 
 TEST_P(TestProdPdf, CachingOpt)
 {
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    using namespace RooFit;
    prod.fitTo(*datap, Optimize(_optimize), PrintLevel(-1), _evalBackend);
@@ -76,7 +76,7 @@ INSTANTIATE_TEST_SUITE_P(RooProdPdf, TestProdPdf,
 TEST(RooProdPdf, TestGetPartIntList)
 {
    RooHelpers::LocalChangeMsgLevel chmsglvl1{RooFit::ERROR, 0u, RooFit::InputArguments, true};
-   RooHelpers::LocalChangeMsgLevel chmsglvl2{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl2{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    // This test checks if RooProdPdf::getPartIntList factorizes the integrals
    // as expected, for the example of a three dimensional RooProdPdf.

--- a/roofit/roofitcore/test/testRooRealIntegral.cxx
+++ b/roofit/roofitcore/test/testRooRealIntegral.cxx
@@ -114,7 +114,7 @@ TEST(RooRealIntegral, IntegrateFuncWithShapeServers)
 {
    using namespace RooFit;
 
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    RooWorkspace ws;
    ws.factory("Product::mu_mod({mu[-0.005, -5.0, 5.0], 10.0})");
@@ -232,7 +232,7 @@ TEST(RooRealIntegral, UseCloneAsIntegrationVariable2)
 TEST(RooRealIntegral, DISABLED_Issue11476)
 {
    // Silence the info about numeric integration because we don't care about it
-   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumIntegration, true};
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::NumericIntegration, true};
 
    RooWorkspace ws{"ws"};
    ws.factory("Gaussian::gs(x[0,10], mu[2, 0, 10], sg[2, 0.1, 10])");
@@ -278,7 +278,7 @@ private:
 /// Related to GitHub issue #11814.
 TEST_P(LevelTest, ProjectConditional)
 {
-   RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::NumIntegration);
+   RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::NumericIntegration);
 
    constexpr bool verbose = false;
 

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -178,7 +178,7 @@ public:
 
       fIntegrator.SetFunction(fLikelihood, bindParams.size() );
 
-      ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction::Compute integral of posterior in nuisance and poi. "
+      ooccoutD(nullptr,NumericIntegration) << "PosteriorCdfFunction::Compute integral of posterior in nuisance and poi. "
                                            << " nllMinimum is " << nllMinimum << std::endl;
 
       std::vector<double> par(bindParams.size());
@@ -187,18 +187,18 @@ public:
          fXmin[i] = var.getMin();
          fXmax[i] = var.getMax();
          par[i] = var.getVal();
-         ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Integrate" << var.GetName()
+         ooccoutD(nullptr,NumericIntegration) << "PosteriorFunction::Integrate" << var.GetName()
                                               << " in interval [ " <<  fXmin[i] << " , " << fXmax[i] << " ] " << std::endl;
       }
 
-      fIntegrator.Options().Print(ooccoutD(nullptr,NumIntegration));
+      fIntegrator.Options().Print(ooccoutD(nullptr,NumericIntegration));
 
       // store max POI value because it will be changed when evaluating the function
       fMaxPOI = fXmax[0];
 
       // compute first the normalization with  the poi
       fNorm = (*this)( fMaxPOI );
-      if (fError) ooccoutE(nullptr,NumIntegration) << "PosteriorFunction::Error computing normalization - norm = " << fNorm << std::endl;
+      if (fError) ooccoutE(nullptr,NumericIntegration) << "PosteriorFunction::Error computing normalization - norm = " << fNorm << std::endl;
       fHasNorm = true;
       fNormCdfValues.insert(std::make_pair(fXmin[0], 0) );
       fNormCdfValues.insert(std::make_pair(fXmax[0], 1.0) );
@@ -239,7 +239,7 @@ public:
 
 
    ROOT::Math::IGenFunction * Clone() const override {
-      ooccoutD(nullptr,NumIntegration) << " cloning function .........." << std::endl;
+      ooccoutD(nullptr,NumericIntegration) << " cloning function .........." << std::endl;
       return new PosteriorCdfFunction(*this);
    }
 
@@ -270,7 +270,7 @@ private:
          if (itr != fNormCdfValues.end() ) {
             fXmin[0] = itr->first;
             normcdf0 = itr->second;
-            // ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction:   computing integral between in poi interval : "
+            // ooccoutD(nullptr,NumericIntegration) << "PosteriorCdfFunction:   computing integral between in poi interval : "
             //                                      << fXmin[0] << " -  " << fXmax[0] << std::endl;
          }
       }
@@ -281,25 +281,25 @@ private:
       double error = fIntegrator.Error();
       double normcdf =  cdf/fNorm;  // normalize the cdf
 
-      ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction: poi = [" << fXmin[0] << " , "
+      ooccoutD(nullptr,NumericIntegration) << "PosteriorCdfFunction: poi = [" << fXmin[0] << " , "
                                            << fXmax[0] << "] integral =  " << cdf << " +/- " << error
                                            << "  norm-integ = " << normcdf << " cdf(x) = " << normcdf+normcdf0
                                            << " ncalls = " << fFunctor.binding().numCall() << std::endl;
 
       if (TMath::IsNaN(cdf) || cdf > std::numeric_limits<double>::max()) {
-         ooccoutE(nullptr,NumIntegration) << "PosteriorFunction::Error computing integral - cdf = "
+         ooccoutE(nullptr,NumericIntegration) << "PosteriorFunction::Error computing integral - cdf = "
                                               << cdf << std::endl;
          fError = true;
       }
 
       if (cdf != 0 && error / cdf > 0.2) {
-         oocoutW(nullptr, NumIntegration)
+         oocoutW(nullptr, NumericIntegration)
             << "PosteriorCdfFunction: integration error  is larger than 20 %   x0 = " << fXmin[0] << " x = " << x
             << " cdf(x) = " << cdf << " +/- " << error << std::endl;
       }
 
       if (!fHasNorm) {
-         oocoutI(nullptr,NumIntegration) << "PosteriorCdfFunction - integral of posterior = "
+         oocoutI(nullptr,NumericIntegration) << "PosteriorCdfFunction - integral of posterior = "
                                              << cdf << " +/- " << error << std::endl;
          fNormErr = error;
          return cdf;
@@ -314,7 +314,7 @@ private:
 
       double errnorm = sqrt( error*error + normcdf*normcdf * fNormErr * fNormErr )/fNorm;
       if (normcdf > 1. + 3 * errnorm) {
-         oocoutW(nullptr,NumIntegration) << "PosteriorCdfFunction: normalized cdf values is larger than 1"
+         oocoutW(nullptr,NumericIntegration) << "PosteriorCdfFunction: normalized cdf values is larger than 1"
                                               << " x = " << x << " normcdf(x) = " << normcdf << " +/- " << error/fNorm << std::endl;
       }
 
@@ -363,12 +363,12 @@ public:
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 
-      ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Evaluate the posterior function by integrating the nuisances: " << std::endl;
+      ooccoutD(nullptr,NumericIntegration) << "PosteriorFunction::Evaluate the posterior function by integrating the nuisances: " << std::endl;
       for (unsigned int i = 0; i < fXmin.size(); ++i) {
          RooRealVar & var = static_cast<RooRealVar &>( nuisParams[i]);
          fXmin[i] = var.getMin();
          fXmax[i] = var.getMax();
-         ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Integrate " << var.GetName()
+         ooccoutD(nullptr,NumericIntegration) << "PosteriorFunction::Integrate " << var.GetName()
                                               << " in interval [" <<  fXmin[i] << " , " << fXmax[i] << " ] " << std::endl;
       }
       if (fXmin.size() == 1) { // 1D case
@@ -377,7 +377,7 @@ public:
          fIntegratorOneDim->SetFunction(fLikelihood);
          // interested only in relative tolerance
          //fIntegratorOneDim->SetAbsTolerance(1.E-300);
-         fIntegratorOneDim->Options().Print(ooccoutD(nullptr,NumIntegration) );
+         fIntegratorOneDim->Options().Print(ooccoutD(nullptr,NumericIntegration) );
       }
       else if (fXmin.size() > 1) { // multiDim case
          fIntegratorMultiDim = std::make_unique<ROOT::Math::IntegratorMultiDim>(ROOT::Math::IntegratorMultiDim::GetType(integType));
@@ -389,7 +389,7 @@ public:
          }
          //fIntegratorMultiDim->SetAbsTolerance(1.E-300);
          // print the options
-         opt.Print(ooccoutD(nullptr,NumIntegration) );
+         opt.Print(ooccoutD(nullptr,NumericIntegration) );
       }
    }
 
@@ -425,13 +425,13 @@ private:
       }
 
       // debug
-      ooccoutD(nullptr,NumIntegration) << "PosteriorFunction:  POI value  =  "
+      ooccoutD(nullptr,NumericIntegration) << "PosteriorFunction:  POI value  =  "
                                            << x << "\tf(x) =  " << f << " +/- " << error
                                            << "  norm-f(x) = " << f/fNorm
                                            << " ncalls = " << fFunctor.binding().numCall() << std::endl;
 
       if (f != 0 && error / f > 0.2) {
-         ooccoutW(nullptr, NumIntegration)
+         ooccoutW(nullptr, NumericIntegration)
             << "PosteriorFunction::DoEval - Error from integration in " << fXmin.size() << " Dim is larger than 20 % "
             << "x = " << x << " p(x) = " << f << " +/- " << error << std::endl;
       }
@@ -594,12 +594,12 @@ private:
       fError = std::sqrt( dval2 / fNumIterations);
 
       // debug
-      ooccoutD(nullptr,NumIntegration) << "PosteriorFunctionFromToyMC:  POI value  =  "
+      ooccoutD(nullptr,NumericIntegration) << "PosteriorFunctionFromToyMC:  POI value  =  "
                                            << x << "\tp(x) =  " << val << " +/- " << fError << std::endl;
 
 
       if (val != 0 && fError/val > 0.2 ) {
-         ooccoutW(nullptr,NumIntegration) << "PosteriorFunctionFromToyMC::DoEval"
+         ooccoutW(nullptr,NumericIntegration) << "PosteriorFunctionFromToyMC::DoEval"
                                               << " - Error in estimating posterior is larger than 20% ! "
                                               << "x = " << x << " p(x) = " << val << " +/- " << fError << std::endl;
       }
@@ -1276,12 +1276,12 @@ void BayesianCalculator::ComputeIntervalFromCdf(double lowerCutOff, double upper
 
    if (lowerCutOff > 0) {
       cdf.SetOffset(lowerCutOff);
-      ccoutD(NumIntegration) << "Integrating posterior to get cdf and search lower limit at p =" << lowerCutOff << std::endl;
+      ccoutD(NumericIntegration) << "Integrating posterior to get cdf and search lower limit at p =" << lowerCutOff << std::endl;
       bool ok = rf.Solve(cdf, poi->getMin(),poi->getMax() , 200,fBrfPrecision, fBrfPrecision);
       if( cdf.HasError() )
          coutW(Eval) <<  "BayesianCalculator: Numerical error integrating the  CDF   " << std::endl;
       if (!ok) {
-         coutE(NumIntegration) << "BayesianCalculator::GetInterval - Error from root finder when searching lower limit !" << std::endl;
+         coutE(NumericIntegration) << "BayesianCalculator::GetInterval - Error from root finder when searching lower limit !" << std::endl;
          return;
       }
       fLower = rf.Root();
@@ -1291,12 +1291,12 @@ void BayesianCalculator::ComputeIntervalFromCdf(double lowerCutOff, double upper
    }
    if (upperCutOff < 1.0) {
       cdf.SetOffset(upperCutOff);
-      ccoutD(NumIntegration) << "Integrating posterior to get cdf and search upper interval limit at p =" << upperCutOff << std::endl;
+      ccoutD(NumericIntegration) << "Integrating posterior to get cdf and search upper interval limit at p =" << upperCutOff << std::endl;
       bool ok = rf.Solve(cdf, fLower,poi->getMax() , 200, fBrfPrecision, fBrfPrecision);
       if( cdf.HasError() )
          coutW(Eval) <<  "BayesianCalculator: Numerical error integrating the  CDF   " << std::endl;
       if (!ok)  {
-         coutE(NumIntegration) << "BayesianCalculator::GetInterval - Error from root finder when searching upper limit !" << std::endl;
+         coutE(NumericIntegration) << "BayesianCalculator::GetInterval - Error from root finder when searching upper limit !" << std::endl;
          return;
       }
       fUpper = rf.Root();

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -148,7 +148,7 @@ ToyMCSampler::ToyMCSampler(TestStatistic &ts, Int_t ntoys)
 {
 
    //suppress messages for num integration of Roofit
-   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
+   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumericIntegration);
 
    AddTestStatistic(&ts);
 }

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -161,7 +161,7 @@ xRooNLLVar::xRooNLLVar(const std::shared_ptr<RooAbsPdf> &pdf,
    : fPdf(pdf), fData(data.first), fGlobs(data.second)
 {
 
-   RooMsgService::instance().getStream(RooFit::INFO).removeTopic(RooFit::NumIntegration);
+   RooMsgService::instance().getStream(RooFit::INFO).removeTopic(RooFit::NumericIntegration);
 
    fOpts = std::shared_ptr<RooLinkedList>(new RooLinkedList, [](RooLinkedList *l) {
       if (l)

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -322,7 +322,7 @@ xRooNode::xRooNode(const char *name, const std::shared_ptr<TObject> &comp, const
    if (auto _ws = get<RooWorkspace>(); _ws && (!parent || parent->get<TFile>())) {
       RooMsgService::instance()
          .getStream(RooFit::INFO)
-         .removeTopic(RooFit::NumIntegration); // stop info message every time
+         .removeTopic(RooFit::NumericIntegration); // stop info message every time
 
       // check if any of the open files have version numbers greater than our major version
       // may not read correctly

--- a/tutorials/roofit/roostats/ModelInspector.C
+++ b/tutorials/roofit/roostats/ModelInspector.C
@@ -127,7 +127,7 @@ ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsDat
    : TGMainFrame(gClient->GetRoot(), 100, 100)
 {
 
-   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
+   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumericIntegration);
    fWS = w;
    fMC = mc;
    fData = data;

--- a/tutorials/roofit/roostats/ModelInspector.py
+++ b/tutorials/roofit/roostats/ModelInspector.py
@@ -476,7 +476,7 @@ class ModelInspectorGUI(ROOT.TGMainFrame):
         self.gTQSender = ROOT.gTQSender
         self.gApplication = ROOT.gApplication
 
-        ROOT.RooMsgService.instance().getStream(1).removeTopic(ROOT.RooFit.NumIntegration)
+        ROOT.RooMsgService.instance().getStream(1).removeTopic(ROOT.RooFit.NumericIntegration)
 
         simPdf = ROOT.nullptr
         numCats = 1

--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.C
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.C
@@ -922,7 +922,7 @@ HypoTestInverterResult *RooStats::HypoTestInvTool::RunInverter(RooWorkspace *w, 
    }
 
    // Get the result
-   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumIntegration);
+   RooMsgService::instance().getStream(1).removeTopic(RooFit::NumericIntegration);
 
    HypoTestInverter calc(*hc);
    calc.SetConfidenceLevel(optHTInv.confLevel);

--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
@@ -847,7 +847,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
             #    hc.StoreFitInfo(True)
 
         # Get the result
-        ROOT.RooMsgService.instance().getStream(1).removeTopic(ROOT.RooFit.NumIntegration)
+        ROOT.RooMsgService.instance().getStream(1).removeTopic(ROOT.RooFit.NumericIntegration)
 
         calc = ROOT.RooStats.HypoTestInverter(hc)
         calc.SetConfidenceLevel(optHTInv.confLevel)


### PR DESCRIPTION
Use the new enum name in all the RooFit code and tutorials, and preserve an alias with the old name for full backwards compatibility.

Closes #19422.