### PR TITLE
[hist] Always use maximum floating point precision in `GetExpFormula`

### DIFF
--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -248,7 +248,7 @@ public:
 #ifdef R__HAS_VECCORE
    ROOT::Double_v EvalParVec(const ROOT::Double_v *x, const Double_t *params = nullptr) const;
 #endif
-   TString        GetExpFormula(Option_t *option = "", const char *fl_format = "%g") const;
+   TString        GetExpFormula(Option_t *option = "") const;
    TString        GetGradientFormula() const;
    TString        GetHessianFormula() const;
    TString        GetUniqueFuncName() const {

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -308,7 +308,7 @@ bool test16()  {
    // test GetExpFormula
    TFormula f("f","[2] + [0]*x + [1]*x*x");
    f.SetParameters(1,2,3);
-   return (f.GetExpFormula("CLING P", "%f") == TString("3.000000+1.000000*x[0]+2.000000*x[0]*x[0] "));
+   return (f.GetExpFormula("CLING P") == TString("3+1*x[0]+2*x[0]*x[0] "));
 }
 
 bool test17() {


### PR DESCRIPTION
In #18194, an optional parameter to `TFormula::GetExpFormula()` was introduced, which can be used to customize the precision when putting parameters into the jitted code.

However, I don't see the reason why wouldn't like to always print the floating point numbers with maximum precision, which is suggested in this commit.

This is achieved using modern C++ functions, which are also not respecting the users locale setting, but instead use the classic C locale by default, which is what we need when generating code.

Follows up on #18194 (and its partial revert #18216).

Closes #17225.

Replaces #17327.