### PR TITLE
Don't include TMathBase.h in TString.h

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -95,6 +95,13 @@ the deprecation period was extended.
 ## JavaScript ROOT
 - A new configuration option `Jupyter.JSRoot` was added in .rootrc to set the default mode for JSROOT in Jupyter notebooks (on or off).
 
+### Optimization of ROOT header files
+
+More unused includes were removed from ROOT header files.
+For instance, `#include "TMathBase.h"` was removed from `TString.h`.
+This change may cause errors during compilation of ROOT-based code. To fix it, provide missing the includes
+where they are really required.
+This improves compile times and reduces code inter-dependency; see https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md for a good overview of the motivation.
 
 ## Versions of built-in packages
 

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -25,7 +25,6 @@
 
 #include "Rtypes.h"
 
-#include "TMathBase.h"
 #include <string_view>
 #include "ROOT/TypeTraits.hxx"
 #include "snprintf.h"
@@ -579,7 +578,7 @@ inline TString &TString::Append(const TString &s)
 { return Replace(Length(), 0, s.Data(), s.Length()); }
 
 inline TString &TString::Append(const TString &s, Ssiz_t n)
-{ return Replace(Length(), 0, s.Data(), TMath::Min(n, s.Length())); }
+{ return Replace(Length(), 0, s.Data(), std::min(n, s.Length())); }
 
 inline TString &TString::operator+=(const char *cs)
 { return Append(cs, cs ? (Ssiz_t)strlen(cs) : 0); }
@@ -668,7 +667,7 @@ inline TString &TString::Insert(Ssiz_t pos, const TString &s)
 { return Replace(pos, 0, s.Data(), s.Length()); }
 
 inline TString &TString::Insert(Ssiz_t pos, const TString &s, Ssiz_t n)
-{ return Replace(pos, 0, s.Data(), TMath::Min(n, s.Length())); }
+{ return Replace(pos, 0, s.Data(), std::min(n, s.Length())); }
 
 inline TString &TString::Prepend(const char *cs)
 { return Replace(0, 0, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
@@ -680,16 +679,16 @@ inline TString &TString::Prepend(const TString &s)
 { return Replace(0, 0, s.Data(), s.Length()); }
 
 inline TString &TString::Prepend(const TString &s, Ssiz_t n)
-{ return Replace(0, 0, s.Data(), TMath::Min(n, s.Length())); }
+{ return Replace(0, 0, s.Data(), std::min(n, s.Length())); }
 
 inline TString &TString::Remove(Ssiz_t pos)
-{ return Replace(pos, TMath::Max(0, Length()-pos), nullptr, 0); }
+{ return Replace(pos, std::max(0, Length()-pos), nullptr, 0); }
 
 inline TString &TString::Remove(Ssiz_t pos, Ssiz_t n)
 { return Replace(pos, n, nullptr, 0); }
 
 inline TString &TString::Chop()
-{ return Remove(TMath::Max(0, Length()-1)); }
+{ return Remove(std::max(0, Length()-1)); }
 
 inline TString &TString::Replace(Ssiz_t pos, Ssiz_t n, const char *cs)
 { return Replace(pos, n, cs, cs ? (Ssiz_t)strlen(cs) : 0); }
@@ -699,7 +698,7 @@ inline TString &TString::Replace(Ssiz_t pos, Ssiz_t n, const TString& s)
 
 inline TString &TString::Replace(Ssiz_t pos, Ssiz_t n1, const TString &s,
                                  Ssiz_t n2)
-{ return Replace(pos, n1, s.Data(), TMath::Min(s.Length(), n2)); }
+{ return Replace(pos, n1, s.Data(), std::min(s.Length(), n2)); }
 
 inline TString &TString::ReplaceAll(const TString &s1, const TString &s2)
 { return ReplaceAll(s1.Data(), s1.Length(), s2.Data(), s2.Length()) ; }

--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -305,7 +305,7 @@ public:
    void             SetFitFormat(const char *format="5.4g") {fFitFormat = format;}
    void             SetHeaderPS(const char *header);
    void             SetHatchesLineWidth(Int_t l) {fHatchesLineWidth = l;}
-   void             SetHatchesSpacing(Double_t h) {fHatchesSpacing = TMath::Max(0.1,h);}
+   void             SetHatchesSpacing(Double_t h) {fHatchesSpacing = std::max(0.1,h);}
    void             SetTitlePS(const char *pstitle);
    void             SetJoinLinePS(Int_t joinline=0) {fJoinLinePS=joinline;} ///< Set the line join method used for PostScript, PDF and SVG output. See `TPostScript::SetLineJoin` for details.
    void             SetCapLinePS(Int_t capline=0) {fCapLinePS=capline;}     ///< Set the line cap method used for PostScript, PDF and SVG output. See `TPostScript::SetLineCap` for details.

--- a/core/base/src/TAttLine.cxx
+++ b/core/base/src/TAttLine.cxx
@@ -235,7 +235,7 @@ Int_t TAttLine::DistancetoLine(Int_t px, Int_t py, Double_t xp1, Double_t yp1, D
    if (c <= 0)  return 9999;
    Double_t v     = sqrt(c);
    Double_t u     = (a - b + c)/(2*v);
-   Double_t d     = TMath::Abs(a - u*u);
+   Double_t d     = std::abs(a - u*u);
    if (d < 0)   return 9999;
 
    return Int_t(sqrt(d) - 0.5*Double_t(fLineWidth));
@@ -247,7 +247,7 @@ Int_t TAttLine::DistancetoLine(Int_t px, Int_t py, Double_t xp1, Double_t yp1, D
 void TAttLine::Modify()
 {
    if (!gPad) return;
-   Int_t lineWidth = TMath::Abs(fLineWidth%100);
+   Int_t lineWidth = std::abs(fLineWidth%100);
    if (!gPad->IsBatch()) {
       gVirtualX->SetLineColor(fLineColor);
       if (fLineStyle > 0 && fLineStyle < 30) gVirtualX->SetLineStyle(fLineStyle);

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -312,10 +312,10 @@ Float_t TAttText::GetTextSizePercent(Float_t size)
 {
    Float_t rsize = size;
    if (fTextFont%10 > 2 && gPad) {
-      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
-                            gPad->XtoAbsPixel(gPad->GetX1()));
-      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
-                            gPad->YtoAbsPixel(gPad->GetY1()));
+      UInt_t w = std::abs(gPad->XtoAbsPixel(gPad->GetX2()) -
+                          gPad->XtoAbsPixel(gPad->GetX1()));
+      UInt_t h = std::abs(gPad->YtoAbsPixel(gPad->GetY2()) -
+                          gPad->YtoAbsPixel(gPad->GetY1()));
       if (w < h)
          rsize = rsize/w;
       else

--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -29,6 +29,9 @@
 
 #include "TSpinLockGuard.h"
 
+#include <algorithm>
+#include <limits>
+
 Bool_t TDirectory::fgAddDirectory = kTRUE;
 
 const Int_t  kMaxLen = 2048;

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -47,6 +47,7 @@ class hierarchies (watch out for overlaps).
 #include <fstream>
 #include <iostream>
 #include <iomanip>
+#include <limits>
 
 #include "Varargs.h"
 #include "snprintf.h"

--- a/core/base/src/TStorage.cxx
+++ b/core/base/src/TStorage.cxx
@@ -98,7 +98,7 @@ void *ROOT::Internal::gMmallocDesc = nullptr; //is used and set in TMapFile
 
 void TStorage::EnterStat(size_t size, void *p)
 {
-   TStorage::SetMaxBlockSize(TMath::Max(TStorage::GetMaxBlockSize(), size));
+   TStorage::SetMaxBlockSize(std::max(TStorage::GetMaxBlockSize(), size));
 
    if (!gMemStatistics) return;
 

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -1033,7 +1033,7 @@ TString &TString::Replace(Ssiz_t pos, Ssiz_t n1, const char *cs, Ssiz_t n2)
       return *this;
    }
 
-   n1 = TMath::Min(n1, len - pos);
+   n1 = std::min(n1, len - pos);
    if (!cs) n2 = 0;
 
    Long64_t tot = static_cast<Long64_t>(len) - n1 + n2;  // Final string length, use 64-bit long instead of 32-bit int to check for overflows
@@ -1225,7 +1225,7 @@ Ssiz_t TString::AdjustCapacity(Ssiz_t oldCap, Ssiz_t newCap)
             newCap, ms);
    }
    Ssiz_t cap = oldCap < ms / 2 - kAlignment ?
-                Recommend(TMath::Max(newCap, 2 * oldCap)) : ms - 1;
+                Recommend(std::max(newCap, 2 * oldCap)) : ms - 1;
    return cap;
 }
 
@@ -2101,7 +2101,7 @@ TString TString::Itoa(Int_t value, Int_t base)
    Int_t quotient = value;
    // Translating number to string with base:
    do {
-      buf += "0123456789abcdefghijklmnopqrstuvwxyz"[ TMath::Abs(quotient % base) ];
+      buf += "0123456789abcdefghijklmnopqrstuvwxyz"[ std::abs(quotient % base) ];
       quotient /= base;
    } while (quotient);
    // Append the negative sign
@@ -2153,7 +2153,7 @@ TString TString::LLtoa(Long64_t value, Int_t base)
    Long64_t quotient = value;
    // Translating number to string with base:
    do {
-      buf += "0123456789abcdefghijklmnopqrstuvwxyz"[ TMath::Abs(quotient % base) ];
+      buf += "0123456789abcdefghijklmnopqrstuvwxyz"[ std::abs(quotient % base) ];
       quotient /= base;
    } while (quotient);
    // Append the negative sign

--- a/core/base/src/TTimeStamp.cxx
+++ b/core/base/src/TTimeStamp.cxx
@@ -49,6 +49,8 @@ NOTE: the use of time_t (and its default implementation as a 32 int)
 #endif
 #include "TVirtualMutex.h"
 
+#include <cmath>
+
 ClassImp(TTimeStamp);
 
 

--- a/core/cont/src/TClonesArray.cxx
+++ b/core/cont/src/TClonesArray.cxx
@@ -252,7 +252,7 @@ TClonesArray& TClonesArray::operator=(const TClonesArray& tc)
    }
 
    if (tc.fSize > fSize)
-      Expand(TMath::Max(tc.fSize, GrowBy(fSize)));
+      Expand(std::max(tc.fSize, GrowBy(fSize)));
 
    Int_t i;
 
@@ -522,7 +522,7 @@ void TClonesArray::ExpandCreate(Int_t n)
       return;
    }
    if (n > fSize)
-      Expand(TMath::Max(n, GrowBy(fSize)));
+      Expand(std::max(n, GrowBy(fSize)));
 
    Int_t i;
    for (i = 0; i < n; i++) {
@@ -559,7 +559,7 @@ void TClonesArray::ExpandCreateFast(Int_t n)
 {
    Int_t oldSize = fKeep->GetSize();
    if (n > fSize)
-      Expand(TMath::Max(n, GrowBy(fSize)));
+      Expand(std::max(n, GrowBy(fSize)));
 
    Int_t i;
    for (i = 0; i < n; i++) {
@@ -731,7 +731,7 @@ void TClonesArray::Sort(Int_t upto)
          }
       }
 
-   QSort(fCont, fKeep->fCont, 0, TMath::Min(nentries, upto-fLowerBound));
+   QSort(fCont, fKeep->fCont, 0, std::min(nentries, upto-fLowerBound));
 
    fLast   = -2;
    fSorted = kTRUE;
@@ -858,7 +858,7 @@ void TClonesArray::Streamer(TBuffer &b)
             }
          }
       }
-      for (Int_t i = TMath::Max(nobjects,0); i < oldLast+1; ++i) fCont[i] = nullptr;
+      for (Int_t i = std::max(nobjects,0); i < oldLast+1; ++i) fCont[i] = nullptr;
       Changed();
       b.CheckByteCount(R__s, R__c,TClonesArray::IsA());
    } else {
@@ -928,7 +928,7 @@ TObject *&TClonesArray::operator[](Int_t idx)
       return fCont[0];
    }
    if (idx >= fSize)
-      Expand(TMath::Max(idx+1, GrowBy(fSize)));
+      Expand(std::max(idx+1, GrowBy(fSize)));
 
    if (!fKeep->fCont[idx]) {
       fKeep->fCont[idx] = (TObject*) TStorage::ObjectAlloc(fClass->Size());
@@ -942,7 +942,7 @@ TObject *&TClonesArray::operator[](Int_t idx)
    }
    fCont[idx] = fKeep->fCont[idx];
 
-   fLast = TMath::Max(idx, GetAbsLast());
+   fLast = std::max(idx, GetAbsLast());
    Changed();
 
    return fCont[idx];
@@ -1098,7 +1098,7 @@ void TClonesArray::MultiSort(Int_t nTCs, TClonesArray** tcs, Int_t upto)
       b[2*i+1] = tcs[i]->fKeep->fCont;
    }
    b[nBs-1] = fKeep->fCont;
-   QSort(fCont, nBs, b, 0, TMath::Min(nentries, upto-fLowerBound));
+   QSort(fCont, nBs, b, 0, std::min(nentries, upto-fLowerBound));
    delete [] b;
 
    fLast = -2;

--- a/core/cont/src/TCollection.cxx
+++ b/core/cont/src/TCollection.cxx
@@ -75,6 +75,8 @@ for (auto br : TRangeDynCast<TBranch>( tree->GetListOfBranches() )) {
 #include "TError.h"
 #include "TSystem.h"
 #include "TObjArray.h"
+#include "TMathBase.h"
+
 #include <iostream>
 #include <sstream>
 

--- a/core/cont/src/THashTable.cxx
+++ b/core/cont/src/THashTable.cxx
@@ -26,6 +26,7 @@ use THashList instead.
 #include "TList.h"
 #include "TError.h"
 #include "TROOT.h"
+#include "TMathBase.h"
 
 ClassImp(THashTable);
 
@@ -48,7 +49,7 @@ THashTable::THashTable(Int_t capacity, Int_t rehashlevel)
    } else if (capacity == 0)
       capacity = TCollection::kInitHashTableCapacity;
 
-   fSize = (Int_t)TMath::NextPrime(TMath::Max(capacity,(int)TCollection::kInitHashTableCapacity));
+   fSize = (Int_t)TMath::NextPrime(std::max(capacity,(int)TCollection::kInitHashTableCapacity));
    fCont = new TList* [fSize];
    memset(fCont, 0, fSize*sizeof(TList*));
 

--- a/core/cont/src/TObjArray.cxx
+++ b/core/cont/src/TObjArray.cxx
@@ -134,7 +134,7 @@ TObject *&TObjArray::operator[](Int_t i)
 
    int j = i-fLowerBound;
    if (j >= 0 && j < fSize) {
-      fLast = TMath::Max(j, GetAbsLast());
+      fLast = std::max(j, GetAbsLast());
       Changed();
       return fCont[j];
    }
@@ -241,9 +241,9 @@ void TObjArray::AddAtAndExpand(TObject *obj, Int_t idx)
       return;
    }
    if (idx-fLowerBound >= fSize)
-      Expand(TMath::Max(idx-fLowerBound+1, GrowBy(fSize)));
+      Expand(std::max(idx-fLowerBound+1, GrowBy(fSize)));
    fCont[idx-fLowerBound] = obj;
-   fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
+   fLast = std::max(idx-fLowerBound, GetAbsLast());
    Changed();
 }
 
@@ -258,7 +258,7 @@ void TObjArray::AddAt(TObject *obj, Int_t idx)
    if (!BoundsOk("AddAt", idx)) return;
 
    fCont[idx-fLowerBound] = obj;
-   fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
+   fLast = std::max(idx-fLowerBound, GetAbsLast());
    Changed();
 }
 
@@ -275,7 +275,7 @@ Int_t  TObjArray::AddAtFree(TObject *obj)
       for (i = 0; i < fSize; i++)
          if (!fCont[i]) {         // Add object at position i
             fCont[i] = obj;
-            fLast = TMath::Max(i, GetAbsLast());
+            fLast = std::max(i, GetAbsLast());
             Changed();
             return i+fLowerBound;
          }
@@ -828,7 +828,7 @@ void TObjArray::Sort(Int_t upto)
          }
       }
 
-   QSort(fCont, 0, TMath::Min(fSize, upto-fLowerBound));
+   QSort(fCont, 0, std::min(fSize, upto-fLowerBound));
 
    fLast   = -2;
    fSorted = kTRUE;
@@ -853,7 +853,7 @@ Int_t TObjArray::BinarySearch(TObject *op, Int_t upto)
    }
 
    base = 0;
-   last = TMath::Min(fSize, upto-fLowerBound) - 1;
+   last = std::min(fSize, upto-fLowerBound) - 1;
 
    while (last >= base) {
       position = (base+last) / 2;

--- a/core/cont/src/TObjectTable.cxx
+++ b/core/cont/src/TObjectTable.cxx
@@ -86,6 +86,7 @@ via the command gObjectTable->Print()
 #include "TROOT.h"
 #include "TClass.h"
 #include "TError.h"
+#include "TMathBase.h"
 
 
 TObjectTable *gObjectTable = nullptr;

--- a/core/cont/src/TOrdCollection.cxx
+++ b/core/cont/src/TOrdCollection.cxx
@@ -63,7 +63,7 @@ void TOrdCollection::AddAt(TObject *obj, Int_t idx)
    if (idx > fSize) idx = fSize;
 
    if (fGapSize <= 0)
-      SetCapacity(GrowBy(TMath::Max(fCapacity, (int)kMinExpand)));
+      SetCapacity(GrowBy(std::max(fCapacity, (int)kMinExpand)));
 
    if (idx == fGapStart) {
       physIdx = fGapStart;
@@ -352,7 +352,7 @@ TObject *TOrdCollection::RemoveAt(Int_t idx)
    Changed();
 
    if (LowWaterMark()) {
-      Int_t newCapacity = TMath::Max(int(fCapacity / kShrinkFactor), 1);
+      Int_t newCapacity = std::max(int(fCapacity / kShrinkFactor), 1);
       if (fCapacity > newCapacity)
          SetCapacity(newCapacity);
    }

--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -342,13 +342,13 @@ void TRefArray::AddAtAndExpand(TObject *obj, Int_t idx)
       return;
    }
    if (idx-fLowerBound >= fSize)
-      Expand(TMath::Max(idx-fLowerBound+1, GrowBy(fSize)));
+      Expand(std::max(idx-fLowerBound+1, GrowBy(fSize)));
 
    // Check if the object can belong here
    Int_t uid;
    if (GetObjectUID(uid, obj, "AddAtAndExpand")) {
       fUIDs[idx-fLowerBound] = uid;   // NOLINT
-      fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
+      fLast = std::max(idx-fLowerBound, GetAbsLast());
       Changed();
    }
 }
@@ -366,7 +366,7 @@ void TRefArray::AddAt(TObject *obj, Int_t idx)
    Int_t uid;
    if (GetObjectUID(uid, obj, "AddAt")) {
       fUIDs[idx-fLowerBound] = uid;
-      fLast = TMath::Max(idx-fLowerBound, GetAbsLast());
+      fLast = std::max(idx-fLowerBound, GetAbsLast());
       Changed();
    }
 }
@@ -386,7 +386,7 @@ Int_t  TRefArray::AddAtFree(TObject *obj)
             Int_t uid;
             if (GetObjectUID(uid, obj, "AddAtFree")) {
                fUIDs[i] = uid;    // NOLINT
-               fLast = TMath::Max(i, GetAbsLast());
+               fLast = std::max(i, GetAbsLast());
                Changed();
                return i+fLowerBound;
             }

--- a/core/imt/src/RTaskArena.cxx
+++ b/core/imt/src/RTaskArena.cxx
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <cmath>
 #include "tbb/task_arena.h"
 #define TBB_PREVIEW_GLOBAL_CONTROL 1 // required for TBB versions preceding 2019_U4
 #include "tbb/global_control.h"

--- a/core/imt/test/testRTaskArena.cxx
+++ b/core/imt/test/testRTaskArena.cxx
@@ -5,6 +5,7 @@
 
 #include "ROOT/TestSupport.hxx"
 
+#include <algorithm>
 #include <fstream>
 #include <random>
 #include <thread>

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -753,7 +753,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
          } else {
             line[kvalue] = '-';
             line[kvalue+1] = '>';
-            strncpy(&line[kvalue+2], membertype->AsString(p3pointer), TMath::Min(kline-1-kvalue-2,(int)strlen(membertype->AsString(p3pointer))));
+            strncpy(&line[kvalue+2], membertype->AsString(p3pointer), std::min(kline-1-kvalue-2,(int)strlen(membertype->AsString(p3pointer))));
          }
       } else if (!strcmp(memberFullTypeName, "char*") ||
                  !strcmp(memberFullTypeName, "const char*")) {
@@ -785,7 +785,7 @@ void TDumpMembers::Inspect(TClass *cl, const char *pname, const char *mname, con
       } else if (isbits) {
          snprintf(&line[kvalue],kline-kvalue,"0x%08x", *(UInt_t*)pointer);
       } else {
-         strncpy(&line[kvalue], membertype->AsString(pointer), TMath::Min(kline-1-kvalue,(int)strlen(membertype->AsString(pointer))));
+         strncpy(&line[kvalue], membertype->AsString(pointer), std::min(kline-1-kvalue,(int)strlen(membertype->AsString(pointer))));
       }
    } else {
       if (isStdString) {

--- a/core/rint/test/TTabComTests.cxx
+++ b/core/rint/test/TTabComTests.cxx
@@ -21,6 +21,7 @@
 
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <string>
 
 TEST(TTabComTests, Sanity)

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -788,11 +788,11 @@ void TUnixSystem::AddFileHandler(TFileHandler *h)
       int fd = h->GetFd();
       if (h->HasReadInterest()) {
          fReadmask->Set(fd);
-         fMaxrfd = TMath::Max(fMaxrfd, fd);
+         fMaxrfd = std::max(fMaxrfd, fd);
       }
       if (h->HasWriteInterest()) {
          fWritemask->Set(fd);
-         fMaxwfd = TMath::Max(fMaxwfd, fd);
+         fMaxwfd = std::max(fMaxwfd, fd);
       }
    }
 }
@@ -819,11 +819,11 @@ TFileHandler *TUnixSystem::RemoveFileHandler(TFileHandler *h)
          int fd = th->GetFd();
          if (th->HasReadInterest()) {
             fReadmask->Set(fd);
-            fMaxrfd = TMath::Max(fMaxrfd, fd);
+            fMaxrfd = std::max(fMaxrfd, fd);
          }
          if (th->HasWriteInterest()) {
             fWritemask->Set(fd);
-            fMaxwfd = TMath::Max(fMaxwfd, fd);
+            fMaxwfd = std::max(fMaxwfd, fd);
          }
       }
    }
@@ -1145,7 +1145,7 @@ void TUnixSystem::DispatchOneEvent(Bool_t pendingOnly)
       *fReadready  = *fReadmask;
       *fWriteready = *fWritemask;
 
-      int mxfd = TMath::Max(fMaxrfd, fMaxwfd);
+      int mxfd = std::max(fMaxrfd, fMaxwfd);
       mxfd++;
 
       // if nothing to select (socket or timer) return
