### PR TITLE
RooFit: Fix plotOn normalization for extended PDFs

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2146,7 +2146,21 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
         scaleFactor *= rangeNevt/nExpected ;
 
       } else {
-        scaleFactor *= frame->getFitRangeNEvt()/nExpected ;
+        // First, check if the PDF *can* be extended.
+        if (this->canBeExtended()) {
+            // If it can, get the expected events.
+            const double nExp = expectedEvents(frame->getNormVars());
+            if (nExp > 0) {
+                // If the prediction is valid, use it for normalization.
+                scaleFactor *= nExp / nExpected;
+            } else {
+                // If prediction is not valid (e.g. 0), fall back to data.
+                scaleFactor *= frame->getFitRangeNEvt() / nExpected;
+            }
+        } else {
+            // If the PDF can't be extended, just use the data.
+            scaleFactor *= frame->getFitRangeNEvt() / nExpected;
+        }
       }
     } else if (stype==RelativeExpected) {
       scaleFactor *= nExpected ;


### PR DESCRIPTION
# This Pull Request:

## Changes or fixes:

This PR fixes an issue where the `plotOn` function incorrectly normalizes an extended PDF to the number of events in a dataset, rather than to its own predicted number of events. This behavior is misleading when the PDF's normalization is a key part of the model's prediction.

The default logic in `RooAbsPdf::plotOn` is modified to check if a PDF is extended by calling `expectedEvents()`. If it is, the function now uses the PDF's prediction for normalization; otherwise, it retains the old behavior of scaling to the data for non-extended PDFs.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

## Testing 
I have verified this fix locally with several tests:

1.  **Reproducer Script:** Confirmed that for an extended PDF, the plotted curve is now normalized to the PDF's `expectedEvents()`.

    ```cpp
    #include "RooRealVar.h"
    #include "RooUniform.h"
    #include "RooDataSet.h"
    #include "RooExtendPdf.h"
    #include "RooPlot.h"
    #include "TCanvas.h"
    #include "RooCurve.h"
    #include <iostream>
    #include <memory>

    void reproducer() {
        RooRealVar x{"x", "x", 0, 1};
        RooRealVar n{"n", "n", 5000, 0, 20000};
        x.setBins(1);
        RooUniform pdf{"pdf", "pdf", x};
        std::unique_ptr<RooAbsData> data{pdf.generateBinned(x, 10000)};
        RooExtendPdf extPdf{"ext_pdf", "ext_pdf", pdf, n};
        auto c1 = new TCanvas{"c1", "c1"};
        auto frame = x.frame();
        data->plotOn(frame);
        extPdf.plotOn(frame);
        std::cout << frame->getCurve()->GetY()[0] << std::endl;
        frame->Draw();
        c1->SaveAs("plot.png");
    }
    ```
<img width="700" height="475" alt="image" src="https://github.com/user-attachments/assets/d09111a9-85f7-423c-8b8c-be5be6922b9e" />

2.  **Regression Test:** Confirmed that for a standard, non-extended `RooGaussian`, the plotted curve is still correctly scaled to the data.

```cpp
#include "RooRealVar.h"
#include "RooGaussian.h"
#include "RooDataSet.h"
#include "RooPlot.h"
#include "TCanvas.h"
#include "RooConstVar.h" 
#include <memory>

void regression_test() {
    // This script checks that non-extended PDFs still
    // correctly scale to the data.

    RooRealVar x("x", "x", -10, 90);
    x.setBins(10);

    // Create the mean and sigma as named RooConstVar objects first
    RooConstVar mean("mean", "mean", 6.0);
    RooConstVar sigma("sigma", "sigma", 3.0);

    // Now pass these named objects to the constructor
    RooGaussian pdf("pdf", "pdf", x, mean, sigma);

    // A dataset with 500 events.
    std::unique_ptr<RooDataSet> data{pdf.generate(x, 500)};

    // Plot both.
    TCanvas* c1 = new TCanvas("c1", "c1");
    RooPlot* frame = x.frame();
    data->plotOn(frame);
    pdf.plotOn(frame); // The curve should scale to the data.

    frame->Draw();
    c1->SaveAs("regression_test.png");
}
```

<img width="700" height="475" alt="image" src="https://github.com/user-attachments/assets/9768c003-5f02-4b83-a98e-cfb519798b52" />

3.  **Comprehensive Test:** A single script was run to verify the default behavior and the `RelativeExpected` and `NumEvent` normalization overrides. The results are shown in the plot below, and all components behave as expected.
```cpp
#include "RooRealVar.h"
#include "RooGaussian.h"
#include "RooExtendPdf.h"
#include "RooDataSet.h"
#include "RooPlot.h"
#include "TCanvas.h"
#include "RooConstVar.h"
#include <memory>

void reproducer() {
    TCanvas* c1 = new TCanvas("c1", "Comprehensive plotOn Test", 1200, 400);
    c1->Divide(3, 1); // Create a 3x1 grid of plots

    // --- Common variables for all tests ---
    RooRealVar x("x", "x", 0, 10);
    x.setBins(20);

    // --- Test 1: Default behavior for NON-EXTENDED PDF ---
    c1->cd(1); // Move to the first pad
    RooPlot* frame1 = x.frame(RooFit::Title("Test 1: Default (Non-Extended)"));
    
    RooConstVar mean1("mean1", "mean1", 5.0);
    RooConstVar sigma1("sigma1", "sigma1", 1.0);
    RooGaussian pdf1("pdf1", "pdf1", x, mean1, sigma1);
    
    std::unique_ptr<RooDataSet> data1{pdf1.generate(x, 1000)};
    
    data1->plotOn(frame1);
    pdf1.plotOn(frame1); // Should scale to 1000 events in data
    frame1->Draw();

    // --- Test 2: RelativeExpected behavior for EXTENDED PDF ---
    c1->cd(2); // Move to the second pad
    RooPlot* frame2 = x.frame(RooFit::Title("Test 2: RelativeExpected"));

    RooRealVar n2("n2", "n2", 2000); // PDF predicts 2000 events
    RooExtendPdf pdf2("pdf2", "pdf2", pdf1, n2);

    // Create dummy data with a DIFFERENT number of events
    std::unique_ptr<RooDataSet> data2{pdf1.generate(x, 5000)};

    data2->plotOn(frame2);
    // Explicitly ask to scale to the PDF's own prediction
    pdf2.plotOn(frame2, RooFit::Normalization(1.0, RooAbsPdf::RelativeExpected));
    frame2->Draw();

    // --- Test 3: NumEvent behavior ---
    c1->cd(3); // Move to the third pad
    RooPlot* frame3 = x.frame(RooFit::Title("Test 3: NumEvent"));

    // Use the same non-extended pdf1 and data1
    data1->plotOn(frame3);
    // Explicitly scale the PDF to a specific number of events (e.g., 2500)
    pdf1.plotOn(frame3, RooFit::Normalization(2500, RooAbsPdf::NumEvent));
    frame3->Draw();

    c1->SaveAs("full_test.png");
}
```
<img width="1200" height="375" alt="image" src="https://github.com/user-attachments/assets/795863ba-2301-499b-8006-6cf65babe77a" />

Fixes #18929