### PR TITLE
[RF] Don't warn about duplicates in temporary RooArgSet in RealIntegral

### DIFF
--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -399,7 +399,12 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   RooArgSet branchListVD;
   branchListVD.reserve(branchListVDAll.size());
   for (RooAbsArg *branch : branchListVDAll) {
-    if (branch != &function) branchListVD.add(*branch);
+    if (branch != &function) {
+      // The branchListVDAll is a RooArgList, so it's not de-duplicated yet.
+      // Add elements to the branchListVD with the "silent" flag, so it
+      // de-duplicates while adding without printing errors.
+      branchListVD.add(*branch, /*silent=*/true);
+    }
   }
 
   for (auto branch: branchList) {


### PR DESCRIPTION
Adding duplicates to a RooArgSet is intended in this case, profiting from the automatic de-duplication. But that means the duplicate errors should be suppressed with the "silent" flag.

Thanks to the following forum post for spotting this problem: https://root-forum.cern.ch/t/ownership-errors-generating-data-from-morphed-pdfs/64028