### PR TITLE
[ntuple] Fixes to iterators

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -489,10 +489,16 @@ public:
       using reference = const RColumnRange &;
 
       RIterator(Iter_t iter) : fIter(iter) {}
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIter;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return fIter->second; }
       pointer operator->() const { return &fIter->second; }
@@ -880,10 +886,16 @@ public:
          : fNTuple(ntuple), fColumns(columns), fIndex(index)
       {
       }
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIndex;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
       pointer operator->() const { return &fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
@@ -936,10 +948,16 @@ public:
          : fNTuple(ntuple), fFieldChildren(fieldChildren), fIndex(index)
       {
       }
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIndex;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return fNTuple.GetFieldDescriptor(fFieldChildren.at(fIndex)); }
       pointer operator->() const { return &fNTuple.GetFieldDescriptor(fFieldChildren.at(fIndex)); }
@@ -991,10 +1009,16 @@ public:
       using reference = const RClusterGroupDescriptor &;
 
       RIterator(Iter_t iter) : fIter(iter) {}
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIter;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return fIter->second; }
       pointer operator->() const { return &fIter->second; }
@@ -1039,10 +1063,16 @@ public:
       using reference = const RClusterDescriptor &;
 
       RIterator(Iter_t iter) : fIter(iter) {}
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIter;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return fIter->second; }
       pointer operator->() const { return &fIter->second; }
@@ -1083,10 +1113,16 @@ public:
       using reference = const RExtraTypeInfoDescriptor &;
 
       RIterator(Iter_t iter) : fIter(iter) {}
-      iterator operator++()
+      iterator &operator++() /* prefix */
       {
          ++fIter;
          return *this;
+      }
+      iterator operator++(int) /* postfix */
+      {
+         auto old = *this;
+         operator++();
+         return old;
       }
       reference operator*() const { return *fIter; }
       pointer operator->() const { return &*fIter; }

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -885,8 +885,8 @@ public:
          ++fIndex;
          return *this;
       }
-      reference operator*() { return fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
-      pointer operator->() { return &fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
+      reference operator*() const { return fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
+      pointer operator->() const { return &fNTuple.GetColumnDescriptor(fColumns.at(fIndex)); }
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
       bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
    };
@@ -928,7 +928,7 @@ public:
       using iterator = RIterator;
       using value_type = RFieldDescriptor;
       using difference_type = std::ptrdiff_t;
-      using pointer = RFieldDescriptor *;
+      using pointer = const RFieldDescriptor *;
       using reference = const RFieldDescriptor &;
 
       RIterator(const RNTupleDescriptor &ntuple, const std::vector<ROOT::DescriptorId_t> &fieldChildren,
@@ -941,7 +941,8 @@ public:
          ++fIndex;
          return *this;
       }
-      reference operator*() { return fNTuple.GetFieldDescriptor(fFieldChildren.at(fIndex)); }
+      reference operator*() const { return fNTuple.GetFieldDescriptor(fFieldChildren.at(fIndex)); }
+      pointer operator->() const { return &fNTuple.GetFieldDescriptor(fFieldChildren.at(fIndex)); }
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
       bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
    };

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -494,8 +494,8 @@ public:
          ++fIter;
          return *this;
       }
-      reference operator*() { return fIter->second; }
-      pointer operator->() { return &fIter->second; }
+      reference operator*() const { return fIter->second; }
+      pointer operator->() const { return &fIter->second; }
       bool operator!=(const iterator &rh) const { return fIter != rh.fIter; }
       bool operator==(const iterator &rh) const { return fIter == rh.fIter; }
    };
@@ -503,7 +503,7 @@ public:
    explicit RColumnRangeIterable(const RClusterDescriptor &desc) : fDesc(desc) {}
 
    RIterator begin() { return RIterator{fDesc.fColumnRanges.cbegin()}; }
-   RIterator end() { return fDesc.fColumnRanges.cend(); }
+   RIterator end() { return RIterator{fDesc.fColumnRanges.cend()}; }
    size_t size() { return fDesc.fColumnRanges.size(); }
 };
 
