### PR TITLE
[636] Backport fix to TF1::DrawCopy

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -1029,7 +1029,13 @@ void TF1::Copy(TObject &obj) const
    ((TF1 &)obj).fParMax    = fParMax;
    ((TF1 &)obj).fParent    = fParent;
    ((TF1 &)obj).fSave      = fSave;
-   ((TF1 &)obj).fHistogram = nullptr;
+   if (fHistogram) {
+      auto *h1 = (TH1 *)fHistogram->Clone();
+      h1->SetDirectory(nullptr);
+      ((TF1 &)obj).fHistogram = h1;
+   } else {
+      ((TF1 &)obj).fHistogram = nullptr;
+   }
    ((TF1 &)obj).fMethodCall = nullptr;
    ((TF1 &)obj).fNormalized = fNormalized;
    ((TF1 &)obj).fNormIntegral = fNormIntegral;

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -26,6 +26,7 @@ ROOT_ADD_GTEST(testMapCppName test_MapCppName.cxx LIBRARIES Hist Gpad)
 ROOT_ADD_GTEST(testTGraphSorting test_TGraph_sorting.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testSpline test_spline.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(testTF1Simple test_tf1_simple.cxx LIBRARIES Hist RIO)
+ROOT_ADD_GTEST(testTF1DrawCopy test_tf1_drawcopy.cxx LIBRARIES Hist)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_tf1_drawcopy.cxx
+++ b/hist/hist/test/test_tf1_drawcopy.cxx
@@ -1,0 +1,13 @@
+#include "TF1.h"
+#include "TAxis.h"
+
+#include "gtest/gtest.h"
+
+// issue #13122
+TEST(TF1, DrawCopy)
+{
+   auto f = new TF1("f", "x*x", -3, 3);
+   f->GetXaxis()->SetTitle("xtitle");
+   auto fcopy = f->DrawCopy();
+   EXPECT_STREQ("xtitle", fcopy->GetXaxis()->GetTitle());
+}


### PR DESCRIPTION
Backport fix to TF1::DrawCopy

