### PR TITLE
[roottest] Make `MissingEntriesROOT-5759` test stable

### DIFF
--- a/roottest/root/meta/autoloading/CMakeLists.txt
+++ b/roottest/root/meta/autoloading/CMakeLists.txt
@@ -47,6 +47,7 @@ ROOTTEST_ADD_TEST(Typeinfo
 
 ROOTTEST_ADD_TEST(MissingEntriesROOT-5759
                   MACRO runFullMissingEntriesROOT-5759.C
+                  OUTCNVCMD sed -e s,input_line_[0-9]*,input_line_FILTERED,g
                   COPY_TO_BUILDDIR MissingEntriesROOT-5759.rootmap
                   OUTREF MissingEntriesROOT-5759.ref)
 

--- a/roottest/root/meta/autoloading/MissingEntriesROOT-5759.ref
+++ b/roottest/root/meta/autoloading/MissingEntriesROOT-5759.ref
@@ -1,8 +1,8 @@
 
 Processing runFullMissingEntriesROOT-5759.C...
-input_line_27:1:10: fatal error: 'does_not_exist.h' file not found
+input_line_FILTERED:1:10: fatal error: 'does_not_exist.h' file not found
 #include "does_not_exist.h"
          ^~~~~~~~~~~~~~~~~~
-input_line_28:2:2: error: unknown type name 'cool'
+input_line_FILTERED:2:2: error: unknown type name 'cool'
  cool d;
  ^


### PR DESCRIPTION
# This Pull request:
This test can be fragile, after removing this [snippet](https://github.com/root-project/root/pull/19672/files#diff-170f7f5b5ea149128527bc143d6aa35b3c6264650b2b6bd9e6968e2cb905b16dL69-L73)

```
# Sed-away the line number. A different number of new-style rootmap files (i.e.
# with forward declarations) for example on different platforms can result in a
# different line number.
MissingEntriesROOT-5759.log: FullMissingEntriesROOT-5759.log
	$(CMDECHO) cat FullMissingEntriesROOT-5759.log |sed 's/input_line_[0-9]*://g' > MissingEntriesROOT-5759.log 2>&1
```

This can result in a different line number based on the platform or simply adding/removing `-e '#define ANYTHING'`

See this [failing](https://github.com/root-project/root/actions/runs/17575584191/job/49919975307#step:11:15458) test. Simply having a different set of `#define`s can break this test.

This patch restores the previous behaviour.

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

