### PR TITLE
roottest: root-tree-branch avoid output name clash.

### DIFF
--- a/roottest/root/tree/branches/CMakeLists.txt
+++ b/roottest/root/tree/branches/CMakeLists.txt
@@ -2,9 +2,8 @@
 ROOTTEST_ADD_TEST(initOffset
                   MACRO  initOffset.C+)
 
-ROOTTEST_ADD_TEST(abc_rflx
-                  COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/abc.h -o abc_rflx.cpp
-                  FIXTURES_SETUP root-tree-branches-abc-rflx-dict-fixture)
+ROOTTEST_ADD_TEST(abc_rflx_gen_dict
+                  COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/abc.h -o standalone_abc_rflx.cpp)
 
 ROOTTEST_COMPILE_MACRO(abc.h
                        FIXTURES_SETUP root-tree-branches-abc-fixture)


### PR DESCRIPTION
Both roottest-root-tree-branches-abc_rflex and
roottest-root-tree-branches-abc_rflx-libgen-build were producing the file roottest/root/tree/branches/abc_rflx_rdict.pcm leading to a race condition leading to failure such as:

```
--- /github/home/ROOT-CI/src/roottest/root/tree/branches/abc.ref	Wed Aug 20 09:27:06 2025
+++ /github/home/ROOT-CI/build/roottest/root/tree/branches/abc-cint-reflex-read.log	Wed Aug 20 10:49:39 2025
@@ -1,4 +1,6 @@

+Error in <TFile::ReadBuffer>: error reading all requested bytes from file /github/home/ROOT-CI/build/roottest/root/tree/branches/abc_rflx_rdict.pcm, got 63 of 300
+Error in <TFile::Init>: /github/home/ROOT-CI/build/roottest/root/tree/branches/abc_rflx_rdict.pcm failed to read the file type data.
 20: read d.abc==20, d.derived==19
 40: read d.abc==40, d.derived==39
 60: read d.abc==60, d.derived==59
```

Side note: the generated dictionary files were not clashing by 'happenstance' with one named `abc_rflx.cpp` and the other named `abc_rflx.cxx`.

See the failures in https://github.com/root-project/root/pull/19691/checks?check_run_id=48501920806
for test `roottest-root-tree-branches-abc-cint-reflex-read`.
