### PR TITLE
[RF] Don't format infinities to large numbers anymore in `codegen`

### DIFF
--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -67,6 +67,14 @@ namespace Experimental {
 
 namespace {
 
+// Return a stringy-field version of the value, formatted to maximum precision.
+std::string doubleToString(double val)
+{
+   std::stringstream ss;
+   ss << std::setprecision(std::numeric_limits<double>::max_digits10) << val;
+   return ss.str();
+}
+
 std::string mathFunc(std::string const &name)
 {
    return "RooFit::Detail::MathFuncs::" + name;
@@ -249,8 +257,9 @@ void codegenImpl(RooMultiPdf &arg, CodegenContext &ctx)
 
    // MathFunc call
 
-   if (numPdfs > 2) { // the value of this number should be discussed.Beyound a certain number of indices MathFunc call
-                      // becomes more efficient.
+   // The value of this number should be discussed. Beyound a certain number of
+   // indices MathFunc call becomes more efficient.
+   if (numPdfs > 2) {
       ctx.addResult(&arg, ctx.buildCall(mathFunc("multipdf"), arg.indexCategory(), arg.getPdfList()));
 
       std::cout << "MathFunc call used\n";
@@ -354,15 +363,7 @@ void codegenImpl(RooChebychev &arg, CodegenContext &ctx)
 
 void codegenImpl(RooConstVar &arg, CodegenContext &ctx)
 {
-   // Just return a stringy-field version of the const value.
-   // Formats to the maximum precision.
-   constexpr auto max_precision{std::numeric_limits<double>::max_digits10};
-   std::stringstream ss;
-   ss.precision(max_precision);
-   // Just use toString to make sure we do not output 'inf'.
-   // This is really ugly for large numbers...
-   ss << std::fixed << RooNumber::toString(arg.getVal());
-   ctx.addResult(&arg, ss.str());
+   ctx.addResult(&arg, doubleToString(arg.getVal()));
 }
 
 void codegenImpl(RooConstraintSum &arg, CodegenContext &ctx)
@@ -507,7 +508,7 @@ void codegenImpl(RooParamHistFunc &arg, CodegenContext &ctx)
       // be binned uniformly.
       double binV = arg.dataHist().binVolume(0);
       std::string weightArr = arg.dataHist().declWeightArrayForCodeSquash(ctx, false);
-      result += " * *(" + weightArr + " + " + idx + ") * " + std::to_string(binV);
+      result += " * *(" + weightArr + " + " + idx + ") * " + doubleToString(binV);
    }
    ctx.addResult(&arg, result);
 }
@@ -650,15 +651,7 @@ void codegenImpl(RooRealVar &arg, CodegenContext &ctx)
    if (!arg.isConstant()) {
       ctx.addResult(&arg, arg.GetName());
    }
-   // Just return a formatted version of the const value.
-   // Formats to the maximum precision.
-   constexpr auto max_precision{std::numeric_limits<double>::max_digits10};
-   std::stringstream ss;
-   ss.precision(max_precision);
-   // Just use toString to make sure we do not output 'inf'.
-   // This is really ugly for large numbers...
-   ss << std::fixed << RooNumber::toString(arg.getVal());
-   ctx.addResult(&arg, ss.str());
+   ctx.addResult(&arg, doubleToString(arg.getVal()));
 }
 
 void codegenImpl(RooRecursiveFraction &arg, CodegenContext &ctx)
@@ -812,7 +805,7 @@ std::string rooHistIntegralTranslateImpl(int code, RooAbsArg const &arg, RooData
                                     << std::endl;
       return "";
    }
-   return std::to_string(dataHist.sum(histFuncMode));
+   return doubleToString(dataHist.sum(histFuncMode));
 }
 
 } // namespace
@@ -853,7 +846,7 @@ std::string codegenIntegralImpl(RooMultiVarGaussian &arg, int code, const char *
       throw std::runtime_error(errorMsg.str().c_str());
    }
 
