### PR TITLE
Fix testPyTourchRegression.C [skip-ci]

### DIFF
--- a/tmva/pymva/test/testPyTorchRegression.C
+++ b/tmva/pymva/test/testPyTorchRegression.C
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cmath>
 
 #include "TString.h"
 #include "TFile.h"


### PR DESCRIPTION
Missing <cmath> include for use of `std:pow`

Fails to compile, seems to be not appears in CI