### PR TITLE
[RF] Don't recreate hash tables in `RooLinkedList::Add()`

### DIFF
--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -327,33 +327,25 @@ RooLinkedList& RooLinkedList::operator=(const RooLinkedList& other)
 
 void RooLinkedList::setHashTableSize(Int_t size)
 {
-  if (size<0) {
-    coutE(InputArguments) << "RooLinkedList::setHashTable() ERROR size must be positive" << std::endl ;
-    return ;
-  }
-  if (size==0) {
-    if (!_htableName) {
-      // No hash table present
-      return ;
-    } else {
+   if (size < 0) {
+      coutE(InputArguments) << "RooLinkedList::setHashTable() ERROR size must be positive" << std::endl;
+      return;
+   }
+   if (size == 0) {
       // Remove existing hash table
       _htableName.reset();
       _htableLink.reset();
-    }
-  } else {
+      return;
+   }
 
-    // (Re)create hash tables
-    _htableName = std::make_unique<HashTableByName>(size) ;
-    _htableLink = std::make_unique<HashTableByLink>(size) ;
+   if (!_htableName) {
+      // (Re)create hash tables
+      _htableName = std::make_unique<HashTableByName>(size);
+      _htableLink = std::make_unique<HashTableByLink>(size);
+   }
 
-    // Fill hash table with existing entries
-    RooLinkedListElem* ptr = _first ;
-    while(ptr) {
-      _htableName->insert({ptr->_arg->GetName(), ptr->_arg}) ;
-      _htableLink->insert({ptr->_arg, reinterpret_cast<TObject*>(ptr)}) ;
-      ptr = ptr->_next ;
-    }
-  }
+   _htableName->reserve(size);
+   _htableLink->reserve(size);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Thanks to #7818, where the `RooHashTable` was migrated to `std::unordered_map`, we can now use proper `reserve()` functions to increase the hash table size when adding elements.

The current mechanism deleting and recreating the hash tables from scratch when the list size changed incurred a pretty large overhead. In fact, it made adding to the list a `O(n)` operation, because it has to iterate over the collection to fill the hash table again. Consequently, copying a `RooLinkedList` was `O(n^2)`, which is unexpected to the user.

This change will speed up the handling of objects in a RooWorkspace, which uses `RooLinkedLists` to manage the elemens.

Taken from #19459 to be merged before, because this is in principle independent of the RooWorkspace developments.