### PR TITLE
[tree] Fix long64 tree index losing precision on 64-bit long double platforms and enable forgotten test

### DIFF
--- a/roottest/root/tree/index/CMakeLists.txt
+++ b/roottest/root/tree/index/CMakeLists.txt
@@ -15,6 +15,10 @@ ROOTTEST_ADD_TEST(index64
                   MACRO runindex64.C
                   OUTREF index64.ref)
 
+ROOTTEST_ADD_TEST(indexl64
+                  MACRO runindexl64.C
+                  OUTREF indexl64.ref)
+
 ROOTTEST_ADD_TEST(varsizearr
                   MACRO runvarsizearr.C
                   OUTREF varsizearr.ref)

--- a/roottest/root/tree/index/runindexl64.C
+++ b/roottest/root/tree/index/runindexl64.C
@@ -5,9 +5,8 @@
 bool test(TTree *);
 
 const char *fname = "indexl64.root";
-https : // github.com/root-project/root/pull/19561
-        const Long64_t bigval =
-           0x0FFFFFFFFFFFFFFF; // here we skip long double, so we can go higher than with runindex64.C
+// https://github.com/root-project/root/pull/19561
+const Long64_t bigval = 0x0FFFFFFFFFFFFFFF; // here we skip long double, so we can go higher than with runindex64.C
 
 int runindexl64()
 {

--- a/tree/treeplayer/src/TTreeIndex.cxx
+++ b/tree/treeplayer/src/TTreeIndex.cxx
@@ -189,7 +189,7 @@ TTreeIndex::TTreeIndex(const TTree *T, const char *majorname, const char *minorn
          Error("TTreeIndex", "In tree entry %lld, Ndata in formula is zero for both '%s' and '%s'", i,
                fMajorName.Data(), fMinorName.Data());
       }
-      auto GetAndRangeCheck = [this](bool isMajor, Long64_t entry) {
+      auto GetAndRangeCheck = [this](bool isMajor, Long64_t entry) -> Long64_t {
          LongDouble_t ret = (isMajor ? fMajorFormula : fMinorFormula)->EvalInstance<LongDouble_t>();
          // Check whether the value (vs significant bits) of ldRet can represent
          // the full precision of the returned value. If we return 10^60, the
@@ -206,11 +206,16 @@ TTreeIndex::TTreeIndex(const TTree *T, const char *majorname, const char *minorn
                     "In tree entry %lld, %s value %s=%Lf possibly out of range for internal `long double`", entry,
                     isMajor ? "major" : "minor", isMajor ? fMajorName.Data() : fMinorName.Data(), ret);
          }
-         return ret;
+         return static_cast<Long64_t>(ret); // static_cast necessary for use in ternary expression below
       };
       auto GetLong64 = [this](bool isMajor) {
          return (isMajor ? fMajorFormula : fMinorFormula)->EvalInstance<Long64_t>();
       };
+      // Note: in ternary expression ensure both branches have same return data type Long64_t.
+      // otherwise, with LongDouble_t, the expression is implicitly cast to their
+      // common type `long double` regardless of the branch taken. On platforms where
+      // `sizeof(long double) == sizeof(double)` (macOS arm64, Windows) this silently
+      // rounds the exact Long64_t value, defeating the purpose of the long64 flag.
       tmp_major[i] = long64major ? GetLong64(true) : GetAndRangeCheck(true, i);
       tmp_minor[i] = long64minor ? GetLong64(false) : GetAndRangeCheck(false, i);
    }


### PR DESCRIPTION
This is a fixup of https://github.com/root-project/root/pull/19561 that was supposed to fix https://github.com/root-project/root/issues/19560

A test was created there, but it was forgotten to add it to the CMakeLists. As a consequence, the CI looked green but the test was not running at all, and it was actually broken.

This PR reenables the test as well as fixes the TTree code to unbreak the test.