### PR TITLE
[Python] Don't add item converters to InitializerListConverter forever

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -3136,8 +3136,9 @@ bool CPyCppyy::InitializerListConverter::SetArg(
             PyObject* item = PySequence_GetItem(pyobject, i);
             bool convert_ok = false;
             if (item) {
-                Converter *converter = CreateConverter(fValueTypeName);
-                if (!converter) {
+                if (fConverters.empty())
+                    fConverters.emplace_back(CreateConverter(fValueTypeName));
+                if (!fConverters.back()) {
                     if (CPPInstance_Check(item)) {
                     // by convention, use byte copy
                         memcpy((char*)fake->_M_array + i*fValueSize,
@@ -3158,9 +3159,11 @@ bool CPyCppyy::InitializerListConverter::SetArg(
                         }
                     }
                     if (memloc) {
-                        convert_ok = converter->ToMemory(item, memloc);
+                        if (i >= fConverters.size()) {
+                            fConverters.emplace_back(CreateConverter(fValueTypeName));
+                        }
+                        convert_ok = fConverters[i]->ToMemory(item, memloc);
                     }
-                    fConverters.emplace_back(converter);
                 }
 
 


### PR DESCRIPTION
When using a `std::initializer_list` multiple times for a specific call, element converters should only be added if not already present, and not forever.

Reproducer:
```Python
import numpy as np
import ROOT
import psutil
import os

def memory_usage_mb():
    process = psutil.Process(os.getpid())
    return process.memory_info().rss / 1024**2

n = 10000
a = np.arange(n, dtype=np.int32).reshape(n,1)

ROOT.gInterpreter.Declare("""

void my_insert(std::initializer_list<std::vector<int>>) {}

""")

for i in range(100):
    ROOT.my_insert(a)

    if i % 10 == 0:
        print(f"Iteration {i}: Memory usage = {memory_usage_mb():.2f} MB")
```

Closes #https://github.com/root-project/root/issues/18924.