### PR TITLE
[CMake] Build `rootcint` and `genreflex` as separate targets

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -94,55 +94,33 @@ set_source_files_properties(src/rootcling.cxx PROPERTIES
   VISIBILITY_INLINES_HIDDEN "ON"
 )
 
-ROOT_EXECUTABLE(rootcling src/rootcling.cxx LIBRARIES RIO Cling Core Rint)
+set(rootcling_exe_names rootcling genreflex rootcint)
 
-# rootcling includes the ROOT complex header which would build the complex
-# dictionary with modules. To make sure that rootcling_stage1 builds this
-# dict before we use it, we add a dependency here.
-add_dependencies(rootcling complexDict)
+foreach(exe_name IN LISTS rootcling_exe_names)
+  ROOT_EXECUTABLE(${exe_name} src/rootcling.cxx LIBRARIES RIO Cling Core Rint)
 
-target_include_directories(rootcling PRIVATE
-        ${CMAKE_SOURCE_DIR}/core/metacling/res
-        ${CMAKE_SOURCE_DIR}/core/dictgen/res
-        ${CMAKE_SOURCE_DIR}/io/rootpcm/res)
-set_property(TARGET rootcling PROPERTY ENABLE_EXPORTS 1)
-if(WIN32)
-  set_target_properties(rootcling PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
-  set_property(TARGET rootcling APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
-endif()
+  # rootcling includes the ROOT complex header which would build the complex
+  # dictionary with modules. To make sure that rootcling_stage1 builds this
+  # dict before we use it, we add a dependency here.
+  add_dependencies(${exe_name} complexDict)
+
+  target_include_directories(${exe_name} PRIVATE
+          ${CMAKE_SOURCE_DIR}/core/metacling/res
+          ${CMAKE_SOURCE_DIR}/core/dictgen/res
+          ${CMAKE_SOURCE_DIR}/io/rootpcm/res)
+  set_property(TARGET ${exe_name} PROPERTY ENABLE_EXPORTS 1)
+  if(WIN32)
+    set_target_properties(${exe_name} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+    set_property(TARGET ${exe_name} APPEND_STRING PROPERTY LINK_FLAGS " -STACK:4000000")
+  endif()
+endforeach()
+
+# To inherit the dependencies from rootcling
+add_dependencies(genreflex rootcling)
+add_dependencies(rootcint rootcint)
+
 
 if (TARGET Gui)
   ROOT_EXECUTABLE(rootbrowse src/rootbrowse.cxx LIBRARIES RIO Core Rint Gui)
 endif()
 ROOT_EXECUTABLE(rootls src/rootls.cxx LIBRARIES RIO Tree Core Rint ROOTNTuple)
-
-# Create aliases: rootcint, genreflex.
-if(WIN32)
-  add_custom_command(TARGET rootcling POST_BUILD
-                     COMMAND copy /y rootcling.exe rootcint.exe
-                     COMMAND copy /y rootcling.exe genreflex.exe
-                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-else()
-  add_custom_command(TARGET rootcling POST_BUILD
-                     COMMAND ln -f rootcling rootcint
-                     COMMAND ln -f rootcling genreflex
-                     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-endif()
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES
-                         "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint;${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex")
-
-if(CMAKE_HOST_UNIX)
-  install(CODE "execute_process(COMMAND ln -f rootcling rootcint WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})" COMPONENT applications)
-  install(CODE "execute_process(COMMAND ln -f rootcling genreflex WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})" COMPONENT applications)
-else()
-  if(MSVC)
-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcling.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex.exe DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
-  else()
-    install(PROGRAMS  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootcint
-                      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/genreflex
-                      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rlibmap
-                      DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT applications)
-  endif()
-endif()

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -111,12 +111,10 @@ ROOT_GENERATE_DICTIONARY(StreamerFieldDict ${CMAKE_CURRENT_SOURCE_DIR}/StreamerF
                          DEPENDENCIES RIO)
 
 if(MSVC)
-  set(genreflex ${CMAKE_BINARY_DIR}/bin/genreflex.exe)
-  set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${genreflex})
+  set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" $<TARGET_FILE:genreflex>)
 else()
-  set(genreflex ${CMAKE_BINARY_DIR}/bin/genreflex)
   set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
-              "ROOTIGNOREPREFIX=1" ${genreflex})
+              "ROOTIGNOREPREFIX=1" $<TARGET_FILE:genreflex>)
 endif()
 
 configure_file(StreamerFieldXML.h . COPYONLY)


### PR DESCRIPTION
This makes the CMake code more robust.

Right now, we use some `install(CODE "execute_process(COMMAND ln -f ...`
solution on unix to install `rootcint` and `genreflex`. This does not
work in all cases, either because of the usage of `\$ENV{DESTDIR}` when
`DESTDIR` is not set, or because hard links are not allowed.

Always copying `rootcling` - already in the build tree - would avoid
that problem, but by copying we risk sidestepping the CMake mechanisms
to set the RPath correctly when installing the copies, which are not
actual targets.

To make makes things simpler and more robust, this commit suggests to
build the `rootcing` and `genreflex` executables as separate targets
from the same source. The cost is very little cost in memory
(`rootcling` is only 31K, so copying two times only increases the size
of ROOTs `bin` directory by 1.5 %) and little in compile time (the extra
compile time is less than a second, not noticable in parallel builds).