### PR TITLE
[roottest] Remove OS-specific workarounds

### DIFF
--- a/roottest/cmake/modules/RoottestCTest.cmake
+++ b/roottest/cmake/modules/RoottestCTest.cmake
@@ -58,39 +58,3 @@ set(ClingWorkAroundNoPrivateClassIO                 TRUE)      # See https://sft
 set(ClingWorkAroundUnnamedDetection2                TRUE)      # See https://sft.its.cern.ch/jira/browse/ROOT-8025
 
 set(PYROOT_EXTRAFLAGS --fixcling)
-
-# set ROOTTEST_OS_ID
-if(APPLE)
-  execute_process(COMMAND sw_vers "-productVersion"
-                  COMMAND cut -d . -f 1-2
-                  OUTPUT_VARIABLE osvers OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(ROOTTEST_OS_ID MacOSX)
-  set(ROOTTEST_OS_VERSION ${osvers})
-elseif(WIN32)
-  set(ROOTTEST_OS_ID Windows)
-else()
-  execute_process(COMMAND lsb_release -is OUTPUT_VARIABLE osid OUTPUT_STRIP_TRAILING_WHITESPACE)
-  execute_process(COMMAND lsb_release -rs OUTPUT_VARIABLE osvers OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(osid MATCHES Ubuntu)
-    string(REGEX REPLACE "([0-9]+)[.].*" "\\1" osvers "${osvers}")
-    set(ROOTTEST_OS_ID Ubuntu)
-    set(ROOTTEST_OS_VERSION ${osvers})
-  elseif(osid MATCHES Scientific)
-    string(REGEX REPLACE "([0-9]+)[.].*" "\\1" osvers "${osvers}")
-    set(ROOTTEST_OS_ID Scientific)
-    set(ROOTTEST_OS_VERSION ${osvers})
-  elseif(osid MATCHES Fedora)
-    string(REGEX REPLACE "([0-9]+)" "\\1" osvers "${osvers}")
-    set(ROOTTEST_OS_ID Fedora)
-    set(ROOTTEST_OS_VERSION ${osvers})
-  elseif(osid MATCHES CentOS)
-    string(REGEX REPLACE "([0-9]+)[.].*" "\\1" osvers "${osvers}")
-    set(ROOTTEST_OS_ID CentOS)
-    set(ROOTTEST_OS_VERSION ${osvers})
-  else()
-    string(REGEX REPLACE "([0-9]+)[.].*" "\\1" osvers "${osvers}")
-    set(ROOTTEST_OS_ID ${osid})
-    set(ROOTTEST_OS_VERSION ${osvers})
-  endif()
-endif()
-

--- a/roottest/root/core/CMakeLists.txt
+++ b/roottest/root/core/CMakeLists.txt
@@ -30,11 +30,6 @@ ROOTTEST_ADD_TEST(assertROOT8542
                   MACRO assertROOT8542.C
                   )
 
-
-if(OPENGL_gl_LIBRARY AND ROOTTEST_OS_ID MATCHES Scientific|CentOS|Ubuntu|Fedora)
-   set(ROOTTEST_ENV_EXTRA LD_PRELOAD=${OPENGL_gl_LIBRARY})
-endif()
-
 ROOTTEST_ADD_TEST(execStatusBitsCheck
                   MACRO execStatusBitsCheck.C
                   OUTCNV ../html/MakeIndex_convert.sh

--- a/roottest/root/dataframe/CMakeLists.txt
+++ b/roottest/root/dataframe/CMakeLists.txt
@@ -4,11 +4,6 @@ endif()
 
 ROOTTEST_ADD_TESTDIRS()
 
-# Workaround (k)ubuntu bug: runtime issue when using pthread and gcc48
-if(ROOTTEST_OS_ID MATCHES Ubuntu)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
-endif()
-
 set(DFLIBRARIES Core RIO Hist Tree MathCore TreePlayer ROOTDataFrame ROOTVecOps ROOTNTuple)
 
 # ROOT-9975

--- a/roottest/root/html/CMakeLists.txt
+++ b/roottest/root/html/CMakeLists.txt
@@ -11,10 +11,6 @@ ROOTTEST_ADD_TEST(runFindSource
                   MACRO runFindSource.C
                   WILLFAIL
                   OUTREF FindSource.ref)
-                  
-if(OPENGL_gl_LIBRARY AND ROOTTEST_OS_ID MATCHES Scientific|CentOS|Ubuntu|Fedora)
-  set(ROOTTEST_ENV_EXTRA LD_PRELOAD=${OPENGL_gl_LIBRARY})
-endif()
 
 ROOTTEST_ADD_TEST(runMakeIndex
                   MACRO runMakeIndex.C

--- a/roottest/root/meta/loadAllLibs/CMakeLists.txt
+++ b/roottest/root/meta/loadAllLibs/CMakeLists.txt
@@ -1,8 +1,3 @@
-
-if(OPENGL_gl_LIBRARY AND ROOTTEST_OS_ID MATCHES Scientific|CentOS|Ubuntu|Fedora)
-  set(ROOTTEST_ENV_EXTRA LD_PRELOAD=${OPENGL_gl_LIBRARY})
-endif()
-
 foreach( t LoadAllLibs LoadAllLibsAZ LoadAllLibsZA)
   ROOTTEST_ADD_TEST(${t} MACRO assert${t}.C FAILREGEX "Error in|rc = -1")
 endforeach()

--- a/roottest/root/multicore/CMakeLists.txt
+++ b/roottest/root/multicore/CMakeLists.txt
@@ -1,8 +1,3 @@
-# Workaround (k)ubuntu bug: runtime issue when using pthread and gcc48
-if(ROOTTEST_OS_ID MATCHES Ubuntu)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
-endif()
-
 if(UNIX AND 32BIT)
   # linux32 llvm-JIT ABI issue constructing the pair of map<tthread::id, uint>.
   # Compile instead.


### PR DESCRIPTION
These workarounds are probably not needed anymore, and the CMake code that figues out the `ROOTTEST_OS_ID` with command line tools that are not always available. For example, `sw_vers` is only available when using XCode, and the CMake configuration fails otherwise. The `lsb_release` is also not standard.