### PR TITLE
[cmake] avoid OS-dependent cat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ add_custom_target(copymodulemap DEPENDS "${CMAKE_BINARY_DIR}/include/ROOT.module
 add_custom_command(
                   OUTPUT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
                   DEPENDS cmake/unix/module.modulemap "${CMAKE_BINARY_DIR}/include/module.modulemap.extra"
-                  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
+                  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" > "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
 )
 install(FILES "${CMAKE_BINARY_DIR}/include/ROOT.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

since CMake 3.18 there is an inbuilt tool.

Helps towards https://github.com/root-project/root/issues/7311

Probably, the logic in the generation of the modulemap can be further optimized by avoiding that "intermediate copy" of unix/modulemap and doing all via "cat", right?

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

