### PR TITLE
Fix deprecation warnings in `TXMLParser.cxx`

### DIFF
--- a/io/xmlparser/src/TXMLParser.cxx
+++ b/io/xmlparser/src/TXMLParser.cxx
@@ -151,9 +151,16 @@ const char *TXMLParser::GetParseCodeMessage(Int_t parseCode) const
 
 void TXMLParser::InitializeContext()
 {
-   fContext->linenumbers = 1; // TRUE - This is the default anyway.
-   fContext->validate = fValidate ? 1 : 0;
-   fContext->replaceEntities = fReplaceEntities ? 1 : 0;
+   if (fValidate)
+      fContext->options |= XML_PARSE_DTDVALID;
+   else
+      fContext->options &= ~XML_PARSE_DTDVALID;
+
+   if (fReplaceEntities)
+      fContext->options |= XML_PARSE_NOENT;
+   else
+      fContext->options &= ~XML_PARSE_NOENT;
+
    fContext->_private = this;
 
    fValidateError = "";


### PR DESCRIPTION
Some data members of the libxml2 context are deprecated, and instead one should change the options flag.

See:

  * https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a6ef6b5c034fb76b5091cd1cbe95f3029
  * https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#a245dd5654f2c6538e305a1fb99766365
  * https://gnome.pages.gitlab.gnome.org/libxml2/html/parser_8h.html#acf14c9a79459dbc52c8c986cffba536f

This commit fixes the following warnings:

```txt
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx: In member function ‘virtual void TXMLParser::InitializeContext()’:
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:154:14: warning: ‘_xmlParserCtxt::linenumbers’ is deprecated [-Wdeprecated-declarations]
  154 |    fContext->linenumbers = 1; // TRUE - This is the default anyway.
      |              ^~~~~~~~~~~
In file included from /home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:36:
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:373:9: note: declared here
  373 |     int linenumbers XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:154:14: warning: ‘_xmlParserCtxt::linenumbers’ is deprecated [-Wdeprecated-declarations]
  154 |    fContext->linenumbers = 1; // TRUE - This is the default anyway.
      |              ^~~~~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:373:9: note: declared here
  373 |     int linenumbers XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:154:14: warning: ‘_xmlParserCtxt::linenumbers’ is deprecated [-Wdeprecated-declarations]
  154 |    fContext->linenumbers = 1; // TRUE - This is the default anyway.
      |              ^~~~~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:373:9: note: declared here
  373 |     int linenumbers XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:155:14: warning: ‘_xmlParserCtxt::validate’ is deprecated [-Wdeprecated-declarations]
  155 |    fContext->validate = fValidate ? 1 : 0;
      |              ^~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:304:9: note: declared here
  304 |     int validate XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:155:14: warning: ‘_xmlParserCtxt::validate’ is deprecated [-Wdeprecated-declarations]
  155 |    fContext->validate = fValidate ? 1 : 0;
      |              ^~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:304:9: note: declared here
  304 |     int validate XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:155:14: warning: ‘_xmlParserCtxt::validate’ is deprecated [-Wdeprecated-declarations]
  155 |    fContext->validate = fValidate ? 1 : 0;
      |              ^~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:304:9: note: declared here
  304 |     int validate XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:156:14: warning: ‘_xmlParserCtxt::replaceEntities’ is deprecated [-Wdeprecated-declarations]
  156 |    fContext->replaceEntities = fReplaceEntities ? 1 : 0;
      |              ^~~~~~~~~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:250:9: note: declared here
  250 |     int replaceEntities XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:156:14: warning: ‘_xmlParserCtxt::replaceEntities’ is deprecated [-Wdeprecated-declarations]
  156 |    fContext->replaceEntities = fReplaceEntities ? 1 : 0;
      |              ^~~~~~~~~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:250:9: note: declared here
  250 |     int replaceEntities XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~~~~~
/home/rembserj/code/root/root_src/io/xmlparser/src/TXMLParser.cxx:156:14: warning: ‘_xmlParserCtxt::replaceEntities’ is deprecated [-Wdeprecated-declarations]
  156 |    fContext->replaceEntities = fReplaceEntities ? 1 : 0;
      |              ^~~~~~~~~~~~~~~
/nix/store/nlqy7cl7gcpiiarxbiwvhrqkz8cy97fy-libxml2-2.14.4-unstable-2025-06-20-dev/include/libxml2/libxml/parser.h:250:9: note: declared here
  250 |     int replaceEntities XML_DEPRECATED_MEMBER;
      |         ^~~~~~~~~~~~~~~
```