### PR TITLE
[roottest] improve cmake for `root/collection`

### DIFF
--- a/roottest/root/collection/.rootrc
+++ b/roottest/root/collection/.rootrc
@@ -1,1 +1,0 @@
-Rint.History:            .root_hist

--- a/roottest/root/collection/CMakeLists.txt
+++ b/roottest/root/collection/CMakeLists.txt
@@ -1,26 +1,50 @@
-#---Copy from source to binary some of the files
-configure_file(HistArray.root . COPYONLY)
+ROOTTEST_ADD_TEST(ROOT-7249
+                  MACRO AccidentalOwnership.C)
 
-ROOTTEST_ADD_AUTOMACROS(EXCLUDE execMissing runTExMap runDeleteWarning)
 
-ROOTTEST_ADD_TEST(execMissing
+ROOTTEST_ADD_TEST(HistArray
+                  MACRO execHistArray.cxx+
+                  COPY_TO_BUILDDIR HistArray.root
+                  OUTREF execHistArray.ref)
+
+ROOTTEST_ADD_TEST(RangeExpression
+                  MACRO execRangeExpression.C
+                  OUTREF execRangeExpression.ref)
+
+ROOTTEST_ADD_TEST(TClonesArrayAbsorb
+                  MACRO execTClonesArrayAbsorb.C
+                  OUTREF execTClonesArrayAbsorb.ref)
+
+ROOTTEST_ADD_TEST(CATTreeClear
+                  MACRO runCATTreeClear.C
+                  OUTREF CATTreeClear.ref)
+
+ROOTTEST_ADD_TEST(TMap
+                  MACRO runTMap.C
+                  OUTREF TMap.ref)
+
+ROOTTEST_ADD_TEST(tbits
+                  MACRO runtbits.C
+                  OUTREF tbits.ref)
+
+ROOTTEST_ADD_TEST(Missing
                   MACRO execMissing.C
                   OUTREF execMissing.oref
                   ERRREF execMissing.eref )
 
 if (32BIT OR MSVC)
-ROOTTEST_ADD_TEST(runTExMap
-                  MACRO runTExMap.C
-                  OUTREF runTExMap32.oref
-                  ERRREF runTExMap32.eref )
+  ROOTTEST_ADD_TEST(TExMap
+                    MACRO runTExMap.C
+                    OUTREF runTExMap32.oref
+                    ERRREF runTExMap32.eref )
 else()
-ROOTTEST_ADD_TEST(runTExMap
-                  MACRO runTExMap.C
-                  OUTREF runTExMap.oref
-                  ERRREF runTExMap.eref )
+  ROOTTEST_ADD_TEST(TExMap
+                    MACRO runTExMap.C
+                    OUTREF runTExMap.oref
+                    ERRREF runTExMap.eref )
 endif()
 
-ROOTTEST_ADD_TEST(runDeleteWarning
+ROOTTEST_ADD_TEST(DeleteWarning
                   MACRO runDeleteWarning.C
                   OUTCNVCMD sed -e s:0x[0-9a-fA-F]*:0xRemoved:g
                   OUTREF DeleteWarning.ref)

--- a/roottest/root/collection/runTExMap.oref
+++ b/roottest/root/collection/runTExMap.oref
@@ -1,5 +1,5 @@
 
-Processing /Users/mato/Development/ROOT/root.git/roottest/root/collection/runTExMap.C...
+Processing runTExMap.C...
 
 TExMap Basic Tests Start
 
@@ -241,63 +241,63 @@ TestRange(hash_div4)
 
 TestDoubleAdd(hash_identity, -9223372036854775808)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, -9223372036854775808)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, -9223372036854775808)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, -9223372036854775808)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 9223372036854775807)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 9223372036854775807)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 9223372036854775807)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 9223372036854775807)
 
-(Expect Error) 
+(Expect Error)
 TExMap Basic Tests End
 

--- a/roottest/root/collection/runTExMap32.oref
+++ b/roottest/root/collection/runTExMap32.oref
@@ -1,5 +1,5 @@
 
-Processing /Users/mato/Development/ROOT/root.git/roottest/root/collection/runTExMap.C...
+Processing runTExMap.C...
 
 TExMap Basic Tests Start
 
@@ -241,63 +241,63 @@ TestRange(hash_div4)
 
 TestDoubleAdd(hash_identity, -2147483648)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, -2147483648)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, -2147483648)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, -2147483648)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, -1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 0)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 1)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_identity, 2147483647)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_min, 2147483647)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_max, 2147483647)
 
-(Expect Error) 
+(Expect Error)
 TestDoubleAdd(hash_div4, 2147483647)
 
-(Expect Error) 
+(Expect Error)
 TExMap Basic Tests End
 


### PR DESCRIPTION
Use explicit list of tests - one test was not present in automatic list 
Copy ROOT file only for specific test
Remove unnecessary `.rootrc`
