### PR TITLE
Update RooSimultaneous.cxx - protect evaluate against missing pdf for current categorical state

### DIFF
--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -447,6 +447,9 @@ double RooSimultaneous::evaluate() const
 {
    // Retrieve the proxy by index name
    RooRealProxy *proxy = static_cast<RooRealProxy *>(_pdfProxyList.FindObject(_indexCat.label()));
+   if(!proxy) {
+      return 0;
+   }
 
    double nEvtTot = 1.0;
    double nEvtCat = 1.0;


### PR DESCRIPTION
A user encountered a nasty crash when evaluating a pdf that didn't have the current state pdf defined for it. Should just return 0, not crash out!