### PR TITLE
[test] reset branch address before pointer goes out of scope

### DIFF
--- a/roottest/root/io/customCollection/execWriteCustomCollection.cxx
+++ b/roottest/root/io/customCollection/execWriteCustomCollection.cxx
@@ -146,8 +146,9 @@ int execWriteCustomCollection() {
       tree->SetBranchAddress("coll",&tvp);
       tree->GetEntry(0);
       if (tvp) tvp->Print();
+      tree->Scan();
+      tree->ResetBranchAddresses(); // since tvp pointer goes out of scope
    }
-   tree->Scan();
    delete file;
 
    printf("Reading file with just a TTree\n");
@@ -158,8 +159,9 @@ int execWriteCustomCollection() {
       tree->SetBranchAddress("coll",&tvp);
       tree->GetEntry(0);
       if (tvp) tvp->Print();
+      tree->Scan();
+      tree->ResetBranchAddresses(); // since tvp pointer goes out of scope
    }
-   tree->Scan();
    delete file;
 
    return 0;


### PR DESCRIPTION
and do not call scan if tree is nullptr

Found out by asan in https://github.com/root-project/root/actions/runs/16941754812/job/48012438974?pr=19636