### PR TITLE
[math][Docs] Further improve GenVector documentation.

### DIFF
--- a/math/genvector/doc/index.md
+++ b/math/genvector/doc/index.md
@@ -121,6 +121,10 @@ The metric used for any such LorentzVector is (-,-,-,+).
 \anchor GenVectorOperations
 ## Operations
 
+### Utility Functions for all Vectors
+
+Check the functions below, as well as in \ref ROOT::Math::VectorUtil for non-member functions such as DeltaR, Angle, boost.
+
 ### Constructors and Assignment
 
 A vector can be constructed from its coordinate representation:
@@ -162,8 +166,7 @@ v3 = v1 - v2;
 Note that the multiplication between two vectors using the `operator *` is not supported
 because it is ambiguous.
 
-> [!note]
-> For the vectors using the 4D coordinate systems based on mass instead of energy (such as **`ROOT::Math::PxPyPzM4D`** or **`ROOT::Math::PtEtaPhiM4D`**) the unary operator `-` (negation) doesn't perform a 4-vector negation. Instead, it negates only the spatial components, which might result in unintuive behaviours (for instance, for PxPyPzM4D coordinate system, \f$\textbf{v}+ \left(-\textbf{v}\right) \neq \textbf{v} -\textbf{v}\f$).
+\note For the vectors using the 4D coordinate systems based on mass instead of energy (such as **`ROOT::Math::PxPyPzM4D`** or **`ROOT::Math::PtEtaPhiM4D`**) the unary operator `-` (negation) doesn't perform a 4-vector negation. Instead, it negates only the spatial components, which might result in unintuive behaviours (for instance, for PxPyPzM4D coordinate system, \f$\textbf{v}+ \left(-\textbf{v}\right) \neq \textbf{v} -\textbf{v}\f$).
 
 ### Other Methods
 

--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -718,31 +718,32 @@ Pt (or rho) refers to transverse momentum, whereas eta refers to pseudorapidity.
 
   // global methods
 
-  /**
-     Scale of a LorentzVector with a scalar quantity a
-     \param a  scalar quantity of type a
-     \param v  mathcore::LorentzVector based on any coordinate system
-     \return a new mathcoreLorentzVector q = v * a same type as v
-   */
-    template< class CoordSystem >
-    inline LorentzVector<CoordSystem> operator *
-    ( const typename  LorentzVector<CoordSystem>::Scalar & a,
-      const LorentzVector<CoordSystem>& v) {
+    /**
+       Scale of a LorentzVector with a scalar quantity a
+       \param a  scalar quantity of type a
+       \param v  LorentzVector based on any coordinate system
+       \return a new mathcoreLorentzVector q = v * a same type as v
+     */
+    template <class CoordSystem>
+    inline LorentzVector<CoordSystem>
+    operator*(const typename LorentzVector<CoordSystem>::Scalar &a, const LorentzVector<CoordSystem> &v)
+    {
        LorentzVector<CoordSystem> tmp(v);
        tmp *= a;
        return tmp;
     }
 
-  /**
-     pair (p+ p-) acoplanarity `alpha = 1 - |phi+ - phi-|/pi`.
-     \param pp p+, mathcore::LorentzVector based on any coordinate system
-     \param pm p-, mathcore::LorentzVector based on any coordinate system
-     \return a scalar
-     \ingroup GenVector
-     \see http://doi.org/10.1103/PhysRevLett.121.212301
-   */
-    template< class CoordSystem >
-    typename LorentzVector<CoordSystem>::Scalar Acoplanarity(LorentzVector<CoordSystem> const &pp, LorentzVector<CoordSystem> const &pm)
+    /**
+       pair (p+ p-) acoplanarity `alpha = 1 - |phi+ - phi-|/pi`.
+       \param pp p+, LorentzVector based on any coordinate system
+       \param pm p-, LorentzVector based on any coordinate system
+       \return a scalar
+       \ingroup GenVector
+       \see http://doi.org/10.1103/PhysRevLett.121.212301
+     */
+    template <class CoordSystem>
+    typename LorentzVector<CoordSystem>::Scalar
+    Acoplanarity(LorentzVector<CoordSystem> const &pp, LorentzVector<CoordSystem> const &pm)
     {
        auto dphi = pp.Phi() - pm.Phi();
        // convert dphi angle to the interval (-PI,PI]
@@ -755,21 +756,22 @@ Pt (or rho) refers to transverse momentum, whereas eta refers to pseudorapidity.
              dphi += TMath::TwoPi() * n;
           }
        }
-       return 1 - std::abs(dphi)/TMath::Pi();
+       return 1 - std::abs(dphi) / TMath::Pi();
     }
 
