### PR TITLE
[ci] Set `check_connection=OFF` globally

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/global.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global.txt
@@ -34,6 +34,7 @@ builtin_zlib=OFF
 builtin_zstd=OFF
 ccache=ON
 cefweb=OFF
+check_connection=OFF
 clad=ON
 clingtest=OFF
 cocoa=OFF


### PR DESCRIPTION
This way, we are not affected by problems downloading the connection check file from `root.cern`.