### PR TITLE
[v636][ci] Disable `tmva` on Fedora 41

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -1,4 +1,5 @@
-builtin_zstd=ON
-builtin_zlib=ON
 builtin_vdt=On
+builtin_zlib=ON
+builtin_zstd=ON
 ccache=On
+tmva=OFF


### PR DESCRIPTION
The GNN parsing in TMVA SOFIE crashes because of compatibility problems
with FlexiBlas on the system and the Blas libraries shipped in the
python packages installed with pip (probably NumPy or TensorFlow).

To disable these tutorials during the tests, the simplest solution is to
disable `tmva` for the Fedora 41 builds. Note that there is also the
`tmva-sofie` flag, but counter-intuitively this only toggles the ONNX
model parsing feature of SOFIE, not SOFIE in general. So
`tmva-sofie=OFF` is not sufficient.

Fedora 41 will be end of life in about 3 months anyway. Also, the
problem doesn't seem on our side and only present on Fedora 41, so we
won't learn anything interesting if we try to fix this.