### PR TITLE
[http] implement chunked requests

### DIFF
--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -206,7 +206,7 @@ public:
 
    TString GetHeader(const char *name);
 
-   void SetChunked();
+   void SetChunked(Bool_t on = kTRUE);
    Bool_t IsChunked();
 
    /** Set Content-Encoding header like gzip */

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -206,6 +206,9 @@ public:
 
    TString GetHeader(const char *name);
 
+   void SetChunked();
+   Bool_t IsChunked();
+
    /** Set Content-Encoding header like gzip */
    void SetEncoding(const char *typ) { AccessHeader(fHeader, "Content-Encoding", typ, kTRUE); }
 

--- a/net/http/inc/THttpServer.h
+++ b/net/http/inc/THttpServer.h
@@ -81,7 +81,7 @@ public:
    THttpServer(const char *engine = "http:8080");
    virtual ~THttpServer();
 
-   Bool_t CreateEngine(const char *engine);
+   virtual Bool_t CreateEngine(const char *engine);
 
    Bool_t IsAnyEngine() const { return fEngines.GetSize() > 0; }
 

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -359,12 +359,11 @@ void THttpCallArg::AddNoCacheHeader()
 ///
 /// Data to the client transferred in chunks.
 /// So many ProcessRequests will be invoked and produced data will be send as next chunk
-/// - until empty conent will be returned
+/// - until empty conent will be returned or chunked flag is cleared
 
-/** mark as chunked - several chunks can be send to the client without closing connection */
-void THttpCallArg::SetChunked()
+void THttpCallArg::SetChunked(Bool_t on)
 {
-   AccessHeader(fHeader, "Transfer-Encoding", "chunked", kTRUE);
+   AccessHeader(fHeader, "Transfer-Encoding", on ? "chunked" : nullptr, kTRUE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -355,6 +355,27 @@ void THttpCallArg::AddNoCacheHeader()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Mark as chunked
+///
+/// Data to the client transferred in chunks.
+/// So many ProcessRequests will be invoked and produced data will be send as next chunk
+/// - until empty conent will be returned
+
+/** mark as chunked - several chunks can be send to the client without closing connection */
+void THttpCallArg::SetChunked()
+{
+   AccessHeader(fHeader, "Transfer-Encoding", "chunked", kTRUE);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// If marked as chunked
+
+Bool_t THttpCallArg::IsChunked()
+{
+   return AccessHeader(fHeader, "Transfer-Encoding") == "chunked";
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Fills HTTP header, which can be send at the beginning of reply on the http request
 ///
 /// @param name is HTTP protocol name (default "HTTP/1.1")
@@ -367,6 +388,13 @@ std::string THttpCallArg::FillHttpHeader(const char *name)
       hdr.append(" 404 Not Found\r\n"
                  "Content-Length: 0\r\n"
                  "Connection: close\r\n\r\n");
+   else if (IsChunked())
+      hdr.append(TString::Format(" 200 OK\r\n"
+                                 "Content-Type: %s\r\n"
+                                 "Connection: keep-alive\r\n"
+                                 "%s\r\n",
+                                 GetContentType(), fHeader.Data())
+                    .Data());
    else
       hdr.append(TString::Format(" 200 OK\r\n"
                                  "Content-Type: %s\r\n"

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -662,6 +662,7 @@ Bool_t THttpServer::ExecuteHttp(std::shared_ptr<THttpCallArg> arg)
 
    // add call arg to the list
    std::unique_lock<std::mutex> lk(fMutex);
+   arg->fNotifyFlag = kFALSE;
    fArgs.push(arg);
    // and now wait until request is processed
    arg->fCond.wait(lk);

--- a/tutorials/http/httpchunked.C
+++ b/tutorials/http/httpchunked.C
@@ -1,0 +1,65 @@
+/// \file
+/// \ingroup tutorial_http
+///  This macro shows implementation of chunked requests
+///  These are special kind of user-defined requests which let
+///  split large http reply on many chunks so that server do not need to allocate
+///  such memory at once
+///
+///  After macro started, try to execute request with
+/// ~~~
+///      wget http://localhost:8080/chunked.txt
+/// ~~~
+///
+///  CAUTION: Example is not able to handle multiple requests at the same time
+///  For this one should create counter for each THttpCallArg instance
+///
+/// \macro_code
+///
+/// \author Sergey Linev
+
+#include "THttpServer.h"
+#include "THttpCallArg.h"
+#include <cstring>
+
+class TChunkedHttpServer : public THttpServer {
+   protected:
+
+      int fCounter = 0;
+
+      /** process only requests which are not handled by THttpServer itself */
+      void MissedRequest(THttpCallArg *arg) override
+      {
+         if (strcmp(arg->GetFileName(), "chunked.txt"))
+            return;
+
+         arg->SetChunked();
+
+         std::string content = "line" + std::to_string(fCounter++) + "   ";
+
+         for (int n = 0; n < 2000; n++)
+            content.append("-");
+         content.append("\n");
+
+         if (fCounter >= 1000) {
+            // to stop chunk transfer either provide empty content or clear chunked flag
+            fCounter = 0;
+            arg->SetChunked(kFALSE);
+         }
+
+         arg->SetTextContent(std::move(content));
+      }
+
+   public:
+      TChunkedHttpServer(const char *engine) : THttpServer(engine) {}
+
+   ClassDefOverride(TChunkedHttpServer, 0)
+};
+
+void httpchunked()
+{
+   // start http server
+   auto serv = new TChunkedHttpServer("http:8080");
+
+   // reduce to minimum timeout for async requests processing
+   serv->SetTimer(1);
+}


### PR DESCRIPTION
These are very special requests when http reply returned not as single buffer
but rather as chunks of many smaller buffers.

This allow to send huge amount of data with single reply - without need of allocate all such memory at once.

Do not used in normal THttpServer requests processing.

Provide `httpchunked.C` tutorial showing usage of such requests.