### PR TITLE
[Python] Fix RPATH info for ROOTPythonizations library

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -182,6 +182,8 @@ else()
   target_link_libraries(${libname} PUBLIC -Wl,--unresolved-symbols=ignore-all)
 endif()
 
+ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH(${libname} ${CMAKE_INSTALL_LIBDIR})
+
 target_include_directories(${libname}
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The RPATH was not properly added to the library info. The PR adds the needed information using the macro ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH.
The  ROOTPythonizations library was the only shared library which missed the information.

## Checklist:

- [x ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

