### PR TITLE
[tutorials] Make ttree tutorials independent of test files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,6 @@ if(roofit)
 endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
-ROOT_ADD_TEST_SUBDIRECTORY(tutorials)
 
 # Each subdirectory added above will register headers to be copied to the build tree.
 # Here, the copy targets are created:
@@ -573,6 +572,8 @@ if(runtime_cxxmodules)
   set_property(TARGET modules_idx PROPERTY modules_idx_file ${library_output_dir}/modules.idx)
   set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${library_output_dir}/modules.timestamp")
 endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(tutorials)
 
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
 add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -20,9 +20,11 @@ if(DEFINED ROOT_SOURCE_DIR)  # Testing using the binary tree
     set(ROOT_environ PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}
                      ${ld_library_path}=${CMAKE_BINARY_DIR}/lib:$ENV{${ld_library_path}}
                      ROOTSYS=${CMAKE_BINARY_DIR}
+                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree
                      PYTHONPATH=${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH})
   else()
     set(ROOT_environ ROOTSYS=${CMAKE_BINARY_DIR}
+                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree
                      PYTHONPATH=${CMAKE_BINARY_DIR}/bin;$ENV{PYTHONPATH})
   endif()
 else()                       # testing using an installation
@@ -423,7 +425,6 @@ set(extra_veto
   io/tree/hsimpleProxy.C # A driver uses this macro which cannot be executed directly
   io/tree/tree103_tree.C
   io/tree/tree106_tree.C
-  io/tree/tree108_tree.C
   roofit/roostats/rs401d_FeldmanCousins.C  # Takes too much time
   roofit/roostats/rs401d_FeldmanCousins.py
   roofit/histfactory/ModifyInterpolation.C
@@ -436,6 +437,11 @@ set(extra_veto
   visualisation/eve7/*.C
   math/r/rootlogon.C
   roofit/roostats/StandardFrequentistDiscovery.C)
+
+configure_file(${CMAKE_SOURCE_DIR}/test/Event.h ${CMAKE_BINARY_DIR}/tutorials/io/tree/Event.h COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/test/Event.cxx ${CMAKE_BINARY_DIR}/tutorials/io/tree/Event.cxx COPYONLY)
+install(FILES ${CMAKE_SOURCE_DIR}/test/Event.h ${CMAKE_SOURCE_DIR}/test/Event.cxx
+        DESTINATION ${CMAKE_INSTALL_TUTDIR}/io/tree COMPONENT tests)
 
 if(MSVC)
   # disable run_h1analysis.C because of Endpoint Security HTTP traffic scanning,
@@ -549,6 +555,9 @@ set(io-xml-xmlmodifyfile-depends tutorial-io-xml-xmlnewfile)
 set(io-xml-xmlreadfile-depends tutorial-io-xml-xmlnewfile)
 set(roofit-roofit-rf503_wspaceread-depends tutorial-roofit-roofit-rf502_wspacewrite)
 set(io-readCode-depends tutorial-io-importCode)
+set(io-tree-tree110_copy-depends tutorial-io-tree-tree108_tree)
+set(io-tree-tree111_copy-depends tutorial-io-tree-tree108_tree)
+set(io-tree-tree112_copy-depends tutorial-io-tree-tree108_tree)
 set(math-fit-fit1-depends tutorial-hist-hist001_TH1_fillrandom)
 set(math-fit-myfit-depends tutorial-math-fit-fitslicesy)
 set(math-foam-foam_demopers-depends tutorial-math-foam-foam_demo)

--- a/tutorials/io/tree/tree108_tree.C
+++ b/tutorials/io/tree/tree108_tree.C
@@ -49,7 +49,10 @@
 ///
 /// \author Rene Brun
 
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent)
+
+#ifdef ACTUAL_RUN  // -------- Second pass: dictionary already built --------
+
+#include "./Event.h"  // now safe to include Event, its dictionary is loaded
 
 #include "TFile.h"
 #include "TTree.h"
@@ -59,7 +62,6 @@ R__LOAD_LIBRARY($ROOTSYS/test/libEvent)
 #include "TClassTable.h"
 #include "TSystem.h"
 #include "TROOT.h"
-#include "../test/Event.h"
 
 void tree108_write()
 {
@@ -168,10 +170,23 @@ void tree108_read()
    t4->StartViewer();
 }
 
-void tree108_tree()
+void run()
 {
    Event::Reset(); // Allow for re-run this script by cleaning static variables.
    tree108_write();
    Event::Reset(); // Allow for re-run this script by cleaning static variables.
    tree108_read();
 }
+
+#else  // -------- First pass: build dictionary + rerun macro --------
+
+void tree108_tree()
+{
+   TString tutdir = gROOT->GetTutorialDir();
+   gROOT->ProcessLine(".L " + tutdir + "/io/tree/Event.cxx+");
+   gROOT->ProcessLine("#define ACTUAL_RUN yes");
+   gROOT->ProcessLine("#include \"" __FILE__ "\"");
+   gROOT->ProcessLine("run()");
+}
+
+#endif

--- a/tutorials/io/tree/tree110_copy.C
+++ b/tutorials/io/tree/tree110_copy.C
@@ -10,31 +10,40 @@
 ///
 /// \author Rene Brun
 
-// Load the library at macro parsing time: we need this to use its content in the code
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent)
+#ifdef ACTUAL_RUN  // -------- Second pass: dictionary already built --------
 
-void tree110_copy()
+#include "./Event.h"  // now safe to include Event, its dictionary is loaded
+
+void run()
 {
-
-   TString dir = "$ROOTSYS/test/Event.root";
-   gSystem->ExpandPathName(dir);
-   const auto filename = gSystem->AccessPathName(dir) ? "./Event.root" : "$ROOTSYS/test/Event.root";
-
-   TFile oldfile(filename);
+   TFile oldfile("tree108.root");
    TTree *oldtree;
-   oldfile.GetObject("T", oldtree);
+   oldfile.GetObject("t4", oldtree);
 
    // Deactivate all branches
    oldtree->SetBranchStatus("*", 0);
 
    // Activate only four of them
-   for (auto activeBranchName : {"event", "fNtrack", "fNseg", "fH"})
+   for (auto activeBranchName : {"event_split", "fNtrack", "fNseg", "fH"})
       oldtree->SetBranchStatus(activeBranchName, 1);
 
    // Create a new file + a clone of old tree in new file
-   TFile newfile("small.root", "recreate");
+   TFile newfile("tree110.root", "recreate");
    auto newtree = oldtree->CloneTree();
 
    newtree->Print();
    newfile.Write();
 }
+
+#else  // -------- First pass: build dictionary + rerun macro --------
+
+void tree110_copy()
+{
+   TString tutdir = gROOT->GetTutorialDir();
+   gROOT->ProcessLine(".L " + tutdir + "/io/tree/Event.cxx+");
+   gROOT->ProcessLine("#define ACTUAL_RUN yes");
+   gROOT->ProcessLine("#include \"" __FILE__ "\"");
+   gROOT->ProcessLine("run()");
+}
+
+#endif

--- a/tutorials/io/tree/tree112_copy.C
+++ b/tutorials/io/tree/tree112_copy.C
@@ -11,26 +11,23 @@
 ///
 /// \author Rene Brun
 
-R__LOAD_LIBRARY($ROOTSYS/test/libEvent)
+#ifdef ACTUAL_RUN  // -------- Second pass: dictionary already built --------
 
-void tree112_copy()
+#include "./Event.h"  // now safe to include Event, its dictionary is loaded
+
+void run()
 {
-   // Get old file, old tree and set top branch address
-   TString dir = "$ROOTSYS/test/Event.root";
-   gSystem->ExpandPathName(dir);
-   const auto filename = gSystem->AccessPathName(dir) ? "./Event.root" : "$ROOTSYS/test/Event.root";
-
-   TFile oldfile(filename);
+   TFile oldfile("tree108.root");
    TTree *oldtree;
-   oldfile.GetObject("T", oldtree);
+   oldfile.GetObject("t4", oldtree);
 
    const auto nentries = oldtree->GetEntries();
 
    Event *event = nullptr;
-   oldtree->SetBranchAddress("event", &event);
+   oldtree->SetBranchAddress("event_split", &event);
 
    // Create a new file + a clone of old tree in new file
-   TFile newfile("small.root", "recreate");
+   TFile newfile("tree112.root", "recreate");
    auto newtree = oldtree->CloneTree(0);
 
    for (auto i : ROOT::TSeqI(nentries)) {
@@ -43,3 +40,16 @@ void tree112_copy()
    newtree->Print();
    newfile.Write();
 }
+
+#else  // -------- First pass: build dictionary + rerun macro --------
+
+void tree112_copy()
+{
+   TString tutdir = gROOT->GetTutorialDir();
+   gROOT->ProcessLine(".L " + tutdir + "/io/tree/Event.cxx+");
+   gROOT->ProcessLine("#define ACTUAL_RUN yes");
+   gROOT->ProcessLine("#include \"" __FILE__ "\"");
+   gROOT->ProcessLine("run()");
+}
+
+#endif


### PR DESCRIPTION
Copy over some test files to the build and install tree to the tutorials directory, in order to enable some more TTree tutorials for testing.

Closes #13548.