@@ -978,37 +978,33 @@ private:
 public:
    class RIterator final {
    private:
-      /// The enclosing range's RNTuple.
-      const RNTupleDescriptor &fNTuple;
-      std::size_t fIndex = 0;
+      using Iter_t = std::unordered_map<ROOT::DescriptorId_t, RClusterGroupDescriptor>::const_iterator;
+      /// The wrapped map iterator
+      Iter_t fIter;
 
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
       using value_type = RClusterGroupDescriptor;
       using difference_type = std::ptrdiff_t;
-      using pointer = RClusterGroupDescriptor *;
+      using pointer = const RClusterGroupDescriptor *;
       using reference = const RClusterGroupDescriptor &;
 
-      RIterator(const RNTupleDescriptor &ntuple, std::size_t index) : fNTuple(ntuple), fIndex(index) {}
+      RIterator(Iter_t iter) : fIter(iter) {}
       iterator operator++()
       {
-         ++fIndex;
+         ++fIter;
          return *this;
       }
-      reference operator*()
-      {
-         auto it = fNTuple.fClusterGroupDescriptors.begin();
-         std::advance(it, fIndex);
-         return it->second;
-      }
-      bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
-      bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
+      reference operator*() const { return fIter->second; }
+      pointer operator->() const { return &fIter->second; }
+      bool operator!=(const iterator &rh) const { return fIter != rh.fIter; }
+      bool operator==(const iterator &rh) const { return fIter == rh.fIter; }
    };
 
    RClusterGroupDescriptorIterable(const RNTupleDescriptor &ntuple) : fNTuple(ntuple) {}
-   RIterator begin() { return RIterator(fNTuple, 0); }
-   RIterator end() { return RIterator(fNTuple, fNTuple.GetNClusterGroups()); }
+   RIterator begin() { return RIterator(fNTuple.fClusterGroupDescriptors.cbegin()); }
+   RIterator end() { return RIterator(fNTuple.fClusterGroupDescriptors.cend()); }
 };
 
 // clang-format off
@@ -1030,37 +1026,33 @@ private:
 public:
    class RIterator final {
    private:
-      /// The enclosing range's RNTuple.
-      const RNTupleDescriptor &fNTuple;
-      std::size_t fIndex = 0;
+      using Iter_t = std::unordered_map<ROOT::DescriptorId_t, RClusterDescriptor>::const_iterator;
+      /// The wrapped map iterator
+      Iter_t fIter;
 
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
       using value_type = RClusterDescriptor;
       using difference_type = std::ptrdiff_t;
-      using pointer = RClusterDescriptor *;
+      using pointer = const RClusterDescriptor *;
       using reference = const RClusterDescriptor &;
 
-      RIterator(const RNTupleDescriptor &ntuple, std::size_t index) : fNTuple(ntuple), fIndex(index) {}
+      RIterator(Iter_t iter) : fIter(iter) {}
       iterator operator++()
       {
-         ++fIndex;
+         ++fIter;
          return *this;
       }
-      reference operator*()
-      {
-         auto it = fNTuple.fClusterDescriptors.begin();
-         std::advance(it, fIndex);
-         return it->second;
-      }
-      bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
-      bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
+      reference operator*() const { return fIter->second; }
+      pointer operator->() const { return &fIter->second; }
+      bool operator!=(const iterator &rh) const { return fIter != rh.fIter; }
+      bool operator==(const iterator &rh) const { return fIter == rh.fIter; }
    };
 
    RClusterDescriptorIterable(const RNTupleDescriptor &ntuple) : fNTuple(ntuple) {}
-   RIterator begin() { return RIterator(fNTuple, 0); }
-   RIterator end() { return RIterator(fNTuple, fNTuple.GetNActiveClusters()); }
+   RIterator begin() { return RIterator(fNTuple.fClusterDescriptors.cbegin()); }
+   RIterator end() { return RIterator(fNTuple.fClusterDescriptors.cend()); }
 };
 
 // clang-format off

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -1070,37 +1070,33 @@ private:
 public:
    class RIterator final {
    private:
-      /// The enclosing range's RNTuple.
-      const RNTupleDescriptor &fNTuple;
-      std::size_t fIndex = 0;
+      using Iter_t = std::vector<RExtraTypeInfoDescriptor>::const_iterator;
+      /// The wrapped vector iterator
+      Iter_t fIter;
 
    public:
       using iterator_category = std::forward_iterator_tag;
       using iterator = RIterator;
       using value_type = RExtraTypeInfoDescriptor;
       using difference_type = std::ptrdiff_t;
-      using pointer = RExtraTypeInfoDescriptor *;
+      using pointer = const RExtraTypeInfoDescriptor *;
       using reference = const RExtraTypeInfoDescriptor &;
 
-      RIterator(const RNTupleDescriptor &ntuple, std::size_t index) : fNTuple(ntuple), fIndex(index) {}
+      RIterator(Iter_t iter) : fIter(iter) {}
       iterator operator++()
       {
-         ++fIndex;
+         ++fIter;
          return *this;
       }
-      reference operator*()
-      {
-         auto it = fNTuple.fExtraTypeInfoDescriptors.begin();
-         std::advance(it, fIndex);
-         return *it;
-      }
-      bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
-      bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
+      reference operator*() const { return *fIter; }
+      pointer operator->() const { return &*fIter; }
+      bool operator!=(const iterator &rh) const { return fIter != rh.fIter; }
+      bool operator==(const iterator &rh) const { return fIter == rh.fIter; }
    };
 
    RExtraTypeInfoDescriptorIterable(const RNTupleDescriptor &ntuple) : fNTuple(ntuple) {}
