### PR TITLE
[ACLiC] Allow unresolved symbols for macOS

### DIFF
--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -3828,6 +3828,10 @@ int TSystem::CompileMacro(const char *filename, Option_t *opt,
          ForeachSharedLibDep(library, CollectF);
 
          TString relink_cmd = cmd.Strip(TString::kTrailing, ';');
+#ifdef R__MACOSX
+         // Allow linking to succeed despite the missing symbols.
+         relink_cmd.ReplaceAll("-dynamiclib", "-dynamiclib -Wl,-w -Wl,-undefined,dynamic_lookup");
+#endif
          relink_cmd += depLibsFullPaths;
          if (verboseLevel > 3 && withInfo) {
             ::Info("ACLiC", "relinking against all dependencies");

--- a/roottest/root/tree/addresses/CMakeLists.txt
+++ b/roottest/root/tree/addresses/CMakeLists.txt
@@ -147,8 +147,7 @@ ROOTTEST_ADD_TEST(ursula
 #for some classes
 if(NOT MSVC OR win_broken_tests)
   ROOTTEST_COMPILE_MACRO(ConfigRecord.cxx
-                         FIXTURES_SETUP root-tree-addresses-ConfigRecord-fixture
-                         FIXTURES_REQUIRED root-tree-addresses-sueloader-fixture)
+                         FIXTURES_SETUP root-tree-addresses-ConfigRecord-fixture)
 
   ROOTTEST_COMPILE_MACRO(sueloader.C
                          FIXTURES_SETUP root-tree-addresses-sueloader-fixture)


### PR DESCRIPTION
This is a follow up to: https://github.com/root-project/root/pull/19716#issuecomment-3214377372

MacOS does not allow unresolved symbols in dynamic libraries unless passed `-Wl,-undefined,dynamic_lookup`.

On linux, ACLiC relies on leaving symbols unresolved and resolving them later at runtime.

We now add the flag when relinking on macOS. Like how it was done in https://github.com/root-project/root/pull/11432

To reproduce this behaviour:
    
```bash
$BUILD/bin/root.exe -e "gSystem->SetBuildDir(\"$BUILD/roottest/root/tree/addresses\", true)" \
-q -l -b "$ROOT/roottest/scripts/build.C(\"$ROOT/roottest/root/tree/addresses/ConfigRecord.cxx\",\"\",\"\")"
```

Which will result in:
```
Undefined symbols for architecture arm64:
  "RecRecordImp<RecHeader>::Class()", referenced from:
      RecRecordImp<RecHeader>::IsA() const in ConfigRecord_cxx_ACLiC_dict.o
      RecRecordImp<RecHeader>::ShowMembers(TMemberInspector&) const in ConfigRecord_cxx_ACLiC_dict.o
  "RecRecordImp<RecHeader>::Streamer(TBuffer&)", referenced from:
      vtable for RecRecordImp<RecHeader> in ConfigRecord_cxx_ACLiC_dict.o
  "RecHeader::Print(char const*) const", referenced from:
      RecRecordImp<RecHeader>::Print(char const*) const in ConfigRecord_cxx_ACLiC_dict.o
  "vtable for Context", referenced from:
      RecRecordImp<RecHeader>::RecRecordImp() in ConfigRecord_cxx_ACLiC_dict.o
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for RecHeader", referenced from:
      ConfigRecord::~ConfigRecord() in ConfigRecord_cxx_ACLiC_dict.o
      ConfigRecord::~ConfigRecord() in ConfigRecord_cxx_ACLiC_dict.o
      ROOT::deleteArray_ConfigRecord(void*) in ConfigRecord_cxx_ACLiC_dict.o
      RecRecordImp<RecHeader>::RecRecordImp() in ConfigRecord_cxx_ACLiC_dict.o
      RecRecordImp<RecHeader>::~RecRecordImp() in ConfigRecord_cxx_ACLiC_dict.o
      RecRecordImp<RecHeader>::~RecRecordImp() in ConfigRecord_cxx_ACLiC_dict.o
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
```

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

