### PR TITLE
[CMake] Don't wrap command in `ROOTTEST_COMPILE_MACRO` in CMake target

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2314,17 +2314,14 @@ macro(ROOTTEST_COMPILE_MACRO filename)
     list(APPEND RootMacroDirDefines "-e;#define ${d}")
   endforeach()
 
-  set(RootMacroBuildDefines
-        -e "#define CMakeEnvironment"
-        -e "#define CMakeBuildDir \"${CMAKE_CURRENT_BINARY_DIR}\""
-        -e "gSystem->AddDynamicPath(\"${CMAKE_CURRENT_BINARY_DIR}\")"
-        -e "gROOT->SetMacroPath(\"${CMAKE_CURRENT_SOURCE_DIR}\")"
-        -e "gInterpreter->AddIncludePath(\"-I${CMAKE_CURRENT_BINARY_DIR}\")"
-        -e "gSystem->AddIncludePath(\"-I${CMAKE_CURRENT_BINARY_DIR}\")"
-        -e "gSystem->SetBuildDir(\"${CMAKE_CURRENT_BINARY_DIR}\", true)"
-        ${RootMacroDirDefines})
-
-  set(root_compile_macro ${ROOT_root_CMD} ${RootMacroBuildDefines} -q -l -b)
+  set(root_compile_macro ${CMAKE_COMMAND} -E env
+      ROOT_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}"
+      ROOT_INCLUDE_PATH="${CMAKE_CURRENT_BINARY_DIR}"
+      ${ROOT_root_CMD}
+      -e "gSystem->SetBuildDir(\"${CMAKE_CURRENT_BINARY_DIR}\", true)"
+      ${RootMacroDirDefines}
+      -q -l -b
+  )
 
   get_filename_component(realfp ${filename} ABSOLUTE)
   if(MSVC)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2291,8 +2291,7 @@ endfunction(ROOTTEST_ADD_AUTOMACROS)
 #-------------------------------------------------------------------------------
 #
 # macro ROOTTEST_COMPILE_MACRO(<filename> [BUILDOBJ object] [BUILDLIB lib]
-#                                         [FIXTURES_SETUP ...] [FIXTURES_CLEANUP ...] [FIXTURES_REQUIRED ...]
-#                                         [DEPENDS dependencies...])
+#                                         [FIXTURES_SETUP ...] [FIXTURES_CLEANUP ...] [FIXTURES_REQUIRED ...])
 #
 # This macro creates and loads a shared library containing the code from
 # the file <filename>. A test that performs the compilation is created.
@@ -2302,7 +2301,7 @@ endfunction(ROOTTEST_ADD_AUTOMACROS)
 #
 #-------------------------------------------------------------------------------
 macro(ROOTTEST_COMPILE_MACRO filename)
-  CMAKE_PARSE_ARGUMENTS(ARG "" "BUILDOBJ;BUILDLIB" "DEPENDS;FIXTURES_SETUP;FIXTURES_CLEANUP;FIXTURES_REQUIRED"  ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(ARG "" "BUILDOBJ;BUILDLIB" "FIXTURES_SETUP;FIXTURES_CLEANUP;FIXTURES_REQUIRED"  ${ARGN})
 
   # Add defines to root_compile_macro, in order to have out-of-source builds
   # when using the scripts/build.C macro.
@@ -2340,37 +2339,15 @@ macro(ROOTTEST_COMPILE_MACRO filename)
                             ${BuildScriptFile}${BuildScriptArg}
                             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-  if(ARG_DEPENDS)
-    set(deps ${ARG_DEPENDS})
-  endif()
-
   ROOTTEST_TARGETNAME_FROM_FILE(COMPILE_MACRO_TEST ${filename})
-
-  set(compile_target ${COMPILE_MACRO_TEST}-compile-macro)
-
-  add_custom_target(${compile_target}
-                    COMMAND ${compile_macro_command}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                    VERBATIM)
-
-  if(ARG_DEPENDS)
-    add_dependencies(${compile_target} ${deps})
-  endif()
 
   set(COMPILE_MACRO_TEST ${COMPILE_MACRO_TEST}-build)
 
-  add_test(NAME ${COMPILE_MACRO_TEST}
-           COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}
-                                    ${build_config}
-                                    --target ${compile_target}${fast}
-                                    -- ${always-make})
+  add_test(NAME ${COMPILE_MACRO_TEST} COMMAND ${compile_macro_command})
   if(NOT MSVC OR win_broken_tests)
     set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY FAIL_REGULAR_EXPRESSION "Warning in")
   endif()
   set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY ENVIRONMENT ${ROOTTEST_ENVIRONMENT})
-  if(CMAKE_GENERATOR MATCHES Ninja AND NOT MSVC)
-    set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY RUN_SERIAL true)
-  endif()
   if (ARG_FIXTURES_SETUP)
     set_property(TEST ${COMPILE_MACRO_TEST} PROPERTY
       FIXTURES_SETUP ${ARG_FIXTURES_SETUP})

--- a/roottest/scripts/build.C
+++ b/roottest/scripts/build.C
@@ -75,9 +75,6 @@ void build(const char *filename, const char *lib = 0, const char *obj = 0, const
    }
    // fprintf(stderr,"from %s to %s\n",filename,fname.Data());
    int result = gSystem->CompileMacro(fname,"kc");
-#elif defined(CMakeEnvironment) && defined(CMakeBuildDir)
-   // fprintf(stderr,"CmakeBuildDir: %s filename: %s", CMakeBuildDir, filename);
-   int result = gSystem->CompileMacro(filename,"kc-", libname, CMakeBuildDir);
 #else
    int result = gSystem->CompileMacro(filename,"kc", libname);
 #endif


### PR DESCRIPTION
Instead of running the `root ... <macro>.C+` build step as the command
associated with a custom CMake target, just run the command directly in
the test added with `add_test`.

This simplification is possible because for the custom CMake target, no
dependencies are ever specified. This makes building it not different
from just running the underlying command directly.

Do some further CMake code simplifications in a second commit (more detail in the commit description).