### PR TITLE
Fix the (TH1*, THStack*) ctor

### DIFF
--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -269,8 +269,7 @@ TRatioPlot::TRatioPlot(TH1 *h1, THStack *st, Option_t *option) : TRatioPlot()
       tmpHist->Add(static_cast<TH1 *>(stackHists->At(i)));
    }
 
-   fHistDrawProxy = st;
-   fHistDrawProxyStack = kTRUE;
+   fHistDrawProxy = h1;
 
    Init(h1, tmpHist, option);
 


### PR DESCRIPTION
In the `TRatioPlot(TH1 *h1, THStack *st, Option_t *option)` constructor the internal variable `fHistDrawProxy` was not set correctly.

This problem was seen ihere https://github.com/root-project/root/issues/19776