### PR TITLE
[RF][Docs] Remove a \see in the RooDataHist/Set documentation.

### DIFF
--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -38,7 +38,7 @@ datahist->get(1)->Print("V"); std::cout << "w=" << datahist->weight(1) << std::e
 See RooAbsData::plotOn().
 
 ### Creating a datahist using RDataFrame
-\see RooAbsDataHelper, rf408_RDataFrameToRooFit.C
+See RooAbsDataHelper, rf408_RDataFrameToRooFit.C
 
 **/
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -67,7 +67,7 @@ For the inverse conversion, see `RooAbsData::convertToVectorStore()`.
 
 
 ### Creating a dataset using RDataFrame
-\see RooAbsDataHelper, rf408_RDataFrameToRooFit.C
+See RooAbsDataHelper, rf408_RDataFrameToRooFit.C
 
 ### Uniquely identifying RooDataSet objects
 


### PR DESCRIPTION
Currently, the documentation seems to show an empty section, since a section title is followed by a \see command, which generates its own section.
It's better to replace it by the plain word "See xxx".

See the second section [here](https://root.cern/doc/master/classRooDataHist.html):
<img width="379" height="171" alt="image" src="https://github.com/user-attachments/assets/6dab1331-2091-417f-b34d-a9fe21dc8d52" />
