### PR TITLE
[ntuple] Allow usage of IMT with `RNTupleParallelWriter`

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
@@ -54,6 +54,9 @@ class RNTupleFillContext {
    friend class RNTupleParallelWriter;
 
 private:
+   /// The page sink's parallel page compression scheduler if IMT is on.
+   /// Needs to be destructed after the page sink is destructed and so declared before.
+   std::unique_ptr<ROOT::Internal::RPageStorage::RTaskScheduler> fZipTasks;
    std::unique_ptr<ROOT::Internal::RPageSink> fSink;
    /// Needs to be destructed before fSink
    std::unique_ptr<ROOT::RNTupleModel> fModel;

--- a/tree/ntuple/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriteOptions.hxx
@@ -148,6 +148,11 @@ performance (with Direct I/O) at a reasonable memory consumption.
 <td>EImplicitMT::kDefault</td>
 <td>
 Whether to use implicit multi-threading to compress pages. Only has an effect if buffered writing is turned on.
+The meaning of EImplicitMT::kDefault depends on the used writer: For the (sequential) RNTupleWriter, it translates
+to EImplicitMT::kOn and the user has to manually disable the use of implicit multi-threading if it is not wanted.
+For the RNTupleParalellWriter, the implementation defaults to EImplicitMT::kOff in order to avoid interference with
+explicit parallelism that might create one RNTupleFillContext per thread. If implicit multi-threading is wanted on
+top of this, the user has to explicitly request EImplicitMT::kOn.
 </td>
 </tr>
 
@@ -178,6 +183,7 @@ class RNTupleWriteOptions {
 public:
    enum class EImplicitMT {
       kOff,
+      kOn,
       kDefault,
    };
 

--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -104,9 +104,6 @@ class RNTupleWriter {
       Internal::CreateRNTupleWriter(std::unique_ptr<ROOT::RNTupleModel>, std::unique_ptr<Internal::RPageSink>);
 
 private:
-   /// The page sink's parallel page compression scheduler if IMT is on.
-   /// Needs to be destructed after the page sink (in the fill context) is destructed and so declared before.
-   std::unique_ptr<Internal::RPageStorage::RTaskScheduler> fZipTasks;
    Experimental::RNTupleFillContext fFillContext;
    Experimental::Detail::RNTupleMetrics fMetrics;
 

--- a/tree/ntuple/src/RNTupleWriter.cxx
+++ b/tree/ntuple/src/RNTupleWriter.cxx
@@ -36,8 +36,8 @@ ROOT::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::RNTupleModel> model,
 #ifdef R__USE_IMT
    if (IsImplicitMTEnabled() &&
        fFillContext.fSink->GetWriteOptions().GetUseImplicitMT() == ROOT::RNTupleWriteOptions::EImplicitMT::kDefault) {
-      fZipTasks = std::make_unique<ROOT::Experimental::Internal::RNTupleImtTaskScheduler>();
-      fFillContext.fSink->SetTaskScheduler(fZipTasks.get());
+      fFillContext.fZipTasks = std::make_unique<ROOT::Experimental::Internal::RNTupleImtTaskScheduler>();
+      fFillContext.fSink->SetTaskScheduler(fFillContext.fZipTasks.get());
    }
 #endif
    // Observe directly the sink's metrics to avoid an additional prefix from the fill context.

--- a/tree/ntuple/src/RNTupleWriter.cxx
+++ b/tree/ntuple/src/RNTupleWriter.cxx
@@ -35,7 +35,7 @@ ROOT::RNTupleWriter::RNTupleWriter(std::unique_ptr<ROOT::RNTupleModel> model,
 {
 #ifdef R__USE_IMT
    if (IsImplicitMTEnabled() &&
-       fFillContext.fSink->GetWriteOptions().GetUseImplicitMT() == ROOT::RNTupleWriteOptions::EImplicitMT::kDefault) {
+       fFillContext.fSink->GetWriteOptions().GetUseImplicitMT() != ROOT::RNTupleWriteOptions::EImplicitMT::kOff) {
       fFillContext.fZipTasks = std::make_unique<ROOT::Experimental::Internal::RNTupleImtTaskScheduler>();
       fFillContext.fSink->SetTaskScheduler(fFillContext.fZipTasks.get());
    }


### PR DESCRIPTION
Contrary to the (sequential) `RNTupleWriter`, it is off by default and has to be explicitly requested by the user. This avoids interference with explicit parallelism by increasing memory usage and additional memory copies that can result in overall worse performance.

Closes #18398

FYI @Dr15Jones 