### PR TITLE
[math] Remove the GenVector namespace to improve doxygen.

### DIFF
--- a/math/genvector/inc/Math/GenVector/GenVector_exception.h
+++ b/math/genvector/inc/Math/GenVector/GenVector_exception.h
@@ -21,9 +21,7 @@ namespace Math {
 
 class GenVector_exception;
 inline void Throw(GenVector_exception &e);
-namespace GenVector {
-inline void Throw(const char *);
-}
+inline void GenVector_Throw(const char *);
 
 // ----------------------------------------------------------------------
 // GenVector_exception class definition
@@ -55,7 +53,7 @@ public:
 
 private:
    friend void Throw(GenVector_exception &);
-   friend void GenVector::Throw(const char *);
+   friend void GenVector_Throw(const char *);
 
    static bool &IsOn()
    {
@@ -75,16 +73,14 @@ inline void Throw(GenVector_exception &e)
       throw e;
 }
 
-namespace GenVector {
 /// function throwing exception, by creating internally a GenVector_exception only when needed
-inline void Throw(const char *s)
+inline void GenVector_Throw(const char *s)
 {
    if (!GenVector_exception::IsOn())
       return;
    GenVector_exception e(s);
    throw e;
 }
-} // namespace GenVector
 
 } // namespace Math
 } // namespace ROOT

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -627,12 +627,14 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
                 // to avoid Nan
                 return 0;
              else {
-                GenVector::Throw ("LorentzVector::Beta() - beta computed for LorentzVector with t = 0. Return an Infinite result");
+                GenVector_Throw(
+                   "LorentzVector::Beta() - beta computed for LorentzVector with t = 0. Return an Infinite result");
                 return 1./E();
              }
           }
           if ( M2() <= 0 ) {
-             GenVector::Throw ("LorentzVector::Beta() - beta computed for non-timelike LorentzVector . Result is physically meaningless" );
+             GenVector_Throw("LorentzVector::Beta() - beta computed for non-timelike LorentzVector . Result is "
+                             "physically meaningless");
           }
           return P() / E();
        }
