### PR TITLE
[roottest] Remove remaining `JENKINS_HOME` hack

### DIFF
--- a/roottest/root/meta/autoloading/headerParsingOnDemand/CMakeLists.txt
+++ b/roottest/root/meta/autoloading/headerParsingOnDemand/CMakeLists.txt
@@ -6,22 +6,18 @@
 # system will complain at startup, making the test fail. Clearly for backwards
 # compatibility reasons the current behaviour should be preserved :)
 
-# disable tests which are failing on Windows because of their PATH being too long
-# (>260 characters) when run in the CI (Jenkins)
-if(NOT MSVC OR NOT DEFINED ENV{JENKINS_HOME} OR win_broken_tests)
-  ROOTTEST_GENERATE_REFLEX_DICTIONARY(FullheaderParsingOnDemand
-                                      FullheaderParsingOnDemand.h
-                                      SELECTION FullheaderParsingOnDemand_selection.xml
-                                      LIBNAME libFullheaderParsingOnDemand_dictrflx
-                                      NO_ROOTMAP)
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(FullheaderParsingOnDemand
+                                    FullheaderParsingOnDemand.h
+                                    SELECTION FullheaderParsingOnDemand_selection.xml
+                                    LIBNAME libFullheaderParsingOnDemand_dictrflx
+                                    NO_ROOTMAP)
 
-  ROOTTEST_ADD_TEST(runFullheaderParsingOnDemand
-                    COPY_TO_BUILDDIR headerParsingOnDemand.rootmap
-                    MACRO runFullheaderParsingOnDemand.C
-                    OUTREF headerParsingOnDemand.ref
-                    OUTCNV FullheaderParsingOnDemand_convert.sh
-                    DEPENDS ${GENERATE_REFLEX_TEST})
-endif()
+ROOTTEST_ADD_TEST(runFullheaderParsingOnDemand
+                  COPY_TO_BUILDDIR headerParsingOnDemand.rootmap
+                  MACRO runFullheaderParsingOnDemand.C
+                  OUTREF headerParsingOnDemand.ref
+                  OUTCNV FullheaderParsingOnDemand_convert.sh
+                  DEPENDS ${GENERATE_REFLEX_TEST})
 
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(complexTypedefs
                                     complexTypedefs.h

--- a/roottest/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
+++ b/roottest/root/meta/genreflex/noStreamer_noInputOperator/CMakeLists.txt
@@ -1,7 +1,3 @@
-# disable tests which are failing on Windows because of their PATH being too long
-# (>260 characters) when run in the CI (Jenkins)
-if(NOT MSVC OR NOT DEFINED ENV{JENKINS_HOME} OR win_broken_tests)
-
 ROOTTEST_ADD_TESTDIRS()
 
 # ------------------------------------------------------------------------------
@@ -46,5 +42,3 @@ ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_rflx foo_custom_input_operat
 
 #   noInputOperator = false
 ROOTTEST_GENERATE_REFLEX_DICTIONARY(noInputOperator_false_rflx foo_custom_input_operator.h SELECTION noInputOperator_false_selection.xml NO_ROOTMAP)
-
-endif()


### PR DESCRIPTION
Since `JENKINS_HOME` is never defined, the if-statement is redundant.