### PR TITLE
[tutorials] Don't import TensorFlow before ROOT

### DIFF
--- a/tutorials/machine_learning/RBatchGenerator_TensorFlow.py
+++ b/tutorials/machine_learning/RBatchGenerator_TensorFlow.py
@@ -8,8 +8,11 @@
 ### \macro_output
 ### \author Dante Niewenhuis
 
-import tensorflow as tf
 import ROOT
+
+# TensorFlow has to be imported after ROOT to avoid LLVM symbol clashes if ROOT
+# was built with LLVM in Debug mode and TensorFlow>=2.20.0.
+import tensorflow as tf
 
 tree_name = "sig_tree"
 file_name = str(ROOT.gROOT.GetTutorialDir()) + "/machine_learning/data/Higgs_data.root"

--- a/tutorials/machine_learning/TMVA_CNN_Classification.py
+++ b/tutorials/machine_learning/TMVA_CNN_Classification.py
@@ -22,21 +22,24 @@
 ## The difference between signal and background is in the gaussian width.
 ## The width for the background gaussian is slightly larger than the signal width by few % values
 
+import ROOT
+
 import os
 import importlib.util
 
+useKerasCNN = False
+
+if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
+    useKerasCNN = True
+
 opt = [1, 1, 1, 1, 1]
 useTMVACNN = opt[0] if len(opt) > 0  else False
-useKerasCNN = opt[1] if len(opt) > 1 else False
+useKerasCNN = opt[1] if len(opt) > 1 else useKerasCNN
 useTMVADNN = opt[2] if len(opt) > 2 else False
 useTMVABDT = opt[3] if len(opt) > 3 else False
 usePyTorchCNN = opt[4] if len(opt) > 4 else False
 
-tf_spec = importlib.util.find_spec("tensorflow")
-if tf_spec is None:
-    useKerasCNN = False
-    print("TMVA_CNN_Classificaton","Skip using Keras since tensorflow is not installed")
-else:
+if useKerasCNN:
     try:
       import tensorflow
     except:

--- a/tutorials/machine_learning/TMVA_RNN_Classification.py
+++ b/tutorials/machine_learning/TMVA_RNN_Classification.py
@@ -152,17 +152,16 @@ maxepochs = 10
 
 nTotEvts = 2000  # total events to be generated for signal or background
 
-useKeras = True
+useKeras = False
 
 useTMVA_RNN = True
 useTMVA_DNN = True
 useTMVA_BDT = False
 
-tf_spec = importlib.util.find_spec("tensorflow")
-if tf_spec is None:
-   useKeras = False
-   ROOT.Warning("TMVA_RNN_Classificaton","Skip using Keras since tensorflow is not installed")
-else:
+if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
+    useKeras = True
+
+if useKeras:
    try:
       import tensorflow
    except:


### PR DESCRIPTION
TensorFlow has to be imported after ROOT to avoid LLVM symbol clashes if
ROOT was built with LLVM in Debug mode and TensorFlow>=2.20.0.