### PR TITLE
[ci] Enable ASAN special build that does not halt

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -385,7 +385,9 @@ jobs:
           - image: ubuntu22
             overrides: ["imt=Off", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2404
-            overrides: ["CMAKE_BUILD_TYPE=Debug"]
+            is_special: true
+            property: ASAN
+            overrides: ["CMAKE_BUILD_TYPE=Debug", "asan=ON"]
           - image: ubuntu2504
             overrides: ["CMAKE_CXX_STANDARD=23"]
           # Disable until binutils 2.45-5 is part of the distro, as it fixes the ".cfi_escape with op" warning.

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -197,7 +197,7 @@ option(minimal "Enable only required options by default" OFF)
 option(rootbench "Build rootbench if rootbench exists in root or if it is a sibling directory." OFF)
 option(roottest "Build roottest if roottest exists in root or if it is a sibling directory." OFF)
 option(testing "Enable testing with CTest" OFF)
-option(asan "Build ROOT with address sanitizer instrumentation" OFF)
+option(asan "Build ROOT with address sanitizer instrumentation (only GCC or Clang)" OFF)
 
 set(gcctoolchain "" CACHE PATH "Set path to GCC toolchain used to build llvm/clang")
 

--- a/core/sanitizer/SanitizerSetup.cxx
+++ b/core/sanitizer/SanitizerSetup.cxx
@@ -31,7 +31,8 @@ const char* __asan_default_options() {
          ":detect_container_overflow=1"
          ":alloc_dealloc_mismatch=0"
          DETECT_LEAKS
-         ":verify_asan_link_order=0";
+         ":verify_asan_link_order=0"
+         ":halt_on_error=0";
 }
 
 /// Default options when leak sanitizer starts up in ROOT exectuables.


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

If it succeeds, before merging, implement this to happen only if "asan build" flag is specified in GitHub via this yml statement:

`    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'asan build')`

Since asan build take many hours.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

