### PR TITLE
[CMake] Fix `asan` builds with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,14 @@ include(RootMacros)
 include(CheckAssembler)
 include(CheckIntrinsics)
 
+#---Enable testing------------------------------------------------------------------------------
+if(testing)
+  enable_testing()
+endif()
+
+#---Here we look for installed software and switch on and off the different build options-------
+include(SearchInstalledSoftware)
+
 # relatedrepo_GetClosestMatch(REPO_NAME <repo> ORIGIN_PREFIX <originp> UPSTREAM_PREFIX <upstreamp>
 #                             FETCHURL_VARIABLE <output_url> FETCHREF_VARIABLE <output_ref>)
 # Return the clone URL and head/tag of the closest match for `repo` (e.g. roottest), based on the
@@ -284,15 +292,6 @@ if(asan)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_EXTRA_SHARED_LINKER_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_EXTRA_EXE_LINKER_FLAGS}")
 endif()
-
-#---Enable CTest package -----------------------------------------------------------------------
-#include(CTest)
-if(testing)
-  enable_testing()
-endif()
-
-#---Here we look for installed software and switch on and of the different build options--------
-include(SearchInstalledSoftware)
 
 #---Here we add tcmalloc to the linker flags if needed------------------------------------------
 if (TCMALLOC_FOUND)

--- a/cmake/modules/SetUpFreeBSD.cmake
+++ b/cmake/modules/SetUpFreeBSD.cmake
@@ -93,6 +93,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   if(asan)
     # See also core/sanitizer/README.md for what's happening.
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # Since a while now, Clang installs libclang_rt.asan.so in an architecture dependent directory.
+    if(ASAN_RUNTIME_LIBRARY STREQUAL "libclang_rt.asan-x86_64.so")
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan.so OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
     set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope)
     set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs")
     set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs -Wl,--undefined=__asan_default_options -Wl,--undefined=__lsan_default_options -Wl,--undefined=__lsan_default_suppressions")

--- a/cmake/modules/SetUpLinux.cmake
+++ b/cmake/modules/SetUpLinux.cmake
@@ -106,6 +106,10 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   if(asan)
     # See also core/sanitizer/README.md for what's happening.
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # Since a while now, Clang installs libclang_rt.asan.so in an architecture dependent directory.
+    if(ASAN_RUNTIME_LIBRARY STREQUAL "libclang_rt.asan-x86_64.so")
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan.so OUTPUT_VARIABLE ASAN_RUNTIME_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
     set(ASAN_EXTRA_CXX_FLAGS -fsanitize=address -fno-omit-frame-pointer -fsanitize-address-use-after-scope)
     set(ASAN_EXTRA_SHARED_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs")
     set(ASAN_EXTRA_EXE_LINKER_FLAGS "-fsanitize=address -static-libsan -z undefs -Wl,--undefined=__asan_default_options -Wl,--undefined=__lsan_default_options -Wl,--undefined=__lsan_default_suppressions")


### PR DESCRIPTION
 * `SearchInstalledSoftware` before adding linker flags, to avoid interference with `-z undefs`
 * Look for new `libclang_rt.asan.so` in architecture dependent directory