### PR TITLE
[ntuple] add test for model extension with streamer fields

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -220,6 +220,8 @@ public:
    /// Get a RNTupleModel::RUpdater that provides limited support for incremental updates to the underlying
    /// model, e.g. addition of new fields.
    ///
+   /// Note that a Model may not be extended with Streamer fields.
+   ///
    /// **Example: add a new field after the model has been used to construct a `RNTupleWriter` object**
    /// ~~~ {.cpp}
    /// #include <ROOT/RNTuple.hxx>

--- a/tree/ntuple/test/ntuple_modelext.cxx
+++ b/tree/ntuple/test/ntuple_modelext.cxx
@@ -587,3 +587,21 @@ TEST(RNTuple, ModelExtensionNullableField)
    EXPECT_FLOAT_EQ(1.0, viewA(1).value());
    EXPECT_FALSE(viewA(2).has_value());
 }
+
+TEST(RNTuple, ModelExtensionStreamerFields)
+{
+   FileRaii fileGuard("test_ntuple_modelext_streamer.root");
+
+   auto writer = RNTupleWriter::Recreate(RNTupleModel::Create(), "ntpl", fileGuard.GetPath());
+   writer->Fill();
+
+   auto modelUpdater = writer->CreateModelUpdater();
+   modelUpdater->BeginUpdate();
+   modelUpdater->AddField(std::make_unique<ROOT::RStreamerField>("foo", "CustomStruct"));
+   try {
+      modelUpdater->CommitUpdate();
+      FAIL() << "extending a Model with a Streamer field should fail";
+   } catch (const ROOT::RException &ex) {
+      EXPECT_THAT(ex.what(), testing::HasSubstr("a Model cannot be extended with Streamer fields"));
+   }
+}


### PR DESCRIPTION
- [x] tested changes locally
- [x] updated the docs (if necessary)

