### PR TITLE
[build] Support source or build directory with spaces

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -46,7 +46,7 @@ except Exception as exc:
     CONNECTION = None
 
 WINDOWS = (os.name == 'nt')
-WORKDIR = (os.environ['HOME'] + '/ROOT-CI') if not WINDOWS else 'C:/ROOT-CI'
+WORKDIR = (os.environ['HOME'] + '/ROOT\ CI') if not WINDOWS else 'C:/ROOT^ CI'
 COMPRESSIONLEVEL = 6 if not WINDOWS else 1
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,20 +421,11 @@ get_property(__allBuiltins GLOBAL PROPERTY ROOT_BUILTIN_TARGETS)
 add_custom_target(move_headers ALL DEPENDS ${__allHeaders} ${__allBuiltins} gitinfotxt)
 
 #---CXX MODULES-----------------------------------------------------------------------------------
-if(MSVC)
-  set(_os_cat "type")
-else()
-  set(_os_cat "cat")
-endif()
-cmake_path(CONVERT "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" TO_NATIVE_PATH_LIST _from_native)
-cmake_path(CONVERT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap" TO_NATIVE_PATH_LIST _to_native)
-
 add_custom_target(copymodulemap DEPENDS "${CMAKE_BINARY_DIR}/include/ROOT.modulemap")
 add_custom_command(
 		  OUTPUT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
                   DEPENDS cmake/unix/module.modulemap "${CMAKE_BINARY_DIR}/include/module.modulemap.extra"
-		  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
-                  COMMAND ${_os_cat} "${_from_native}" >> "${_to_native}"
+                  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
 )
 install(FILES "${CMAKE_BINARY_DIR}/include/ROOT.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
 
@@ -506,22 +497,22 @@ else()
       ${CMAKE_SOURCE_DIR} . ${pyroot_legacy} ${__cling_pch}
     COMMAND
       ${CMAKE_COMMAND} -E env ROOTIGNOREPREFIX=1 ${Python3_EXECUTABLE}
-      ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py etc/allDict.cxx.pch
-      ${__allIncludes} -I${CMAKE_BINARY_DIR}/include -I${CMAKE_SOURCE_DIR}/core
+      "${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py" etc/allDict.cxx.pch
+      ${__allIncludes} -I"${CMAKE_BINARY_DIR}/include" -I"${CMAKE_SOURCE_DIR}/core"
     DEPENDS
       rootcling ${__pch_dependencies} ${__pch_dictionaries}
-      ${CMAKE_SOURCE_DIR}/cmake/unix/makepchinput.py
-      ${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py
+      "${CMAKE_SOURCE_DIR}/cmake/unix/makepchinput.py"
+      "${CMAKE_SOURCE_DIR}/etc/dictpch/makepch.py"
   )
   add_custom_target(onepcm ALL DEPENDS etc/allDict.cxx.pch)
-  install(FILES ${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
-  install(DIRECTORY ${CMAKE_BINARY_DIR}/etc/dictpch DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+  install(FILES "${CMAKE_BINARY_DIR}/etc/allDict.cxx.pch" DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+  install(DIRECTORY "${CMAKE_BINARY_DIR}/etc/dictpch" DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
 endif()
 
 # FIXME: move installation of PCMS in ROOT_GENERATE_DICTIONARY().
 # We are excluding directories, which are accidentaly copied via unxpected behaviour of install(DIRECTORY ..)
 install(
-   DIRECTORY ${CMAKE_BINARY_DIR}/lib/
+   DIRECTORY "${CMAKE_BINARY_DIR}/lib/"
    DESTINATION ${CMAKE_INSTALL_LIBDIR}
    FILES_MATCHING
    PATTERN "*.pcm"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,7 @@ add_custom_target(move_headers ALL DEPENDS ${__allHeaders} ${__allBuiltins} giti
 #---CXX MODULES-----------------------------------------------------------------------------------
 add_custom_target(copymodulemap DEPENDS "${CMAKE_BINARY_DIR}/include/ROOT.modulemap")
 add_custom_command(
-		  OUTPUT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
+          OUTPUT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
                   DEPENDS cmake/unix/module.modulemap "${CMAKE_BINARY_DIR}/include/module.modulemap.extra"
                   COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
 )
@@ -536,7 +536,8 @@ if(runtime_cxxmodules)
     set(modules_idx_cmd COMMAND ${CMAKE_COMMAND} -E env PATH="${library_output_dir}\\\;%PATH%"
                                 ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b)
   else()
-    set(modules_idx_cmd COMMAND ${ld_library_path}=${library_output_dir}:$ENV{${ld_library_path}}
+    cmake_path(CONVERT ${library_output_dir} TO_NATIVE_PATH_LIST library_output_dir)
+    set(modules_idx_cmd COMMAND ${CMAKE_COMMAND} -E env ${ld_library_path}=${library_output_dir}:$ENV{${ld_library_path}}
                                 ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b)
   endif()
   add_custom_command(OUTPUT ${library_output_dir}/modules.idx
@@ -560,7 +561,7 @@ if(WIN32)
   set(hsimple_cmd COMMAND ${CMAKE_COMMAND} -E env PATH="${CMAKE_RUNTIME_OUTPUT_DIRECTORY}\\\;%PATH%"
                           ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C -e return)
 else()
-  set(hsimple_cmd COMMAND ${MODULES_ROOT_INCPATH} ${ld_library_path}=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{${ld_library_path}}
+  set(hsimple_cmd COMMAND ${CMAKE_COMMAND} -E env ${ld_library_path}=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:$ENV{${ld_library_path}}
                           ROOTIGNOREPREFIX=1 ROOT_HIST=0 $<TARGET_FILE:root.exe> -l -q -b -n -x ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C -e return)
 endif()
 add_custom_command(OUTPUT tutorials/hsimple.root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,7 @@ add_custom_target(copymodulemap DEPENDS "${CMAKE_BINARY_DIR}/include/ROOT.module
 add_custom_command(
           OUTPUT "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
                   DEPENDS cmake/unix/module.modulemap "${CMAKE_BINARY_DIR}/include/module.modulemap.extra"
-                  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" >> "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
+                  COMMAND ${CMAKE_COMMAND} -E cat "${CMAKE_SOURCE_DIR}/cmake/unix/module.modulemap" "${CMAKE_BINARY_DIR}/include/module.modulemap.extra" > "${CMAKE_BINARY_DIR}/include/ROOT.modulemap"
 )
 install(FILES "${CMAKE_BINARY_DIR}/include/ROOT.modulemap" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT headers)
 

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -81,7 +81,7 @@ target_include_directories(Thread PUBLIC
 
 # keep include directory for ROOT/RSha256.hxx private
 set_source_files_properties(src/RConcurrentHashColl.cxx
-  PROPERTIES COMPILE_FLAGS -I${CMAKE_SOURCE_DIR}/core/foundation/res)
+  PROPERTIES COMPILE_FLAGS -I"${CMAKE_SOURCE_DIR}/core/foundation/res")
 
 if((tbb OR builtin_tbb) AND NOT MSVC)
   target_include_directories(Thread PRIVATE ${TBB_INCLUDE_DIRS})

--- a/graf2d/asimage/src/libAfterImage/Makefile.in
+++ b/graf2d/asimage/src/libAfterImage/Makefile.in
@@ -143,7 +143,7 @@ mkdir:
 		)
 
 install.static: 	mkdir
-		$(INSTALL_SCRIPT) afterimage-libs afterimage-config $(AFTER_BIN_DIR)
+		$(INSTALL_SCRIPT) afterimage-libs afterimage-config "$(AFTER_BIN_DIR)"
 		@(if [ -d $(LIBDIR) ] && [ -w $(LIBDIR) ]; then \
 		    echo "$(INSTALL_LIB) $(LIB_STATIC) $(LIBDIR)"; \
 		    $(INSTALL_LIB) $(LIB_STATIC) $(LIBDIR); \
@@ -155,7 +155,7 @@ install.script:
 install.dyn:	mkdir
 		@( echo "$(INSTALL_LIB) $(LIB_SHARED).$(LIBVER) $(LIBDIR)"; \
 		$(INSTALL_LIB) $(LIB_SHARED).$(LIBVER) $(LIBDIR); \
-		$(INSTALL_SCRIPT) afterimage-libs afterimage-config $(AFTER_BIN_DIR); \
+		$(INSTALL_SCRIPT) afterimage-libs afterimage-config "$(AFTER_BIN_DIR)"; \
 		$(RM) -f $(LIBDIR)/$(LIB_SHARED).$(LIBVERMAJOR) $(LIBDIR)/$(LIB_SHARED); \
 		$(LN_S) -f $(LIB_SHARED).$(LIBVER) $(LIBDIR)/$(LIB_SHARED).$(LIBVERMAJOR); \
 		$(LN_S) -f $(LIB_SHARED).$(LIBVERMAJOR) $(LIBDIR)/$(LIB_SHARED); \

--- a/interpreter/llvm-project/llvm/cmake/modules/AddLLVM.cmake
+++ b/interpreter/llvm-project/llvm/cmake/modules/AddLLVM.cmake
@@ -2392,7 +2392,7 @@ function(llvm_setup_rpath name)
     if(LLVM_LINKER_IS_GNULD AND NOT ${LLVM_LIBRARY_OUTPUT_INTDIR} STREQUAL "")
       # $ORIGIN is not interpreted at link time by ld.bfd
       set_property(TARGET ${name} APPEND_STRING PROPERTY
-                   LINK_FLAGS " -Wl,-rpath-link,${LLVM_LIBRARY_OUTPUT_INTDIR} ")
+                   LINK_FLAGS " -Wl,-rpath-link,\"${LLVM_LIBRARY_OUTPUT_INTDIR}\" ")
     endif()
   else()
     return()


### PR DESCRIPTION
With these changes, I was able to build ROOT with -Dminimal=ON locally, using a space in both the source dir and the build dir.

Trying now on the CI.

Fixes https://github.com/root-project/root/issues/7311