### PR TITLE
[ntuple] Default `RBulkValues` move constructor and assignment

### DIFF
--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -891,8 +891,8 @@ public:
    ~RBulkValues();
    RBulkValues(const RBulkValues &) = delete;
    RBulkValues &operator=(const RBulkValues &) = delete;
-   RBulkValues(RBulkValues &&other);
-   RBulkValues &operator=(RBulkValues &&other);
+   RBulkValues(RBulkValues &&other) = default;
+   RBulkValues &operator=(RBulkValues &&other) = default;
 
    // Sets `fValues` and `fSize`/`fCapacity` to the given values. The capacity is specified in number of values.
    // Once a buffer is adopted, an attempt to read more values then available throws an exception.

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -122,35 +122,6 @@ void ROOT::RFieldBase::RValue::BindRawPtr(void *rawPtr)
 
 //------------------------------------------------------------------------------
 
-ROOT::RFieldBase::RBulkValues::RBulkValues(RBulkValues &&other)
-   : fField(other.fField),
-     fValueSize(other.fValueSize),
-     fCapacity(other.fCapacity),
-     fSize(other.fSize),
-     fIsAdopted(other.fIsAdopted),
-     fNValidValues(other.fNValidValues),
-     fFirstIndex(other.fFirstIndex)
-{
-   std::swap(fDeleter, other.fDeleter);
-   std::swap(fValues, other.fValues);
-   std::swap(fMaskAvail, other.fMaskAvail);
-}
-
-ROOT::RFieldBase::RBulkValues &ROOT::RFieldBase::RBulkValues::operator=(RBulkValues &&other)
-{
-   std::swap(fField, other.fField);
-   std::swap(fDeleter, other.fDeleter);
-   std::swap(fValues, other.fValues);
-   std::swap(fValueSize, other.fValueSize);
-   std::swap(fCapacity, other.fCapacity);
-   std::swap(fSize, other.fSize);
-   std::swap(fIsAdopted, other.fIsAdopted);
-   std::swap(fMaskAvail, other.fMaskAvail);
-   std::swap(fNValidValues, other.fNValidValues);
-   std::swap(fFirstIndex, other.fFirstIndex);
-   return *this;
-}
-
 ROOT::RFieldBase::RBulkValues::~RBulkValues()
 {
    if (fValues)


### PR DESCRIPTION
All members are moveable and there seems to be no custom code.