### PR TITLE
[tutorials] Fix vetos for UHI tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -934,8 +934,14 @@ if(ROOT_pyroot_FOUND)
       machine_learning/RBatchGenerator_TensorFlow.py
   )
 
-  file(GLOB requires_matplotlib requires_mplhep RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-      hist/hist002_TH1_fillrandom_userfunc_uhi.py
+  file(GLOB requires_matplotlib RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+      hist/hist003_TH1_draw_uhi.py
+      hist/hist007_TH1_liveupdate_uhi.py
+      hist/hist010_TH1_two_scales_uhi.py
+      hist/hist015_TH1_read_and_draw_uhi.py
+  )
+
+  file(GLOB requires_mplhep RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
       hist/hist003_TH1_draw_uhi.py
       hist/hist007_TH1_liveupdate_uhi.py
       hist/hist010_TH1_two_scales_uhi.py


### PR DESCRIPTION
Following up on #19472. One can't do `file(GLOB ..)` with two separate output variables. Also, don't claim that the tutorial `hist002_TH1_fillrandom_userfunc_uhi.py` requires mplhep and matplotlib, because it only requires NumPy.