### PR TITLE
[core] Generalize TROOT::GetLibDir()

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -207,6 +207,21 @@ target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
+if(ROOT_NEED_STDCXXFS)
+    target_link_libraries(Core PRIVATE stdc++fs)
+endif()
+
+# This code about the LIB_CORE_NAME define is important for TROOT::GetLibDir()
+get_target_property(core_prefix Core PREFIX)
+get_target_property(core_suffix Core SUFFIX)
+get_target_property(core_soversion Core SOVERSION)
+if(core_soversion)
+    set(full_core_filename "${core_prefix}Core${core_suffix}.${core_soversion}")
+else()
+    set(full_core_filename "${core_prefix}Core${core_suffix}")
+endif()
+target_compile_options(Core PRIVATE -DLIB_CORE_NAME=${full_core_filename})
+
 if(PCRE2_FOUND)
   target_link_libraries(Core PRIVATE PCRE2::PCRE2)
   set_source_files_properties(src/TPRegexp.cxx

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -5111,6 +5111,19 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
 #endif
 
 #if defined(R__LINUX)
+
+namespace {
+bool parseLine(TString &s, const char *prefix, Int_t &field)
+{
+   if (s.BeginsWith(prefix)) {
+      TPRegexp{"^.+: *([^ ]+).*"}.Substitute(s, "$1");
+      field = (s.Atoi() / 1024);
+      return true;
+   }
+   return false;
+};
+} // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Get system info for Linux. Only fBusSpeed is not set.
 
@@ -5124,17 +5137,9 @@ static void GetLinuxSysInfo(SysInfo_t *sysinfo)
             TPRegexp("^.+: *(.*$)").Substitute(s, "$1");
             sysinfo->fModel = s;
          }
-         if (s.BeginsWith("cpu MHz")) {
-            TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-            sysinfo->fCpuSpeed = s.Atoi();
-         }
-         if (s.BeginsWith("cache size")) {
-            TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-            sysinfo->fL2Cache = s.Atoi();
-         }
-         if (s.BeginsWith("processor")) {
-            TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-            sysinfo->fCpus = s.Atoi();
+         parseLine(s, "cpu MHz", sysinfo->fCpuSpeed);
+         parseLine(s, "cache size", sysinfo->fL2Cache);
+         if (parseLine(s, "processor", sysinfo->fCpus)) {
             sysinfo->fCpus++;
          }
       }
@@ -5144,9 +5149,7 @@ static void GetLinuxSysInfo(SysInfo_t *sysinfo)
    f = fopen("/proc/meminfo", "r");
    if (f) {
       while (s.Gets(f)) {
-         if (s.BeginsWith("MemTotal")) {
-            TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-            sysinfo->fPhysRam = (s.Atoi() / 1024);
+         if (parseLine(s, "MemTotal", sysinfo->fPhysRam)) {
             break;
          }
       }
@@ -5225,49 +5228,20 @@ static void GetLinuxMemInfo(MemInfo_t *meminfo)
 {
    TString s;
    FILE *f = fopen("/proc/meminfo", "r");
-   if (!f) return;
+   if (!f)
+      return;
+
    while (s.Gets(f)) {
-      if (s.BeginsWith("MemTotal")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemTotal = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("MemFree")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemFree = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("MemAvailable")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemAvailable = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("Cached")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemCached = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("Buffers")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemBuffer = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("Shmem")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fMemShared = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("SwapTotal")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fSwapTotal = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("SwapFree")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fSwapFree = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("SwapCached")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fSwapCached = (s.Atoi() / 1024);
-      }
-      if (s.BeginsWith("SReclaimable")) {
-         TPRegexp("^.+: *([^ ]+).*").Substitute(s, "$1");
-         meminfo->fSReclaimable = (s.Atoi() / 1024);
-      }
-      
+      parseLine(s, "MemTotal", meminfo->fMemTotal);
+      parseLine(s, "MemFree", meminfo->fMemFree);
+      parseLine(s, "MemAvailable", meminfo->fMemAvailable);
+      parseLine(s, "Cached", meminfo->fMemCached);
+      parseLine(s, "Buffers", meminfo->fMemBuffer);
+      parseLine(s, "Shmem", meminfo->fMemShared);
+      parseLine(s, "SwapTotal", meminfo->fSwapTotal);
+      parseLine(s, "SwapFree", meminfo->fSwapFree);
+      parseLine(s, "SwapCached", meminfo->fSwapCached);
+      parseLine(s, "SReclaimable", meminfo->fSReclaimable);
    }
    fclose(f);
 


### PR DESCRIPTION
The problem with `TROOT::GetLibDir()` was that it either hardcodes the install directory inside it if `ROOTLIBDIR` was set (which is the case for `gnuinstall=ON`), or it assumes that it's always called `lib` and is inside the `$ROOTSYS`, which might or might not be set. This is broken if the `CMAKE_INSTALL_LIBDIR` is different from the default `lib`.

This commit suggests to automatically figure out the ROOT library directory instead.

Closes the following JIRA ticket:
https://its.cern.ch/jira/browse/ROOT-9569