### PR TITLE
Fix TF1::DrawCopy issue

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -602,7 +602,6 @@ public:
    void SetFunction(PtrObj &p, MemFn memFn);
    template <typename Func>
    void SetFunction(Func f);
-   virtual void     SetHistogram(TH1 *h) {fHistogram = h;}
    virtual void     SetMaximum(Double_t maximum = -1111); // *MENU*
    virtual void     SetMinimum(Double_t minimum = -1111); // *MENU*
    virtual void     SetNDF(Int_t ndf);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -602,6 +602,7 @@ public:
    void SetFunction(PtrObj &p, MemFn memFn);
    template <typename Func>
    void SetFunction(Func f);
+   virtual void     SetHistogram(TH1 *h) {fHistogram = h;}
    virtual void     SetMaximum(Double_t maximum = -1111); // *MENU*
    virtual void     SetMinimum(Double_t minimum = -1111); // *MENU*
    virtual void     SetNDF(Int_t ndf);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1029,7 +1029,13 @@ void TF1::Copy(TObject &obj) const
    ((TF1 &)obj).fParMax    = fParMax;
    ((TF1 &)obj).fParent    = fParent;
    ((TF1 &)obj).fSave      = fSave;
-   ((TF1 &)obj).fHistogram = nullptr;
+   if (fHistogram) {
+      auto *h1 = (TH1*)fHistogram->Clone();
+      h1->SetDirectory(nullptr);
+      ((TF1 &)obj).fHistogram = h1;
+   } else {
+      ((TF1 &)obj).fHistogram = nullptr;
+   }
    ((TF1 &)obj).fMethodCall = nullptr;
    ((TF1 &)obj).fNormalized = fNormalized;
    ((TF1 &)obj).fNormIntegral = fNormIntegral;
@@ -1368,7 +1374,6 @@ TF1 *TF1::DrawCopy(Option_t *option) const
    Copy(*newf1);
    newf1->AppendPad(option);
    newf1->SetBit(kCanDelete);
-   if (fHistogram) newf1->SetHistogram(fHistogram);
    return newf1;
 }
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1368,6 +1368,7 @@ TF1 *TF1::DrawCopy(Option_t *option) const
    Copy(*newf1);
    newf1->AppendPad(option);
    newf1->SetBit(kCanDelete);
+   if (fHistogram) newf1->SetHistogram(fHistogram);
    return newf1;
 }
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1030,7 +1030,7 @@ void TF1::Copy(TObject &obj) const
    ((TF1 &)obj).fParent    = fParent;
    ((TF1 &)obj).fSave      = fSave;
    if (fHistogram) {
-      auto *h1 = (TH1*)fHistogram->Clone();
+      auto *h1 = (TH1 *)fHistogram->Clone();
       h1->SetDirectory(nullptr);
       ((TF1 &)obj).fHistogram = h1;
    } else {

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -28,6 +28,7 @@ ROOT_ADD_GTEST(testMapCppName test_MapCppName.cxx LIBRARIES Hist Gpad)
 ROOT_ADD_GTEST(testTGraphSorting test_TGraph_sorting.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testSpline test_spline.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTF1Simple test_tf1_simple.cxx LIBRARIES Hist RIO)
+ROOT_ADD_GTEST(testTF1DrawCopy test_tf1_drawcopy.cxx LIBRARIES Hist)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_tf1_drawcopy.cxx
+++ b/hist/hist/test/test_tf1_drawcopy.cxx
@@ -1,0 +1,12 @@
+#include "TF1.h"
+#include "TAxis.h"
+
+#include "gtest/gtest.h"
+
+// issue #13122
+TEST(TF1, DrawCopy) {
+   auto f = new TF1("f", "x*x", -3, 3);
+   f->GetXaxis()->SetTitle("xtitle");
+   auto fcopy = f->DrawCopy();
+   EXPECT_STREQ("xtitle", fcopy->GetXaxis()->GetTitle());
+}

--- a/hist/hist/test/test_tf1_drawcopy.cxx
+++ b/hist/hist/test/test_tf1_drawcopy.cxx
@@ -4,7 +4,8 @@
 #include "gtest/gtest.h"
 
 // issue #13122
-TEST(TF1, DrawCopy) {
+TEST(TF1, DrawCopy)
+{
    auto f = new TF1("f", "x*x", -3, 3);
    f->GetXaxis()->SetTitle("xtitle");
    auto fcopy = f->DrawCopy();


### PR DESCRIPTION
TF1::Copy didn't copy fHistogram if it exited.
It fixes this issue: https://github.com/root-project/root/issues/13122