-   return std::to_string(arg.analyticalIntegral(code, rangeName));
+   return doubleToString(arg.analyticalIntegral(code, rangeName));
 }
 
 std::string codegenIntegralImpl(RooPoisson &arg, int code, const char *rangeName, CodegenContext &ctx)
@@ -905,7 +898,7 @@ std::string codegenIntegralImpl(RooUniform &arg, int code, const char *rangeName
 {
    // The integral of a uniform distribution is static, so we can just hardcode
    // the result in a string.
-   return std::to_string(arg.analyticalIntegral(code, rangeName));
+   return doubleToString(arg.analyticalIntegral(code, rangeName));
 }
 
 } // namespace Experimental

--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -356,7 +356,7 @@ void codegenImpl(RooConstVar &arg, CodegenContext &ctx)
 {
    // Just return a stringy-field version of the const value.
    // Formats to the maximum precision.
-   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
+   constexpr auto max_precision{std::numeric_limits<double>::max_digits10};
    std::stringstream ss;
    ss.precision(max_precision);
    // Just use toString to make sure we do not output 'inf'.
@@ -652,7 +652,7 @@ void codegenImpl(RooRealVar &arg, CodegenContext &ctx)
    }
    // Just return a formatted version of the const value.
    // Formats to the maximum precision.
-   constexpr auto max_precision{std::numeric_limits<double>::digits10 + 1};
+   constexpr auto max_precision{std::numeric_limits<double>::max_digits10};
    std::stringstream ss;
    ss.precision(max_precision);
    // Just use toString to make sure we do not output 'inf'.

--- a/roofit/roofit/inc/RooLagrangianMorphFunc.h
+++ b/roofit/roofit/inc/RooLagrangianMorphFunc.h
@@ -185,9 +185,6 @@ private:
    RooRealVar *setupObservable(const char *obsname, TClass *mode, TObject *inputExample);
 
 public:
-   /// length of floating point digits precision supported by implementation.
-   static constexpr double implementedPrecision = RooFit::SuperFloatPrecision::digits10;
-
    void writeMatrixToFile(const TMatrixD &matrix, const char *fname);
    void writeMatrixToStream(const TMatrixD &matrix, std::ostream &stream);
    TMatrixD readMatrixFromFile(const char *fname);

--- a/roofit/roofitcore/inc/RooFit/CodegenContext.h
+++ b/roofit/roofitcore/inc/RooFit/CodegenContext.h
@@ -16,11 +16,11 @@
 
 #include <RooAbsCollection.h>
 #include <RooFit/EvalContext.h>
-#include <RooNumber.h>
 
 #include <ROOT/RSpan.hxx>
 
 #include <cstddef>
+#include <iomanip>
 #include <map>
 #include <sstream>
 #include <string>
@@ -150,7 +150,9 @@ private:
    template <class T, typename std::enable_if<std::is_floating_point<T>{}, bool>::type = true>
    std::string buildArg(T x)
    {
-      return RooNumber::toString(x);
+      std::stringstream ss;
+      ss << std::setprecision(std::numeric_limits<double>::max_digits10) << x;
+      return ss.str();
    }
 
    // If input is integer, we want to print it into the code like one (i.e. avoid the unnecessary '.0000').

--- a/roofit/roofitcore/inc/RooNumber.h
+++ b/roofit/roofitcore/inc/RooNumber.h
@@ -39,7 +39,6 @@ public:
    /// Get the absolute epsilon that is used by range checks in RooFit,
    /// e.g., in RooAbsRealLValue::inRange().
    inline static double rangeEpsAbs() { return staticRangeEpsAbs(); }
-   static std::string toString(double x);
 
 private:
    static double &staticRangeEpsRel();

