### PR TITLE
[TestSupport] Remove a special case for RNTuple.

### DIFF
--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -58,12 +58,6 @@ static struct ForbidDiagnostics {
         return;
       }
 
-      // FIXME: RNTuple warns that it's in beta stage.
-      if (level == kWarning && strstr(msg, "Merging RNTuples is experimental") != nullptr) {
-         std::cerr << "Warning in " << location << " " << msg << std::endl;
-         return;
-      }
-
       // FIXME: DOAS backend is exprimental.
       if (level == kWarning
           && strstr(msg, "The DAOS backend is experimental and still under development") != nullptr) {


### PR DESCRIPTION
Now that RNT is not experimental, TestSupport doesn't need to mask its warning messages when running gtest.
The remaining warning message about merging can be masked explicitly (which is already happening in ntuple_merger.cxx).