@@ -646,16 +648,16 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
              if ( P2() == 0) {
                 return 1;
              } else {
-                GenVector::Throw ("LorentzVector::Gamma() - gamma computed for LorentzVector with t = 0. Return a zero result");
-
+                GenVector_Throw(
+                   "LorentzVector::Gamma() - gamma computed for LorentzVector with t = 0. Return a zero result");
              }
           }
           if ( t2 < v2 ) {
-             GenVector::Throw ("LorentzVector::Gamma() - gamma computed for a spacelike LorentzVector. Imaginary result");
+             GenVector_Throw("LorentzVector::Gamma() - gamma computed for a spacelike LorentzVector. Imaginary result");
              return 0;
           }
           else if ( t2 == v2 ) {
-             GenVector::Throw ("LorentzVector::Gamma() - gamma computed for a lightlike LorentzVector. Infinite result");
+             GenVector_Throw("LorentzVector::Gamma() - gamma computed for a lightlike LorentzVector. Infinite result");
           }
           using std::sqrt;
           return Scalar(1) / sqrt(Scalar(1) - v2 / t2);

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiE4D.h
@@ -170,8 +170,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw ("PtEtaPhiE4D::M() - Tachyonic:\n"
-                           "    Pt and Eta give P such that P^2 > E^2, so the mass would be imaginary");
+         GenVector_Throw("PtEtaPhiE4D::M() - Tachyonic:\n"
+                         "    Pt and Eta give P such that P^2 > E^2, so the mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }
@@ -198,8 +198,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw ("PtEtaPhiE4D::Mt() - Tachyonic:\n"
-                           "    Pt and Eta give Pz such that Pz^2 > E^2, so the mass would be imaginary");
+         GenVector_Throw("PtEtaPhiE4D::Mt() - Tachyonic:\n"
+                         "    Pt and Eta give Pz such that Pz^2 > E^2, so the mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }

--- a/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
+++ b/math/genvector/inc/Math/GenVector/PtEtaPhiM4D.h
@@ -209,8 +209,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw  ("PtEtaPhiM4D::Mt() - Tachyonic:\n"
-                            "    Pz^2 > E^2 so the transverse mass would be imaginary");
+         GenVector_Throw("PtEtaPhiM4D::Mt() - Tachyonic:\n"
+                         "    Pz^2 > E^2 so the transverse mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }
@@ -241,7 +241,7 @@ private:
    inline void RestrictNegMass() {
       if (fM < 0) {
          if (P2() - fM * fM < 0) {
-            GenVector::Throw("PtEtaPhiM4D::unphysical value of mass, set to closest physical value");
+            GenVector_Throw("PtEtaPhiM4D::unphysical value of mass, set to closest physical value");
             fM = -P();
          }
       }
@@ -299,7 +299,7 @@ public:
    void Negate( ) {
       fPhi = ( (fPhi > 0) ? fPhi - pi() : fPhi + pi()  );
       fEta = - fEta;
-      GenVector::Throw ("PtEtaPhiM4D::Negate - cannot negate the energy - can negate only the spatial components");
+      GenVector_Throw("PtEtaPhiM4D::Negate - cannot negate the energy - can negate only the spatial components");
    }
 
    /**

--- a/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzE4D.h
@@ -135,8 +135,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw ("PxPyPzE4D::M() - Tachyonic:\n"
-                   "    P^2 > E^2 so the mass would be imaginary");
+         GenVector_Throw("PxPyPzE4D::M() - Tachyonic:\n"
+                         "    P^2 > E^2 so the mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }
@@ -170,8 +170,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw ("PxPyPzE4D::Mt() - Tachyonic:\n"
-                           "    Pz^2 > E^2 so the transverse mass would be imaginary");
+         GenVector_Throw("PxPyPzE4D::Mt() - Tachyonic:\n"
+                         "    Pz^2 > E^2 so the transverse mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }

--- a/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
+++ b/math/genvector/inc/Math/GenVector/PxPyPzM4D.h
@@ -198,8 +198,8 @@ public :
          using std::sqrt;
          return sqrt(mm);
       } else {
-         GenVector::Throw ("PxPyPzM4D::Mt() - Tachyonic:\n"
-                           "    Pz^2 > E^2 so the transverse mass would be imaginary");
+         GenVector_Throw("PxPyPzM4D::Mt() - Tachyonic:\n"
+                         "    Pz^2 > E^2 so the transverse mass would be imaginary");
          using std::sqrt;
          return -sqrt(-mm);
       }
@@ -285,7 +285,7 @@ public :
       fX = -fX;
       fY = -fY;
       fZ = -fZ;
-      GenVector::Throw ("PxPyPzM4D::Negate - cannot negate the energy - can negate only the spatial components");
+      GenVector_Throw("PxPyPzM4D::Negate - cannot negate the energy - can negate only the spatial components");
    }
 
    /**
@@ -340,7 +340,7 @@ private:
    inline void RestrictNegMass() {
       if ( fM >=0 ) return;
       if ( P2() - fM*fM  < 0 ) {
-         GenVector::Throw("PxPyPzM4D::unphysical value of mass, set to closest physical value");
+         GenVector_Throw("PxPyPzM4D::unphysical value of mass, set to closest physical value");
          fM = - P();
       }
       return;

--- a/math/genvector/inc/Math/GenVector/Rotation3D.h
+++ b/math/genvector/inc/Math/GenVector/Rotation3D.h
@@ -356,8 +356,8 @@ public:
       if (i < 3 && j < 3)
          return fM[i + 3 * j];
       else
-         GenVector::Throw("Rotation3D::operator(size_t i, size_t j):\n"
-                          "    indices i and j must range in {0,1,2}");
+         GenVector_Throw("Rotation3D::operator(size_t i, size_t j):\n"
+                         "    indices i and j must range in {0,1,2}");
       return 0.0;
    }
 

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -350,7 +350,7 @@ namespace ROOT {
                return v;
             const double ll = std::sqrt(axis.X() * axis.X() + axis.Y() * axis.Y() + axis.Z() * axis.Z());
             if (ll == 0.)
-               GenVector::Throw("Axis Vector has zero magnitude");
+               GenVector_Throw("Axis Vector has zero magnitude");
             const double sa = std::sin(alpha);
             const double ca = std::cos(alpha);
             const double dx = axis.X() / ll;
@@ -407,7 +407,7 @@ namespace ROOT {
             double bz = b.Z();
             double b2 = bx*bx + by*by + bz*bz;
             if (b2 >= 1) {
-               GenVector::Throw ( "Beta Vector supplied to set Boost represents speed >= c");
+               GenVector_Throw("Beta Vector supplied to set Boost represents speed >= c");
                return LVector();
             }
             using std::sqrt;
@@ -433,7 +433,7 @@ namespace ROOT {
          template <class LVector, class T>
          LVector boostX(const LVector & v, T beta) {
             if (beta >= 1) {
-               GenVector::Throw ("Beta Vector supplied to set Boost represents speed >= c");
+               GenVector_Throw("Beta Vector supplied to set Boost represents speed >= c");
                return LVector();
             }
             using std::sqrt;
@@ -455,7 +455,7 @@ namespace ROOT {
          template <class LVector>
          LVector boostY(const LVector & v, double beta) {
             if (beta >= 1) {
-               GenVector::Throw ("Beta Vector supplied to set Boost represents speed >= c");
+               GenVector_Throw("Beta Vector supplied to set Boost represents speed >= c");
                return LVector();
             }
             using std::sqrt;
@@ -476,7 +476,7 @@ namespace ROOT {
          template <class LVector>
          LVector boostZ(const LVector & v, double beta) {
             if (beta >= 1) {
-               GenVector::Throw ( "Beta Vector supplied to set Boost represents speed >= c");
+               GenVector_Throw("Beta Vector supplied to set Boost represents speed >= c");
                return LVector();
             }
             using std::sqrt;

--- a/math/genvector/src/Boost.cxx
+++ b/math/genvector/src/Boost.cxx
@@ -77,8 +77,7 @@ void Boost::SetComponents (Scalar bx, Scalar by, Scalar bz) {
    // set the boost beta as 3 components
    Scalar bp2 = bx*bx + by*by + bz*bz;
    if (bp2 >= 1) {
-      GenVector::Throw (
-                              "Beta Vector supplied to set Boost represents speed >= c");
+      GenVector_Throw("Beta Vector supplied to set Boost represents speed >= c");
       // SetIdentity();
       return;
    }
@@ -127,8 +126,7 @@ void Boost::Rectify() {
    // again.
 
    if (fM[kTT] <= 0) {
-      GenVector::Throw (
-                              "Attempt to rectify a boost with non-positive gamma");
+      GenVector_Throw("Attempt to rectify a boost with non-positive gamma");
       return;
    }
    DisplacementVector3D< Cartesian3D<Scalar> > beta ( fM[kXT], fM[kYT], fM[kZT] );

--- a/math/genvector/src/BoostX.cxx
+++ b/math/genvector/src/BoostX.cxx
@@ -34,8 +34,7 @@ void BoostX::SetComponents (Scalar bx ) {
    // set component
    Scalar bp2 = bx*bx;
    if (bp2 >= 1) {
-      GenVector::Throw (
-                              "Beta Vector supplied to set BoostX represents speed >= c");
+      GenVector_Throw("Beta Vector supplied to set BoostX represents speed >= c");
       return;
    }
    fBeta = bx;
@@ -68,8 +67,7 @@ void BoostX::Rectify() {
    // again.
 
    if (fGamma <= 0) {
-      GenVector::Throw (
-                              "Attempt to rectify a boost with non-positive gamma");
+      GenVector_Throw("Attempt to rectify a boost with non-positive gamma");
       return;
    }
    Scalar beta = fBeta;

--- a/math/genvector/src/BoostY.cxx
+++ b/math/genvector/src/BoostY.cxx
@@ -33,8 +33,7 @@ void BoostY::SetComponents (Scalar by) {
    // set component
    Scalar bp2 = by*by;
    if (bp2 >= 1) {
-      GenVector::Throw(
-                              "Beta Vector supplied to set BoostY represents speed >= c");
+      GenVector_Throw("Beta Vector supplied to set BoostY represents speed >= c");
       return;
    }
    fBeta = by;
@@ -67,8 +66,7 @@ void BoostY::Rectify() {
    // again.
 
    if (fGamma <= 0) {
-      GenVector::Throw (
-                              "Attempt to rectify a boost with non-positive gamma");
+      GenVector_Throw("Attempt to rectify a boost with non-positive gamma");
       return;
    }
    Scalar beta = fBeta;

--- a/math/genvector/src/BoostZ.cxx
+++ b/math/genvector/src/BoostZ.cxx
@@ -33,8 +33,7 @@ void BoostZ::SetComponents (Scalar bz) {
    // set component
    Scalar bp2 = bz*bz;
    if (bp2 >= 1) {
-      GenVector::Throw (
-                              "Beta Vector supplied to set BoostZ represents speed >= c");
+      GenVector_Throw("Beta Vector supplied to set BoostZ represents speed >= c");
       return;
    }
    fBeta = bz;
@@ -68,8 +67,7 @@ void BoostZ::Rectify() {
    // again.
 
    if (fGamma <= 0) {
-      GenVector::Throw (
-                              "Attempt to rectify a boost with non-positive gamma");
+      GenVector_Throw("Attempt to rectify a boost with non-positive gamma");
       return;
    }
    Scalar beta = fBeta;

--- a/math/genvector/src/LorentzRotation.cxx
+++ b/math/genvector/src/LorentzRotation.cxx
@@ -127,15 +127,13 @@ LorentzRotation::Rectify() {
 
    typedef LorentzVector< PxPyPzE4D<Scalar> > FourVector;
    if (fM[kTT] <= 0) {
-      GenVector::Throw (
-                              "LorentzRotation:Rectify(): Non-positive TT component - cannot rectify");
+      GenVector_Throw("LorentzRotation:Rectify(): Non-positive TT component - cannot rectify");
       return;
    }
    FourVector t ( fM[kTX], fM[kTY], fM[kTZ], fM[kTT] );
    Scalar m2 = t.M2();
    if ( m2 <= 0 ) {
-      GenVector::Throw (
-                              "LorentzRotation:Rectify(): Non-timelike time row - cannot rectify");
+      GenVector_Throw("LorentzRotation:Rectify(): Non-timelike time row - cannot rectify");
       return;
    }
    t /= std::sqrt(m2);
@@ -143,9 +141,8 @@ LorentzRotation::Rectify() {
    z = z - z.Dot(t)*t;
    m2 = z.M2();
    if ( m2 >= 0 ) {
-      GenVector::Throw (
-                              "LorentzRotation:Rectify(): Non-spacelike Z row projection - "
-                              "cannot rectify");
+      GenVector_Throw("LorentzRotation:Rectify(): Non-spacelike Z row projection - "
+                      "cannot rectify");
       return;
    }
    z /= std::sqrt(-m2);
@@ -153,9 +150,8 @@ LorentzRotation::Rectify() {
    y = y - y.Dot(t)*t - y.Dot(z)*z;
    m2 = y.M2();
    if ( m2 >= 0 ) {
-      GenVector::Throw (
-                              "LorentzRotation:Rectify(): Non-spacelike Y row projection - "
-                              "cannot rectify");
+      GenVector_Throw("LorentzRotation:Rectify(): Non-spacelike Y row projection - "
+                      "cannot rectify");
       return;
    }
    y /= std::sqrt(-m2);
@@ -163,9 +159,8 @@ LorentzRotation::Rectify() {
    x = x - x.Dot(t)*t - x.Dot(z)*z - x.Dot(y)*y;
    m2 = x.M2();
    if ( m2 >= 0 ) {
-      GenVector::Throw (
-                              "LorentzRotation:Rectify(): Non-spacelike X row projection - "
-                              "cannot rectify");
+      GenVector_Throw("LorentzRotation:Rectify(): Non-spacelike X row projection - "
+                      "cannot rectify");
       return;
    }
    x /= std::sqrt(-m2);


### PR DESCRIPTION
With free functions being added to for the GenVector package in #19618, it will be a problem to find these functions in the ROOT documentation. This is because of a name clash between the GenVector namespace vs the GenVector doxygen group.
Doxygen links to the former, whereas the latter has all the documentation. Since the namespace was only wrapping the Throw function, GenVector::Throw can be replaced by GenVector_Throw, and the namespace can be removed. This should make the doxygen documentation more useful.

