### PR TITLE
[roottest] Fix build order for `root/tree/address` tests

### DIFF
--- a/roottest/root/tree/addresses/CMakeLists.txt
+++ b/roottest/root/tree/addresses/CMakeLists.txt
@@ -147,7 +147,8 @@ ROOTTEST_ADD_TEST(ursula
 #for some classes
 if(NOT MSVC OR win_broken_tests)
   ROOTTEST_COMPILE_MACRO(ConfigRecord.cxx
-                         FIXTURES_SETUP root-tree-addresses-ConfigRecord-fixture)
+                         FIXTURES_SETUP root-tree-addresses-ConfigRecord-fixture
+                         FIXTURES_REQUIRED root-tree-addresses-sueloader-fixture)
 
   ROOTTEST_COMPILE_MACRO(sueloader.C
                          FIXTURES_SETUP root-tree-addresses-sueloader-fixture)


### PR DESCRIPTION
This restores the behaviour of the old Makefile rule:

    ConfigRecord_cxx.$(DllSuf): ConfigRecord.cxx ConfigRecord.h sueloader_C.$(DllSuf)
        $(BuildWithLib)

which ensured sueloader_C.so was available before linking ConfigRecord_cxx.so.

# This Pull request:

## Changes or fixes:
Test failures on mac beta.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

