### PR TITLE
[core] Avoid errors when using std::span backport from Python

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/support.py
+++ b/bindings/pyroot/cppyy/cppyy/test/support.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os, py, sys, subprocess
+from contextlib import contextmanager
 
 currpath = py.path.local(__file__).dirpath()
 
@@ -45,6 +46,49 @@ if 'darwin' in sys.platform:
 
 IS_MAC = IS_MAC_ARM or IS_MAC_X86
 IS_LINUX = not (IS_WINDOWS or IS_MAC) 
+
+def _register_root_error_counter():
+
+    import cppyy
+
+    # already registered
+    if hasattr(cppyy.gbl, "rootErrorCount"):
+        return
+
+    cppyy.cppdef("""
+    auto originalErrorHandler = ::GetErrorHandler();
+
+    int &rootErrorCount()
+    {
+        static int count = 0;
+        return count;
+    }
+
+    void handleErrorWithException(int severity,
+                              bool abort,
+                              const char * location,
+                              const char * msg)
+    {
+        originalErrorHandler(severity, abort, location, msg);
+        rootErrorCount()++;
+    }
+
+    ::SetErrorHandler(handleErrorWithException);
+    """)
+
+@contextmanager
+def no_root_errors():
+    """Context manager to ensure no new ROOT errors occur."""
+    import cppyy
+
+    _register_root_error_counter()
+
+    start_count = cppyy.gbl.rootErrorCount()
+    yield
+    end_count = cppyy.gbl.rootErrorCount()
+    if end_count != start_count:
+        raise AssertionError(f"ROOT emitted {end_count - start_count} error(s) during block!")
+
 
 try:
     import __pypy__

--- a/bindings/pyroot/cppyy/cppyy/test/test_operators.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_operators.py
@@ -1,6 +1,6 @@
 import py, pytest, os
 from pytest import raises, skip, mark
-from support import setup_make, pylong, maxvalue, IS_WINDOWS, IS_MAC
+from support import setup_make, pylong, maxvalue, IS_WINDOWS, IS_MAC, no_root_errors
 
 
 currpath = os.getcwd()
@@ -222,12 +222,16 @@ class TestOPERATORS:
             assert m[1]    == 74
             assert m(1,2)  == 74
 
+    @mark.xfail(reason="Compilation of unused call wrappers emits errors")
     def test09_templated_operator(self):
         """Templated operator<()"""
 
         from cppyy.gbl import TOIClass
 
-        assert (TOIClass() < 1)
+        # We don't want to see compile errors for overloads that were tried
+        # but didn't succeed
+        with no_root_errors():
+            assert (TOIClass() < 1)
 
     def test10_r_non_associative(self):
         """Use of radd/rmul with non-associative types"""

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1,8 +1,7 @@
 # -*- coding: UTF-8 -*-
 import py, sys, pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, pyunicode, maxvalue, ispypy
-
+from support import setup_make, pylong, pyunicode, maxvalue, ispypy, no_root_errors
 
 currpath = os.getcwd()
 test_dct = currpath + "/libstltypesDict"
@@ -820,6 +819,30 @@ class TestSTLVECTOR:
 
             for i, d in zip(range(-5, 5, 1), data):
                 assert d == i
+
+    def test24_vector_to_span(self):
+        """Vectors should convert to std::span without errors"""
+
+        import cppyy
+
+        cppyy.cppdef("""
+        double calc_cumsum(std::size_t n, std::span<double> v)
+        {
+            double sum = 0.0;
+            for (int i = 0; i < n; i += 1) {
+                sum += v[i];
+            }
+            return sum;
+        }
+        """)
+
+        l = list(range(4))
+        v = cppyy.gbl.std.vector["double"](l)
+
+        with no_root_errors():
+            result = cppyy.gbl.calc_cumsum(len(v), v)
+
+        assert result == sum(l)
 
 
 class TestSTLSTRING:

--- a/core/foundation/inc/ROOT/span.hxx
+++ b/core/foundation/inc/ROOT/span.hxx
@@ -204,6 +204,13 @@ public:
     static_assert(N > 0, "Zero-length array is not permitted in ISO C++.");
   }
 
+  // Note:
+  // This constructor needs to be disabled if T is not a const type, because we
+  // don't want to create span<T> from vector<T> const&.
+  // The explicit disabling via SFINAE is necessary to this overload is not
+  // accidentally taken by cppyy, resulting in the failure of constructor
+  // wrapper code compilation.
+  template <class U = T, class = typename std::enable_if<std::is_const<U>::value>::type>
   /*implicit*/ span(std::vector<typename std::remove_cv<T>::type> const& v) noexcept
      : length_(v.size()), data_(v.empty() ? nullptr : v.data())
   {}


### PR DESCRIPTION
The `vector<T> const&` constructor needs to be disabled if T is not a const type, because we don't want to create `span<T>` from `vector<T> const&`. The explicit disabling via SFINAE is necessary to this overload is not accidentally taken by cppyy, resulting in the failure of constructor wrapper code compilation.

Avoids errors like these when compiling ROOT with C++17:

```txt
In module 'Core':
/home/rembserj/code/root/root_install/include/ROOT/span.hxx:208:27: error: cannot initialize a member subobject of type 'pointer' (aka 'double *') with an rvalue of type 'const double *'
     : length_(v.size()), data_(v.empty() ? nullptr : v.data())
                          ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
input_line_45:7:41: note: in instantiation of member function 'std::span<double>::span' requested here
      (*(std::span<double>**)ret) = new std::span<double>((const std::vector<double, std::allocator<double> >&)*(const std::vector<double, std::allocator<double> >*)args[0]);
                                        ^
0
1
2
3
```

Reproducer:
```Python
import ROOT

ROOT.gInterpreter.Declare("""
void calc_cumsum(std::size_t n, std::span<double> v)
{
    for (int i = 0; i < n; i += 1) {
        std::cout << v[i] << std::endl;
    }
}
""")

v = ROOT.std.vector["double"](list(range(4)))

ROOT.calc_cumsum(len(v), v)
```