### PR TITLE
[core] reduce maxsize of string to prevent int overflow when calling Align

### DIFF
--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -255,9 +255,9 @@ private:
    char          *GetPointer() { return IsLong() ? GetLongPointer() : GetShortPointer(); }
    const char    *GetPointer() const { return IsLong() ? GetLongPointer() : GetShortPointer(); }
 #ifdef R__BYTESWAP
-   static Ssiz_t  MaxSize() { return kMaxInt - 1; }
+   static Ssiz_t  MaxSize() { return kMaxInt - 1 - (kAlignment - 1); }
 #else
-   static Ssiz_t  MaxSize() { return (kMaxInt >> 1) - 1; }
+   static Ssiz_t  MaxSize() { return (kMaxInt >> 1) - 1 - (kAlignment - 1); }
 #endif
    void           UnLink() const { if (IsLong()) delete [] fRep.fLong.fData; }
    void           Zero() {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes a alloc-size-larger compiler warning often seen in the CI of the PRs.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

