### PR TITLE
[skip-ci] Fix a missing period in build instructions.

### DIFF
--- a/interpreter/cling/README.md
+++ b/interpreter/cling/README.md
@@ -50,7 +50,7 @@ cd llvm-project
 git checkout cling-latest
 cd ..
 mkdir llvm-build && cd llvm-build
-cmake -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ./llvm-project/llvm
+cmake -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_TARGETS_TO_BUILD="host;NVPTX" -DCMAKE_BUILD_TYPE=Release ../llvm-project/llvm
 cmake --build .
 ```
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

By @thomwiggers

See https://github.com/root-project/cling/pull/554/