@@ -1212,11 +1212,11 @@ Int_t TUnixSystem::Select(TList *act, Long_t to)
       if (fd > -1) {
          if (h->HasReadInterest()) {
             rd.Set(fd);
-            mxfd = TMath::Max(mxfd, fd);
+            mxfd = std::max(mxfd, fd);
          }
          if (h->HasWriteInterest()) {
             wr.Set(fd);
-            mxfd = TMath::Max(mxfd, fd);
+            mxfd = std::max(mxfd, fd);
          }
          h->ResetReadyMask();
       }

--- a/geom/geom/inc/TGeoArb8.h
+++ b/geom/geom/inc/TGeoArb8.h
@@ -14,6 +14,8 @@
 
 #include "TGeoBBox.h"
 
+#include <cstdlib>
+
 class TGeoArb8 : public TGeoBBox {
 protected:
    enum EGeoArb8Type {
@@ -73,7 +75,7 @@ public:
    Bool_t IsCylType() const override { return kFALSE; }
    static Bool_t IsSamePoint(const Double_t *p1, const Double_t *p2)
    {
-      return (TMath::Abs(p1[0] - p2[0]) < 1.E-16 && TMath::Abs(p1[1] - p2[1]) < 1.E-16) ? kTRUE : kFALSE;
+      return (std::abs(p1[0] - p2[0]) < 1.E-16 && std::abs(p1[1] - p2[1]) < 1.E-16) ? kTRUE : kFALSE;
    }
    static Bool_t InsidePolygon(Double_t x, Double_t y, Double_t *pts);
    void InspectShape() const override;

--- a/geom/geom/inc/TGeoNavigator.h
+++ b/geom/geom/inc/TGeoNavigator.h
@@ -16,6 +16,8 @@
 
 #include "TGeoCache.h"
 
+#include <cmath>
+
 ////////////////////////////////////////////////////////////////////////////
 //                                                                        //
 // TGeoNavigator - Class containing the implementation of all navigation  //

--- a/geom/geom/inc/TGeoVoxelGrid.h
+++ b/geom/geom/inc/TGeoVoxelGrid.h
@@ -12,6 +12,10 @@
 #ifndef ROOT_TGeoVoxelGrid
 #define ROOT_TGeoVoxelGrid
 
+#include <array>
+#include <cmath>
+#include <limits>
+
 // a simple structure to encode voxel indices, to address
 // individual voxels in the 3D grid.
 struct TGeoVoxelGridIndex {

--- a/geom/geom/src/TGeoBuilder.cxx
+++ b/geom/geom/src/TGeoBuilder.cxx
@@ -171,7 +171,7 @@ TGeoVolume *TGeoBuilder::MakeBox(const char *name, TGeoMedium *medium, Double_t 
 TGeoVolume *TGeoBuilder::MakePara(const char *name, TGeoMedium *medium, Double_t dx, Double_t dy, Double_t dz,
                                   Double_t alpha, Double_t theta, Double_t phi)
 {
-   if (TMath::Abs(alpha) < TGeoShape::Tolerance() && TMath::Abs(theta) < TGeoShape::Tolerance()) {
+   if (std::abs(alpha) < TGeoShape::Tolerance() && std::abs(theta) < TGeoShape::Tolerance()) {
       Warning("MakePara", "parallelepiped %s having alpha=0, theta=0 -> making box instead", name);
       return MakeBox(name, medium, dx, dy, dz);
    }
@@ -708,8 +708,8 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
       else
          amother->AddNodeOverlap(volume, nr, new TGeoCombiTrans(x, y, z, matrix));
    } else {
-      if (TMath::Abs(x) < TGeoShape::Tolerance() && TMath::Abs(y) < TGeoShape::Tolerance() &&
-          TMath::Abs(z) < TGeoShape::Tolerance()) {
+      if (std::abs(x) < TGeoShape::Tolerance() && std::abs(y) < TGeoShape::Tolerance() &&
+          std::abs(z) < TGeoShape::Tolerance()) {
          if (isOnly)
             amother->AddNode(volume, nr);
          else
@@ -860,8 +860,8 @@ void TGeoBuilder::Node(const char *name, Int_t nr, const char *mother, Double_t 
       else
          amother->AddNodeOverlap(volume, nr, new TGeoCombiTrans(x, y, z, matrix));
    } else {
-      if (TMath::Abs(x) < TGeoShape::Tolerance() && TMath::Abs(y) < TGeoShape::Tolerance() &&
-          TMath::Abs(z) < TGeoShape::Tolerance()) {
+      if (std::abs(x) < TGeoShape::Tolerance() && std::abs(y) < TGeoShape::Tolerance() &&
+          std::abs(z) < TGeoShape::Tolerance()) {
          if (isOnly)
             amother->AddNode(volume, nr);
          else

--- a/geom/geom/src/TGeoParallelWorld.cxx
+++ b/geom/geom/src/TGeoParallelWorld.cxx
@@ -1170,13 +1170,13 @@ Double_t TGeoParallelWorld::SafetyOrig(Double_t point[3], Double_t safmax)
    for (Int_t id = 0; id < nd; id++) {
       Int_t ist = 6 * id;
       Double_t dxyz = 0.;
-      Double_t dxyz0 = TMath::Abs(point[0] - boxes[ist + 3]) - boxes[ist];
+      Double_t dxyz0 = std::abs(point[0] - boxes[ist + 3]) - boxes[ist];
       if (dxyz0 > safe)
          continue;
-      Double_t dxyz1 = TMath::Abs(point[1] - boxes[ist + 4]) - boxes[ist + 1];
+      Double_t dxyz1 = std::abs(point[1] - boxes[ist + 4]) - boxes[ist + 1];
       if (dxyz1 > safe)
          continue;
-      Double_t dxyz2 = TMath::Abs(point[2] - boxes[ist + 5]) - boxes[ist + 2];
+      Double_t dxyz2 = std::abs(point[2] - boxes[ist + 5]) - boxes[ist + 2];
       if (dxyz2 > safe)
          continue;
       if (dxyz0 > 0)

--- a/graf2d/asimage/src/TASPluginGS.cxx
+++ b/graf2d/asimage/src/TASPluginGS.cxx
@@ -110,8 +110,8 @@ ASImage *TASPluginGS::File2ASImage(const char *filename)
             int lx, ly, ux, uy;
             line = line(14, line.Length());
             sscanf(line.Data(), "%d %d %d %d", &lx, &ly, &ux, &uy);
-            width = TMath::Abs(ux - lx);
-            height = TMath::Abs(uy - ly);
+            width = std::abs(ux - lx);
+            height = std::abs(uy - ly);
             break;
          }
       } while (!feof(fd));

--- a/graf2d/cocoa/src/X11Buffer.mm
+++ b/graf2d/cocoa/src/X11Buffer.mm
@@ -11,6 +11,7 @@
 
 //#define NDEBUG
 
+#include <algorithm>
 #include <stdexcept>
 #include <cstring>
 #include <cassert>

--- a/graf2d/gpad/src/TSliderBox.cxx
+++ b/graf2d/gpad/src/TSliderBox.cxx
@@ -124,25 +124,25 @@ again:
       pL = pR  = pTop = pBot = pINSIDE = kFALSE;
 
       if (vertical && (px > pxl+kMaxDiff && px < pxt-kMaxDiff) &&
-          TMath::Abs(py - pyl) < kMaxDiff) {             // top edge
+          std::abs(py - pyl) < kMaxDiff) {             // top edge
          pxold = pxl; pyold = pyl; pTop = kTRUE;
          gPad->SetCursor(kTopSide);
       }
 
       if (vertical && (px > pxl+kMaxDiff && px < pxt-kMaxDiff) &&
-          TMath::Abs(py - pyt) < kMaxDiff) {             // bottom edge
+          std::abs(py - pyt) < kMaxDiff) {             // bottom edge
          pxold = pxt; pyold = pyt; pBot = kTRUE;
          gPad->SetCursor(kBottomSide);
       }
 
       if (!vertical && (py > pyl+kMaxDiff && py < pyt-kMaxDiff) &&
-          TMath::Abs(px - pxl) < kMaxDiff) {             // left edge
+          std::abs(px - pxl) < kMaxDiff) {             // left edge
          pxold = pxl; pyold = pyl; pL = kTRUE;
          gPad->SetCursor(kLeftSide);
       }
 
       if (!vertical && (py > pyl+kMaxDiff && py < pyt-kMaxDiff) &&
-          TMath::Abs(px - pxt) < kMaxDiff) {             // right edge
+          std::abs(px - pxt) < kMaxDiff) {             // right edge
          pxold = pxt; pyold = pyt; pR = kTRUE;
          gPad->SetCursor(kRightSide);
       }

--- a/graf2d/graf/inc/TLatex.h
+++ b/graf2d/graf/inc/TLatex.h
@@ -40,9 +40,9 @@ protected:
 
       // definition of operators + and +=
       TLatexFormSize operator+(TLatexFormSize f)
-      { return TLatexFormSize(f.Width()+fWidth,TMath::Max(f.Over(),fOver),TMath::Max(f.Under(),fUnder)); }
+      { return TLatexFormSize(f.Width()+fWidth,std::max(f.Over(),fOver),std::max(f.Under(),fUnder)); }
       void operator+=(TLatexFormSize f)
-      { fWidth += f.Width(); fOver = TMath::Max(fOver,f.Over()); fUnder = TMath::Max(fUnder,f.Under()); }
+      { fWidth += f.Width(); fOver = std::max(fOver,f.Over()); fUnder = std::max(fUnder,f.Under()); }
 
       inline void Set(Double_t x, Double_t y1, Double_t y2) { fWidth=x; fOver=y1; fUnder=y2; }
       TLatexFormSize AddOver(TLatexFormSize f)
@@ -50,7 +50,7 @@ protected:
       TLatexFormSize AddUnder(TLatexFormSize f)
       { return TLatexFormSize(f.Width()+fWidth,fOver,f.Height()+fUnder); }
       TLatexFormSize AddOver(TLatexFormSize f1, TLatexFormSize f2)
-      { return TLatexFormSize(fWidth+TMath::Max(f1.Width(),f2.Width()),fOver+f1.Over(),fUnder+f2.Under()); }
+      { return TLatexFormSize(fWidth+std::max(f1.Width(),f2.Width()),fOver+f1.Over(),fUnder+f2.Under()); }
 
       // return members
       inline Double_t Width()  const { return fWidth; }

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -938,7 +938,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
 
    else if (opPower>-1 && opUnder>-1) { // ^ and _ found
       min = TMath::Min(opPower,opUnder);
-      max = TMath::Max(opPower,opUnder);
+      max = std::max(opPower,opUnder);
       Double_t xfpos = 0. ; //GetHeight()*spec.fSize/5.;
       Double_t prop=1, propU=1; // scale factor for #sum & #int
       switch (abovePlace) {
@@ -985,7 +985,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
             Analyse(x+addW,y+addH1,specNewSize,text+min+1,max-min-1);
          } else {
             Double_t addW1, addW2, addH1, addH2;
-            Double_t m = TMath::Max(fs1.Width(),TMath::Max(fs2.Width(),fs3.Width()));
+            Double_t m = std::max(fs1.Width(),std::max(fs2.Width(),fs3.Width()));
             pos = (m-fs1.Width())/2;
             if (opPower<opUnder) {
                addH1 = -fs1.Over()*propU-fs2.Under();
@@ -1013,20 +1013,20 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
 
       if (!abovePlace) {
          if (opPower<opUnder) {
-            result.Set(fs1.Width()+xfpos+TMath::Max(fs2.Width(),fs3.Width()),
+            result.Set(fs1.Width()+xfpos+std::max(fs2.Width(),fs3.Width()),
                        fs1.Over()*fFactorPos+fs2.Height(),
                        fs1.Under()+fs3.Height()-fs3.Over()*(1-fFactorPos));
          } else {
-            result.Set(fs1.Width()+xfpos+TMath::Max(fs2.Width(),fs3.Width()),
+            result.Set(fs1.Width()+xfpos+std::max(fs2.Width(),fs3.Width()),
                        fs1.Over()*fFactorPos+fs3.Height(),
                        fs1.Under()+fs2.Height()-fs2.Over()*(1-fFactorPos));
          }
       } else {
          if (opPower<opUnder) {
-            result.Set(TMath::Max(fs1.Width(),TMath::Max(fs2.Width(),fs3.Width())),
+            result.Set(std::max(fs1.Width(),std::max(fs2.Width(),fs3.Width())),
                        fs1.Over()*propU+fs2.Height(),fs1.Under()*prop+fs3.Height());
          } else {
-            result.Set(TMath::Max(fs1.Width(),TMath::Max(fs2.Width(),fs3.Width())),
+            result.Set(std::max(fs1.Width(),std::max(fs2.Width(),fs3.Width())),
                        fs1.Over()*propU+fs3.Height(),fs1.Under()*prop+fs2.Height());
          }
       }
@@ -1082,7 +1082,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
          result.Set(fs1.Width()+xfpos+fs2.Width(),
                     fs1.Over()*fFactorPos+fs2.Over(),fs1.Under());
       else
-         result.Set(TMath::Max(fs1.Width(),fs2.Width()),fs1.Over()*prop+fs2.Height(),fs1.Under());
+         result.Set(std::max(fs1.Width(),fs2.Width()),fs1.Over()*prop+fs2.Height(),fs1.Under());
 
    }
    else if (opUnder>-1) { // _ found
@@ -1128,7 +1128,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
          result.Set(fs1.Width()+xfpos+fs2.Width(),fs1.Over(),
                     fs1.Under()+fs2.Under()+fs2.Over()*fpos);
       else
-         result.Set(TMath::Max(fs1.Width(),fs2.Width()),fs1.Over(),fs1.Under()*prop+fs2.Height());
+         result.Set(std::max(fs1.Width(),fs2.Width()),fs1.Over(),fs1.Under()*prop+fs2.Height());
    }
    else if (opBox) {
       Double_t square = GetHeight()*spec.fSize/2;
@@ -1394,7 +1394,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
             break;
          }
          case 2: { // dot
-            Double_t dd = TMath::Max(0.5*GetLineWidth(), 0.5*sub), // dot size
+            Double_t dd = std::max(0.5*GetLineWidth(), 0.5*sub), // dot size
                      midx = x + fs1.Width()/2,
                      midy = y - sub - fs1.Over() - dd;
             Double_t xx[5] = { midx - dd, midx - dd, midx + dd, midx + dd, midx - dd },
@@ -1414,7 +1414,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
             break;
          }
          case 4: { // ddot
-            Double_t dd = TMath::Max(0.5*GetLineWidth(), 0.5*sub), // dot size
+            Double_t dd = std::max(0.5*GetLineWidth(), 0.5*sub), // dot size
                      midx = x + fs1.Width()/2 - 1.5*sub,
                      midy = y - sub - fs1.Over() - dd;
             Double_t xx1[5] = { midx - dd, midx - dd, midx + dd, midx + dd, midx - dd },
@@ -1622,10 +1622,10 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
          Analyse(x+addW2,y+fs2.Over()-height,spec,text+opCurlyCurly+2,length-opCurlyCurly-3);  // denominator
          Analyse(x+addW1,y-fs1.Under()-3*height,spec,text+opFrac+6,opCurlyCurly-opFrac-6); //numerator
 
-         DrawLine(x,y-2*height,x+TMath::Max(fs1.Width(),fs2.Width()),y-2*height,spec);
+         DrawLine(x,y-2*height,x+std::max(fs1.Width(),fs2.Width()),y-2*height,spec);
       }
 
-      result.Set(TMath::Max(fs1.Width(),fs2.Width()),fs1.Height()+3*height,fs2.Height()-height);
+      result.Set(std::max(fs1.Width(),fs2.Width()),fs1.Height()+3*height,fs2.Height()-height);
 
    }
    else if (opSplitLine>-1) { // \splitline found
@@ -1648,7 +1648,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
          Analyse(x,y-fs1.Under()-3*height,spec,text+opSplitLine+11,opCurlyCurly-opSplitLine-11); //first line
       }
 
-      result.Set(TMath::Max(fs1.Width(),fs2.Width()),fs1.Height()+3*height,fs2.Height()-height);
+      result.Set(std::max(fs1.Width(),fs2.Width()),fs1.Height()+3*height,fs2.Height()-height);
 
    }
    else if (opSqrt>-1) { // \sqrt found
@@ -1659,7 +1659,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
             fs2 = Anal1(spec,text+opSquareCurly+1,length-opSquareCurly-1);
             Savefs(&fs1);
             Savefs(&fs2);
-            result.Set(fs2.Width()+ GetHeight()*spec.fSize/10+TMath::Max(GetHeight()*spec.fSize/2,(Double_t)fs1.Width()),
+            result.Set(fs2.Width()+ GetHeight()*spec.fSize/10+std::max(GetHeight()*spec.fSize/2,(Double_t)fs1.Width()),
                        fs2.Over()+fs1.Height()+GetHeight()*spec.fSize/4,fs2.Under());
          } else {
             fs1 = Anal1(spec,text+opSqrt+5,length-opSqrt-5);
@@ -1670,7 +1670,7 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
          if (opSquareCurly>-1) { // ]{
             fs2 = Readfs();
             fs1 = Readfs();
-            Double_t pas = TMath::Max(GetHeight()*spec.fSize/2,(Double_t)fs1.Width());
+            Double_t pas = std::max(GetHeight()*spec.fSize/2,(Double_t)fs1.Width());
             Double_t pas2 = pas + GetHeight()*spec.fSize/10;
             Double_t y1 = y-fs2.Over() ;
             Double_t y2 = y+fs2.Under() ;
@@ -1695,9 +1695,9 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, const TextSpec_t 
             Double_t dx = (y2-y3)/8;
             UInt_t a,d;
             GetTextAscentDescent(a, d, text);
-            if (a>12) SetLineWidth(TMath::Max(2,(Int_t)(dx/2)));
+            if (a>12) SetLineWidth(std::max(2,(Int_t)(dx/2)));
             DrawLine(x1-2*dx,y1,x1-dx,y2,spec);
-            if (a>12) SetLineWidth(TMath::Max(1,(Int_t)(dx/4)));
+            if (a>12) SetLineWidth(std::max(1,(Int_t)(dx/4)));
             DrawLine(x1-dx,y2,x1,y3,spec);
             DrawLine(x1,y3,x2,y3,spec);
             SetLineWidth(lineW);
@@ -2594,7 +2594,7 @@ Double_t TLatex::GetXsize()
    TLatexFormSize fs = FirstParse(0,GetTextSize(),text);
    SetTextAngle(angle_old);
    fTabSize.clear();
-   return TMath::Abs(gPad->AbsPixeltoX(Int_t(fs.Width())) - gPad->AbsPixeltoX(0));
+   return std::abs(gPad->AbsPixeltoX(Int_t(fs.Width())) - gPad->AbsPixeltoX(0));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2682,7 +2682,7 @@ Double_t TLatex::GetYsize()
    TLatexFormSize fs = FirstParse(0,GetTextSize(),text);
    fTextAngle = angsav;
    fTabSize.clear();
-   return TMath::Abs(gPad->AbsPixeltoY(Int_t(fs.Height())) - gPad->AbsPixeltoY(0));
+   return std::abs(gPad->AbsPixeltoY(Int_t(fs.Height())) - gPad->AbsPixeltoY(0));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveLabel.cxx
+++ b/graf2d/graf/src/TPaveLabel.cxx
@@ -151,9 +151,9 @@ void TPaveLabel::PaintPaveLabel(Double_t x1, Double_t y1,Double_t x2, Double_t  
    if (GetTextFont()%10 > 2) {  // fixed size font specified in pixels
       labelsize = GetTextSize();
    } else {
-      if (TMath::Abs(textsize -0.99) < 0.001) automat = 1;
+      if (std::abs(textsize -0.99) < 0.001) automat = 1;
       if (textsize == 0)   { textsize = 0.99; automat = 1;}
-      Int_t ypixel      = TMath::Abs(gPad->YtoPixel(y1) - gPad->YtoPixel(y2));
+      Int_t ypixel      = std::abs(gPad->YtoPixel(y1) - gPad->YtoPixel(y2));
       labelsize = textsize*ypixel/hh;
       if (wh < hh) labelsize *= hh/wh;
    }
@@ -168,7 +168,7 @@ void TPaveLabel::PaintPaveLabel(Double_t x1, Double_t y1,Double_t x2, Double_t  
       latex.GetTextExtent(w,h,GetTitle());
       if (!w) return;
       labelsize = h/hh;
-      Double_t wxlabel   = TMath::Abs(gPad->XtoPixel(x2) - gPad->XtoPixel(x1));
+      Double_t wxlabel   = std::abs(gPad->XtoPixel(x2) - gPad->XtoPixel(x1));
       latex.GetTextExtent(w1,h,GetTitle());
       while (w > 0.99*wxlabel) {
          labelsize *= 0.99*wxlabel/w;

--- a/graf2d/graf/src/TPaveStats.cxx
+++ b/graf2d/graf/src/TPaveStats.cxx
@@ -351,11 +351,11 @@ void TPaveStats::Paint(Option_t *option)
 
    if (!fLines) return;
    TString typolabel;
-   Double_t y2ref = TMath::Max(fY1,fY2);
-   Double_t x1ref = TMath::Min(fX1,fX2);
-   Double_t x2ref = TMath::Max(fX1,fX2);
-   Double_t dx    = TMath::Abs(fX2 - fX1);
-   Double_t dy    = TMath::Abs(fY2 - fY1);
+   Double_t y2ref = std::max(fY1,fY2);
+   Double_t x1ref = std::min(fX1,fX2);
+   Double_t x2ref = std::max(fX1,fX2);
+   Double_t dx    = std::abs(fX2 - fX1);
+   Double_t dy    = std::abs(fY2 - fY1);
    Double_t titlesize=0;
    Double_t textsize = GetTextSize();
    Int_t nlines = GetSize();

--- a/graf2d/win32gdk/src/TGWin32GL.cxx
+++ b/graf2d/win32gdk/src/TGWin32GL.cxx
@@ -355,7 +355,7 @@ Bool_t TGWin32GLManager::ResizeOffScreenDevice(Int_t ctxInd, Int_t x, Int_t y, U
    TGLContext &ctx = fPimpl->fGLContexts[ctxInd];
 
    if (ctx.fPixmapIndex != -1)
-      if (TMath::Abs(Int_t(w) - Int_t(ctx.fW)) > 1 || TMath::Abs(Int_t(h) - Int_t(ctx.fH)) > 1) {
+      if (std::abs(Int_t(w) - Int_t(ctx.fW)) > 1 || std::abs(Int_t(h) - Int_t(ctx.fH)) > 1) {
          TGLContext newCtx = {ctx.fWindowIndex, -1, ctx.fDC, 0, ctx.fGLContext, w, h, x, y, ctx.fHighColor};
          if (CreateDIB(newCtx)) {
             //new DIB created

--- a/graf3d/gl/src/TX11GL.cxx
+++ b/graf3d/gl/src/TX11GL.cxx
@@ -398,7 +398,7 @@ Bool_t TX11GLManager::ResizeOffScreenDevice(Int_t ctxInd, Int_t x, Int_t y, UInt
    TGLContext_t &ctx = fPimpl->fGLContexts[ctxInd];
 
    if (ctx.fPixmapIndex != -1) {
-      if (TMath::Abs(Int_t(w) - Int_t(ctx.fW)) > 1 || TMath::Abs(Int_t(h) - Int_t(ctx.fH)) > 1) {
+      if (std::abs(Int_t(w) - Int_t(ctx.fW)) > 1 || std::abs(Int_t(h) - Int_t(ctx.fH)) > 1) {
          TGLContext_t newCtx;
          newCtx.fWindowIndex = ctx.fWindowIndex;
          newCtx.fW = w, newCtx.fH = h, newCtx.fX = x, newCtx.fY = y;

--- a/gui/browsable/src/RElement.cxx
+++ b/gui/browsable/src/RElement.cxx
@@ -14,6 +14,8 @@
 
 #include "TBufferJSON.h"
 
+#include <algorithm>
+
 using namespace ROOT::Browsable;
 using namespace std::string_literals;
 

--- a/gui/fitpanel/src/TTreeInput.cxx
+++ b/gui/fitpanel/src/TTreeInput.cxx
@@ -74,13 +74,13 @@ ClassImp(TTreeInput);
    fOk = new TGTextButton(hf, "&Ok", 1);
    fOk->Associate(this);
    hf->AddFrame(fOk, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 5, 5, 0, 0));
-   width  = TMath::Max(width, fOk->GetDefaultWidth());
+   width  = std::max(width, fOk->GetDefaultWidth());
 
    fCancel = new TGTextButton(hf, "&Cancel", 2);
    fCancel->Associate(this);
    hf->AddFrame(fCancel, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 5, 5, 0, 0));
    height = fCancel->GetDefaultHeight();
-   width  = TMath::Max(width, fCancel->GetDefaultWidth());
+   width  = std::max(width, fCancel->GetDefaultWidth());
 
    // place button frame (hf) at the bottom
    AddFrame(hf, new TGLayoutHints(kLHintsBottom | kLHintsCenterX, 0, 0, 5, 5));

--- a/gui/ged/src/TAttLineEditor.cxx
+++ b/gui/ged/src/TAttLineEditor.cxx
@@ -126,7 +126,7 @@ void TAttLineEditor::SetModel(TObject* obj)
    fStyleCombo->Select(fAttLine->GetLineStyle());
 
    if (obj->InheritsFrom(TGraph::Class())) {
-      fWidthCombo->Select(TMath::Abs(fAttLine->GetLineWidth()%100));
+      fWidthCombo->Select(std::abs(fAttLine->GetLineWidth()%100));
    } else {
       fWidthCombo->Select(fAttLine->GetLineWidth());
    }
@@ -199,7 +199,7 @@ void TAttLineEditor::DoLineWidth(Int_t width)
       if (graphLineWidth >= 0) {
          fAttLine->SetLineWidth(graphLineWidth+width);
       } else {
-         fAttLine->SetLineWidth(-(TMath::Abs(graphLineWidth)+width));
+         fAttLine->SetLineWidth(-(std::abs(graphLineWidth)+width));
       }
    } else if (fAttLine) {
       fAttLine->SetLineWidth(width);

--- a/gui/ged/src/TGedFrame.cxx
+++ b/gui/ged/src/TGedFrame.cxx
@@ -263,8 +263,8 @@ void TGedNameFrame::SetModel(TObject* obj)
       TGVScrollBar *vsb    = canvas->GetVScrollbar();
 
       Int_t hscrollw = (vsb && vsb->IsMapped()) ? vsb->GetWidth() : 0;
-      Int_t labwidth = TMath::Min(fLabel->GetDefaultSize().fWidth,
+      Int_t labwidth = std::min(fLabel->GetDefaultSize().fWidth,
                                   canvas->GetWidth() - 10 - hscrollw);
-      f2->SetWidth(TMath::Max(labwidth, 80));
+      f2->SetWidth(std::max(labwidth, 80));
    }
 }

--- a/gui/ged/src/TGraphEditor.cxx
+++ b/gui/ged/src/TGraphEditor.cxx
@@ -204,7 +204,7 @@ void TGraphEditor::SetModel(TObject* obj)
    // Exclusion zone parameters
    if (fGraph->GetLineWidth()<0) fExSide->SetState(kButtonDown, kFALSE);
    else fExSide->SetState(kButtonUp, kFALSE);
-   fWidthCombo->Select(TMath::Abs(Int_t(fGraph->GetLineWidth()/100)), kFALSE);
+   fWidthCombo->Select(std::abs(Int_t(fGraph->GetLineWidth()/100)), kFALSE);
 
    if (fInit) ConnectSignals2Slots();
    fAvoidSignal = kFALSE;
@@ -355,7 +355,7 @@ void TGraphEditor::DoGraphLineWidth()
 
    if (fAvoidSignal) return;
    Int_t width = fWidthCombo->GetSelected();
-   Int_t lineWidth = TMath::Abs(fGraph->GetLineWidth()%100);
+   Int_t lineWidth = std::abs(fGraph->GetLineWidth()%100);
    Int_t side = 1;
    if (fExSide->GetState() == kButtonDown) side = -1;
    fGraph->SetLineWidth(side*(100*width+lineWidth));

--- a/gui/ged/src/TH1Editor.cxx
+++ b/gui/ged/src/TH1Editor.cxx
@@ -1906,12 +1906,12 @@ void TH1Editor::DoBinLabel()
    else nx = fHist->GetXaxis()->GetNbins();
    if (nx < 2) return;
    Int_t *div = Dividers(nx);
-   Int_t diff = TMath::Abs(num - div[1]);
+   Int_t diff = std::abs(num - div[1]);
    Int_t c = 1;
    for (Int_t i = 2; i <= div[0]; i++) {
-      if ((TMath::Abs(num - div[i])) < diff) {
+      if ((std::abs(num - div[i])) < diff) {
          c = i;
-         diff = TMath::Abs(num - div[i]);
+         diff = std::abs(num - div[i]);
       }
    }
    fBinNumberEntry->SetNumber(div[c]);

--- a/gui/ged/src/TH2Editor.cxx
+++ b/gui/ged/src/TH2Editor.cxx
@@ -1761,19 +1761,19 @@ void TH2Editor::DoBinLabel()
    // Get the divider of nx/ny which is closest to numx/numy
    Int_t *divx = Dividers(nx);
    Int_t *divy = Dividers(ny);
-   Int_t diff = TMath::Abs(numx - divx[1]);
+   Int_t diff = std::abs(numx - divx[1]);
    Int_t c = 1; Int_t d = 1;
    for (i = 2; i <= divx[0]; i++) {
-      if ((TMath::Abs(numx - divx[i])) < diff) {
+      if ((std::abs(numx - divx[i])) < diff) {
          c = i;
-         diff = TMath::Abs(numx - divx[i]);
+         diff = std::abs(numx - divx[i]);
       }
    }
-   diff = TMath::Abs(numy - divy[1]);
+   diff = std::abs(numy - divy[1]);
    for (i = 2; i <= divy[0]; i++) {
-      if ((TMath::Abs(numy - divy[i])) < diff) {
+      if ((std::abs(numy - divy[i])) < diff) {
          d = i;
-         diff = TMath::Abs(numy - divy[i]);
+         diff = std::abs(numy - divy[i]);
       }
    }
    if (divx[c]!= fHist->GetXaxis()->GetNbins() ||

--- a/gui/ged/src/TStyleManager.cxx
+++ b/gui/ged/src/TStyleManager.cxx
@@ -453,7 +453,7 @@ TStyleManager::TStyleManager(const TGWindow *p) : TGMainFrame(p)
    gVirtualX->TranslateCoordinates(GetId(), GetParent()->GetId(), 0, 0, x, y, win);
    x -= 6;
    y -= 21;
-   MoveResize(x, TMath::Max(TMath::Min(y, (Int_t) (gClient->GetDisplayHeight() - h)), 0), w, h);
+   MoveResize(x, std::max(std::min(y, (Int_t) (gClient->GetDisplayHeight() - h)), 0), w, h);
 
    // Only the top level interface is shown, at the begining.
    DoMoreLess();
@@ -1488,9 +1488,9 @@ void TStyleManager::UpdateEditor(Int_t tabNum)
             fOptLogx->SetState(kButtonDown, kFALSE);
          else
             fOptLogx->SetState(kButtonUp, kFALSE);
-         fXNdivMain->SetIntNumber(TMath::Abs(fCurSelStyle->GetNdivisions("X")) % 100);
-         fXNdivSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("X")) % 10000)/100);
-         fXNdivSubSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("X")) % 1000000)/10000);
+         fXNdivMain->SetIntNumber(std::abs(fCurSelStyle->GetNdivisions("X")) % 100);
+         fXNdivSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("X")) % 10000)/100);
+         fXNdivSubSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("X")) % 1000000)/10000);
          if (fCurSelStyle->GetNdivisions("X") > 0)
             fXNdivisionsOptimize->SetState(kButtonDown, kFALSE);
          else
@@ -1523,9 +1523,9 @@ void TStyleManager::UpdateEditor(Int_t tabNum)
             fOptLogy->SetState(kButtonDown, kFALSE);
          else
             fOptLogy->SetState(kButtonUp, kFALSE);
-         fYNdivMain->SetIntNumber(TMath::Abs(fCurSelStyle->GetNdivisions("Y")) % 100);
-         fYNdivSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("Y")) % 10000)/100);
-         fYNdivSubSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("Y")) % 1000000)/10000);
+         fYNdivMain->SetIntNumber(std::abs(fCurSelStyle->GetNdivisions("Y")) % 100);
+         fYNdivSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("Y")) % 10000)/100);
+         fYNdivSubSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("Y")) % 1000000)/10000);
          if (fCurSelStyle->GetNdivisions("Y") > 0)
             fYNdivisionsOptimize->SetState(kButtonDown, kFALSE);
          else
@@ -1560,9 +1560,9 @@ void TStyleManager::UpdateEditor(Int_t tabNum)
          else
             fOptLogz->SetState(kButtonUp, kFALSE);
 
-         fZNdivMain->SetIntNumber(TMath::Abs(fCurSelStyle->GetNdivisions("Z")) % 100);
-         fZNdivSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("Z")) % 10000)/100);
-         fZNdivSubSub->SetIntNumber((TMath::Abs(fCurSelStyle->GetNdivisions("Z")) % 1000000)/10000);
+         fZNdivMain->SetIntNumber(std::abs(fCurSelStyle->GetNdivisions("Z")) % 100);
+         fZNdivSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("Z")) % 10000)/100);
+         fZNdivSubSub->SetIntNumber((std::abs(fCurSelStyle->GetNdivisions("Z")) % 1000000)/10000);
          if (fCurSelStyle->GetNdivisions("Z") > 0)
             fZNdivisionsOptimize->SetState(kButtonDown, kFALSE);
          else
