### PR TITLE
[ntuple] Fix offset warning with gcc 14 in ntuple_basics tests

### DIFF
--- a/tree/ntuple/test/ntuple_basics.cxx
+++ b/tree/ntuple/test/ntuple_basics.cxx
@@ -734,7 +734,12 @@ TEST(RNTuple, FillBytesWritten)
    *fieldStr = "abc";
    // A 32bit integer + "abc" literal + one 64bit integer for each index column
    EXPECT_EQ(7U + (3 * sizeof(std::uint64_t)), ntuple->Fill());
-   *fieldBoolVec = {true, false, true};
+   // For the bool vector, we can't assign an initializer list. It would lead
+   // to memory copy routines trying to operate on the packed bits that are
+   // particular to vector<bool> - resulting in invalid offset warnings.
+   for (bool b : {true, false, true}) {
+      fieldBoolVec->push_back(b);
+   }
    *fieldFloatVec = {42.0f, 1.1f};
    // A 32bit integer + "abc" literal + one 64bit integer for each index column + 3 bools + 2 floats
    EXPECT_EQ(18U + (3 * sizeof(std::uint64_t)), ntuple->Fill());


### PR DESCRIPTION
Assigning an initializer list to `std::vector<bool>` can result in offset warnings as the the following on my system:

```
[6/7] Building CXX object tree/ntuple/test/CMakeFiles/ntuple_basics.dir/ntuple_basics.cxx.o
In file included from /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/list:62,
                 from /home/rembserj/code/root/root_src/core/foundation/inc/ROOT/RLogger.hxx:18,
                 from /home/rembserj/code/root/root_src/core/foundation/inc/ROOT/RError.hxx:18,
                 from /home/rembserj/code/root/root_src/tree/ntuple/inc/ROOT/RColumnElementBase.hxx:18,
                 from /home/rembserj/code/root/root_src/tree/ntuple/test/ntuple_test.hxx:4,
                 from /home/rembserj/code/root/root_src/tree/ntuple/test/ntuple_basics.cxx:1:
In static member function ‘static constexpr _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = long unsigned int; _Up = long unsigned int; bool _IsMove = false]’,
    inlined from ‘constexpr _OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_algobase.h:521:30,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_algobase.h:548:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_algobase.h:555:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_algobase.h:651:7,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::_M_copy_aligned(const_iterator, const_iterator, iterator) [with _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_bvector.h:1342:28,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_insert_range(iterator, _ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/vector.tcc:1133:33,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::insert(const_iterator, _InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_bvector.h:1219:19,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_bvector.h:1479:14,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::assign(_InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_bvector.h:974:17,
    inlined from ‘constexpr std::vector<bool, _Alloc>& std::vector<bool, _Alloc>::operator=(std::initializer_list<bool>) [with _Alloc = std::allocator<bool>]’ at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_bvector.h:954:14,
    inlined from ‘virtual void RNTuple_FillBytesWritten_Test::TestBody()’ at /home/rembserj/code/root/root_src/tree/ntuple/test/ntuple_basics.cxx:737:38:
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-14.3.0/include/c++/14.3.0/bits/stl_algobase.h:452:23: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] [-Warray-bounds=]
```