### PR TITLE
Fix warning in `rmkdepend/main.c`

### DIFF
--- a/misc/rmkdepend/main.c
+++ b/misc/rmkdepend/main.c
@@ -184,9 +184,12 @@ int main_orig(int argc, char **argv)
          fatalerr("cannot open \"%s\"\n", argv[1] + 1);
       fstat(afd, &ast);
       args = (char *)malloc(ast.st_size + 1);
-      if ((ast.st_size = read(afd, args, ast.st_size)) < 0)
+      if (!args)
+         fatalerr("failed to allocate memory\n");
+      int bytes_read = read(afd, args, ast.st_size);
+      if (bytes_read < 0)
          fatalerr("failed to read %s\n", argv[1] + 1);
-      args[ast.st_size] = '\0';
+      args[bytes_read] = '\0';
       close(afd);
       for (p = args; *p; p++) {
          if (quotechar) {


### PR DESCRIPTION
Fix the following warning by not overwriting the buffer size:

The code reuses the `ast.st_size` field to store the return value of
read(), but this causes static analysis to lose track of the buffer
size.

As a result, the compiler thinks you're passing a very large size (e.g.,
-2 wrapped as size_t, i.e., 18446744073709551614) to read(), leading to
the warning.

```txt
[365/3665] Building C object misc/rmkdepend/CMakeFiles/rmkdepend.dir/main.c.o
In file included from /nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/features.h:511,
                 from /nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/stdio.h:28,
                 from /home/rembserj/code/root/root_src/misc/rmkdepend/def.h:38,
                 from /home/rembserj/code/root/root_src/misc/rmkdepend/main.c:36:
In function ‘read’,
    inlined from ‘main_orig’ at /home/rembserj/code/root/root_src/misc/rmkdepend/main.c:187:26:
/nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/bits/unistd.h:32:10: warning: ‘__read_alias’ specified size 18446744073709551614 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
   32 |   return __glibc_fortify (read, __nbytes, sizeof (char),
      |          ^~~~~~~~~~~~~~~
/nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/bits/unistd-decl.h: In function ‘main_orig’:
/nix/store/74qjr01q87nwfl0dbsr1s45p8crw3q1f-glibc-2.40-66-dev/include/bits/unistd-decl.h:29:16: note: in a call to function ‘__read_alias’ declared with attribute ‘access (write_only, 2, 3)’
   29 | extern ssize_t __REDIRECT_FORTIFY (__read_alias, (int __fd, void *__buf,
      |
```