### PR TITLE
[Python] Remove all code related to `CLING_STANDARD_PCH` check

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/python/cppyy/__init__.py
+++ b/bindings/pyroot/cppyy/cppyy/python/cppyy/__init__.py
@@ -56,20 +56,6 @@ import sys
 import sysconfig
 import warnings
 
-if not 'CLING_STANDARD_PCH' in os.environ:
-    def _set_pch():
-        try:
-            import cppyy_backend as cpb
-            local_pch = os.path.join(
-                    os.path.dirname(__file__), 'allDict.cxx.pch.'+str(cpb.__version__))
-            if os.path.exists(local_pch):
-                os.putenv('CLING_STANDARD_PCH', local_pch)
-                os.environ['CLING_STANDARD_PCH'] = local_pch
-        except (ImportError, AttributeError):
-            pass
-    _set_pch()
-    del _set_pch
-
 try:
     import __pypy__
     del __pypy__

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -12,9 +12,6 @@ import importlib
 import os
 import sys
 
-# Prevent cppyy's check for the PCH
-os.environ["CLING_STANDARD_PCH"] = "none"
-
 # Prevent cppyy's check for extra header directory
 os.environ["CPPYY_API_PATH"] = "none"
 

--- a/roottest/python/basic/CMakeLists.txt
+++ b/roottest/python/basic/CMakeLists.txt
@@ -9,14 +9,12 @@ if(NOT MSVC OR win_broken_tests)
                     MACRO PyROOT_datatypetest.py
                     COPY_TO_BUILDDIR DataTypes.C DataTypes.h
                     PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ DataTypes.C+
-                    FIXTURES_SETUP python-basic-datatype-fixture
-                    ENVIRONMENT CLING_STANDARD_PCH=none)
+                    FIXTURES_SETUP python-basic-datatype-fixture)
 
   ROOTTEST_ADD_TEST(datatype-numpy
                     MACRO PyROOT_datatypetest_numpy.py
                     FIXTURES_REQUIRED python-basic-datatype-fixture
-                    PYTHON_DEPS numpy
-                    ENVIRONMENT CLING_STANDARD_PCH=none)
+                    PYTHON_DEPS numpy)
 endif()
 
   ROOTTEST_ADD_TEST(operator
@@ -28,7 +26,6 @@ if(NOT MSVC OR win_broken_tests)
   ROOTTEST_ADD_TEST(overload
                     MACRO PyROOT_overloadtests.py
                     COPY_TO_BUILDDIR Overloads.C Overloads.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+
-                    ENVIRONMENT CLING_STANDARD_PCH=none)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ Overloads.C+)
 endif()
 endif()

--- a/roottest/python/cling/CMakeLists.txt
+++ b/roottest/python/cling/CMakeLists.txt
@@ -3,8 +3,7 @@ if(ROOT_pyroot_FOUND)
   ROOTTEST_ADD_TEST(api
                     MACRO ${api_macro_file}
                     WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    OUTREF PyAPITest.ref
-                    ENVIRONMENT CLING_STANDARD_PCH=none)
+                    OUTREF PyAPITest.ref)
 
   # TPython::LoadMacro and TPython::Import are broken in the new Cppyy
   # https://bitbucket.org/wlav/cppyy/issues/65
@@ -14,8 +13,7 @@ if(ROOT_pyroot_FOUND)
       ROOTTEST_ADD_TEST(class MACRO
                         runPyClassTest.C
                         WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                        OUTREF PyClassTest.ref
-                        ENVIRONMENT CLING_STANDARD_PCH=none)
+                        OUTREF PyClassTest.ref)
     endif()
   endif()
 

--- a/roottest/python/regression/CMakeLists.txt
+++ b/roottest/python/regression/CMakeLists.txt
@@ -21,8 +21,7 @@ endif()
   ROOTTEST_ADD_TEST(root_6023
                     MACRO exec_root_6023.py
                     COPY_TO_BUILDDIR root_6023.h
-                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ root_6023.h+
-                    ENVIRONMENT CLING_STANDARD_PCH=none)
+                    PRECMD ${ROOT_root_CMD} -b -q -l -e .L\ root_6023.h+)
 
   ROOTTEST_ADD_TEST(gh_16406
                     MACRO gh_16406.py

--- a/roottest/root/meta/tclass/regression/CMakeLists.txt
+++ b/roottest/root/meta/tclass/regression/CMakeLists.txt
@@ -9,8 +9,7 @@ ROOTTEST_ADD_TEST(execNormalizationInf
 if(pyroot)
     ROOTTEST_ADD_TEST(execNormalizationInfPy
                   MACRO execNormalizationInf.py
-                  OUTREF execNormalizationInf.py.ref
-                  ENVIRONMENT CLING_STANDARD_PCH=none)
+                  OUTREF execNormalizationInf.py.ref)
 endif()
 
 ROOTTEST_ADD_TEST(6038


### PR DESCRIPTION
Follows up on #19470, where the Python part of the cppyy backend was removed from ROOT. That means we should also not run the function in `cppyy` that tries to import it.

Also, any code that manipulates the `CLING_STANDARD_PCH` environment variable can be removed, as this variable was only relevant for the Python libs of the cppyy backend.

Closes #19505 and fixes `import cppyy` with ROOT master.