### PR TITLE
[cling][AST] Desugar TemplateName before fully qualifying it

### DIFF
--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -849,7 +849,14 @@ namespace utils {
 
     if (arg.getKind() == TemplateArgument::Template) {
       TemplateName tname = arg.getAsTemplate();
-      // Note: should we not also desugar?
+      // Desugar before fully qualifying.
+      if (std::optional<TemplateName> UnderlyingOrNone =
+              tname.desugar(/*IgnoreDeduced=*/false)) {
+        if (*UnderlyingOrNone != tname) {
+          tname = *UnderlyingOrNone;
+          changed = true;
+        }
+      }
       changed = GetFullyQualifiedTemplateName(Ctx, tname);
       if (changed) {
         arg = TemplateArgument(tname);
@@ -1286,8 +1293,20 @@ namespace utils {
 
         if (I->getKind() == TemplateArgument::Template) {
           TemplateName tname = I->getAsTemplate();
-          // Note: should we not also desugar?
-          bool changed = GetFullyQualifiedTemplateName(Ctx, tname);
+          bool changed = false;
+
+          // In some case tname can be unqualified, desugar first.
+          // The following example fixed:
+          // __common_pool_policy<__pool,true> ->
+          // __common_pool_policy<__gnu_cxx::__pool, true>
+          if (std::optional<TemplateName> UnderlyingOrNone =
+                  tname.desugar(/*IgnoreDeduced=*/false)) {
+            if (*UnderlyingOrNone != tname) {
+              tname = *UnderlyingOrNone;
+              changed = true;
+            }
+          }
+          changed |= GetFullyQualifiedTemplateName(Ctx, tname);
           if (changed) {
             desArgs.push_back(TemplateArgument(tname));
             mightHaveChanged = true;


### PR DESCRIPTION
TemplateArgument can return a QualType that may contain unqualified parts.

Before (incorrect):
  __gnu_cxx::__common_pool_policy<__pool, true>

After (correct):
  __gnu_cxx::__common_pool_policy<__gnu_cxx::__pool, true>

This appeared during LLVM20 upgrade in normalization of types like:

`LHCb::FastAllocVector<int,__gnu_cxx::__mt_alloc<int,__gnu_cxx::__common_pool_policy<__gnu_cxx::__pool,true>`

# This Pull request:


## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