-  /**
-     pair (p+ p-) vectorial asymmetry `Av = |Pt+ - Pt-|/|Pt+ + Pt-|`.
-     In an experimental setting, it reﬂects a convolution of the experimental resolutions
-     of particle energy and azimuthal angle measurement.
-     \param pp p+, mathcore::LorentzVector based on any coordinate system
-     \param pm p-, mathcore::LorentzVector based on any coordinate system
-     \return a scalar. Returns -1 if both momenta are exactly mirrored.
-     \ingroup GenVector
-     \see http://doi.org/10.1103/PhysRevLett.121.212301, https://doi.org/10.1103/PhysRevD.99.093013
-   */
-    template< class CoordSystem >
-    typename LorentzVector<CoordSystem>::Scalar AsymmetryVectorial(LorentzVector<CoordSystem> const &pp, LorentzVector<CoordSystem> const &pm)
+    /**
+       pair (p+ p-) vectorial asymmetry `Av = |Pt+ - Pt-|/|Pt+ + Pt-|`.
+       In an experimental setting, it reflects a convolution of the experimental resolutions
+       of particle energy and azimuthal angle measurement.
+       \param pp p+, LorentzVector based on any coordinate system
+       \param pm p-, LorentzVector based on any coordinate system
+       \return a scalar. Returns -1 if both momenta are exactly mirrored.
+       \ingroup GenVector
+       \see http://doi.org/10.1103/PhysRevLett.121.212301, https://doi.org/10.1103/PhysRevD.99.093013
+     */
+    template <class CoordSystem>
+    typename LorentzVector<CoordSystem>::Scalar
+    AsymmetryVectorial(LorentzVector<CoordSystem> const &pp, LorentzVector<CoordSystem> const &pm)
     {
        ROOT::Math::XYVector vp(pp.Px(), pp.Py());
        ROOT::Math::XYVector vm(pm.Px(), pm.Py());
@@ -779,16 +781,16 @@ Pt (or rho) refers to transverse momentum, whereas eta refers to pseudorapidity.
        return (vp - vm).R() / denom;
     }
 
-  /**
-     pair (p+ p-) scalar asymmetry `As = ||Pt+| - |Pt-|/||Pt+| + |Pt-||`.
-     Measures the relative difference in transverse momentum of the pair, e.g. two photons,
-     and would be ideally zero for two back-to-back photons.
-     \param pp p+, mathcore::LorentzVector based on any coordinate system
-     \param pm p-, mathcore::LorentzVector based on any coordinate system
-     \return a scalar. Returns 0 if both transverse momenta are zero
-     \ingroup GenVector
-     \see http://doi.org/10.1103/PhysRevLett.121.212301, https://doi.org/10.1103/PhysRevD.99.093013
-   */
+    /**
+       pair (p+ p-) scalar asymmetry `As = ||Pt+| - |Pt-|/||Pt+| + |Pt-||`.
+       Measures the relative difference in transverse momentum of the pair, e.g. two photons,
+       and would be ideally zero for two back-to-back photons.
+       \param pp p+, LorentzVector based on any coordinate system
+       \param pm p-, LorentzVector based on any coordinate system
+       \return a scalar. Returns 0 if both transverse momenta are zero
+       \ingroup GenVector
+       \see http://doi.org/10.1103/PhysRevLett.121.212301, https://doi.org/10.1103/PhysRevD.99.093013
+     */
     template< class CoordSystem >
     typename LorentzVector<CoordSystem>::Scalar AsymmetryScalar(LorentzVector<CoordSystem> const &pp, LorentzVector<CoordSystem> const &pm)
     {

--- a/math/genvector/inc/Math/GenVector/VectorUtil.h
+++ b/math/genvector/inc/Math/GenVector/VectorUtil.h
@@ -45,6 +45,8 @@ namespace ROOT {
 
       namespace VectorUtil {
 
+      /// \addtogroup GenVector
+      /// @{
 
          // methods for 3D vectors
 
@@ -258,6 +260,8 @@ namespace ROOT {
             //return ( v1 + v2).mag();
          }
 
+         /// @brief Returns the square of what InvariantMass(const Vector1&, const Vector2&) would return.
+         /// This is mostly useful for speed optimisations, because the expensive sqrt operation is skipped.
          template <class Vector1, class Vector2>
          inline typename Vector1::Scalar InvariantMass2( const Vector1 & v1, const Vector2 & v2) {
             typedef typename  Vector1::Scalar Scalar;
@@ -553,7 +557,8 @@ namespace ROOT {
           */
          double  Phi_mpi_pi(double phi);
 
-
+         // Close of doxygen group:
+         /// @}
 
       }  // end namespace Vector Util
 


### PR DESCRIPTION
- Group helper functions in the GenVector group, so all helpers can be found on one page.
- Remove mathcore::LorentzVector references from doxygen.
- Add a missing docstring.
- Change a [!note] into \note for doxygen

