### PR TITLE
[tree] fix TBranchElement for split collection with renamed inner type

### DIFF
--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -59,7 +59,7 @@ protected:
 protected:
    TString                  fClassName;     ///<  Class name of referenced object
    TString                  fParentName;    ///<  Name of parent class
-   TString                  fClonesName;    ///<  Name of class in TClonesArray (if any)
+   TString                  fClonesName;    ///<  Name of class in TClonesArray or (STL) collection (if any)
    TVirtualCollectionProxy *fCollProxy;     ///<! collection interface (if any)
    UInt_t                   fCheckSum;      ///<  CheckSum of class
    Version_t                fClassVersion;  ///<  Version number of class

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -42,3 +42,10 @@ ROOT_ADD_GTEST(entrylist_enter entrylist_enter.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(entrylist_enterrange entrylist_enterrange.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(friendinfo friendinfo.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(testTTreeCompression TTreeCompression.cxx LIBRARIES RIO Tree MathCore)
+ROOT_ADD_GTEST(evolution evolution.cxx LIBRARIES RIO Tree)
+ROOT_GENERATE_DICTIONARY(EvolutionStruct ${CMAKE_CURRENT_SOURCE_DIR}/EvolutionStruct.hxx
+                         MODULE evolution
+                         LINKDEF EvolutionStructLinkDef.h
+                         OPTIONS -inlineInputHeader
+                         DEPENDENCIES RIO)
+

--- a/tree/tree/test/EvolutionStruct.hxx
+++ b/tree/tree/test/EvolutionStruct.hxx
@@ -1,0 +1,18 @@
+#ifndef EXAMPLE_MC_H_
+#define EXAMPLE_MC_H_
+
+#include <Rtypes.h>
+
+struct EvolutionStruct_V2 {
+   float fOldMember = 0.;
+
+   ClassDefNV(EvolutionStruct_V2, 2);
+};
+
+struct EvolutionStruct_V3 {
+   float fNewMember = 0.;
+
+   ClassDefNV(EvolutionStruct_V3, 3);
+};
+
+#endif

--- a/tree/tree/test/EvolutionStructLinkDef.h
+++ b/tree/tree/test/EvolutionStructLinkDef.h
@@ -1,0 +1,11 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class EvolutionStruct_V2+;
+#pragma link C++ class EvolutionStruct_V3+;
+#pragma link C++ class std::vector<EvolutionStruct_V2>+;
+#pragma link C++ class std::vector<EvolutionStruct_V3>+;
+
+#pragma read sourceClass = "EvolutionStruct_V2" source = "float fOldMember" version = "[2]" targetClass = \
+   "EvolutionStruct_V3" target = "fNewMember" code = "{ fNewMember = onfile.fOldMember; }"
+
+#endif

--- a/tree/tree/test/evolution.cxx
+++ b/tree/tree/test/evolution.cxx
@@ -1,0 +1,41 @@
+#include "gtest/gtest.h"
+
+#include "EvolutionStruct.hxx"
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+TEST(TTree, RenameSplitCollection)
+{
+   constexpr auto fileName{"test_ttree_rename_split_collection.root"};
+   struct FileGuard {
+      ~FileGuard() { std::remove("test_ttree_rename_split_collection.root"); }
+   } _;
+
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileName, "RECREATE"));
+      TTree tree = TTree("t", "");
+
+      auto vec = new std::vector<EvolutionStruct_V2>({EvolutionStruct_V2{1.0}});
+      tree.Branch("vec", "std::vector<EvolutionStruct_V2>", &vec, 32000, 99);
+
+      tree.Fill();
+      tree.Write();
+
+      file->Close();
+   }
+
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileName));
+   auto tree = file->Get<TTree>("t");
+
+   std::vector<EvolutionStruct_V3> *vec = nullptr;
+   tree->SetBranchAddress("vec", &vec);
+
+   tree->GetEntry(0);
+   ASSERT_EQ(1u, vec->size());
+   EXPECT_FLOAT_EQ(1.0, vec->at(0).fNewMember);
+}


### PR DESCRIPTION
When setting up the branch addresses of `TBranchElement` for a `vector<U>` that is a `vector<T>` on disk, `InitInfo` fails to recognize that the parent branch and the sub branch should share the staging object.

Fixes  #19650 
