### PR TITLE
Add extra code to specify workflow conditions

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -15,7 +15,10 @@ on:
 
 jobs:
   build-wheels:
-    if: contains(github.event.pull_request.labels.*.name, 'build-python-wheels')
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'build-python-wheels')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -118,6 +118,7 @@ set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS cppyy)
 if(NOT MSVC)
   # Make sure that relative RUNPATH to main ROOT libraries is always correct.
   ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH(cppyy ${CMAKE_INSTALL_PYTHONDIR})
+  ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH(CPyCppyy ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # Install library


### PR DESCRIPTION
I noticed the workflow is being skipped (e.g. https://github.com/root-project/root/actions/runs/16792883609). The gh UI doesn't say why. I have a suspicion that it is yet another undocumented behaviour. This commit suggests to add extra code to specify each and every  scenario where the workflow can run.

Even though it is redundant with the `on` section, it looks like this is the way to have the workflow properly run.
