### PR TITLE
[core] Handle deserialization during `TCling::AutoLoad`

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6381,6 +6381,9 @@ Int_t TCling::AutoLoad(const char *cls, Bool_t knowDictNotLoaded /* = kFALSE */)
    // quality of the search (i.e. bad in case of library with no pcm and no rootmap
    // file).
    TInterpreter::SuspendAutoParsing autoParseRaii(this);
+   // During the process, we might need to look at member properties which could
+   // trigger deserialization with modules enabled.
+   cling::Interpreter::PushTransactionRAII deserRaii(GetInterpreterImpl());
    std::unordered_set<std::string> visited;
    return DeepAutoLoadImpl(cls, visited, false /*normalized*/);
 }


### PR DESCRIPTION
This fixes a failing assertion `getState() == kCollecting` during `pyunittests-roottest-root-ntuple-atlas-datavector-rentry-getptr` on `mac13` since effectively enabling assertions in Cling with commit 842dad25d9.

FYI @jblomer @vepadulano 