--- a/roofit/roofitcore/src/RooFit/CodegenContext.cxx
+++ b/roofit/roofitcore/src/RooFit/CodegenContext.cxx
@@ -350,6 +350,7 @@ CodegenContext::buildFunction(RooAbsArg const &arg, std::map<RooFit::Detail::Dat
    // Declare the function
    std::stringstream bodyWithSigStrm;
    bodyWithSigStrm << "double " << funcName << "(double* params, double const* obs, double const* xlArr) {\n"
+                   << "constexpr double inf = std::numeric_limits<double>::infinity();\n"
                    << funcBody << "\n}";
    ctx._collectedFunctions.emplace_back(funcName);
    if (!gInterpreter->Declare(bodyWithSigStrm.str().c_str())) {

--- a/roofit/roofitcore/src/RooNumber.cxx
+++ b/roofit/roofitcore/src/RooNumber.cxx
@@ -24,19 +24,6 @@ Provides numeric constants used in \ref Roofitmain.
 
 #include <RooNumber.h>
 
-/// @brief  Returns an std::to_string compatible number (i.e. rounds infinities back to the nearest representable
-/// value). This function is primarily used in the code-squashing for AD and as such encodes infinities to double's
-/// maximum value. We do this because 1, std::to_string cannot handle infinities correctly on some platforms
-/// (e.g. 32 bit debian) and 2, Clad (the AD tool) cannot handle differentiating std::numeric_limits::infinity directly.
-std::string RooNumber::toString(double x)
-{
-   int sign = isInfinite(x);
-   double out = x;
-   if (sign)
-      out = sign == 1 ? std::numeric_limits<double>::max() : std::numeric_limits<double>::min();
-   return std::to_string(out);
-}
-
 double &RooNumber::staticRangeEpsRel()
 {
    static double epsRel = 0.0;

--- a/roofit/roofitcore/test/testRooFuncWrapper.cxx
+++ b/roofit/roofitcore/test/testRooFuncWrapper.cxx
@@ -219,7 +219,9 @@ TEST_P(FactoryTest, NLLFit)
 /// Initial minimization that was not based on any other tutorial/test.
 FactoryTestParams param1{"Gaussian",
                          [](RooWorkspace &ws) {
-                            ws.factory("sum::mu_shifted(mu[0, -10, 10], shift[1.0, -10, 10])");
+                            constexpr double inf = std::numeric_limits<double>::infinity();
+                            ws.import(RooRealVar{"mu", "mu", -inf, inf});
+                            ws.factory("sum::mu_shifted(mu, shift[1.0, -10, 10])");
                             ws.factory("prod::sigma_scaled(sigma[3.0, 0.01, 10], 1.5)");
                             ws.factory("Gaussian::model(x[0, -10, 10], mu_shifted, sigma_scaled)");
 
@@ -428,7 +430,10 @@ FactoryTestParams param9{"Poisson",
 // A RooPoisson where x is not rounded, like it is used in HistFactory
 FactoryTestParams param10{"PoissonNoRounding",
                           [](RooWorkspace &ws) {
-                             ws.factory("Poisson::model(x[5, 0, 10], mu[5, 0, 10])");
+                             constexpr double inf = std::numeric_limits<double>::infinity();
+                             RooRealVar mu{"mu", "mu", 5., 0., inf};
+                             ws.import(mu);
+                             ws.factory("Poisson::model(x[5, 0, 10], mu)");
                              auto poisson = static_cast<RooPoisson *>(ws.pdf("model"));
                              poisson->setNoRounding(true);
                              ws.defineSet("observables", "x");

--- a/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/GeneralLayer.h
@@ -526,7 +526,7 @@ auto VGeneralLayer<Architecture_t>::WriteMatrixToXML(void * node, const char * n
    xmlengine.NewAttr(matnode,nullptr,"Rows", gTools().StringFromInt(matrix.GetNrows()) );
    xmlengine.NewAttr(matnode,nullptr,"Columns", gTools().StringFromInt(matrix.GetNcols()) );
    std::stringstream s;
-   s.precision( std::numeric_limits<Scalar_t>::digits10 );
+   s.precision(std::numeric_limits<Scalar_t>::max_digits10);
    size_t nrows = matrix.GetNrows();
    size_t ncols = matrix.GetNcols();
    for (size_t row = 0; row < nrows; row++) {


### PR DESCRIPTION
By now, Clad should have learned how to deal with the `inf` infinities.

The unit tests are tweaked the check this.