### PR TITLE
Fix the line attributes in TPaveStats

### DIFF
--- a/graf2d/graf/src/TPaveStats.cxx
+++ b/graf2d/graf/src/TPaveStats.cxx
@@ -333,7 +333,7 @@ void TPaveStats::SetOption(Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Invalid method to change drawing option for stats box
 /// While stats box should never appear in pad list of primitives, this method cannot work
-/// Please use SetOption() method insted
+/// Please use SetOption() method instead
 /// Redefined here to remove **MENU** qualifier and exclude it from context menu
 
 void TPaveStats::SetDrawOption(Option_t *option)
@@ -490,6 +490,7 @@ void TPaveStats::Paint(Option_t *option)
             latex->PaintLatex(xtext,ytext,latex->GetTextAngle(),
                                           titlesize,
                                           sl);
+            TAttLine::Modify();
             gPad->PaintLine(x1ref,y2ref-yspace,x2ref,y2ref-yspace);
          }
          delete [] sl;


### PR DESCRIPTION
In the following example the attributes of the line below the title os the statistics box could not
be changed. The line attibute were not set in that case.
```
{
   gStyle->SetOptStat();
   auto h1 = new TH1F("Hist","Hist",100,-3,3); h1->Draw();
   gPad->Update();
   TPaveStats *ps = (TPaveStats*)h1->FindObject("stats");
   ps->SetName("stats_1"); ps->Draw();
   h1->SetStats(0);
   ps->SetFillStyle(0);
   ps->SetBorderSize(0);
   ps->SetLineWidth(3);
   ps->SetLineColor(kBlue);
}
```

This PR fixes  https://root-forum.cern.ch/t/adding-new-entry-to-the-stats-box-doesnt-work/64062