-   RIterator begin() { return RIterator(fNTuple, 0); }
-   RIterator end() { return RIterator(fNTuple, fNTuple.GetNExtraTypeInfos()); }
+   RIterator begin() { return RIterator(fNTuple.fExtraTypeInfoDescriptors.cbegin()); }
+   RIterator end() { return RIterator(fNTuple.fExtraTypeInfoDescriptors.cend()); }
 };
 
 // clang-format off

--- a/tree/ntuple/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleRange.hxx
@@ -37,11 +37,11 @@ public:
 
    public:
       using iterator = RIterator;
-      using iterator_category = std::forward_iterator_tag;
+      using iterator_category = std::input_iterator_tag;
       using value_type = ROOT::NTupleSize_t;
-      using difference_type = ROOT::NTupleSize_t;
-      using pointer = ROOT::NTupleSize_t *;
-      using reference = ROOT::NTupleSize_t &;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const ROOT::NTupleSize_t *;
+      using reference = const ROOT::NTupleSize_t &;
 
       RIterator() = default;
       explicit RIterator(ROOT::NTupleSize_t index) : fIndex(index) {}
@@ -58,8 +58,8 @@ public:
          ++fIndex;
          return *this;
       }
-      reference operator*() { return fIndex; }
-      pointer operator->() { return &fIndex; }
+      reference operator*() const { return fIndex; }
+      pointer operator->() const { return &fIndex; }
       bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
    };
@@ -91,11 +91,11 @@ public:
 
    public:
       using iterator = RIterator;
-      using iterator_category = std::forward_iterator_tag;
+      using iterator_category = std::input_iterator_tag;
       using value_type = RNTupleLocalIndex;
-      using difference_type = RNTupleLocalIndex;
-      using pointer = RNTupleLocalIndex *;
-      using reference = RNTupleLocalIndex &;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const RNTupleLocalIndex *;
+      using reference = const RNTupleLocalIndex &;
 
       RIterator() = default;
       explicit RIterator(RNTupleLocalIndex localIndex) : fLocalIndex(localIndex) {}
@@ -112,8 +112,8 @@ public:
          fLocalIndex++;
          return *this;
       }
-      reference operator*() { return fLocalIndex; }
-      pointer operator->() { return &fLocalIndex; }
+      reference operator*() const { return fLocalIndex; }
+      pointer operator->() const { return &fLocalIndex; }
       bool operator==(const iterator &rh) const { return fLocalIndex == rh.fLocalIndex; }
       bool operator!=(const iterator &rh) const { return fLocalIndex != rh.fLocalIndex; }
    };

--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -105,11 +105,11 @@ public:
 
    public:
       using iterator = RIterator;
-      using iterator_category = std::forward_iterator_tag;
+      using iterator_category = std::input_iterator_tag;
       using value_type = ROOT::NTupleSize_t;
-      using difference_type = ROOT::NTupleSize_t;
-      using pointer = ROOT::NTupleSize_t *;
-      using reference = ROOT::NTupleSize_t &;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const ROOT::NTupleSize_t *;
+      using reference = const ROOT::NTupleSize_t &;
 
       RIterator() = default;
       explicit RIterator(ROOT::NTupleSize_t index) : fIndex(index) {}
@@ -126,8 +126,8 @@ public:
          ++fIndex;
          return *this;
       }
-      reference operator*() { return fIndex; }
-      pointer operator->() { return &fIndex; }
+      reference operator*() const { return fIndex; }
+      pointer operator->() const { return &fIndex; }
       bool operator==(const iterator &rh) const { return fIndex == rh.fIndex; }
       bool operator!=(const iterator &rh) const { return fIndex != rh.fIndex; }
    };


### PR DESCRIPTION
 * Fix input iterators that cannot be forward iterators
 * Implement `RFieldDescriptorIterable::operator->`
 * Optimize `R{Cluster,ClusterGroup}DescriptorIterable`, `RExtraTypeInfoDescriptorIterable`
 * Fix operators for descriptor iterators

More details in the individual commit messages.