@@ -4784,7 +4784,7 @@ void TStyleManager::ModTextSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetTextFont() / 10;
    Int_t mod = fCurSelStyle->GetTextFont() % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetTextFont(tmp * 10 + 3);
       fTextSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -4940,7 +4940,7 @@ void TStyleManager::ModAttDateTextSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetAttDate()->GetTextFont() / 10;
    Int_t mod = fCurSelStyle->GetAttDate()->GetTextFont() % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
 
    if (b) {
       fCurSelStyle->GetAttDate()->SetTextFont(tmp * 10 + 3);
@@ -5511,7 +5511,7 @@ void TStyleManager::ModXTitleSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetTitleFont("X") / 10;
    Int_t mod = fCurSelStyle->GetTitleFont("X") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetTitleFont(tmp * 10 + 3, "X");
       fXTitleSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -5575,7 +5575,7 @@ void TStyleManager::ModXLabelSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetLabelFont("X") / 10;
    Int_t mod = fCurSelStyle->GetLabelFont("X") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetLabelFont(tmp * 10 + 3, "X");
       fXLabelSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -5681,7 +5681,7 @@ void TStyleManager::ModYTitleSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetTitleFont("Y") / 10;
    Int_t mod = fCurSelStyle->GetTitleFont("Y") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetTitleFont(tmp * 10 + 3, "Y");
       fYTitleSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -5745,7 +5745,7 @@ void TStyleManager::ModYLabelSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetLabelFont("Y") / 10;
    Int_t mod = fCurSelStyle->GetLabelFont("Y") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetLabelFont(tmp * 10 + 3, "Y");
       fYLabelSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -5850,7 +5850,7 @@ void TStyleManager::ModZTitleSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetTitleFont("Z") / 10;
    Int_t mod = fCurSelStyle->GetTitleFont("Z") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetTitleFont(tmp * 10 + 3, "Z");
       fZTitleSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -5914,7 +5914,7 @@ void TStyleManager::ModZLabelSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetLabelFont("Z") / 10;
    Int_t mod = fCurSelStyle->GetLabelFont("Z") % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetLabelFont(tmp * 10 + 3, "Z");
       fZLabelSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -6058,7 +6058,7 @@ void TStyleManager::ModTitleFontSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetTitleFont() / 10;
    Int_t mod = fCurSelStyle->GetTitleFont() % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetTitleFont(tmp * 10 + 3);
       fTitleFontSize->SetFormat(TGNumberFormat::kNESInteger,
@@ -6194,7 +6194,7 @@ void TStyleManager::ModStatFontSizeInPixels(Bool_t b)
 {
    Int_t tmp = fCurSelStyle->GetStatFont() / 10;
    Int_t mod = fCurSelStyle->GetStatFont() % 10;
-   Double_t h = TMath::Max(fCurSelStyle->GetCanvasDefH(), 100);
+   Double_t h = std::max(fCurSelStyle->GetCanvasDefH(), 100);
    if (b) {
       fCurSelStyle->SetStatFont(tmp * 10 + 3);
       fStatFontSize->SetFormat(TGNumberFormat::kNESInteger,

--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -1445,7 +1445,7 @@ void TGCheckButton::DoRedraw()
 
    y0 = !fTHeight ? 0 : y + 1;
    if (fOn && fOff) {
-      Int_t smax = TMath::Max(fOn->GetHeight(), fOff->GetHeight());
+      Int_t smax = std::max(fOn->GetHeight(), fOff->GetHeight());
       y0 = ((Int_t)fHeight <= smax) ? 0 : 1 + (((Int_t)fHeight - smax) >> 1);
    }
 
@@ -1811,7 +1811,7 @@ void TGRadioButton::DoRedraw()
 //   pw = 12;
    y0 = !fTHeight ? 0 : ty + 1;
    if (fOn && fOff) {
-      Int_t smax = TMath::Max(fOn->GetHeight(), fOff->GetHeight());
+      Int_t smax = std::max(fOn->GetHeight(), fOff->GetHeight());
       y0 = ((Int_t)fHeight <= smax) ? 0 : 1 + (((Int_t)fHeight - smax) >> 1);
    }
 

--- a/gui/gui/src/TGCanvas.cxx
+++ b/gui/gui/src/TGCanvas.cxx
@@ -203,7 +203,7 @@ void TGViewPort::SetHPos(Int_t xpos)
    //to read window's pixels, skip "optimization".
    ((TGContainer*)fContainer)->DrawRegion(0, 0, fWidth, fHeight);
 #else
-   UInt_t adiff = TMath::Abs(diff);
+   UInt_t adiff = std::abs(diff);
 
    if (adiff < fWidth) {
       if (diff < 0) {
@@ -255,7 +255,7 @@ void TGViewPort::SetVPos(Int_t ypos)
    //to read window's pixels, skip "optimization".
    ((TGContainer*)fContainer)->DrawRegion(0, 0, fWidth, fHeight);
 #else
-   UInt_t adiff = TMath::Abs(diff);
+   UInt_t adiff = std::abs(diff);
 
    if (adiff < fHeight) {
       if (diff < 0) {
@@ -1160,10 +1160,10 @@ Bool_t TGContainer::HandleMotion(Event_t *event)
 
       gVirtualX->DrawRectangle(fId, GetLineGC()(), fX0-pos.fX, fY0-pos.fY,
                                fXf-fX0, fYf-fY0);
-      fX0 =  TMath::Min(fXp,x);
-      fY0 =  TMath::Min(fYp,y);
-      fXf =  TMath::Max(fXp,x);
-      fYf =  TMath::Max(fYp,y);
+      fX0 =  std::min(fXp,x);
+      fY0 =  std::min(fYp,y);
+      fXf =  std::max(fXp,x);
+      fYf =  std::max(fYp,y);
 
       total = selected = 0;
 
@@ -1528,8 +1528,8 @@ void TGContainer::OnAutoScroll()
    if (dx || dy) {
       if (dx) dx /= 5;
       if (dy) dy /= 5;
-      Int_t adx = TMath::Abs(dx);
-      Int_t ady = TMath::Abs(dy);
+      Int_t adx = std::abs(dx);
+      Int_t ady = std::abs(dy);
       if (adx > kAutoScrollFudge) adx = kAutoScrollFudge;
       if (ady > kAutoScrollFudge) ady = kAutoScrollFudge;
 
@@ -1546,10 +1546,10 @@ void TGContainer::OnAutoScroll()
       x += pos.fX;
       y += pos.fY;
 
-      fX0 =  TMath::Min(fXp, x);
-      fY0 =  TMath::Min(fYp, y);
-      fXf =  TMath::Max(fXp, x);
-      fYf =  TMath::Max(fYp ,y);
+      fX0 =  std::min(fXp, x);
+      fY0 =  std::min(fYp, y);
+      fXf =  std::max(fXp, x);
+      fYf =  std::max(fYp ,y);
 
       total = selected = 0;
 
@@ -1667,14 +1667,14 @@ TGFrameElement *TGContainer::FindFrame(Int_t x, Int_t y, Bool_t exclude)
    el = (TGFrameElement *) next();
    if (!el) return 0;
 
-   dx = TMath::Abs(el->fFrame->GetX()-x);
-   dy = TMath::Abs(el->fFrame->GetY()-y);
+   dx = std::abs(el->fFrame->GetX()-x);
+   dy = std::abs(el->fFrame->GetY()-y);
    d = dx + dy;
 
    while ((el = (TGFrameElement *) next())) {
       if (exclude && (el==fLastActiveEl) ) continue;
-      dx = TMath::Abs(el->fFrame->GetX()-x);
-      dy = TMath::Abs(el->fFrame->GetY()-y);
+      dx = std::abs(el->fFrame->GetX()-x);
+      dy = std::abs(el->fFrame->GetY()-y);
       dd = dx+dy;
 
       if (dd<d) {
@@ -1810,12 +1810,12 @@ void TGContainer::AdjustPosition()
       vh =  pos + (Int_t)fViewPort->GetHeight();
 
       if (f->GetY() < pos) {
-         v = TMath::Max(0, f->GetY() - (Int_t)fViewPort->GetHeight()/2);
+         v = std::max(0, f->GetY() - (Int_t)fViewPort->GetHeight()/2);
          v = (v*pg)/GetHeight();
 
          SetVsbPosition(v);
       } else if (f->GetY() + (Int_t)f->GetHeight() > vh) {
-         v = TMath::Min((Int_t)GetHeight() - (Int_t)fViewPort->GetHeight(),
+         v = std::min((Int_t)GetHeight() - (Int_t)fViewPort->GetHeight(),
                         f->GetY() + (Int_t)f->GetHeight() - (Int_t)fViewPort->GetHeight()/2);
          v = (v*pg)/GetHeight();
          SetVsbPosition(v);
@@ -1831,12 +1831,12 @@ void TGContainer::AdjustPosition()
       hw = pos + (Int_t)fViewPort->GetWidth();
 
       if (f->GetX() < pos) {
-         h = TMath::Max(0, f->GetX() - (Int_t)fViewPort->GetWidth()/2);
+         h = std::max(0, f->GetX() - (Int_t)fViewPort->GetWidth()/2);
          h = (h*pg)/GetWidth();
 
          SetHsbPosition(h);
       } else if (f->GetX() + (Int_t)f->GetWidth() > hw) {
-         h = TMath::Min((Int_t)GetWidth() - (Int_t)fViewPort->GetWidth(),
+         h = std::min((Int_t)GetWidth() - (Int_t)fViewPort->GetWidth(),
                         f->GetX() + (Int_t)f->GetWidth() - (Int_t)fViewPort->GetWidth()/2);
          h = (h*pg)/GetWidth();
 
@@ -2293,8 +2293,8 @@ void TGCanvas::Layout()
 
    fVport->MoveResize(fBorderWidth, fBorderWidth, cw, ch);
 
-   tcw = TMath::Max(container->GetDefaultWidth(), cw);
-   tch = TMath::Max(container->GetDefaultHeight(), ch);
+   tcw = std::max(container->GetDefaultWidth(), cw);
+   tch = std::max(container->GetDefaultHeight(), ch);
    UInt_t curw = container->GetDefaultWidth();
 
    container->SetWidth(0); // force a resize in TGFrame::Resize

--- a/gui/gui/src/TGClient.cxx
+++ b/gui/gui/src/TGClient.cxx
@@ -469,13 +469,13 @@ Pixel_t TGClient::GetHilite(Pixel_t base_color) const
    GetColorByName("white", white_p.fPixel);
    gVirtualX->QueryColor(attributes.fColormap, white_p);
 
-   color.fRed   = TMath::Max((UShort_t)(white_p.fRed/5),   color.fRed);
-   color.fGreen = TMath::Max((UShort_t)(white_p.fGreen/5), color.fGreen);
-   color.fBlue  = TMath::Max((UShort_t)(white_p.fBlue/5),  color.fBlue);
+   color.fRed   = std::max((UShort_t)(white_p.fRed/5),   color.fRed);
+   color.fGreen = std::max((UShort_t)(white_p.fGreen/5), color.fGreen);
+   color.fBlue  = std::max((UShort_t)(white_p.fBlue/5),  color.fBlue);
 
-   color.fRed   = (UShort_t)TMath::Min((Int_t)white_p.fRed,   (Int_t)(color.fRed*140)/100);
-   color.fGreen = (UShort_t)TMath::Min((Int_t)white_p.fGreen, (Int_t)(color.fGreen*140)/100);
-   color.fBlue  = (UShort_t)TMath::Min((Int_t)white_p.fBlue,  (Int_t)(color.fBlue*140)/100);
+   color.fRed   = (UShort_t)std::min((Int_t)white_p.fRed,   (Int_t)(color.fRed*140)/100);
+   color.fGreen = (UShort_t)std::min((Int_t)white_p.fGreen, (Int_t)(color.fGreen*140)/100);
+   color.fBlue  = (UShort_t)std::min((Int_t)white_p.fBlue,  (Int_t)(color.fBlue*140)/100);
 
    if (!gVirtualX->AllocColor(attributes.fColormap, color))
       Error("GetHilite", "couldn't allocate hilight color");

--- a/gui/gui/src/TGFSComboBox.cxx
+++ b/gui/gui/src/TGFSComboBox.cxx
@@ -156,7 +156,7 @@ TGDimension TGTreeLBEntry::GetDefaultSize() const
    TGDimension lsize(fTWidth, fTHeight+1);
 
    return TGDimension(isize.fWidth + lsize.fWidth + 4,
-                      TMath::Max(isize.fHeight, lsize.fHeight) + 2);
+                      std::max(isize.fHeight, lsize.fHeight) + 2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFileDialog.cxx
+++ b/gui/gui/src/TGFileDialog.cxx
@@ -340,7 +340,7 @@ TGFileDialog::TGFileDialog(const TGWindow *p, const TGWindow *main,
    fVbf->AddFrame(fOk, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 0, 0, 2, 2));
    fVbf->AddFrame(fCancel, new TGLayoutHints(kLHintsTop | kLHintsExpandX, 0, 0, 2, 2));
 
-   UInt_t width = TMath::Max(fOk->GetDefaultWidth(), fCancel->GetDefaultWidth()) + 20;
+   UInt_t width = std::max(fOk->GetDefaultWidth(), fCancel->GetDefaultWidth()) + 20;
    fVbf->Resize(width + 20, fVbf->GetDefaultHeight());
 
    fHf->AddFrame(fVbf, new TGLayoutHints(kLHintsLeft | kLHintsCenterY));

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -493,8 +493,8 @@ Bool_t TGFrame::HandleEvent(Event_t *event)
 
             if ((event->fTime - fgLastClick < 350) &&
                 (event->fCode == fgLastButton) &&
-                (TMath::Abs(event->fXRoot - fgDbx) < 6) &&
-                (TMath::Abs(event->fYRoot - fgDby) < 6) &&
+                (std::abs(event->fXRoot - fgDbx) < 6) &&
+                (std::abs(event->fYRoot - fgDby) < 6) &&
                 (event->fWindow == fgDbw))
                dbl_clk = kTRUE;
 

--- a/gui/gui/src/TGGC.cxx
+++ b/gui/gui/src/TGGC.cxx
@@ -45,7 +45,7 @@ TGGC::TGGC(GCValues_t *values, Bool_t)
          if (values->fDashLen > (Int_t)sizeof(fValues.fDashes))
             Warning("TGGC", "dash list can have only up to %ld elements",
                     (Long_t)sizeof(fValues.fDashes));
-         fValues.fDashLen = TMath::Min(values->fDashLen, (Int_t)sizeof(fValues.fDashes));
+         fValues.fDashLen = std::min(values->fDashLen, (Int_t)sizeof(fValues.fDashes));
          gVirtualX->SetDashes(fContext, fValues.fDashOffset, fValues.fDashes,
                               fValues.fDashLen);
       }
@@ -219,7 +219,7 @@ void TGGC::UpdateValues(GCValues_t *values)
             if (values->fDashLen > (Int_t)sizeof(fValues.fDashes))
                Warning("UpdateValues", "dash list can have only up to %ld elements",
                        (Long_t)sizeof(fValues.fDashes));
-            fValues.fDashLen = TMath::Min(values->fDashLen, (Int_t)sizeof(fValues.fDashes));
+            fValues.fDashLen = std::min(values->fDashLen, (Int_t)sizeof(fValues.fDashes));
             memcpy(fValues.fDashes, values->fDashes, fValues.fDashLen);
             break;
          case kGCArcMode:
@@ -491,7 +491,7 @@ void TGGC::SetDashList(const char v[], Int_t len)
    if (len > (Int_t)sizeof(values.fDashes))
       Warning("SetDashList", "dash list can have only up to %ld elements",
               (Long_t)sizeof(values.fDashes));
-   values.fDashLen = TMath::Min(len, (Int_t)sizeof(values.fDashes));
+   values.fDashLen = std::min(len, (Int_t)sizeof(values.fDashes));
    memcpy(values.fDashes, v, values.fDashLen);
    values.fMask    = kGCDashList;
    SetAttributes(&values);
@@ -846,7 +846,7 @@ void TGGC::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                Warning("SavePrimitive", "dash list can have only up to %ld elements",
                        (Long_t)sizeof(GetDashes()));
             out << "   " << valname << ".fDashLen = "
-                << TMath::Min(GetDashLen(),(Int_t)sizeof(GetDashes())) << ";\n";
+                << std::min(GetDashLen(),(Int_t)sizeof(GetDashes())) << ";\n";
             out << "   memcpy(GetDashes()," << valname << ".fDashes,"
                                             << valname << ".fDashLen);\n";
             break;

--- a/gui/gui/src/TGInputDialog.cxx
+++ b/gui/gui/src/TGInputDialog.cxx
@@ -79,13 +79,13 @@ TGInputDialog::TGInputDialog(const TGWindow *p, const TGWindow *main,
    fOk = new TGTextButton(hf, "&Ok", 1);
    fOk->Associate(this);
    hf->AddFrame(fOk, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 5, 5, 0, 0));
-   width  = TMath::Max(width, fOk->GetDefaultWidth());
+   width  = std::max(width, fOk->GetDefaultWidth());
 
    fCancel = new TGTextButton(hf, "&Cancel", 2);
    fCancel->Associate(this);
    hf->AddFrame(fCancel, new TGLayoutHints(kLHintsCenterY | kLHintsExpandX, 5, 5, 0, 0));
    height = fCancel->GetDefaultHeight();
-   width  = TMath::Max(width, fCancel->GetDefaultWidth());
+   width  = std::max(width, fCancel->GetDefaultWidth());
 
    // place button frame (hf) at the bottom
    AddFrame(hf, new TGLayoutHints(kLHintsBottom | kLHintsCenterX, 0, 0, 5, 5));

--- a/gui/gui/src/TGLayout.cxx
+++ b/gui/gui/src/TGLayout.cxx
@@ -222,7 +222,7 @@ void TGVerticalLayout::Layout()
             nb_expand++;
             exp += size.fHeight;
             if (hints & kLHintsExpandY) exp_max = 0;
-            else exp_max = TMath::Max(exp_max, (Int_t)size.fHeight);
+            else exp_max = std::max(exp_max, (Int_t)size.fHeight);
          } else {
             remain -= size.fHeight;
             if (remain < 0)
@@ -330,7 +330,7 @@ TGDimension TGVerticalLayout::GetDefaultSize() const
    while ((ptr = (TGFrameElement *) next())) {
       if (ptr->fState & kIsVisible) {
          csize = ptr->fFrame->GetDefaultSize();
-         size.fWidth = TMath::Max(size.fWidth, csize.fWidth + ptr->fLayout->GetPadLeft() +
+         size.fWidth = std::max(size.fWidth, csize.fWidth + ptr->fLayout->GetPadLeft() +
                                   ptr->fLayout->GetPadRight());
          size.fHeight += csize.fHeight + ptr->fLayout->GetPadTop() +
                          ptr->fLayout->GetPadBottom();
@@ -384,7 +384,7 @@ void TGHorizontalLayout::Layout()
             nb_expand++;
             exp += size.fWidth;
             if (hints & kLHintsExpandX) exp_max = 0;
-            else exp_max = TMath::Max(exp_max, (Int_t)size.fWidth);
+            else exp_max = std::max(exp_max, (Int_t)size.fWidth);
          } else {
             remain -= size.fWidth;
             if (remain < 0)
@@ -490,7 +490,7 @@ TGDimension TGHorizontalLayout::GetDefaultSize() const
          size.fWidth += csize.fWidth + ptr->fLayout->GetPadLeft() +
                         ptr->fLayout->GetPadRight();
 
-         size.fHeight = TMath::Max(size.fHeight, csize.fHeight + ptr->fLayout->GetPadTop() +
+         size.fHeight = std::max(size.fHeight, csize.fHeight + ptr->fLayout->GetPadTop() +
                                    ptr->fLayout->GetPadBottom());
       }
    }
@@ -545,7 +545,7 @@ TGDimension TGRowLayout::GetDefaultSize() const
    while ((ptr = (TGFrameElement *) next())) {
       if (ptr->fState & kIsVisible) {
          dsize   = ptr->fFrame->GetDefaultSize();
-         size.fHeight  = TMath::Max(size.fHeight, dsize.fHeight);
+         size.fHeight  = std::max(size.fHeight, dsize.fHeight);
          size.fWidth  += dsize.fWidth + fSep;
       }
    }
@@ -601,7 +601,7 @@ TGDimension TGColumnLayout::GetDefaultSize() const
       if (ptr->fState & kIsVisible) {
          dsize   = ptr->fFrame->GetDefaultSize();
          size.fHeight += dsize.fHeight + fSep;
-         size.fWidth   = TMath::Max(size.fWidth, dsize.fWidth);
+         size.fWidth   = std::max(size.fWidth, dsize.fWidth);
       }
    }
 
@@ -644,8 +644,8 @@ void TGMatrixLayout::Layout()
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       csize = ptr->fFrame->GetDefaultSize();
-      maxsize.fWidth  = TMath::Max(maxsize.fWidth, csize.fWidth);
-      maxsize.fHeight = TMath::Max(maxsize.fHeight, csize.fHeight);
+      maxsize.fWidth  = std::max(maxsize.fWidth, csize.fWidth);
+      maxsize.fHeight = std::max(maxsize.fHeight, csize.fHeight);
    }
 
    next.Reset();
@@ -699,8 +699,8 @@ TGDimension TGMatrixLayout::GetDefaultSize() const
    while ((ptr = (TGFrameElement *) next())) {
       count++;
       csize = ptr->fFrame->GetDefaultSize();
-      maxsize.fWidth  = TMath::Max(maxsize.fWidth, csize.fWidth);
-      maxsize.fHeight = TMath::Max(maxsize.fHeight, csize.fHeight);
+      maxsize.fWidth  = std::max(maxsize.fWidth, csize.fWidth);
+      maxsize.fHeight = std::max(maxsize.fHeight, csize.fHeight);
    }
 
    if (fRows == 0) {
@@ -744,11 +744,11 @@ void TGTileLayout::Layout()
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       csize = ptr->fFrame->GetDefaultSize();
-      max_osize.fWidth  = TMath::Max(max_osize.fWidth, csize.fWidth);
-      max_osize.fHeight = TMath::Max(max_osize.fHeight, csize.fHeight);
+      max_osize.fWidth  = std::max(max_osize.fWidth, csize.fWidth);
+      max_osize.fHeight = std::max(max_osize.fHeight, csize.fHeight);
    }
 
-   max_width = TMath::Max(msize.fWidth, max_osize.fWidth + (fSep << 1));
+   max_width = std::max(msize.fWidth, max_osize.fWidth + (fSep << 1));
    x = fSep; y = fSep << 1;
 
    next.Reset();
@@ -796,11 +796,11 @@ TGDimension TGTileLayout::GetDefaultSize() const
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       max_size = ptr->fFrame->GetDefaultSize();
-      max_osize.fWidth  = TMath::Max(max_osize.fWidth, max_size.fWidth);
-      max_osize.fHeight = TMath::Max(max_osize.fHeight, max_size.fHeight);
+      max_osize.fWidth  = std::max(max_osize.fWidth, max_size.fWidth);
+      max_osize.fHeight = std::max(max_osize.fHeight, max_size.fHeight);
    }
 
-   max_size.fWidth = TMath::Max(msize.fWidth, max_osize.fWidth + (fSep << 1));
+   max_size.fWidth = std::max(msize.fWidth, max_osize.fWidth + (fSep << 1));
 
    x = fSep; y = fSep << 1;
 
@@ -814,7 +814,7 @@ TGDimension TGTileLayout::GetDefaultSize() const
       }
    }
    if (x != fSep) y += max_osize.fHeight + fSep;
-   max_size.fHeight = TMath::Max(y, (Int_t)msize.fHeight);
+   max_size.fHeight = std::max(y, (Int_t)msize.fHeight);
 
    return max_size;
 }
@@ -835,11 +835,11 @@ void TGListLayout::Layout()
    // coverity[returned_pointer]
    while ((ptr = (TGFrameElement *) next())) {
       csize = ptr->fFrame->GetDefaultSize();
-      max_osize.fWidth  = TMath::Max(max_osize.fWidth, csize.fWidth);
-      max_osize.fHeight = TMath::Max(max_osize.fHeight, csize.fHeight);
+      max_osize.fWidth  = std::max(max_osize.fWidth, csize.fWidth);
+      max_osize.fHeight = std::max(max_osize.fHeight, csize.fHeight);
    }
 
-   max_height = TMath::Max(msize.fHeight, max_osize.fHeight + (fSep << 1));
+   max_height = std::max(msize.fHeight, max_osize.fHeight + (fSep << 1));
 
    x = fSep; y = fSep << 1;
 
@@ -889,11 +889,11 @@ TGDimension TGListLayout::GetDefaultSize() const
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       max_size = ptr->fFrame->GetDefaultSize();
-      max_osize.fWidth  = TMath::Max(max_osize.fWidth, max_size.fWidth);
-      max_osize.fHeight = TMath::Max(max_osize.fHeight, max_size.fHeight);
+      max_osize.fWidth  = std::max(max_osize.fWidth, max_size.fWidth);
+      max_osize.fHeight = std::max(max_osize.fHeight, max_size.fHeight);
    }
 
-   max_size.fHeight = TMath::Max(msize.fHeight, max_osize.fHeight + (fSep << 1));
+   max_size.fHeight = std::max(msize.fHeight, max_osize.fHeight + (fSep << 1));
 
    x = fSep; y = fSep << 1;
 
@@ -906,7 +906,7 @@ TGDimension TGListLayout::GetDefaultSize() const
       }
    }
    if (y != (fSep << 1)) x += (Int_t)max_osize.fWidth + fSep;
-   max_size.fWidth = TMath::Max(x, (Int_t)msize.fWidth);
+   max_size.fWidth = std::max(x, (Int_t)msize.fWidth);
 
    return max_size;
 }
@@ -924,7 +924,7 @@ void TGListDetailsLayout::Layout()
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       csize = ptr->fFrame->GetDefaultSize();
-      max_oh = TMath::Max(max_oh, (Int_t)csize.fHeight);
+      max_oh = std::max(max_oh, (Int_t)csize.fHeight);
    }
 
    next.Reset();
@@ -955,8 +955,8 @@ TGDimension TGListDetailsLayout::GetDefaultSize() const
    TIter next(fList);
    while ((ptr = (TGFrameElement *) next())) {
       csize = ptr->fFrame->GetDefaultSize();
-      max_osize.fWidth  = TMath::Max(max_osize.fWidth, csize.fWidth);
-      max_osize.fHeight = TMath::Max(max_osize.fHeight, csize.fHeight);
+      max_osize.fWidth  = std::max(max_osize.fWidth, csize.fWidth);
+      max_osize.fHeight = std::max(max_osize.fHeight, csize.fHeight);
    }
 
    next.Reset();

--- a/gui/gui/src/TGListTree.cxx
+++ b/gui/gui/src/TGListTree.cxx
@@ -578,7 +578,7 @@ Bool_t TGListTree::HandleButton(Event_t *event)
 //                              fCanvas->GetContainer()->GetHeight());
          // choose page size either 1/5 of viewport or 5 lines (90)
          Int_t r = fCanvas->GetViewPort()->GetHeight() / 5;
-         page = TMath::Min(r, 90);
+         page = std::min(r, 90);
       }
    }
 
@@ -1314,10 +1314,10 @@ void TGListTree::AdjustPosition(TGListTreeItem *item)
       vh = fCanvas->GetVScrollbar()->GetPosition()+(Int_t)fViewPort->GetHeight();
 
       if (y<fCanvas->GetVScrollbar()->GetPosition()) {
-         v = TMath::Max(0,y-(Int_t)fViewPort->GetHeight()/2);
+         v = std::max(0,y-(Int_t)fViewPort->GetHeight()/2);
          fCanvas->SetVsbPosition(v);
       } else if (y+(Int_t)it->fHeight>vh) {
-         v = TMath::Min((Int_t)GetHeight()-(Int_t)fViewPort->GetHeight(),
+         v = std::min((Int_t)GetHeight()-(Int_t)fViewPort->GetHeight(),
                         y+(Int_t)it->fHeight-(Int_t)fViewPort->GetHeight()/2);
          if (v<0) v = 0;
          fCanvas->SetVsbPosition(v);

--- a/gui/gui/src/TGListView.cxx
+++ b/gui/gui/src/TGListView.cxx
@@ -476,7 +476,7 @@ TGDimension TGLVEntry::GetDefaultSize() const
    switch (fViewMode) {
       default:
       case kLVLargeIcons:
-         size.fWidth = TMath::Max(isize.fWidth, lsize.fWidth);
+         size.fWidth = std::max(isize.fWidth, lsize.fWidth);
          size.fHeight = isize.fHeight + lsize.fHeight + 6;
          break;
 
@@ -484,7 +484,7 @@ TGDimension TGLVEntry::GetDefaultSize() const
       case kLVList:
       case kLVDetails:
          size.fWidth = isize.fWidth + lsize.fWidth + 4;
-         size.fHeight = TMath::Max(isize.fHeight, lsize.fHeight);
+         size.fHeight = std::max(isize.fHeight, lsize.fHeight);
          break;
    }
    return size;
@@ -701,8 +701,8 @@ TGDimension TGLVContainer::GetMaxItemSize() const
    TIter next(fList);
    while ((el = (TGFrameElement *) next())) {
       csize = el->fFrame->GetDefaultSize();
-      maxsize.fWidth  = TMath::Max(maxsize.fWidth, csize.fWidth);
-      maxsize.fHeight = TMath::Max(maxsize.fHeight, csize.fHeight);
+      maxsize.fWidth  = std::max(maxsize.fWidth, csize.fWidth);
+      maxsize.fHeight = std::max(maxsize.fHeight, csize.fHeight);
    }
    if (fViewMode == kLVLargeIcons) {
       maxsize.fWidth  += 8;
@@ -730,7 +730,7 @@ Int_t TGLVContainer::GetMaxSubnameWidth(Int_t idx) const
    while ((el = (TGFrameElement *) next())) {
       TGLVEntry *entry = (TGLVEntry *) el->fFrame;
       width = entry->GetSubnameWidth(idx-1);
-      maxwidth = TMath::Max(maxwidth, width);
+      maxwidth = std::max(maxwidth, width);
    }
    return maxwidth;
 }
@@ -1417,9 +1417,9 @@ void TGListView::SetDefaultColumnWidth(TGVFileSplitter* splitter)
          TString dt = fColHeader[i]->GetString();
          UInt_t bsize = gVirtualX->TextWidth(fColHeader[i]->GetFontStruct(),
                                              dt.Data(), dt.Length());
-         UInt_t w = TMath::Max(fColHeader[i]->GetDefaultWidth(), bsize + 20);
-         if (i == 0) w = TMath::Max(fMaxSize.fWidth + 10, w);
-         if (i > 0)  w = TMath::Max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
+         UInt_t w = std::max(fColHeader[i]->GetDefaultWidth(), bsize + 20);
+         if (i == 0) w = std::max(fMaxSize.fWidth + 10, w);
+         if (i > 0)  w = std::max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
          fColHeader[i]->Resize(w, fColHeader[i]->GetHeight());
          Layout();
       }
@@ -1467,14 +1467,14 @@ void TGListView::Layout()
          fColHeader[i]->SetText(fColNames[i]);
 
          if ( fJustChanged ) {
-            w = TMath::Min(fMaxSize.fWidth + 10, fColHeader[i]->GetDefaultWidth());
+            w = std::min(fMaxSize.fWidth + 10, fColHeader[i]->GetDefaultWidth());
             if (w < fMinColumnSize) w = fColHeader[i]->GetDefaultWidth();
-            if (i == 0) w = TMath::Max(fMaxSize.fWidth + 10, w);
-            if (i > 0)  w = TMath::Max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
+            if (i == 0) w = std::max(fMaxSize.fWidth + 10, w);
+            if (i > 0)  w = std::max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
          } else {
             w = fColHeader[i]->GetWidth();
          }
-         w = TMath::Max(fMinColumnSize, w);
+         w = std::max(fMinColumnSize, w);
          if ( fColHeader[i]->GetDefaultWidth() > w ) {
             for (int j = fColNames[i].Length() - 1 ; j > 0; j--) {
                fColHeader[i]->SetText( fColNames[i](0,j) + "..." );
@@ -1560,14 +1560,14 @@ void TGListView::LayoutHeader(TGFrame *head)
          fColHeader[i]->SetText(fColNames[i]);
 
          if ( fJustChanged ) {
-            w = TMath::Min(fMaxSize.fWidth + 10, fColHeader[i]->GetDefaultWidth());
+            w = std::min(fMaxSize.fWidth + 10, fColHeader[i]->GetDefaultWidth());
             if (w < fMinColumnSize) w = fColHeader[i]->GetDefaultWidth();
-            if (i == 0) w = TMath::Max(fMaxSize.fWidth + 10, w);
-            if (i > 0)  w = TMath::Max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
+            if (i == 0) w = std::max(fMaxSize.fWidth + 10, w);
+            if (i > 0)  w = std::max(container->GetMaxSubnameWidth(i) + 40, (Int_t)w);
          } else {
             w = fColHeader[i]->GetWidth();
          }
-         w = TMath::Max(fMinColumnSize, w);
+         w = std::max(fMinColumnSize, w);
          if ( fColHeader[i]->GetDefaultWidth() > w ) {
             for (int j = fColNames[i].Length() - 1 ; j > 0; j--) {
                fColHeader[i]->SetText( fColNames[i](0,j) + "..." );

--- a/gui/gui/src/TGMdiMainFrame.cxx
+++ b/gui/gui/src/TGMdiMainFrame.cxx
@@ -1189,8 +1189,8 @@ TGDimension TGMdiContainer::GetDefaultSize() const
    Int_t xpos = -fMain->GetViewPort()->GetHPos() - rect.LeftTop().fX;
    Int_t ypos = -fMain->GetViewPort()->GetVPos() - rect.LeftTop().fY;
 
-   return TGDimension(TMath::Max(Int_t(xpos + fWidth), rect.RightBottom().fX + 1),
-                      TMath::Max(Int_t(ypos + fHeight), rect.RightBottom().fY + 1));
+   return TGDimension(std::max(Int_t(xpos + fWidth), rect.RightBottom().fX + 1),
+                      std::max(Int_t(ypos + fHeight), rect.RightBottom().fY + 1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1204,8 +1204,8 @@ Bool_t TGMdiContainer::HandleConfigureNotify(Event_t *event)
       Int_t vw = fMain->GetViewPort()->GetWidth();
       Int_t vh = fMain->GetViewPort()->GetHeight();
 
-      Int_t w = TMath::Max(vw, rect.RightBottom().fX + 1);
-      Int_t h = TMath::Max(vh, rect.RightBottom().fY + 1);
+      Int_t w = std::max(vw, rect.RightBottom().fX + 1);
+      Int_t h = std::max(vh, rect.RightBottom().fY + 1);
 
       if ((w != (Int_t)fWidth) || (h != (Int_t)fHeight)) {
          ((TGMdiMainFrame*)fMain)->Layout();

--- a/gui/gui/src/TGMsgBox.cxx
+++ b/gui/gui/src/TGMsgBox.cxx
@@ -142,91 +142,91 @@ void TGMsgBox::PMsgBox(const char *title, const char *msg,
       fYes = new TGTextButton(fButtonFrame, new TGHotString("&Yes"), kMBYes);
       fYes->Associate(this);
       fButtonFrame->AddFrame(fYes, fL1);
-      width = TMath::Max(width, fYes->GetDefaultWidth()); ++nb;
+      width = std::max(width, fYes->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBNo) {
       fNo = new TGTextButton(fButtonFrame, new TGHotString("&No"), kMBNo);
       fNo->Associate(this);
       fButtonFrame->AddFrame(fNo, fL1);
-      width = TMath::Max(width, fNo->GetDefaultWidth()); ++nb;
+      width = std::max(width, fNo->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBOk) {
       fOK = new TGTextButton(fButtonFrame, new TGHotString("&OK"), kMBOk);
       fOK->Associate(this);
       fButtonFrame->AddFrame(fOK, fL1);
-      width = TMath::Max(width, fOK->GetDefaultWidth()); ++nb;
+      width = std::max(width, fOK->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBApply) {
       fApply = new TGTextButton(fButtonFrame, new TGHotString("&Apply"), kMBApply);
       fApply->Associate(this);
       fButtonFrame->AddFrame(fApply, fL1);
-      width = TMath::Max(width, fApply->GetDefaultWidth()); ++nb;
+      width = std::max(width, fApply->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBRetry) {
       fRetry = new TGTextButton(fButtonFrame, new TGHotString("&Retry"), kMBRetry);
       fRetry->Associate(this);
       fButtonFrame->AddFrame(fRetry, fL1);
-      width = TMath::Max(width, fRetry->GetDefaultWidth()); ++nb;
+      width = std::max(width, fRetry->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBIgnore) {
       fIgnore = new TGTextButton(fButtonFrame, new TGHotString("&Ignore"), kMBIgnore);
       fIgnore->Associate(this);
       fButtonFrame->AddFrame(fIgnore, fL1);
-      width = TMath::Max(width, fIgnore->GetDefaultWidth()); ++nb;
+      width = std::max(width, fIgnore->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBCancel) {
       fCancel = new TGTextButton(fButtonFrame, new TGHotString("&Cancel"), kMBCancel);
       fCancel->Associate(this);
       fButtonFrame->AddFrame(fCancel, fL1);
-      width = TMath::Max(width, fCancel->GetDefaultWidth()); ++nb;
+      width = std::max(width, fCancel->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBClose) {
       fClose = new TGTextButton(fButtonFrame, new TGHotString("C&lose"), kMBClose);
       fClose->Associate(this);
       fButtonFrame->AddFrame(fClose, fL1);
-      width = TMath::Max(width, fClose->GetDefaultWidth()); ++nb;
+      width = std::max(width, fClose->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBYesAll) {
       fYesAll = new TGTextButton(fButtonFrame, new TGHotString("Y&es to All"), kMBYesAll);
       fYesAll->Associate(this);
       fButtonFrame->AddFrame(fYesAll, fL1);
-      width = TMath::Max(width, fYesAll->GetDefaultWidth()); ++nb;
+      width = std::max(width, fYesAll->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBNoAll) {
       fNoAll = new TGTextButton(fButtonFrame, new TGHotString("No &to All"), kMBNoAll);
       fNoAll->Associate(this);
       fButtonFrame->AddFrame(fNoAll, fL1);
-      width = TMath::Max(width, fNoAll->GetDefaultWidth()); ++nb;
+      width = std::max(width, fNoAll->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBNewer) {
       fNewer = new TGTextButton(fButtonFrame, new TGHotString("Ne&wer Only"), kMBNewer);
       fNewer->Associate(this);
       fButtonFrame->AddFrame(fNewer, fL1);
-      width = TMath::Max(width, fNewer->GetDefaultWidth()); ++nb;
+      width = std::max(width, fNewer->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBAppend) {
       fAppend = new TGTextButton(fButtonFrame, new TGHotString("A&ppend"), kMBAppend);
       fAppend->Associate(this);
       fButtonFrame->AddFrame(fAppend, fL1);
-      width = TMath::Max(width, fAppend->GetDefaultWidth()); ++nb;
+      width = std::max(width, fAppend->GetDefaultWidth()); ++nb;
    }
 
    if (buttons & kMBDismiss) {
       fDismiss = new TGTextButton(fButtonFrame, new TGHotString("&Dismiss"), kMBDismiss);
       fDismiss->Associate(this);
       fButtonFrame->AddFrame(fDismiss, fL1);
-      width = TMath::Max(width, fDismiss->GetDefaultWidth()); ++nb;
+      width = std::max(width, fDismiss->GetDefaultWidth()); ++nb;
    }
 
    // place buttons at the bottom

--- a/gui/gui/src/TGScrollBar.cxx
+++ b/gui/gui/src/TGScrollBar.cxx
@@ -344,7 +344,7 @@ TGScrollBar::TGScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                          kButtonReleaseMask | kPointerMotionMask, kNone, kNone);
 
    fDragging = kFALSE;
-   fX0 = fY0 = (fgScrollBarWidth = TMath::Max(fgScrollBarWidth, 5));
+   fX0 = fY0 = (fgScrollBarWidth = std::max(fgScrollBarWidth, 5));
    fPos = 0;
 
    fSliderSize  = 50;
@@ -461,7 +461,7 @@ TGHScrollBar::TGHScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
     TGScrollBar(p, w, h, options, back, "arrow_left.xpm", "arrow_right.xpm")
 {
-   fRange = TMath::Max((Int_t) w - (fgScrollBarWidth << 1), 1);
+   fRange = std::max((Int_t) w - (fgScrollBarWidth << 1), 1);
    fPsize = fRange >> 1;
    fEditDisabled |= kEditDisableHeight;
 }
@@ -514,13 +514,13 @@ Bool_t TGHScrollBar::HandleButton(Event_t *event)
    if (event->fType == kButtonPress) {
       if (event->fCode == kButton3) {
          fX0 = event->fX - fSliderSize/2;
-         fX0 = TMath::Max(fX0, fgScrollBarWidth);
-         fX0 = TMath::Min(fX0, fgScrollBarWidth + fSliderRange);
+         fX0 = std::max(fX0, fgScrollBarWidth);
+         fX0 = std::min(fX0, fgScrollBarWidth + fSliderRange);
          ULong_t pos = (ULong_t)(fX0 - fgScrollBarWidth) * (ULong_t)(fRange-fPsize) / (ULong_t)fSliderRange;
          fPos = (Int_t)pos;
 
-         fPos = TMath::Max(fPos, 0);
-         fPos = TMath::Min(fPos, fRange-fPsize);
+         fPos = std::max(fPos, 0);
+         fPos = std::min(fPos, fRange-fPsize);
          fSlider->Move(fX0, 0);
 
          SendMessage(fMsgWindow, MK_MSG(kC_HSCROLL, kSB_SLIDERTRACK), fPos, 0);
@@ -562,13 +562,13 @@ Bool_t TGHScrollBar::HandleButton(Event_t *event)
          else if (event->fX > fX0+fSliderSize && event->fX < (Int_t)fWidth-fgScrollBarWidth)
             fPos += fPsize;
 
-         fPos = TMath::Max(fPos, 0);
-         fPos = TMath::Min(fPos, fRange-fPsize);
+         fPos = std::max(fPos, 0);
+         fPos = std::min(fPos, fRange-fPsize);
 
-         fX0 = fgScrollBarWidth + fPos * fSliderRange / TMath::Max(fRange-fPsize, 1);
+         fX0 = fgScrollBarWidth + fPos * fSliderRange / std::max(fRange-fPsize, 1);
 
-         fX0 = TMath::Max(fX0, fgScrollBarWidth);
-         fX0 = TMath::Min(fX0, fgScrollBarWidth + fSliderRange);
+         fX0 = std::max(fX0, fgScrollBarWidth);
+         fX0 = std::min(fX0, fgScrollBarWidth + fSliderRange);
 
          fSlider->Move(fX0, 0);
 
@@ -593,8 +593,8 @@ Bool_t TGHScrollBar::HandleButton(Event_t *event)
 
       fDragging = kFALSE;
 
-      fPos = TMath::Max(fPos, 0);
-      fPos = TMath::Min(fPos, fRange-fPsize);
+      fPos = std::max(fPos, 0);
+      fPos = std::min(fPos, fRange-fPsize);
 
       SendMessage(fMsgWindow, MK_MSG(kC_HSCROLL, kSB_SLIDERPOS), fPos, 0);
       PositionChanged(fPos);
@@ -614,14 +614,14 @@ Bool_t TGHScrollBar::HandleMotion(Event_t *event)
       fX0 = event->fX - fXp;
       fY0 = event->fY - fYp;
 
-      fX0 = TMath::Max(fX0, fgScrollBarWidth);
-      fX0 = TMath::Min(fX0, fgScrollBarWidth + fSliderRange);
+      fX0 = std::max(fX0, fgScrollBarWidth);
+      fX0 = std::min(fX0, fgScrollBarWidth + fSliderRange);
       fSlider->Move(fX0, 0);
       ULong_t pos = (ULong_t)(fX0 - fgScrollBarWidth) * (ULong_t)(fRange-fPsize) / (ULong_t)fSliderRange;
       fPos = (Int_t)pos;
 
-      fPos = TMath::Max(fPos, 0);
-      fPos = TMath::Min(fPos, fRange-fPsize);
+      fPos = std::max(fPos, 0);
+      fPos = std::min(fPos, fRange-fPsize);
 
       SendMessage(fMsgWindow, MK_MSG(kC_HSCROLL, kSB_SLIDERTRACK), fPos, 0);
       PositionChanged(fPos);
@@ -634,21 +634,21 @@ Bool_t TGHScrollBar::HandleMotion(Event_t *event)
 
 void TGHScrollBar::SetRange(Int_t range, Int_t page_size)
 {
-   fRange = TMath::Max(range, 1);
-   fPsize = TMath::Max(page_size, 0);
-   fPos = TMath::Max(fPos, 0);
-   fPos = TMath::Min(fPos, fRange-fPsize);
+   fRange = std::max(range, 1);
+   fPsize = std::max(page_size, 0);
+   fPos = std::max(fPos, 0);
+   fPos = std::min(fPos, fRange-fPsize);
 
-   fSliderSize = TMath::Max(fPsize * (fWidth - (fgScrollBarWidth << 1)) /
+   fSliderSize = std::max(fPsize * (fWidth - (fgScrollBarWidth << 1)) /
                             fRange, (UInt_t) 6);
-   fSliderSize = TMath::Min((UInt_t)fSliderSize, fWidth - (fgScrollBarWidth << 1));
+   fSliderSize = std::min((UInt_t)fSliderSize, fWidth - (fgScrollBarWidth << 1));
 
-   fSliderRange = TMath::Max(fWidth - (fgScrollBarWidth << 1) - fSliderSize,
+   fSliderRange = std::max(fWidth - (fgScrollBarWidth << 1) - fSliderSize,
                              (UInt_t) 1);
 
-   fX0 = fgScrollBarWidth + fPos * fSliderRange / TMath::Max(fRange-fPsize, 1);
-   fX0 = TMath::Max(fX0, fgScrollBarWidth);
-   fX0 = TMath::Min(fX0, fgScrollBarWidth + fSliderRange);
+   fX0 = fgScrollBarWidth + fPos * fSliderRange / std::max(fRange-fPsize, 1);
+   fX0 = std::max(fX0, fgScrollBarWidth);
+   fX0 = std::min(fX0, fgScrollBarWidth + fSliderRange);
 
    fSlider->Move(fX0, 0);
    fSlider->Resize(fSliderSize, fgScrollBarWidth);
@@ -667,12 +667,12 @@ void TGHScrollBar::SetRange(Int_t range, Int_t page_size)
 
 void TGHScrollBar::SetPosition(Int_t pos)
 {
-   fPos = TMath::Max(pos, 0);
-   fPos = TMath::Min(pos, fRange-fPsize);
+   fPos = std::max(pos, 0);
+   fPos = std::min(pos, fRange-fPsize);
 
-   fX0 = fgScrollBarWidth + fPos * fSliderRange / TMath::Max(fRange-fPsize, 1);
-   fX0 = TMath::Max(fX0, fgScrollBarWidth);
-   fX0 = TMath::Min(fX0, fgScrollBarWidth + fSliderRange);
+   fX0 = fgScrollBarWidth + fPos * fSliderRange / std::max(fRange-fPsize, 1);
+   fX0 = std::max(fX0, fgScrollBarWidth);
+   fX0 = std::min(fX0, fgScrollBarWidth + fSliderRange);
 
    fSlider->Move(fX0, 0);
    fSlider->Resize(fSliderSize, fgScrollBarWidth);
@@ -690,7 +690,7 @@ TGVScrollBar::TGVScrollBar(const TGWindow *p, UInt_t w, UInt_t h,
                            UInt_t options, ULong_t back) :
     TGScrollBar(p, w, h, options, back, "arrow_up.xpm", "arrow_down.xpm")
 {
-   fRange = TMath::Max((Int_t) h - (fgScrollBarWidth << 1), 1);
+   fRange = std::max((Int_t) h - (fgScrollBarWidth << 1), 1);
    fPsize = fRange >> 1;
    fEditDisabled |= kEditDisableWidth;
 }
@@ -744,13 +744,13 @@ Bool_t TGVScrollBar::HandleButton(Event_t *event)
    if (event->fType == kButtonPress) {
       if (event->fCode == kButton3) {
          fY0 = event->fY - fSliderSize/2;
-         fY0 = TMath::Max(fY0, fgScrollBarWidth);
-         fY0 = TMath::Min(fY0, fgScrollBarWidth + fSliderRange);
+         fY0 = std::max(fY0, fgScrollBarWidth);
+         fY0 = std::min(fY0, fgScrollBarWidth + fSliderRange);
          ULong_t pos = (ULong_t)(fY0 - fgScrollBarWidth) * (ULong_t)(fRange-fPsize) / (ULong_t)fSliderRange;
          fPos = (Int_t)pos;
 
-         fPos = TMath::Max(fPos, 0);
-         fPos = TMath::Min(fPos, fRange-fPsize);
+         fPos = std::max(fPos, 0);
+         fPos = std::min(fPos, fRange-fPsize);
          fSlider->Move(0, fY0);
 
          SendMessage(fMsgWindow, MK_MSG(kC_VSCROLL, kSB_SLIDERTRACK), fPos, 0);
@@ -792,14 +792,14 @@ Bool_t TGVScrollBar::HandleButton(Event_t *event)
          else if (event->fY > fY0+fSliderSize && event->fY < (Int_t)fHeight-fgScrollBarWidth)
             fPos += fPsize;
 
-         fPos = TMath::Max(fPos, 0);
-         fPos = TMath::Min(fPos, fRange-fPsize);
+         fPos = std::max(fPos, 0);
+         fPos = std::min(fPos, fRange-fPsize);
 
-         ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)TMath::Max(fRange-fPsize, 1);
+         ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)std::max(fRange-fPsize, 1);
          fY0 = (Int_t)y0;
 
-         fY0 = TMath::Max(fY0, fgScrollBarWidth);
-         fY0 = TMath::Min(fY0, fgScrollBarWidth + fSliderRange);
+         fY0 = std::max(fY0, fgScrollBarWidth);
+         fY0 = std::min(fY0, fgScrollBarWidth + fSliderRange);
 
          fSlider->Move(0, fY0);
 
@@ -824,8 +824,8 @@ Bool_t TGVScrollBar::HandleButton(Event_t *event)
 
       fDragging = kFALSE;
 
-      fPos = TMath::Max(fPos, 0);
-      fPos = TMath::Min(fPos, fRange-fPsize);
+      fPos = std::max(fPos, 0);
+      fPos = std::min(fPos, fRange-fPsize);
 
       SendMessage(fMsgWindow, MK_MSG(kC_VSCROLL, kSB_SLIDERPOS), fPos, 0);
       PositionChanged(fPos);
@@ -846,14 +846,14 @@ Bool_t TGVScrollBar::HandleMotion(Event_t *event)
       fX0 = event->fX - fXp;
       fY0 = event->fY - fYp;
 
-      fY0 = TMath::Max(fY0, fgScrollBarWidth);
-      fY0 = TMath::Min(fY0, fgScrollBarWidth + fSliderRange);
+      fY0 = std::max(fY0, fgScrollBarWidth);
+      fY0 = std::min(fY0, fgScrollBarWidth + fSliderRange);
       fSlider->Move(0, fY0);
       ULong_t pos = (ULong_t)(fY0 - fgScrollBarWidth) * (ULong_t)(fRange-fPsize) / fSliderRange;
       fPos = (Int_t)pos;
 
-      fPos = TMath::Max(fPos, 0);
-      fPos = TMath::Min(fPos, fRange-fPsize);
+      fPos = std::max(fPos, 0);
+      fPos = std::min(fPos, fRange-fPsize);
 
       SendMessage(fMsgWindow, MK_MSG(kC_VSCROLL, kSB_SLIDERTRACK), fPos, 0);
       PositionChanged(fPos);
@@ -866,22 +866,22 @@ Bool_t TGVScrollBar::HandleMotion(Event_t *event)
 
 void TGVScrollBar::SetRange(Int_t range, Int_t page_size)
 {
-   fRange = TMath::Max(range, 1);
-   fPsize = TMath::Max(page_size, 0);
-   fPos = TMath::Max(fPos, 0);
-   fPos = TMath::Min(fPos, fRange-fPsize);
+   fRange = std::max(range, 1);
+   fPsize = std::max(page_size, 0);
+   fPos = std::max(fPos, 0);
+   fPos = std::min(fPos, fRange-fPsize);
 
-   fSliderSize = TMath::Max(fPsize * (fHeight - (fgScrollBarWidth << 1)) /
+   fSliderSize = std::max(fPsize * (fHeight - (fgScrollBarWidth << 1)) /
                             fRange, (UInt_t) 6);
-   fSliderSize = TMath::Min((UInt_t)fSliderSize, fHeight - (fgScrollBarWidth << 1));
+   fSliderSize = std::min((UInt_t)fSliderSize, fHeight - (fgScrollBarWidth << 1));
 
-   fSliderRange = TMath::Max(fHeight - (fgScrollBarWidth << 1) - fSliderSize,
+   fSliderRange = std::max(fHeight - (fgScrollBarWidth << 1) - fSliderSize,
                              (UInt_t)1);
 
-   ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)TMath::Max(fRange-fPsize, 1);
+   ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)std::max(fRange-fPsize, 1);
    fY0 = (Int_t)y0;
-   fY0 = TMath::Max(fY0, fgScrollBarWidth);
-   fY0 = TMath::Min(fY0, fgScrollBarWidth + fSliderRange);
+   fY0 = std::max(fY0, fgScrollBarWidth);
+   fY0 = std::min(fY0, fgScrollBarWidth + fSliderRange);
 
    fSlider->Move(0, fY0);
    fSlider->Resize(fgScrollBarWidth, fSliderSize);
@@ -901,13 +901,13 @@ void TGVScrollBar::SetRange(Int_t range, Int_t page_size)
 
 void TGVScrollBar::SetPosition(Int_t pos)
 {
-   fPos = TMath::Max(pos, 0);
-   fPos = TMath::Min(pos, fRange-fPsize);
+   fPos = std::max(pos, 0);
+   fPos = std::min(pos, fRange-fPsize);
 
-   ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)TMath::Max(fRange-fPsize, 1);
+   ULong_t y0 = (ULong_t)fgScrollBarWidth + (ULong_t)fPos * (ULong_t)fSliderRange / (ULong_t)std::max(fRange-fPsize, 1);
    fY0 = (Int_t)y0;
-   fY0 = TMath::Max(fY0, fgScrollBarWidth);
-   fY0 = TMath::Min(fY0, fgScrollBarWidth + fSliderRange);
+   fY0 = std::max(fY0, fgScrollBarWidth);
+   fY0 = std::min(fY0, fgScrollBarWidth + fSliderRange);
 
    fSlider->Move(0, fY0);
    fSlider->Resize(fgScrollBarWidth, fSliderSize);

--- a/gui/gui/src/TGStatusBar.cxx
+++ b/gui/gui/src/TGStatusBar.cxx
@@ -366,7 +366,7 @@ TGDimension TGStatusBar::GetDefaultSize() const
    UInt_t h = fHeight;
 
    for (int i = 0; i < fNpart; i++) {
-      h = TMath::Max(h,fStatusPart[i]->GetDefaultHeight()+1);
+      h = std::max(h,fStatusPart[i]->GetDefaultHeight()+1);
    }
    return TGDimension(fWidth, h);
 }

--- a/gui/gui/src/TGTab.cxx
+++ b/gui/gui/src/TGTab.cxx
@@ -85,7 +85,7 @@ TGTabElement::TGTabElement(const TGWindow *p, TGString *text, UInt_t w, UInt_t h
       fTWidth = gVirtualX->TextWidth(fFontStruct, fText->GetString(), fText->GetLength());
    gVirtualX->GetFontProperties(fFontStruct, max_ascent, max_descent);
    fTHeight = max_ascent + max_descent;
-   Resize(TMath::Max(fTWidth+12, (UInt_t)45), fTHeight+6);
+   Resize(std::max(fTWidth+12, (UInt_t)45), fTHeight+6);
    fEnabled = kTRUE;
    gVirtualX->GrabButton(fId, kAnyButton, kAnyModifier, kButtonPressMask |
                          kPointerMotionMask, kNone, kNone);
@@ -202,9 +202,9 @@ Bool_t TGTabElement::HandleButton(Event_t *event)
 TGDimension TGTabElement::GetDefaultSize() const
 {
    if (fShowClose && fClosePic && fClosePicD)
-      return TGDimension(TMath::Max(fTWidth+30, (UInt_t)45), fTHeight+6);
+      return TGDimension(std::max(fTWidth+30, (UInt_t)45), fTHeight+6);
    else
-      return TGDimension(TMath::Max(fTWidth+12, (UInt_t)45), fTHeight+6);
+      return TGDimension(std::max(fTWidth+12, (UInt_t)45), fTHeight+6);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -232,9 +232,9 @@ void TGTabElement::ShowClose(Bool_t show)
    TGTab* main = (TGTab*)fParent;
    fShowClose = show;
    if (fShowClose && fClosePic && fClosePicD)
-      Resize(TMath::Max(fTWidth+30, (UInt_t)45), fTHeight+6);
+      Resize(std::max(fTWidth+30, (UInt_t)45), fTHeight+6);
    else
-      Resize(TMath::Max(fTWidth+12, (UInt_t)45), fTHeight+6);
+      Resize(std::max(fTWidth+12, (UInt_t)45), fTHeight+6);
    if (main)
       main->GetLayoutManager()->Layout();
 }

--- a/gui/gui/src/TGTable.cxx
+++ b/gui/gui/src/TGTable.cxx
@@ -1341,8 +1341,8 @@ void TGTable::GotoTableRange(Int_t xtl,  Int_t ytl, Int_t xbr,  Int_t ybr)
       return;
    }
 
-   Int_t nrows    = TMath::Abs(ybr - ytl);
-   Int_t ncolumns = TMath::Abs(xbr - xtl);
+   Int_t nrows    = std::abs(ybr - ytl);
+   Int_t ncolumns = std::abs(xbr - xtl);
 
    if (xtl > xbr) {
       Info("TGTable::GotoTableRange","Swapping x-range boundries");
@@ -1363,7 +1363,7 @@ void TGTable::GotoTableRange(Int_t xtl,  Int_t ytl, Int_t xbr,  Int_t ybr)
       xbr = ncolumns;
       if (xbr > (Int_t)fDataRange->fXbr) {
          xbr = fDataRange->fXbr;
-         ncolumns = TMath::Abs(xbr - xtl);
+         ncolumns = std::abs(xbr - xtl);
       }
    }
 
@@ -1373,7 +1373,7 @@ void TGTable::GotoTableRange(Int_t xtl,  Int_t ytl, Int_t xbr,  Int_t ybr)
       ybr = nrows;
       if (ybr > (Int_t)fDataRange->fYbr) {
          ybr = fDataRange->fYbr;
-         nrows =  TMath::Abs(ybr - ytl);
+         nrows =  std::abs(ybr - ytl);
       }
    }
 
@@ -1401,8 +1401,8 @@ void TGTable::GotoTableRange(Int_t xtl,  Int_t ytl, Int_t xbr,  Int_t ybr)
       }
    }
 
-   nrows    = TMath::Abs(ybr - ytl);
-   ncolumns = TMath::Abs(xbr - xtl);
+   nrows    = std::abs(ybr - ytl);
+   ncolumns = std::abs(xbr - xtl);
 
    // Resize rows and columns if needed
    ResizeTable(nrows, ncolumns);

--- a/gui/gui/src/TGTableLayout.cxx
+++ b/gui/gui/src/TGTableLayout.cxx
@@ -164,14 +164,14 @@ void TGTableLayout::FindRowColSizesSinglyAttached()
       }
       UInt_t col = layout->GetAttachLeft();
       if (col == (layout->GetAttachRight() - 1))
-         fCol[col].fDefSize = TMath::Max(fCol[col].fDefSize,
+         fCol[col].fDefSize = std::max(fCol[col].fDefSize,
                                          ptr->fFrame->GetDefaultWidth() +
                                          layout->GetPadLeft() +
                                          layout->GetPadRight());
 
       UInt_t row = layout->GetAttachTop();
       if (row == (layout->GetAttachBottom() - 1))
-         fRow[row].fDefSize = TMath::Max(fRow[row].fDefSize,
+         fRow[row].fDefSize = std::max(fRow[row].fDefSize,
                                          ptr->fFrame->GetDefaultHeight() +
                                          layout->GetPadTop() +
                                          layout->GetPadBottom());
@@ -190,10 +190,10 @@ void TGTableLayout::FindRowColSizesHomogeneous()
 
    // find max
    for (col = 0; col < fNcols; ++col)
-      max_width = TMath::Max(max_width,fCol[col].fDefSize);
+      max_width = std::max(max_width,fCol[col].fDefSize);
 
    for (row = 0; row < fNrows; ++row)
-      max_height = TMath::Max(max_height,fRow[row].fDefSize);
+      max_height = std::max(max_height,fRow[row].fDefSize);
 
    // set max
    for (col = 0; col < fNcols; ++col) fCol[col].fDefSize = max_width;
@@ -278,7 +278,7 @@ void TGTableLayout::SetRowColResize(UInt_t real_size, UInt_t nthings,
             UInt_t size = real_size;
             for (ind = 0; ind < nthings; ++ ind) {
                UInt_t extra = size / (nthings - ind);
-               thing[ind].fRealSize = TMath::Max(1U, extra);
+               thing[ind].fRealSize = std::max(1U, extra);
                size -= extra;
             }
          }
@@ -290,7 +290,7 @@ void TGTableLayout::SetRowColResize(UInt_t real_size, UInt_t nthings,
             UInt_t size = real_size;
             for (ind = 0; ind < nthings; ++ ind) {
                UInt_t extra = size / (nthings - ind);
-               thing[ind].fRealSize = TMath::Max(1U, extra);
+               thing[ind].fRealSize = std::max(1U, extra);
                size -= extra;
             }
          }
@@ -325,7 +325,7 @@ void TGTableLayout::SetRowColResize(UInt_t real_size, UInt_t nthings,
             for (ind = 0; ind < nthings; ++ind)
                if (thing[ind].fShrink) {
                   UInt_t size2 = thing[ind].fRealSize;
-                  thing[ind].fRealSize = TMath::Max(1U,thing[ind].fRealSize - extra / nshrink);
+                  thing[ind].fRealSize = std::max(1U,thing[ind].fRealSize - extra / nshrink);
                   extra -= size2 - thing[ind].fRealSize;
                   --nshrink;
                   if (thing[ind].fRealSize < 2) {

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -538,8 +538,8 @@ Int_t TGTextEntry::GetCharacterIndex(Int_t xcoord)
    ix = down;
 
    // safety check...
-   ix = TMath::Max(ix, 0);
-   ix = TMath::Min(ix, len); // len-1
+   ix = std::max(ix, 0);
+   ix = std::min(ix, len); // len-1
 
    return ix;
 }
@@ -797,7 +797,7 @@ void TGTextEntry::Insert(const char *newText)
    }
 
    if (fInsertMode == kReplace) fText->RemoveText(cp,t.Length());
-   Int_t ncp = TMath::Min(cp+t.Length(), GetMaxLength());
+   Int_t ncp = std::min(cp+t.Length(), GetMaxLength());
    fText->AddText(cp, t.Data());
    Int_t dlen = fText->GetTextLength()-GetMaxLength();
    if (dlen>0) fText->RemoveText(GetMaxLength(),dlen); // truncate
@@ -1128,10 +1128,10 @@ void TGTextEntry::DoRedraw()
    if (fSelectionOn) {
       int xs, ws, ixs, iws;
 
-      xs  = TMath::Min(fStartX, fEndX);
-      ws  = TMath::Abs(fEndX - fStartX);
-      ixs = TMath::Min(fStartIX, fEndIX);
-      iws = TMath::Abs(fEndIX - fStartIX);
+      xs  = std::min(fStartX, fEndX);
+      ws  = std::abs(fEndX - fStartX);
+      ixs = std::min(fStartIX, fEndIX);
+      iws = std::abs(fEndIX - fStartIX);
 
       gVirtualX->FillRectangle(fId, fSelbackGC, xs, y, ws, h + 1);
 
@@ -1674,7 +1674,7 @@ void TGTextEntry::SetFocus()
 
 void TGTextEntry::InsertText(const char *text, Int_t pos)
 {
-   Int_t position = TMath::Min((Int_t)fText->GetTextLength(), pos);
+   Int_t position = std::min((Int_t)fText->GetTextLength(), pos);
    TString newText(GetText());
    newText.Insert(position, text);
    SetText(newText.Data());
@@ -1698,8 +1698,8 @@ void TGTextEntry::AppendText(const char *text)
 
 void TGTextEntry::RemoveText(Int_t start, Int_t end)
 {
-   Int_t pos = TMath::Min(start, end);
-   Int_t len = TMath::Abs(end-start);
+   Int_t pos = std::min(start, end);
+   Int_t len = std::abs(end-start);
    TString newText(GetText());
    newText.Remove(pos, len);
    SetText(newText.Data());

--- a/gui/gui/src/TGTextView.cxx
+++ b/gui/gui/src/TGTextView.cxx
@@ -751,7 +751,7 @@ Bool_t TGTextView::HandleTimer(TTimer *)
          } else if ((Int_t)fCanvas->GetHeight() - kAutoScrollFudge <= y) {
             dy = fCanvas->GetHeight() - kAutoScrollFudge - y;
          }
-         Int_t ady = TMath::Abs(dy) >> 3;
+         Int_t ady = std::abs(dy) >> 3;
 
          if (dy) {
             if (ady > kAutoScrollFudge) ady = kAutoScrollFudge;

--- a/gui/gui/src/TGWindow.cxx
+++ b/gui/gui/src/TGWindow.cxx
@@ -73,8 +73,8 @@ TGWindow::TGWindow(const TGWindow *p, Int_t x, Int_t y, UInt_t w, UInt_t h,
       fParent = p;
       if (fParent && fParent->IsMapSubwindows()) {
          fId = gVirtualX->CreateWindow(fParent->fId, x, y,
-                                     TMath::Max(w, (UInt_t) 1),
-                                     TMath::Max(h, (UInt_t) 1), border,
+                                     std::max(w, (UInt_t) 1),
+                                     std::max(h, (UInt_t) 1), border,
                                      depth, clss, visual, attr, type);
          fClient->RegisterWindow(this);
       }
@@ -278,7 +278,7 @@ void TGWindow::Move(Int_t x, Int_t y)
 
 void TGWindow::Resize(UInt_t w, UInt_t h)
 {
-   gVirtualX->ResizeWindow(fId, TMath::Max(w, (UInt_t)1), TMath::Max(h, (UInt_t)1));
+   gVirtualX->ResizeWindow(fId, std::max(w, (UInt_t)1), std::max(h, (UInt_t)1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -286,7 +286,7 @@ void TGWindow::Resize(UInt_t w, UInt_t h)
 
 void TGWindow::MoveResize(Int_t x, Int_t y, UInt_t w, UInt_t h)
 {
-   gVirtualX->MoveResizeWindow(fId, x, y, TMath::Max(w, (UInt_t)1), TMath::Max(h, (UInt_t)1));
+   gVirtualX->MoveResizeWindow(fId, x, y, std::max(w, (UInt_t)1), std::max(h, (UInt_t)1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TRootDialog.cxx
+++ b/gui/gui/src/TRootDialog.cxx
@@ -187,7 +187,7 @@ void TRootDialog::Popup()
       b->Associate(fMenu);
       hf->AddFrame(b, l1);
       height = b->GetDefaultHeight();
-      width  = TMath::Max(width, b->GetDefaultWidth()); ++nb;
+      width  = std::max(width, b->GetDefaultWidth()); ++nb;
    }
    if (fApply) {
       b = new TGTextButton(hf, "&Apply", 2);
@@ -195,7 +195,7 @@ void TRootDialog::Popup()
       b->Associate(fMenu);
       hf->AddFrame(b, l1);
       height = b->GetDefaultHeight();
-      width  = TMath::Max(width, b->GetDefaultWidth()); ++nb;
+      width  = std::max(width, b->GetDefaultWidth()); ++nb;
    }
    if (fCancel) {
       b = new TGTextButton(hf, "&Cancel", 3);
@@ -203,7 +203,7 @@ void TRootDialog::Popup()
       b->Associate(fMenu);
       hf->AddFrame(b, l1);
       height = b->GetDefaultHeight();
-      width  = TMath::Max(width, b->GetDefaultWidth()); ++nb;
+      width  = std::max(width, b->GetDefaultWidth()); ++nb;
    }
    if (fHelp) {
       b = new TGTextButton(hf, "Online &Help", 4);
@@ -211,7 +211,7 @@ void TRootDialog::Popup()
       b->Associate(fMenu);
       hf->AddFrame(b, l1);
       height = b->GetDefaultHeight();
-      width  = TMath::Max(width, b->GetDefaultWidth()); ++nb;
+      width  = std::max(width, b->GetDefaultWidth()); ++nb;
    }
 
    // place buttons at the bottom

--- a/gui/guibuilder/src/TGuiBldDragManager.cxx
+++ b/gui/guibuilder/src/TGuiBldDragManager.cxx
@@ -397,21 +397,21 @@ void TGuiBldMenuDialog::Build()
    fOK = new TGTextButton(hf, "&OK", 1);
    hf->AddFrame(fOK, l1);
    fWidgets->Add(fOK);
-   width  = TMath::Max(width, fOK->GetDefaultWidth());
+   width  = std::max(width, fOK->GetDefaultWidth());
 
 /*
    fApply = new TGTextButton(hf, "&Apply", 2);
    hf->AddFrame(fApply, l1);
    fWidgets->Add(fApply);
    height = fApply->GetDefaultHeight();
-   width  = TMath::Max(width, fApply->GetDefaultWidth());
+   width  = std::max(width, fApply->GetDefaultWidth());
 */
 
    fCancel = new TGTextButton(hf, "&Cancel", 3);
    hf->AddFrame(fCancel, l1);
    fWidgets->Add(fCancel);
    height = fCancel->GetDefaultHeight();
-   width  = TMath::Max(width, fCancel->GetDefaultWidth());
+   width  = std::max(width, fCancel->GetDefaultWidth());
 
    // place buttons at the bottom
    l1 = new TGLayoutHints(kLHintsBottom | kLHintsCenterX, 0, 0, 5, 5);
@@ -1272,10 +1272,10 @@ void TGuiBldDragManager::SelectFrame(TGFrame *frame, Bool_t add)
                                       0, 0, xx, yy, c);
 
       fDragType = kDragLasso;
-      fPimpl->fX0 = x0 = TMath::Min(x0, xx);
-      fPimpl->fX = x = TMath::Max(x, xx + (Int_t)frame->GetWidth());
-      fPimpl->fY0 = y0 = TMath::Min(y0, yy);
-      fPimpl->fY = y = TMath::Max(y, yy + (Int_t)frame->GetHeight());
+      fPimpl->fX0 = x0 = std::min(x0, xx);
+      fPimpl->fX = x = std::max(x, xx + (Int_t)frame->GetWidth());
+      fPimpl->fY0 = y0 = std::min(y0, yy);
+      fPimpl->fY = y = std::max(y, yy + (Int_t)frame->GetHeight());
 
       DrawLasso();
    }
@@ -2033,8 +2033,8 @@ Bool_t TGuiBldDragManager::HandleEvent(Event_t *event)
 
             if ((event->fTime - gLastClick < 350) &&
                 (event->fCode == gLastButton) &&
-                (TMath::Abs(event->fXRoot - gDbx) < 6) &&
-                (TMath::Abs(event->fYRoot - gDby) < 6) &&
+                (std::abs(event->fXRoot - gDbx) < 6) &&
+                (std::abs(event->fYRoot - gDby) < 6) &&
                 (event->fWindow == gDbw)) {
                dbl_clk = kTRUE;
             }
@@ -2579,8 +2579,8 @@ TList *TGuiBldDragManager::GetFramesInside(Int_t x0, Int_t y0, Int_t x, Int_t y)
    TList *list = new TList();
 
    xx = x0; yy = y0;
-   x0 = TMath::Min(xx, x); x = TMath::Max(xx, x);
-   y0 = TMath::Min(yy, y); y = TMath::Max(yy, y);
+   x0 = std::min(xx, x); x = std::max(xx, x);
+   y0 = std::min(yy, y); y = std::max(yy, y);
 
    TIter next(((TGCompositeFrame*)fClient->GetRoot())->GetList());
    TGFrameElement *el;
@@ -2740,8 +2740,8 @@ void TGuiBldDragManager::HandleReturn(Bool_t on)
                                       fPimpl->fX0, fPimpl->fY0, x0, y0, c);
 
       xx = x0; yy = y0;
-      x0 = TMath::Min(xx, x); x = TMath::Max(xx, x);
-      y0 = TMath::Min(yy, y); y = TMath::Max(yy, y);
+      x0 = std::min(xx, x); x = std::max(xx, x);
+      y0 = std::min(yy, y); y = std::max(yy, y);
 
       li = GetFramesInside(x0, y0, x, y);
 
@@ -2819,8 +2819,8 @@ void TGuiBldDragManager::HandleAlignment(Int_t to, Bool_t lineup)
                                       fPimpl->fX0, fPimpl->fY0, x0, y0, c);
 
       xx = x0; yy = y0;
-      x0 = TMath::Min(xx, x); x = TMath::Max(xx, x);
-      y0 = TMath::Min(yy, y); y = TMath::Max(yy, y);
+      x0 = std::min(xx, x); x = std::max(xx, x);
+      y0 = std::min(yy, y); y = std::max(yy, y);
 
       comp = (TGCompositeFrame*)fClient->GetRoot();
 
@@ -2955,8 +2955,8 @@ void TGuiBldDragManager::HandleDelete(Bool_t crop)
    }
 
    xx = x0; yy = y0;
-   x0 = TMath::Min(xx, x); x = TMath::Max(xx, x);
-   y0 = TMath::Min(yy, y); y = TMath::Max(yy, y);
+   x0 = std::min(xx, x); x = std::max(xx, x);
+   y0 = std::min(yy, y); y = std::max(yy, y);
    w = x - x0;
    h = y - y0;
 
@@ -3909,8 +3909,8 @@ Bool_t TGuiBldDragManager::HandleMotion(Event_t *event)
    gx = event->fXRoot;
 
    if (!fDragging) {
-      if (fMoveWaiting && ((TMath::Abs(fPimpl->fX - event->fXRoot) > 10) ||
-          (TMath::Abs(fPimpl->fY - event->fYRoot) > 10))) {
+      if (fMoveWaiting && ((std::abs(fPimpl->fX - event->fXRoot) > 10) ||
+          (std::abs(fPimpl->fY - event->fYRoot) > 10))) {
 
          return StartDrag(fSource, event->fXRoot, event->fYRoot);
       }
@@ -3964,8 +3964,8 @@ void TGuiBldDragManager::PlaceFrame(TGFrame *frame, TGLayoutHints *hints)
    ToGrid(x, y);
    ToGrid(x0, y0);
 
-   UInt_t w = TMath::Abs(x - x0);
-   UInt_t h = TMath::Abs(y - y0);
+   UInt_t w = std::abs(x - x0);
+   UInt_t h = std::abs(y - y0);
    x = x > x0 ? x0 : x;
    y = y > y0 ? y0 : y;
 

--- a/gui/guibuilder/src/TGuiBldHintsButton.cxx
+++ b/gui/guibuilder/src/TGuiBldHintsButton.cxx
@@ -94,7 +94,7 @@ void TGuiBldHintsButton::DoRedraw()
 void TGuiBldHintsButton::DrawExpandX()
 {
    const int dist = 3;
-   const int amplitude = TMath::Min(3, (int)fHeight/3);
+   const int amplitude = std::min(3, (int)fHeight/3);
    int base = fHeight/2;
    int i = 0;
    const TGResourcePool *pool = fClient->GetResourcePool();
@@ -124,7 +124,7 @@ void TGuiBldHintsButton::DrawExpandX()
 void TGuiBldHintsButton::DrawExpandY()
 {
    const int dist = 3;
-   const int amplitude = TMath::Min(3, (int)fWidth/3);
+   const int amplitude = std::min(3, (int)fWidth/3);
    int base = fWidth/2;
    int i = 0;
 

--- a/gui/guihtml/src/TGHtml.cxx
+++ b/gui/guihtml/src/TGHtml.cxx
@@ -1391,7 +1391,7 @@ Bool_t TGHtml::HandleButton(Event_t *event)
    int amount, ch;
 
    ch = fCanvas->GetHeight();
-   amount = fScrollVal.fY * TMath::Max(ch/6, 1);
+   amount = fScrollVal.fY * std::max(ch/6, 1);
 
    int ix = event->fX + fVisible.fX;
    int iy = event->fY + fVisible.fY;

--- a/gui/guihtml/src/TGHtmlForm.cxx
+++ b/gui/guihtml/src/TGHtmlForm.cxx
@@ -473,7 +473,7 @@ int TGHtml::ControlSize(TGHtmlInput *pElem)
             for (int i=0;i<lb->GetNumberOfEntries();++i) {
                TGHtmlLBEntry *te = (TGHtmlLBEntry *)lb->GetEntry(i);
                if (te && te->GetText())
-                  width = TMath::Max(width, te->GetDefaultWidth());
+                  width = std::max(width, te->GetDefaultWidth());
             }
             height = lb->GetItemVsize() ? lb->GetItemVsize()+4 : 22;
             cb->Resize(width > 0 ? width+30 : 200,
@@ -488,7 +488,7 @@ int TGHtml::ControlSize(TGHtmlInput *pElem)
             for (int i=0;i<lb->GetNumberOfEntries();++i) {
                TGHtmlLBEntry *te = (TGHtmlLBEntry *)lb->GetEntry(i);
                if (te && te->GetText())
-                  width = TMath::Max(width, te->GetDefaultWidth());
+                  width = std::max(width, te->GetDefaultWidth());
             }
             height = lb->GetItemVsize() ? lb->GetItemVsize() : 22;
             lb->Resize(width > 0 ? width+30 : 200, height * size);

--- a/gui/recorder/src/TRecorder.cxx
+++ b/gui/recorder/src/TRecorder.cxx
@@ -2103,8 +2103,8 @@ void TRecGuiEvent::ReplayEvent(Bool_t showMouseCursor)
                                       e->fX, e->fY, px, py, wtarget);
       dx = px - gCursorWin->GetX();
       dy = py - gCursorWin->GetY();
-      if (TMath::Abs(dx) > 5) gDecorWidth += dx;
-      if (TMath::Abs(dy) > 5) gDecorHeight += dy;
+      if (std::abs(dx) > 5) gDecorWidth += dx;
+      if (std::abs(dy) > 5) gDecorHeight += dy;
    }
    // Displays fake mouse cursor for MotionNotify event
    if (showMouseCursor && e->fType == kMotionNotify) {

--- a/gui/webgui6/src/TWebPainting.cxx
+++ b/gui/webgui6/src/TWebPainting.cxx
@@ -97,7 +97,7 @@ Float_t *TWebPainting::Reserve(Int_t sz)
       return nullptr;
 
    if (fSize + sz > fBuf.GetSize()) {
-      Int_t nextsz = fBuf.GetSize() + TMath::Max(1024, (sz/128 + 1) * 128);
+      Int_t nextsz = fBuf.GetSize() + std::max(1024, (sz/128 + 1) * 128);
       fBuf.Set(nextsz);
    }
 

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -43,6 +43,7 @@
 
 #include "TFitResultPtr.h"
 
+#include <algorithm>
 #include <cfloat>
 #include <string>
 #include <stdexcept>

--- a/hist/hist/src/TH1Merger.cxx
+++ b/hist/hist/src/TH1Merger.cxx
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <limits>
 #include <utility>
+#include <cmath>
 
 #define PRINTRANGE(a, b, bn)                                                                                          \
    Printf(" base: %f %f %d, %s: %f %f %d", a->GetXmin(), a->GetXmax(), a->GetNbins(), bn, b->GetXmin(), b->GetXmax(), \
@@ -707,7 +708,7 @@ Bool_t TH1Merger::AutoP2Merge()
       for (Int_t ibin = 0; ibin < hist->fNcells; ibin++) {
 
          Double_t cu = hist->RetrieveBinContent(ibin);
-         Double_t e1sq = TMath::Abs(cu);
+         Double_t e1sq = std::abs(cu);
          if (fH0->fSumw2.fN)
             e1sq = hist->GetBinErrorSqUnchecked(ibin);
 

--- a/hist/hist/test/test_MapCppName.cxx
+++ b/hist/hist/test/test_MapCppName.cxx
@@ -11,6 +11,8 @@
 #include "TProfile.h"
 #include "TSystem.h"
 
+#include <cmath>
+
 TEST(TH1, MapCppNameTest)
 {
    gROOT->SetBatch();

--- a/hist/hist/test/test_TEfficiency.cxx
+++ b/hist/hist/test/test_TEfficiency.cxx
@@ -8,6 +8,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 bool testTEfficiency_vs_TGA(int nexp = 1000, TEfficiency::EStatOption statOpt = TEfficiency::kBUniform,
                             bool mode = true, bool central = false)
 {

--- a/hist/hist/test/test_TGraph_sorting.cxx
+++ b/hist/hist/test/test_TGraph_sorting.cxx
@@ -5,6 +5,7 @@
 #include "TGraphMultiErrors.h"
 #include "TGraphBentErrors.h"
 
+#include <algorithm>
 #include <vector>
 
 TEST(TGraphSortTest, TGraphSortingTest)

--- a/hist/hist/test/test_TH2Poly_BinError.cxx
+++ b/hist/hist/test/test_TH2Poly_BinError.cxx
@@ -5,6 +5,8 @@
 #include "TH2Poly.h"
 #include "TRandom.h"
 
+#include <cmath>
+
 TH2Poly * CreateHist() {
 
    TH2Poly *h2p = new TH2Poly();

--- a/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
+++ b/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
@@ -8,6 +8,8 @@
 #include "TGraph.h"
 #include "TH1.h"
 
+#include <cmath>
+
 TEST(TMultiGraph, GetHistogram)
 {
    gROOT->SetBatch(true);

--- a/hist/hist/test/test_spline.cxx
+++ b/hist/hist/test/test_spline.cxx
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <string>
+#include <cmath>
 
 class FileDeleterRAII {
    const std::string fFileName;

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -3339,7 +3339,7 @@ Int_t TBufferFile::ReadBuf(void *buf, Int_t max)
 
    if (max == 0) return 0;
 
-   Int_t n = TMath::Min(max, (Int_t)(fBufMax - fBufCur));
+   Int_t n = std::min(max, (Int_t)(fBufMax - fBufCur));
 
    memcpy(buf, fBufCur, n);
    fBufCur += n;

--- a/io/io/src/TBufferText.cxx
+++ b/io/io/src/TBufferText.cxx
@@ -32,6 +32,8 @@ actions list for both are the same.
 #include "TError.h"
 #include "snprintf.h"
 
+#include <cmath>
+
 ClassImp(TBufferText);
 
 const char *TBufferText::fgFloatFmt = "%e";

--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -1077,7 +1077,7 @@ Bool_t TFileMerger::PartialMerge(Int_t in_type)
 Bool_t TFileMerger::OpenExcessFiles()
 {
    if (fPrintLevel > 0) {
-      Printf("%s Opening the next %d files", fMsgPrefix.Data(), TMath::Min(fExcessFiles.GetEntries(), fMaxOpenedFiles - 1));
+      Printf("%s Opening the next %d files", fMsgPrefix.Data(), std::min(fExcessFiles.GetEntries(), fMaxOpenedFiles - 1));
    }
    Int_t nfiles = 0;
    TIter next(&fExcessFiles);

--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -251,7 +251,7 @@ TKey::TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* moth
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(GetFile() ? GetFile()->GetCompressionAlgorithm() : 0);
    if (cxlevel > 0 && fObjlen > 256) {
       Int_t nbuffers = 1 + (fObjlen - 1)/kMAXZIPBUF;
-      Int_t buflen = TMath::Max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
+      Int_t buflen = std::max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
       fBuffer = new char[buflen];
       char *objbuf = fBufferRef->Buffer() + fKeylen;
       char *bufcur = &fBuffer[fKeylen];
@@ -346,7 +346,7 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
    ROOT::RCompressionSetting::EAlgorithm::EValues cxAlgorithm = static_cast<ROOT::RCompressionSetting::EAlgorithm::EValues>(GetFile() ? GetFile()->GetCompressionAlgorithm() : 0);
    if (cxlevel > 0 && fObjlen > 256) {
       Int_t nbuffers = 1 + (fObjlen - 1)/kMAXZIPBUF;
-      Int_t buflen = TMath::Max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
+      Int_t buflen = std::max(512,fKeylen + fObjlen + 9*nbuffers + 28); //add 28 bytes in case object is placed in a deleted gap
       fBuffer = new char[buflen];
       char *objbuf = fBufferRef->Buffer() + fKeylen;
       char *bufcur = &fBuffer[fKeylen];

--- a/io/io/src/TMakeProject.cxx
+++ b/io/io/src/TMakeProject.cxx
@@ -479,7 +479,7 @@ UInt_t TMakeProject::GenerateIncludeForTemplate(FILE *fp, const char *clname, ch
                   // Not a class name, nothing to do.
                } else if ((stlType = TClassEdit::IsSTLCont(incName))) {
                   const char *what = "";
-                  switch (TMath::Abs(stlType))  {
+                  switch (std::abs(stlType))  {
                      case ROOT::kSTLvector:
                         what = "vector";
                         break;
@@ -669,7 +669,7 @@ TString TMakeProject::UpdateAssociativeToVector(const char *name)
       int nestedLoc;
       unsigned int narg = TClassEdit::GetSplit( name, inside, nestedLoc, TClassEdit::kLong64 );
 
-      Int_t stlkind =  TMath::Abs(TClassEdit::STLKind(inside[0]));
+      Int_t stlkind =  std::abs(TClassEdit::STLKind(inside[0]));
 
       for(unsigned int i = 1; i<narg; ++i) {
          inside[i] = UpdateAssociativeToVector( inside[i].c_str() );

--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -1143,7 +1143,7 @@ Int_t TMapFile::GetBestBuffer()
 {
    if (!fWritten) return TBuffer::kMinimalSize;
    Double_t mean = fSumBuffer/fWritten;
-   Double_t rms2 = TMath::Abs(fSum2Buffer/fSumBuffer - mean*mean);
+   Double_t rms2 = std::abs(fSum2Buffer/fSumBuffer - mean*mean);
    return (Int_t)(mean + std::sqrt(rms2));
 }
 

--- a/io/io/src/TZIPFile.cxx
+++ b/io/io/src/TZIPFile.cxx
@@ -99,17 +99,17 @@ Long64_t TZIPFile::FindEndHeader()
 {
    const Int_t kBUFSIZE = 1024;
    Long64_t    size = fFile->GetSize();
-   Long64_t    limit = TMath::Min(size, Long64_t(kMAX_VAR_LEN));
+   Long64_t    limit = std::min(size, Long64_t(kMAX_VAR_LEN));
    char        buf[kBUFSIZE+4];
 
    // Note, this works correctly even if the signature straddles read
    // boundaries since we always read an overlapped area of four
    // bytes on the next read
    for (Long64_t offset = 4; offset < limit; ) {
-      offset = TMath::Min(offset + kBUFSIZE, limit);
+      offset = std::min(offset + kBUFSIZE, limit);
 
       Long64_t pos = size - offset;
-      Int_t    n = TMath::Min(kBUFSIZE+4, Int_t(offset));
+      Int_t    n = std::min(kBUFSIZE+4, Int_t(offset));
 
       fFile->Seek(pos);
       if (fFile->ReadBuffer(buf, n)) {

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -21,6 +21,8 @@
 #include "TROOT.h"
 #include "TStreamerInfo.h"
 #include "TClassEdit.h"
+
+#include <algorithm>
 #include <memory>
 
 std::string gPCMFilename;

--- a/io/sql/src/TBufferSQL2.cxx
+++ b/io/sql/src/TBufferSQL2.cxx
@@ -38,8 +38,9 @@ few other, which can not be converted to SQL (yet).
 #include "TStreamerInfoActions.h"
 #include "snprintf.h"
 
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
+#include <limits>
 #include <string>
 
 #include "TSQLServer.h"

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -48,6 +48,7 @@ There are limitations for complex objects like TTree, which can not be converted
 #include "RZip.h"
 #include "snprintf.h"
 
+#include <limits>
 #include <memory>
 
 ClassImp(TBufferXML);

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -30,6 +30,10 @@
 #include <string>
 #include <memory>
 
+#ifdef WIN32
+#include <algorithm> // for std::replace
+#endif
+
 #define JUPYTER_CMD        "jupyter"
 #define NB_OPT             "notebook"
 #define JUPYTER_CONF_PATH_V "JUPYTER_CONFIG_PATH"

--- a/math/foam/src/TFoamMaxwt.cxx
+++ b/math/foam/src/TFoamMaxwt.cxx
@@ -151,7 +151,7 @@ void TFoamMaxwt::GetMCeff(Double_t eps, Double_t &MCeff, Double_t &wtLim)
          sumWt += bin1;
       }
       aveWt1 = sumWt/sum;
-      if( TMath::Abs(1.0-aveWt1/aveWt) > eps ) break;
+      if( std::abs(1.0-aveWt1/aveWt) > eps ) break;
    }
    /////////////////////////////////////////////////////////////////////////////
 

--- a/montecarlo/eg/src/TDatabasePDG.cxx
+++ b/montecarlo/eg/src/TDatabasePDG.cxx
@@ -128,7 +128,7 @@ void TDatabasePDG::BuildPdgMap() const
 {
    // It is preferrable to waste some work in presence of high contention
    // for the benefit of reducing the critical section to the bare minimum
-   auto pdgMap = new TExMap(4 * TMath::Max(600, fParticleList->GetEntries()) / 3 + 3);
+   auto pdgMap = new TExMap(4 * std::max(600, fParticleList->GetEntries()) / 3 + 3);
    TIter next(fParticleList);
    TParticlePDG *p;
    while ((p = (TParticlePDG*)next())) {

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -29,12 +29,11 @@
 #include <TObjArray.h>
 #include <TRefArray.h>
 
-#include <deque>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
-#include <stack>
 #include <string>
 #include <unordered_map>
 

--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -18,9 +18,10 @@
 
 #include "RooAbsArg.h"
 
-#include <string>
-#include <map>
 #include <functional>
+#include <limits>
+#include <map>
+#include <string>
 #include <vector>
 
 class RooCatType;

--- a/roofit/roofitcore/src/Roo1DTable.cxx
+++ b/roofit/roofitcore/src/Roo1DTable.cxx
@@ -33,6 +33,7 @@ equivalent of a plot. To create a table use the RooDataSet::table() method.
 
 #include <iostream>
 #include <iomanip>
+#include <cmath>
 
 using std::ostream, std::setw, std::setfill;
 

--- a/roottest/root/io/prefetching/runPrefetchReading.C
+++ b/roottest/root/io/prefetching/runPrefetchReading.C
@@ -14,6 +14,8 @@
 #include "TError.h"
 #include "TSystemDirectory.h"
 
+#include <cmath>
+
 Int_t runPrefetchReading(bool prefetch = true, bool caching = false)
 {
    //const char *options = 0;

--- a/roottest/root/io/uniquePointer/classes.h
+++ b/roottest/root/io/uniquePointer/classes.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <list>
 #include <string>
+#include <cmath>
+
 #include "TH1F.h"
 #include "TRandom.h"
 #include "ROOT/TSeq.hxx"
@@ -50,7 +52,7 @@ public:
          for (auto i : ROOT::TSeqI(h->GetNbinsX())) {
             auto bContent = h->GetBinContent(i);
             auto bVar = bContent*.6;
-            h->SetBinContent(i, fabs(gRandom->Gaus(bContent,bVar)));
+            h->SetBinContent(i, std::fabs(gRandom->Gaus(bContent,bVar)));
          }
       };
       rndMizeBins(fTH1FPtr);

--- a/roottest/root/io/uniquePointer/classesError1.h
+++ b/roottest/root/io/uniquePointer/classesError1.h
@@ -1,10 +1,12 @@
 #ifndef __CLASSESERROR1_H__
 #define __CLASSESERROR1_H__
 
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "TH1F.h"
 #include "TRandom.h"
 #include "ROOT/TSeq.hxx"
@@ -35,7 +37,7 @@ public:
          for (auto i : ROOT::TSeqI(h->GetNbinsX())) {
             auto bContent = h->GetBinContent(i);
             auto bVar = bContent*.6;
-            h->SetBinContent(i, fabs(gRandom->Gaus(bContent,bVar)));
+            h->SetBinContent(i, std::fabs(gRandom->Gaus(bContent,bVar)));
          }
       };
       rndMizeBins(TH1FPtr);

--- a/roottest/root/meta/dt_RunDrawTest.C
+++ b/roottest/root/meta/dt_RunDrawTest.C
@@ -40,16 +40,16 @@ Int_t HistCompare(TH1 *ref, TH1 *comp)
 
    Float_t xrange = ref->GetXaxis()->GetXmax() - ref->GetXaxis()->GetXmin();
    if (xrange==0) { fprintf(stderr,"no range for %s\n",ref->GetName()); return -4; }
-   if (xrange>0.0001 && TMath::Abs((mean1-mean2)/xrange) > 0.001) {
-      printf("xrange=%g, mean1=%g, mean2=%g, abs=%g\n",xrange,mean1,mean2,TMath::Abs((mean1-mean2)/xrange));
+   if (xrange>0.0001 && std::abs((mean1-mean2)/xrange) > 0.001) {
+      printf("xrange=%g, mean1=%g, mean2=%g, abs=%g\n",xrange,mean1,mean2,std::abs((mean1-mean2)/xrange));
       return -1;
    }
-   if (mean2> 0.0001 && TMath::Abs((mean1-mean2)/mean2) > 0.01) {
-      printf("mean1=%g, mean2=%g, abs=%g\n",mean1,mean2,TMath::Abs((mean1-mean2)/mean2));
+   if (mean2> 0.0001 && std::abs((mean1-mean2)/mean2) > 0.01) {
+      printf("mean1=%g, mean2=%g, abs=%g\n",mean1,mean2,std::abs((mean1-mean2)/mean2));
       return -2;
    }
-   if (rms1 > 0.0001 && TMath::Abs((rms1-rms2)/rms1) > 0.0003) {
-      printf("rms1=%g, rms2=%g, abs=%g\n",rms1,rms2,TMath::Abs((rms1-rms2)/rms1));
+   if (rms1 > 0.0001 && std::abs((rms1-rms2)/rms1) > 0.0003) {
+      printf("rms1=%g, rms2=%g, abs=%g\n",rms1,rms2,std::abs((rms1-rms2)/rms1));
       return -3;
    }
    return n1*factor-n2;

--- a/roottest/root/multicore/th1f_fill.cpp
+++ b/roottest/root/multicore/th1f_fill.cpp
@@ -1,6 +1,8 @@
+#include <cmath>
 #include <vector>
 #include <thread>
 #include <map>
+
 #include "TH1F.h"
 #include "TFile.h"
 #include "TNtuple.h"

--- a/roottest/root/tree/reader/hardTreeReaderTest.cpp
+++ b/roottest/root/tree/reader/hardTreeReaderTest.cpp
@@ -5,8 +5,10 @@
 #include "TSystem.h"
 #include "TTreeReaderValue.h"
 #include "TTreeReaderArray.h"
-#include <vector>
 #include "A.h"
+
+#include <cmath>
+#include <vector>
 
 #define TREE_ENTRIES 10
 #define LIST_ENTRIES 10
@@ -323,7 +325,7 @@ void readVectorFloatValue(const char* branchName, Bool_t printOut, Bool_t testVa
         if (printOut) fprintf(stderr, "vectorFloat values:");
 
         for (int j = 0; j < LIST_ENTRIES; ++j){
-            if (testValues && fabs(myVectorFloat->at(j) - i * j * MULTIPLIER_VECTOR_FLOAT) > 0.001f) success = false;
+            if (testValues && std::fabs(myVectorFloat->at(j) - i * j * MULTIPLIER_VECTOR_FLOAT) > 0.001f) success = false;
             if (printOut) fprintf(stderr, " %.2f", myVectorFloat->at(j));
         }
 
@@ -426,7 +428,7 @@ void readVectorFloatArray(const char* branchName, Bool_t printOut, Bool_t testVa
         if (printOut) fprintf(stderr, "vectorFloat values(%lu):", myVectorFloat.GetSize());
 
         for (int j = 0; j < LIST_ENTRIES && j < (int)myVectorFloat.GetSize(); ++j){
-            if (testValues && fabs(myVectorFloat.At(j) - i * j * MULTIPLIER_VECTOR_FLOAT) > 0.001f) success = false;
+            if (testValues && std::fabs(myVectorFloat.At(j) - i * j * MULTIPLIER_VECTOR_FLOAT) > 0.001f) success = false;
             if (printOut) fprintf(stderr, " %.2f", myVectorFloat.At(j));
         }
 
@@ -741,7 +743,7 @@ void readLeafDoubleAArray(Bool_t printOut, Bool_t testValues, TreeGetter& getter
         if (printOut) fprintf(stderr, "MyLeafList.a(%lu):", myDoubles.GetSize());
 
         for (size_t j = 0; j < myDoubles.GetSize() && j < 10; ++j){
-            if (testValues && fabs(myDoubles.At(j) - (i * j) / 10.0f) > 0.0001f) success = false;
+            if (testValues && std::fabs(myDoubles.At(j) - (i * j) / 10.0f) > 0.0001f) success = false;
             if (printOut) fprintf(stderr, " %f", myDoubles.At(j));
         }
 

--- a/roottest/root/treeformula/array/Data.h
+++ b/roottest/root/treeformula/array/Data.h
@@ -3,7 +3,6 @@
 #ifndef DATA_H
 #define DATA_H
 
-#include <iostream>
 #include "TObject.h"
 
 

--- a/roottest/root/treeformula/event/dt_RunDrawTest.C
+++ b/roottest/root/treeformula/event/dt_RunDrawTest.C
@@ -40,9 +40,9 @@ Int_t HistCompare(TH1 *ref, TH1 *comp)
 
    Float_t xrange = ref->GetXaxis()->GetXmax() - ref->GetXaxis()->GetXmin();
    if (xrange==0) { fprintf(stderr,"no range for %s\n",ref->GetName()); return -4; }
-   if (xrange>0.0001 && TMath::Abs((mean1-mean2)/xrange) > 0.001)  return -1;
-   if (mean2> 0.0001 && TMath::Abs((mean1-mean2)/mean2) > 0.01)    return -2;
-   if (rms1 > 0.0001 && TMath::Abs((rms1-rms2)/rms1) > 0.0001)     return -3;
+   if (xrange>0.0001 && std::abs((mean1-mean2)/xrange) > 0.001)  return -1;
+   if (mean2> 0.0001 && std::abs((mean1-mean2)/mean2) > 0.01)    return -2;
+   if (rms1 > 0.0001 && std::abs((rms1-rms2)/rms1) > 0.0001)     return -3;
    return n1*factor-n2;
 }
 

--- a/test/dt_RunDrawTest.C
+++ b/test/dt_RunDrawTest.C
@@ -40,16 +40,16 @@ Int_t HistCompare(TH1 *ref, TH1 *comp)
 
    Float_t xrange = ref->GetXaxis()->GetXmax() - ref->GetXaxis()->GetXmin();
    if (xrange==0) { fprintf(stderr,"no range for %s\n",ref->GetName()); return -4; }
-   if (xrange>0.0001 && TMath::Abs((mean1-mean2)/xrange) > 0.001) {
-      printf("xrange=%g, mean1=%g, mean2=%g, abs=%g\n",xrange,mean1,mean2,TMath::Abs((mean1-mean2)/xrange));
+   if (xrange>0.0001 && std::abs((mean1-mean2)/xrange) > 0.001) {
+      printf("xrange=%g, mean1=%g, mean2=%g, abs=%g\n",xrange,mean1,mean2,std::abs((mean1-mean2)/xrange));
       return -1;
    }
-   if (mean2> 0.0001 && TMath::Abs((mean1-mean2)/mean2) > 0.01) {
-      printf("mean1=%g, mean2=%g, abs=%g\n",mean1,mean2,TMath::Abs((mean1-mean2)/mean2));
+   if (mean2> 0.0001 && std::abs((mean1-mean2)/mean2) > 0.01) {
+      printf("mean1=%g, mean2=%g, abs=%g\n",mean1,mean2,std::abs((mean1-mean2)/mean2));
       return -2;
    }
-   if (rms1 > 0.0001 && TMath::Abs((rms1-rms2)/rms1) > 0.0003) {
-      printf("rms1=%g, rms2=%g, abs=%g\n",rms1,rms2,TMath::Abs((rms1-rms2)/rms1));
+   if (rms1 > 0.0001 && std::abs((rms1-rms2)/rms1) > 0.0003) {
+      printf("rms1=%g, rms2=%g, abs=%g\n",rms1,rms2,std::abs((rms1-rms2)/rms1));
       return -3;
    }
    return n1*factor-n2;

--- a/test/stressEntryList.cxx
+++ b/test/stressEntryList.cxx
@@ -95,7 +95,7 @@ Bool_t Test1(bool fixedCut)
    smallchain->Draw("x >> hcheck", "", "goff");
    wrongentries1 = 0;
    for (Int_t i=1; i<=range; i++){
-      if (TMath::Abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
+      if (std::abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
          wrongentries1++;
       }
    }
@@ -107,7 +107,7 @@ Bool_t Test1(bool fixedCut)
    bigchain->Draw("x >> hcheck_", "", "goff");
    wrongentries2 = 0;
    for (Int_t i=1; i<=range; i++){
-      if (TMath::Abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
+      if (std::abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
          wrongentries2++;
       }
    }
@@ -163,7 +163,7 @@ Bool_t Test1(bool fixedCut)
    smallchain->Draw("x>>hcheck", "", "goff");
    wrongentries4 = 0;
    for (Int_t i=1; i<=range; i++){
-      if (TMath::Abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
+      if (std::abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
          //printf("%d hx: %f hcheck %f\n", i, hx->GetBinContent(i), hcheck->GetBinContent(i));
          wrongentries4++;
       }
@@ -177,7 +177,7 @@ Bool_t Test1(bool fixedCut)
    smallchain->Draw("x >> hcheck", "", "goff");
    wrongentries5 = 0;
    for (Int_t i=1; i<=range; i++){
-      if (TMath::Abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
+      if (std::abs(hx->GetBinContent(i)-hcheck->GetBinContent(i)) > 0.1){
          //printf("i=%d hx(i)=%f, hcheck(i)=%f\n", i, hx->GetBinContent(i), hcheck->GetBinContent(i));
          wrongentries5++;
       }
@@ -360,7 +360,7 @@ Bool_t Test3()
       bin1 = h1->GetBinContent(i);
       bin2 = h2->GetBinContent(i);
       bin3 = h3->GetBinContent(i);
-      if (TMath::Abs(bin1-bin2) > 0.1 || TMath::Abs(bin1-bin3) || TMath::Abs(bin2-bin3) > 0.1) {
+      if (std::abs(bin1-bin2) > 0.1 || std::abs(bin1-bin3) || std::abs(bin2-bin3) > 0.1) {
          //printf("bin1=%f, bin2=%f, bin3=%f\n", bin1, bin2, bin3);
          wrongbins++;
       }
@@ -408,7 +408,7 @@ Bool_t Test4()
       bin1 = h1->GetBinContent(i);
       bin2 = h2->GetBinContent(i);
       bin3 = h3->GetBinContent(i);
-      if (TMath::Abs(bin1-bin2) > 0.1 || TMath::Abs(bin1-bin3) || TMath::Abs(bin2-bin3) > 0.1) {
+      if (std::abs(bin1-bin2) > 0.1 || std::abs(bin1-bin3) || std::abs(bin2-bin3) > 0.1) {
          //printf("bin1=%f, bin2=%f, bin3=%f\n", bin1, bin2, bin3);
          wrongbins++;
       }
@@ -456,7 +456,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
       for (Int_t i=offset[itree]; i<offset[itree+1]; i++){
          real = i-offset[itree];
          cur = elfull->GetEntry(i);
-         if (TMath::Abs(real-cur)>0.1){
+         if (std::abs(real-cur)>0.1){
             //printf("real=%lld, cur=%lld\n", real, cur);
             wrongentries1++;
          }
@@ -468,7 +468,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
       for (Int_t i=offset[itree]; i<offset[itree+1]; i+=2){
          real = i-offset[itree];
          cur = elfull->GetEntry(i);
-         if (TMath::Abs(real-cur)>0.1){
+         if (std::abs(real-cur)>0.1){
             //printf("real=%lld, cur=%lld\n", real, cur);
             wrongentries2++;
          }
@@ -482,7 +482,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
    TEntryList *elempty = (TEntryList*)gDirectory->Get("elempty");
    //just a check
    Long64_t temp = elempty->GetEntry(3);
-   if (TMath::Abs(temp+1)>0.1)
+   if (std::abs(temp+1)>0.1)
    wrongentries5++;
 
    //Merge the almost full list with the almost empty list
@@ -499,7 +499,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
       for (Int_t i=offset[itree]; i<offset[itree+1]; i++){
          real = i-offset[itree];
          cur = elfull->GetEntry(i);
-         if (TMath::Abs(real-cur)>0.1){
+         if (std::abs(real-cur)>0.1){
             //printf("real=%lld, cur=%lld\n", real, cur);
             wrongentries3++;
          }
@@ -512,7 +512,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
       for (Int_t i=offset[itree]; i<offset[itree+1]; i+=2){
          real = i-offset[itree];
          cur = elfull->GetEntry(i);
-         if (TMath::Abs(real-cur)>0.1){
+         if (std::abs(real-cur)>0.1){
             //printf("real=%lld, cur=%lld\n", real, cur);
             wrongentries4++;
          }
@@ -524,7 +524,7 @@ Bool_t Test5And6(const std::list<const char*>& treeNamesForChain )
    chain->SetEntryList(elfull);
    chain->Draw("x>>hx", "", "goff");
    TH1F *hx = (TH1F*)gDirectory->Get("hx");
-   if (TMath::Abs(hx->GetEntries()-chain->GetEntries())>0.1){
+   if (std::abs(hx->GetEntries()-chain->GetEntries())>0.1){
       wrongentries5++;
       //printf("entries in chain: %lld, entries in histo: %f\n", chain->GetEntries(), hx->GetEntries());
    }

--- a/test/stressGUI.cxx
+++ b/test/stressGUI.cxx
@@ -2199,7 +2199,7 @@ void guitest_playback()
    guitest_ref[10] = 68657;
    for (i=0;i<11;++i) {
       printf("guitest %02d: output............................................", i+1);
-      if (TMath::Abs(guitest_ref[i] - guitest_size[i]) <= guitest_err[i]) {
+      if (std::abs(guitest_ref[i] - guitest_size[i]) <= guitest_err[i]) {
          printf("..... OK\n");
          // delete successful tests, keep only the failing ones (for verification)
          gSystem->Unlink(TString::Format("%s/guitest%03d.C", dir.Data(), i+1));

--- a/tmva/tmva/inc/TMVA/Event.h
+++ b/tmva/tmva/inc/TMVA/Event.h
@@ -82,7 +82,7 @@ namespace TMVA {
       //      Double_t GetWeight()         const { return fWeight*fBoostWeight; }
       Double_t GetWeight()         const;
       Double_t GetOriginalWeight() const { return fWeight; }
-      Double_t GetBoostWeight()    const { return TMath::Max(Double_t(0.0001),fBoostWeight); }
+      Double_t GetBoostWeight()    const { return std::max(Double_t(0.0001),fBoostWeight); }
       UInt_t   GetClass()          const { return fClass; }
 
       UInt_t   GetNVariables()        const;

--- a/tmva/tmva/src/Ranking.cxx
+++ b/tmva/tmva/src/Ranking.cxx
@@ -127,7 +127,7 @@ void TMVA::Ranking::Print() const
    for (std::vector<Rank>::const_iterator ir = fRanking.begin(); ir != fRanking.end(); ++ir ) {
       Log() << kINFO
             << TString::Format( "%4i : ",(*ir).GetRank() )
-            << std::setw(TMath::Max(maxL+0,9)) << (*ir).GetVariable().Data()
+            << std::setw(std::max(maxL+0,9)) << (*ir).GetVariable().Data()
             << TString::Format( " : %3.3e", (*ir).GetRankValue() ) << Endl;
    }
    Log() << kINFO << hline << Endl;

--- a/tmva/tmva/src/ResultsRegression.cxx
+++ b/tmva/tmva/src/ResultsRegression.cxx
@@ -168,7 +168,7 @@ TH2F*  TMVA::ResultsRegression::DeviationAsAFunctionOf( UInt_t varNum, UInt_t tg
    Int_t   nxbins = 50;
    Int_t   nybins = 50;
 
-   Float_t epsilon = TMath::Abs(xmax-xmin)/((Float_t)nxbins-1);
+   Float_t epsilon = std::abs(xmax-xmin)/((Float_t)nxbins-1);
    xmin -= 1.01*epsilon;
    xmax += 1.01*epsilon;
 

--- a/tmva/tmva/src/VariableImportance.cxx
+++ b/tmva/tmva/src/VariableImportance.cxx
@@ -29,6 +29,7 @@
 #include "TStyle.h"
 
 #include <bitset>
+#include <cmath>
 #include <memory>
 #include <utility>
 

--- a/tmva/tmvagui/src/MovieMaker.cxx
+++ b/tmva/tmvagui/src/MovieMaker.cxx
@@ -134,15 +134,15 @@ void TMVA::DrawMLPoutputMovie(TString dataset, TFile* file, const TString& metho
       // set only first time, then same for all plots
       if (first) {
          if (xmin == 0 && xmax == 0) {
-            xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
+            xmin = std::max( std::min(sig->GetMean() - nrms*sig->GetRMS(),
                                           bgd->GetMean() - nrms*bgd->GetRMS() ),
                                sig->GetXaxis()->GetXmin() );
-            xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
+            xmax = std::min( std::max(sig->GetMean() + nrms*sig->GetRMS(),
                                           bgd->GetMean() + nrms*bgd->GetRMS() ),
                                sig->GetXaxis()->GetXmax() );
          }
          ymin = 0;
-         ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*maxMult;
+         ymax = std::max( sig->GetMaximum(), bgd->GetMaximum() )*maxMult;
          first = kFALSE;
       }
 

--- a/tmva/tmvagui/src/annconvergencetest.cxx
+++ b/tmva/tmvagui/src/annconvergencetest.cxx
@@ -24,10 +24,10 @@ void TMVA::annconvergencetest(TString dataset, TDirectory *lhdir )
 
    Double_t m1  = estimatorHistTrain->GetMaximum();
    Double_t m2  = estimatorHistTest ->GetMaximum();
-   Double_t max = TMath::Max( m1, m2 );
+   Double_t max = std::max( m1, m2 );
    m1  = estimatorHistTrain->GetMinimum();
    m2  = estimatorHistTest ->GetMinimum();
-   Double_t min = TMath::Min( m1, m2 );
+   Double_t min = std::min( m1, m2 );
    estimatorHistTrain->SetMaximum( max + 0.1*(max - min) );
    estimatorHistTrain->SetMinimum( min - 0.1*(max - min) );
    estimatorHistTrain->SetLineColor( 2 );

--- a/tmva/tmvagui/src/compareanapp.cxx
+++ b/tmva/tmvagui/src/compareanapp.cxx
@@ -100,14 +100,14 @@ void TMVA::compareanapp( TString finAn , TString finApp ,
 
          // frame limits (choose judicuous x range)
          Float_t nrms = 4;
-         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
+         Float_t xmin = std::max( std::min(sig->GetMean() - nrms*sig->GetRMS(),
                                                bgd->GetMean() - nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmin() );
-         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
+         Float_t xmax = std::min( std::max(sig->GetMean() + nrms*sig->GetRMS(),
                                                bgd->GetMean() + nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmax() );
          Float_t ymin = 0;
-         Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*1.2 ;
+         Float_t ymax = std::max( sig->GetMaximum(), bgd->GetMaximum() )*1.2 ;
 
          if (Draw_CFANN_Logy && methodName == "CFANN") ymin = 0.01;
 

--- a/tmva/tmvagui/src/efficiencies.cxx
+++ b/tmva/tmvagui/src/efficiencies.cxx
@@ -184,7 +184,7 @@ void TMVA::plot_efficiencies(TString dataset, TFile* /*file*/, Int_t type , TDir
       legend->SetY1( y0H - dyH );
    }
    else {
-      dyH *= (Float_t(TMath::Min(10,nmva) - 3.0)/4.0);
+      dyH *= (Float_t(std::min(10,nmva) - 3.0)/4.0);
       legend->SetY2( y0H + dyH);
    }
 

--- a/tmva/tmvagui/src/efficienciesMulticlass.cxx
+++ b/tmva/tmvagui/src/efficienciesMulticlass.cxx
@@ -444,7 +444,7 @@ void EfficiencyPlotWrapper::addLegendEntry(TString methodTitle, TGraph *graph)
 {
    fLegend->AddEntry(graph, methodTitle, "l");
 
-   Float_t dyH_local = fdyH * (Float_t(TMath::Min((UInt_t)10, fNumMethods) - 3.0) / 4.0);
+   Float_t dyH_local = fdyH * (Float_t(std::min((UInt_t)10, fNumMethods) - 3.0) / 4.0);
    fLegend->SetY2(fy0H + dyH_local);
 
    fLegend->Paint();

--- a/tmva/tmvagui/src/mvas.cxx
+++ b/tmva/tmvagui/src/mvas.cxx
@@ -108,15 +108,15 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
          Float_t nrms = 10;
          cout << "--- Mean and RMS (S): " << sig->GetMean() << ", " << sig->GetRMS() << endl;
          cout << "--- Mean and RMS (B): " << bgd->GetMean() << ", " << bgd->GetRMS() << endl;
-         Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
+         Float_t xmin = std::max( std::min(sig->GetMean() - nrms*sig->GetRMS(),
                                                bgd->GetMean() - nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmin() );
-         Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
+         Float_t xmax = std::min( std::max(sig->GetMean() + nrms*sig->GetRMS(),
                                                bgd->GetMean() + nrms*bgd->GetRMS() ),
                                     sig->GetXaxis()->GetXmax() );
          Float_t ymin = 0;
          Float_t maxMult = (htype == kCompareType) ? 1.3 : 1.2;
-         Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*maxMult;
+         Float_t ymax = std::max( sig->GetMaximum(), bgd->GetMaximum() )*maxMult;
 
          // build a frame
          Int_t nb = 500;
@@ -194,7 +194,7 @@ void TMVA::mvas(TString dataset, TString fin, HistType htype, Bool_t useTMVAStyl
             bgdOv->SetLineColor( col );
             bgdOv->Draw("e1same");
 
-            ymax = TMath::Max( ymax, float(TMath::Max( sigOv->GetMaximum(), bgdOv->GetMaximum() )*maxMult ));
+            ymax = std::max( ymax, float(std::max( sigOv->GetMaximum(), bgdOv->GetMaximum() )*maxMult ));
             frame->GetYaxis()->SetLimits( 0, ymax );
 
             // for better visibility, plot thinner lines

--- a/tmva/tmvagui/src/network.cxx
+++ b/tmva/tmvagui/src/network.cxx
@@ -89,7 +89,7 @@ void TMVA::draw_network(TString dataset, TFile* f, TDirectory* d, const TString&
          Int_t n2 = h->GetNbinsY();
          for (Int_t i = 0; i < n1; i++) {
             for (Int_t j = 0; j < n2; j++) {
-               Double_t weight = TMath::Abs(h->GetBinContent(i+1, j+1));
+               Double_t weight = std::abs(h->GetBinContent(i+1, j+1));
                if (maxWeight < weight) maxWeight = weight;
             }
          }
@@ -415,7 +415,7 @@ void TMVA::draw_synapse(Double_t cx1, Double_t cy1, Double_t cx2, Double_t cy2,
    TArrow *arrow = new TArrow(cx1+rad1, cy1, cx2-rad2, cy2, TIP_SIZE, ">");
    arrow->SetFillColor(1);
    arrow->SetFillStyle(1001);
-   arrow->SetLineWidth((Int_t)(TMath::Abs(weightNormed)*MAX_WEIGHT+0.5));
+   arrow->SetLineWidth((Int_t)(std::abs(weightNormed)*MAX_WEIGHT+0.5));
    arrow->SetLineColor((Int_t)((weightNormed+1.0)/2.0*(MAX_COLOR-MIN_COLOR)+MIN_COLOR+0.5));
    arrow->Draw();
 }

--- a/tmva/tmvagui/src/paracoor.cxx
+++ b/tmva/tmvagui/src/paracoor.cxx
@@ -84,7 +84,7 @@ void TMVA::paracoor(TString dataset, TString fin , Bool_t useTMVAStyle )
 
          para->AddSelection("-1");
 
-         for (Int_t ivar=1; ivar<TMath::Min(Int_t(vars.size()) + 1,3); ivar++) {
+         for (Int_t ivar=1; ivar<std::min(Int_t(vars.size()) + 1,3); ivar++) {
             TParallelCoordVar* var = (TParallelCoordVar*)para->GetVarList()->FindObject( vars[ivar] );
             minrange = tree->GetMinimum( var->GetName() );
             maxrange = tree->GetMaximum( var->GetName() );

--- a/tmva/tmvagui/src/probas.cxx
+++ b/tmva/tmvagui/src/probas.cxx
@@ -150,14 +150,14 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
 
                      // frame limits (choose judicuous x range)
                      Float_t nrms = 4;
-                     Float_t xmin = TMath::Max( TMath::Min(sig->GetMean() - nrms*sig->GetRMS(),
+                     Float_t xmin = std::max( std::min(sig->GetMean() - nrms*sig->GetRMS(),
                                                            bgd->GetMean() - nrms*bgd->GetRMS() ),
                                                 sig->GetXaxis()->GetXmin() );
-                     Float_t xmax = TMath::Min( TMath::Max(sig->GetMean() + nrms*sig->GetRMS(),
+                     Float_t xmax = std::min( std::max(sig->GetMean() + nrms*sig->GetRMS(),
                                                            bgd->GetMean() + nrms*bgd->GetRMS() ),
                                                 sig->GetXaxis()->GetXmax() );
                      Float_t ymin = 0;
-                     Float_t ymax = TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*1.5;
+                     Float_t ymax = std::max( sig->GetMaximum(), bgd->GetMaximum() )*1.5;
 
                      if (Draw_CFANN_Logy && methodName == "CFANN") ymin = 0.01;
 

--- a/tmva/tmvagui/src/regression_averagedevs.cxx
+++ b/tmva/tmvagui/src/regression_averagedevs.cxx
@@ -6,6 +6,8 @@
 #include "TGraphErrors.h"
 #include "TFrame.h"
 
+#include <cmath>
+
 /*
   this macro plots the quadratic deviation of the estimated from the target value, averaged over the first nevt events in test sample (all if Nevt=-1)
   a) normal average

--- a/tmva/tmvagui/src/rulevisCorr.cxx
+++ b/tmva/tmvagui/src/rulevisCorr.cxx
@@ -235,7 +235,7 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
          hrf2->Draw("colz ah");
          Float_t sc = 1.1;
          if (countPad==2) sc = 1.3;
-         sig->SetMaximum( TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
+         sig->SetMaximum( std::max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
          Double_t smax = sig->GetMaximum();
 
          sig->Scale(1.0/smax);

--- a/tmva/tmvagui/src/rulevisHists.cxx
+++ b/tmva/tmvagui/src/rulevisHists.cxx
@@ -208,7 +208,7 @@ void TMVA::rulevisHists( TDirectory *rfdir, TDirectory *vardir, TDirectory *corr
          // finally plot and overlay       
          Float_t sc = 1.1;
          if (countPad==2) sc = 1.3;
-         sig->SetMaximum( TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
+         sig->SetMaximum( std::max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
          Double_t smax = sig->GetMaximum();
 
          if (first) {

--- a/tmva/tmvagui/src/training_history.cxx
+++ b/tmva/tmvagui/src/training_history.cxx
@@ -157,7 +157,7 @@ void TMVA::plot_training_history(TString dataset, TFile* /*file*/, TDirectory* B
 
    // rescale legend box size
    // current box size has been tuned for 3 MVAs + 1 title
-   dyH *= (1. + (Float_t(TMath::Min(10,nmva) - 3.0)/4.0) );
+   dyH *= (1. + (Float_t(std::min(10,nmva) - 3.0)/4.0) );
    legend->SetY1( y0H - dyH);
 
    // redraw axes

--- a/tmva/tmvagui/src/variables.cxx
+++ b/tmva/tmvagui/src/variables.cxx
@@ -118,7 +118,7 @@ void TMVA::variables(TString dataset, TString fin, TString dirName , TString tit
       // finally plot and overlay
       Float_t sc = 1.1;
       if (countPad == 1) sc = 1.3;
-      sig->SetMaximum( TMath::Max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
+      sig->SetMaximum( std::max( sig->GetMaximum(), bgd->GetMaximum() )*sc );
       sig->Draw( "hist" );
       cPad->SetLeftMargin( 0.17 );
 

--- a/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
@@ -22,7 +22,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <vector>
+#include <cmath>
 
 #include "RtypesCore.h"
 #include "TError.h" // R__ASSERT

--- a/tree/tree/inc/TEntryListFromFile.h
+++ b/tree/tree/inc/TEntryListFromFile.h
@@ -35,6 +35,8 @@
 
 #include "TEntryList.h"
 
+#include <limits>
+
 class TFile;
 
 class TEntryListFromFile: public TEntryList

--- a/tree/tree/src/TBufferSQL.cxx
+++ b/tree/tree/src/TBufferSQL.cxx
@@ -24,6 +24,7 @@ Implement TBuffer for a SQL backend.
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 
 ClassImp(TBufferSQL);
 

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -430,7 +430,7 @@ void TEntryList::Add(const TEntryList *elist)
             TEntryListBlock *block1=nullptr;
             TEntryListBlock *block2=nullptr;
             Int_t i;
-            Int_t nmin = TMath::Min(fNBlocks, elist->fNBlocks);
+            Int_t nmin = std::min(fNBlocks, elist->fNBlocks);
             Long64_t nnew, nold;
             for (i=0; i<nmin; i++){
                block1 = (TEntryListBlock*)fBlocks->UncheckedAt(i);

--- a/tree/tree/test/BulkApiMultiple.cxx
+++ b/tree/tree/test/BulkApiMultiple.cxx
@@ -12,6 +12,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 static const Long64_t gRollOver = std::pow(10, (std::numeric_limits<float>::digits10-1));
 
 class BulkApiMultipleTest : public ::testing::Test {

--- a/tree/tree/test/BulkApiVarLength.cxx
+++ b/tree/tree/test/BulkApiVarLength.cxx
@@ -15,6 +15,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 class BulkApiVariableTest : public ::testing::Test {
 public:
    static constexpr Long64_t fClusterSize = 1e5;

--- a/tree/treeplayer/src/TTreeFormulaManager.cxx
+++ b/tree/treeplayer/src/TTreeFormulaManager.cxx
@@ -133,7 +133,7 @@ Int_t TTreeFormulaManager::GetNdata(bool forceLoadDim)
 
    // Reset the registers.
    for (k = 0; k <= kMAXFORMDIM; k++) {
-      fUsedSizes[k] = TMath::Abs(fVirtUsedSizes[k]);
+      fUsedSizes[k] = std::abs(fVirtUsedSizes[k]);
       if (fVarDims[k]) {
          for (Int_t i0 = 0; i0 < fVarDims[k]->GetSize(); i0++) {
             fVarDims[k]->AddAt(0, i0);
@@ -254,7 +254,7 @@ bool TTreeFormulaManager::Sync()
       if (fUsedSizes[k - 1] >= 0) {
          fCumulUsedSizes[k - 1] = fUsedSizes[k - 1] * fCumulUsedSizes[k];
       } else {
-         fCumulUsedSizes[k - 1] = -TMath::Abs(fCumulUsedSizes[k]);
+         fCumulUsedSizes[k - 1] = -std::abs(fCumulUsedSizes[k]);
       }
    }
 
@@ -308,8 +308,8 @@ void TTreeFormulaManager::UpdateFormulaLeaves()
 void TTreeFormulaManager::UpdateUsedSize(Int_t &virt_dim, Int_t vsize)
 {
    if (vsize < 0)
-      fVirtUsedSizes[virt_dim] = -1 * TMath::Abs(fVirtUsedSizes[virt_dim]);
-   else if (TMath::Abs(fVirtUsedSizes[virt_dim]) == 1 || (vsize < TMath::Abs(fVirtUsedSizes[virt_dim]))) {
+      fVirtUsedSizes[virt_dim] = -1 * std::abs(fVirtUsedSizes[virt_dim]);
+   else if (std::abs(fVirtUsedSizes[virt_dim]) == 1 || (vsize < std::abs(fVirtUsedSizes[virt_dim]))) {
       // Absolute values represent the min of all real dimensions
       // that are known.  The fact that it is negatif indicates
       // that one of the leaf has a variable size for this

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -24,6 +24,7 @@ of a ROOT::TThreadedObject, so that each thread works with its own TFile and TTr
 objects.
 */
 
+#include <cmath>
 #include <memory>
 
 #include "TROOT.h"

--- a/tree/treeplayer/test/gh16804.cxx
+++ b/tree/treeplayer/test/gh16804.cxx
@@ -13,7 +13,9 @@
 #include "gtest/gtest.h"
 #include "ROOT/TestSupport.hxx"
 
+#include <algorithm>
 #include <iostream>
+
 // Test regression for https://github.com/root-project/root/issues/16804
 struct RegressionGH16804 : public ::testing::Test {
 

--- a/tree/treeplayer/test/gh16805.cxx
+++ b/tree/treeplayer/test/gh16805.cxx
@@ -2,6 +2,8 @@
 #include <TFile.h>
 #include <TTree.h>
 #include <TTreePlayer.h>
+
+#include <algorithm>
 #include <memory>
 #include <iostream>
 #include <vector>

--- a/tree/treeviewer/src/TTVLVContainer.cxx
+++ b/tree/treeviewer/src/TTVLVContainer.cxx
@@ -527,7 +527,7 @@ bool TTVLVContainer::HandleButton(Event_t *event)
                fViewer->Message(msg);
             }
          }
-         if ((TMath::Abs(event->fX - fXp) < 2) && (TMath::Abs(event->fY - fYp) < 2)) {
+         if ((std::abs(event->fX - fXp) < 2) && (std::abs(event->fY - fYp) < 2)) {
             SendMessage(fMsgWindow, MK_MSG(kC_CONTAINER, kCT_ITEMCLICK),
                         event->fCode, (event->fYRoot << 16) | event->fXRoot);
          }

--- a/tree/treeviewer/src/TTreeViewer.cxx
+++ b/tree/treeviewer/src/TTreeViewer.cxx
@@ -478,7 +478,7 @@ void TTreeViewer::SetNexpressions(Int_t expr)
    Int_t diff = expr - fNexpressions;
    if (diff <= 0) return;
    if (!fLVContainer) return;
-   for (Int_t i=0; i<TMath::Abs(diff); i++) NewExpression();
+   for (Int_t i=0; i<std::abs(diff); i++) NewExpression();
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the name of the file where to redirect `<Scan>` output.


### PR DESCRIPTION
The TString header only uses `TMath` functions that are readily available in the standard library.

The `TMathBase.h` header is quite big, and avoiding to include it reduces the overall cold-ccache compile time of the full ROOT project (excluding LLVM/Clang) with all default features by about 2 % on my machine, namely from 870 s to 855 s on average (I repeated the measurement several times, they are reproducible to a second).

In the places there the `TMath` functions were used but only indirectly included via `TString.h` inclusion, the commit suggests to use the `<cmath>` functions instead.