### PR TITLE
[CMake] Remove overriding `CMAKE_OSX_SYSROOT`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,6 @@ if(WIN32)
   cmake_policy(SET CMP0091 OLD)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
 endif()
-if(CMAKE_HOST_APPLE AND (NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL ""))
-  # The SYSROOT *must* be set before the project() call
-  execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
-    OUTPUT_VARIABLE SDK_PATH
-    ERROR_QUIET
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-  if(NOT EXISTS "${SDK_PATH}")
-    message(FATAL_ERROR "Could not detect macOS SDK path")
-  endif()
-
-  set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "SDK path" FORCE)
-endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT ALLOW_IN_SOURCE)
   message(FATAL_ERROR


### PR DESCRIPTION
The internet says that newer CMake versions got more reliable in figuring out the SDK path. So setting `CMAKE_OSX_SYSROOT` ourselves is maybe not needed anymore.

Follows up on #19218.