### PR TITLE
[CMake] Don't cache `CPPINTEROP_INCLUDE_DIRS` and `CLING_INCLUDE_DIRS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,9 @@ unset(artifact_files)
 
 add_custom_target(move_artifacts DEPENDS ${stamp_file} ${all_artifacts})
 
+if(builtin_cling)
+    set(CLING_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
+endif()
 
 #---Add the main sources ---------------------------------
 add_subdirectory (interpreter)

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(MetaCling SYSTEM PRIVATE
   ${CLANG_INCLUDE_DIRS}
   ${LLVM_INCLUDE_DIRS}
   ${CLAD_INCLUDE_DIRS}
-  ${CPPINTEROP_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/interpreter/CppInterOp/include
 )
 
 target_include_directories(MetaCling PRIVATE

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -467,8 +467,6 @@ if (builtin_cling)
   add_subdirectory(cling EXCLUDE_FROM_ALL)
   add_dependencies(CLING ${CLING_LIBRARIES})
 
-  set(CLING_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/cling/include CACHE STRING "")
-
 
 
   #---These are the libraries that we link ROOT with CLING---------------------------
@@ -543,11 +541,6 @@ mark_as_advanced(FORCE BUG_REPORT_URL BUILD_CLANG_FORMAT_VS_PLUGIN BUILD_SHARED_
 mark_as_advanced(CLEAR LLVM_ENABLE_ASSERTIONS LLVM_BUILD_TYPE)
 
 ##################### LIBINTEROP ###########################
-
-#---Set InterOp include directories, for any ROOT component that requires the headers--------------------------------------------------------
-set(CPPINTEROP_INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}/CppInterOp/include
-  CACHE STRING "CppInterOp include directories.")
 
 #---Set InterOp to build on Cling, this can be toggled to use Clang-REPL-------------------------------------------------------
 set(CPPINTEROP_USE_CLING ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Cached variables end up in `root-config --config`, and we don't want to have absolute paths to the bulid directory inside its output.

After this change, no trace of the full ROOT source or build directory path is left in the output of `root-config --config`.

Closes https://its.cern.ch/jira/browse/ROOT-9481