### PR TITLE
[browsable] Add treemap v6 visualization in RBrowser for ntuples

### DIFF
--- a/gui/browsable/CMakeLists.txt
+++ b/gui/browsable/CMakeLists.txt
@@ -123,6 +123,7 @@ if(root7)
        ROOTNTuple
        ROOTNTupleBrowse
        Gpad
+       ROOTTreeMap
   )
 
   ROOT_LINKER_LIBRARY(ROOTNTupleDraw7Provider
@@ -132,6 +133,7 @@ if(root7)
        ROOTNTuple
        ROOTNTupleBrowse
        ROOTGpadv7
+       ROOTTreeMap
 )
 endif()
 

--- a/gui/browsable/src/RNTupleBrowseProvider.cxx
+++ b/gui/browsable/src/RNTupleBrowseProvider.cxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -18,21 +18,197 @@
 #include "TClass.h"
 #include "RFieldHolder.hxx"
 
+#include "RVisualizationHolder.hxx"
 
+namespace ROOT::Experimental {
+class TObjectDrawable;
+}
 using namespace std::string_literals;
-
 using namespace ROOT::Browsable;
 
+// ==============================================================================================
+/** \class RTreeMapElement
+\ingroup rbrowser
+\brief Browsing element representing TreeMap visualization for RNTuple
+\author Patryk Pilichowski
+\date 2025
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
+*/
+
+class RTreeMapElement : public RElement {
+protected:
+   std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
+   std::string fFileName;
+
+public:
+   RTreeMapElement(std::shared_ptr<ROOT::RNTupleReader> ntplReader, const std::string &fileName = "")
+      : RElement(), fNtplReader(ntplReader), fFileName(fileName)
+   {
+   }
+
+   ~RTreeMapElement() override = default;
+
+   /** Name of TreeMap visualization */
+   std::string GetName() const override { return "TreeMap"; }
+
+   /** Title of TreeMap visualization */
+   std::string GetTitle() const override { return "TreeMap visualization of RNTuple structure and disk usage"; }
+
+   /** No children for TreeMap visualization */
+   std::unique_ptr<RLevelIter> GetChildsIter() override { return nullptr; }
+
+   /** Return class of RNTuple for consistency */
+   const TClass *GetClass() const { return TClass::GetClass<ROOT::RNTuple>(); }
+
+   /** Return holder with visualization data */
+   std::unique_ptr<RHolder> GetObject() override
+   {
+      return std::make_unique<RVisualizationHolder>(fNtplReader, fFileName, fNtplReader->GetDescriptor().GetName());
+   }
+
+   /** Default action is to draw the treemap */
+   EActionKind GetDefaultAction() const override { return kActDraw6; /*temporary, replace with kActDraw7; */ }
+
+   /** Check if visualization is capable of being drawn */
+   bool IsCapable(EActionKind kind) const override
+   {
+      return kind == kActDraw6;
+   }
+
+   /** Create item with TreeMap icon */
+   std::unique_ptr<RItem> CreateItem() const override
+   {
+      auto item = std::make_unique<RItem>(GetName(), 0, "sap-icon://Chart-Tree-Map");
+      item->SetTitle(GetTitle());
+      return item;
+   }
+
+   /** Not expandable by default */
+   bool IsFolder() const override { return false; }
+
+   /** Set filename for treemap creation */
+   void SetFileName(const std::string &fileName) { fFileName = fileName; }
+};
 
 // ==============================================================================================
-
-/** \class RFieldElement
+/** \class RVisualizationElement
 \ingroup rbrowser
-\brief Browsing element representing of RField
-\author Sergey Linev <S.Linev@gsi.de>
-\date 2021-03-08
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\brief Browsing element representing visualization folder for RNTuple
+\author Patryk Pilichowski
+\date 2025
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
+
+class RVisualizationElement : public RElement {
+protected:
+   std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
+   std::string fFileName;
+
+public:
+   RVisualizationElement(std::shared_ptr<ROOT::RNTupleReader> ntplReader, const std::string &fileName = "")
+      : RElement(), fNtplReader(ntplReader), fFileName(fileName)
+   {
+   }
+
+   ~RVisualizationElement() override = default;
+
+   /** Name of visualization folder */
+   std::string GetName() const override { return "Visualization"; }
+
+   /** Title of visualization folder */
+   std::string GetTitle() const override { return "Visualization tools and options for RNTuple data"; }
+
+   /** Create iterator for visualization children */
+   std::unique_ptr<RLevelIter> GetChildsIter() override;
+
+   /** Return class of RNTuple for consistency */
+   const TClass *GetClass() const { return TClass::GetClass<ROOT::RNTuple>(); }
+
+   /** No direct object for folder */
+   std::unique_ptr<RHolder> GetObject() override { return nullptr; }
+
+   /** Default action is none for folder */
+   EActionKind GetDefaultAction() const override { return kActNone; }
+
+   /** Create item with visualization folder icon */
+   std::unique_ptr<RItem> CreateItem() const override
+   {
+      auto item = std::make_unique<RItem>(GetName(), 1, "sap-icon://show");
+      item->SetTitle(GetTitle());
+      return item;
+   }
+
+   /** This is a folder */
+   bool IsFolder() const override { return true; }
+
+   /** Set filename for child elements */
+   void SetFileName(const std::string &fileName) { fFileName = fileName; }
+};
+
+// ==============================================================================================
+/** \class RVisualizationIterator
+\ingroup rbrowser
+\brief Iterator over visualization options
+\author Patryk Pilichowski
+\date 2025
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
+*/
+
+class RVisualizationIterator : public RLevelIter {
+   std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
+   std::string fFileName;
+   int fCounter{-1};
+   int fTotalItems{1};
+
+public:
+   RVisualizationIterator(std::shared_ptr<ROOT::RNTupleReader> ntplReader, const std::string &fileName = "")
+      : fNtplReader(ntplReader), fFileName(fileName)
+   {
+   }
+
+   ~RVisualizationIterator() override = default;
+
+   bool Next() override { return ++fCounter < fTotalItems; }
+
+   std::string GetItemName() const override
+   {
+      if (fCounter == 0) {
+         return "TreeMap";
+      }
+      return "";
+   }
+
+   bool CanItemHaveChilds() const override { return false; }
+
+   /** Create item for the browser */
+   std::unique_ptr<RItem> CreateItem() override
+   {
+      if (fCounter == 0) {
+         auto item = std::make_unique<RItem>("TreeMap", 0, "sap-icon://Chart-Tree-Map");
+         item->SetTitle("TreeMap visualization of RNTuple structure and disk usage");
+         return item;
+      }
+      return nullptr;
+   }
+
+   std::shared_ptr<RElement> GetElement() override
+   {
+      if (fCounter == 0) {
+         return std::make_shared<RTreeMapElement>(fNtplReader, fFileName);
+      }
+      return nullptr;
+   }
+};
+
+std::unique_ptr<RLevelIter> RVisualizationElement::GetChildsIter()
+{
+   return std::make_unique<RVisualizationIterator>(fNtplReader, fFileName);
+}
+
+// ==============================================================================================
 
 class RFieldElement : public RElement {
 protected:
@@ -76,7 +252,8 @@ public:
    EActionKind GetDefaultAction() const override
    {
       auto range = fNtplReader->GetDescriptor().GetFieldIterable(fFieldId);
-      if (range.begin() != range.end()) return kActNone;
+      if (range.begin() != range.end())
+         return kActNone;
       return kActDraw7;
    }
 
@@ -87,7 +264,6 @@ public:
 
       return false;
    }
-
 };
 
 // ==============================================================================================
@@ -97,15 +273,17 @@ public:
 \brief Browsing element representing of RNTuple
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-08
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
 class RNTupleElement : public RElement {
 protected:
    std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
+   std::string fFileName;
 
 public:
-   RNTupleElement(const std::string &ntplName, const std::string &filename)
+   RNTupleElement(const std::string &ntplName, const std::string &filename) : fFileName(filename)
    {
       fNtplReader = ROOT::RNTupleReader::Open(ntplName, filename);
    }
@@ -121,6 +299,9 @@ public:
    /** Title of NTuple */
    std::string GetTitle() const override { return "RNTuple title"s; }
 
+   /** Get the filename */
+   const std::string &GetFileName() const { return fFileName; }
+
    /** Create iterator for childs elements if any */
    std::unique_ptr<RLevelIter> GetChildsIter() override;
 
@@ -132,85 +313,110 @@ public:
       item->SetTitle(GetTitle());
       return item;
    }
-
-   //EActionKind GetDefaultAction() const override;
-
-   //bool IsCapable(EActionKind) const override;
 };
-
 
 // ==============================================================================================
 
-/** \class RFieldsIterator
+/** \class RNTupleIterator
 \ingroup rbrowser
-\brief Iterator over RNTuple fields
+\brief Iterator over RNTuple fields & visualization entry
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-08
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
-
-class RFieldsIterator : public RLevelIter {
-
+class RNTupleIterator : public RLevelIter {
    std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
    std::vector<ROOT::DescriptorId_t> fProvidedFieldIds;
    std::vector<ROOT::DescriptorId_t> fActualFieldIds;
    std::string fParentName;
+   std::string fFileName;
    int fCounter{-1};
+   bool fHasVisualization{false};
+   int fTotalItems{0};
 
 public:
-   RFieldsIterator(std::shared_ptr<ROOT::RNTupleReader> ntplReader, std::vector<ROOT::DescriptorId_t> &&ids,
-                   const std::string &parent_name = "")
-      : fNtplReader(ntplReader), fProvidedFieldIds(ids), fParentName(parent_name)
+   RNTupleIterator(std::shared_ptr<ROOT::RNTupleReader> ntplReader, std::vector<ROOT::DescriptorId_t> &&ids,
+                   const std::string &parent_name = "", bool includeVisualization = false,
+                   const std::string &fileName = "")
+      : fNtplReader(ntplReader),
+        fProvidedFieldIds(ids),
+        fParentName(parent_name),
+        fFileName(fileName),
+        fHasVisualization(includeVisualization)
    {
       const auto &desc = fNtplReader->GetDescriptor();
       fActualFieldIds.reserve(fProvidedFieldIds.size());
       for (auto fid : fProvidedFieldIds) {
          fActualFieldIds.emplace_back(ROOT::Internal::GetNextBrowsableField(fid, desc));
       }
+
+      fTotalItems = fProvidedFieldIds.size();
+      if (fHasVisualization) {
+         fTotalItems++;
+      }
    }
 
-   ~RFieldsIterator() override = default;
+   ~RNTupleIterator() override = default;
 
-   bool Next() override { return ++fCounter < (int)fProvidedFieldIds.size(); }
+   bool Next() override { return ++fCounter < fTotalItems; }
 
    std::string GetItemName() const override
    {
-      return fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fCounter]).GetFieldName();
+      if (fHasVisualization && fCounter == 0) {
+         return "Visualization";
+      }
+      int fieldIndex = fHasVisualization ? fCounter - 1 : fCounter;
+      return fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fieldIndex]).GetFieldName();
    }
 
    bool CanItemHaveChilds() const override
    {
-      auto subrange = fNtplReader->GetDescriptor().GetFieldIterable(fActualFieldIds[fCounter]);
+      if (fHasVisualization && fCounter == 0) {
+         return true;
+      }
+      int fieldIndex = fHasVisualization ? fCounter - 1 : fCounter;
+      auto subrange = fNtplReader->GetDescriptor().GetFieldIterable(fActualFieldIds[fieldIndex]);
       return subrange.begin() != subrange.end();
    }
 
    /** Create element for the browser */
    std::unique_ptr<RItem> CreateItem() override
    {
+      if (fHasVisualization && fCounter == 0) {
+         auto item = std::make_unique<RItem>("Visualization", 1, "sap-icon://show");
+         item->SetTitle("Visualization tools and options for RNTuple data");
+         return item;
+      }
+
+      int fieldIndex = fHasVisualization ? fCounter - 1 : fCounter;
       int nchilds = 0;
-      for (auto &sub : fNtplReader->GetDescriptor().GetFieldIterable(fActualFieldIds[fCounter])) {
+      for (auto &sub : fNtplReader->GetDescriptor().GetFieldIterable(fActualFieldIds[fieldIndex])) {
          (void)sub;
          nchilds++;
       }
 
-      const auto &field = fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fCounter]);
+      const auto &field = fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fieldIndex]);
 
       auto item =
          std::make_unique<RItem>(field.GetFieldName(), nchilds, nchilds > 0 ? "sap-icon://split" : "sap-icon://e-care");
 
       item->SetTitle("RField name "s + field.GetFieldName() + " type "s + field.GetTypeName());
-
       return item;
    }
 
    std::shared_ptr<RElement> GetElement() override
    {
-      const auto name = fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fCounter]).GetFieldName();
-      return std::make_shared<RFieldElement>(fNtplReader, fParentName, fActualFieldIds[fCounter], name);
+      if (fHasVisualization && fCounter == 0) {
+         return std::make_shared<RVisualizationElement>(fNtplReader, fFileName);
+      }
+
+      int fieldIndex = fHasVisualization ? fCounter - 1 : fCounter;
+      const auto name = fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fieldIndex]).GetFieldName();
+      return std::make_shared<RFieldElement>(fNtplReader, fParentName, fActualFieldIds[fieldIndex], name);
    }
 };
-
 
 std::unique_ptr<RLevelIter> RFieldElement::GetChildsIter()
 {
@@ -229,7 +435,7 @@ std::unique_ptr<RLevelIter> RFieldElement::GetChildsIter()
    prefix.append(fld.GetFieldName());
    prefix.append(".");
 
-   return std::make_unique<RFieldsIterator>(fNtplReader, std::move(ids), prefix);
+   return std::make_unique<RNTupleIterator>(fNtplReader, std::move(ids), prefix);
 }
 
 std::unique_ptr<RLevelIter> RNTupleElement::GetChildsIter()
@@ -239,10 +445,11 @@ std::unique_ptr<RLevelIter> RNTupleElement::GetChildsIter()
    for (auto &f : fNtplReader->GetDescriptor().GetTopLevelFields())
       ids.emplace_back(f.GetId());
 
-   if (ids.size() == 0) return nullptr;
-   return std::make_unique<RFieldsIterator>(fNtplReader, std::move(ids));
-}
+   if (ids.size() == 0)
+      return nullptr;
 
+   return std::make_unique<RNTupleIterator>(fNtplReader, std::move(ids), "", true, fFileName);
+}
 
 // ==============================================================================================
 
@@ -251,13 +458,13 @@ std::unique_ptr<RLevelIter> RNTupleElement::GetChildsIter()
 \brief Provider for browsing RNTuple classes
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-08
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
 class RNTupleBrowseProvider : public RProvider {
 
 public:
-
    RNTupleBrowseProvider()
    {
       RegisterNTupleFunc([](const std::string &tuple_name, const std::string &filename) -> std::shared_ptr<RElement> {

--- a/gui/browsable/src/RNTupleDraw6Provider.cxx
+++ b/gui/browsable/src/RNTupleDraw6Provider.cxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -10,7 +10,7 @@
 #include "TClass.h"
 
 #include "RFieldProvider.hxx"
-
+#include "RVisualizationProvider.hxx"
 
 // ==============================================================================================
 
@@ -19,26 +19,40 @@
 \brief Provider for RNTuple drawing on TCanvas
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-09
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
-class RNTupleDraw6Provider : public RFieldProvider {
+class RNTupleDraw6Provider : public RProvider {
+private:
+   RFieldProvider fieldProvider;
+   RVisualizationProvider visualizationProvider;
 
 public:
-
    RNTupleDraw6Provider()
    {
       RegisterDraw6(TClass::GetClass<ROOT::RNTuple>(),
                     [this](TVirtualPad *pad, std::unique_ptr<RHolder> &obj, const std::string &opt) -> bool {
-                       auto h1 = DrawField(dynamic_cast<RFieldHolder *>(obj.get()));
-                       if (!h1)
-                          return false;
+                       auto visHolder = dynamic_cast<RVisualizationHolder *>(obj.get());
+                       if (visHolder) {
+                          auto treeMap = visualizationProvider.CreateTreeMap(visHolder);
+                          if (!treeMap)
+                             return false;
 
-                       pad->Add(h1, opt.c_str());
+                          treeMap->Paint(opt.c_str());
+                          return true;
+                       }
 
-                       return true;
+                       auto fieldHolder = dynamic_cast<RFieldHolder *>(obj.get());
+                       if (fieldHolder) {
+                          auto h1 = fieldProvider.DrawField(fieldHolder);
+                          if (!h1)
+                             return false;
+
+                          pad->Add(h1, opt.c_str());
+                          return true;
+                       }
+                       return false;
                     });
    }
-
 } newRNTupleDraw6Provider;
-

--- a/gui/browsable/src/RNTupleDraw7Provider.cxx
+++ b/gui/browsable/src/RNTupleDraw7Provider.cxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -12,6 +12,7 @@
 #include <ROOT/TObjectDrawable.hxx>
 
 #include "RFieldProvider.hxx"
+#include "RVisualizationProvider.hxx"
 
 using namespace ROOT::Browsable;
 
@@ -22,30 +23,48 @@ using namespace ROOT::Browsable;
 \brief Provider for RNTuple drawing on RCanvas
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-09
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
 */
 
-class RNTupleDraw7Provider : public RFieldProvider {
+class RNTupleDraw7Provider : public RProvider {
+private:
+   RFieldProvider fieldProvider;
+   RVisualizationProvider visualizationProvider;
 
 public:
-
    RNTupleDraw7Provider()
    {
       RegisterDraw7(TClass::GetClass<ROOT::RNTuple>(),
                     [this](std::shared_ptr<ROOT::Experimental::RPadBase> &subpad, std::unique_ptr<RHolder> &obj,
                            const std::string &opt) -> bool {
-                       auto h1 = DrawField(dynamic_cast<RFieldHolder *>(obj.get()));
-                       if (!h1)
-                          return false;
+                       auto visHolder = dynamic_cast<RVisualizationHolder *>(obj.get());
+                       if (visHolder) {
+                          auto treeMap = visualizationProvider.CreateTreeMap(visHolder);
+                          if (!treeMap)
+                             return false;
 
-                       std::shared_ptr<TH1> shared;
-                       shared.reset(h1);
+                          std::shared_ptr<ROOT::Experimental::RTreeMapPainter> shared;
+                          shared.reset(treeMap.release());
 
-                       subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
-                       subpad->GetCanvas()->Update(true);
-                       return true;
+                          subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
+                          return true;
+                       }
+
+                       auto fieldHolder = dynamic_cast<RFieldHolder *>(obj.get());
+                       if (fieldHolder) {
+                          auto h1 = fieldProvider.DrawField(fieldHolder);
+                          if (!h1)
+                             return false;
+
+                          std::shared_ptr<TH1> shared;
+                          shared.reset(h1);
+
+                          subpad->Draw<ROOT::Experimental::TObjectDrawable>(shared, opt);
+                          return true;
+                       }
+
+                       return false;
                     });
    }
-
 } newRNTupleDraw7Provider;
-

--- a/gui/browsable/src/RVisualizationHolder.hxx
+++ b/gui/browsable/src/RVisualizationHolder.hxx
@@ -1,0 +1,47 @@
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RVISUALIZATIONHOLDER_HXX
+#define ROOT_RVISUALIZATIONHOLDER_HXX
+
+#include <ROOT/Browsable/RHolder.hxx>
+#include <ROOT/RNTupleReader.hxx>
+
+/** \class RVisualizationHolder
+\ingroup rbrowser
+\brief Holder for RNTuple visualization data
+\author Patryk Pilichowski
+\date 2025
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
+*/
+
+class RVisualizationHolder : public ROOT::Browsable::RHolder {
+protected:
+   std::shared_ptr<ROOT::RNTupleReader> fNtplReader;
+   std::string fFileName;
+   std::string fTupleName;
+
+public:
+   RVisualizationHolder(std::shared_ptr<ROOT::RNTupleReader> ntplReader, const std::string &fileName,
+                        const std::string &tupleName)
+      : fNtplReader(ntplReader), fFileName(fileName), fTupleName(tupleName)
+   {
+   }
+
+   const TClass *GetClass() const override { return TClass::GetClass<ROOT::RNTuple>(); }
+
+   /** Returns direct (temporary) object pointer */
+   const void *GetObject() const override { return nullptr; }
+
+   std::shared_ptr<ROOT::RNTupleReader> GetNTupleReader() const { return fNtplReader; }
+   const std::string &GetFileName() const { return fFileName; }
+   const std::string &GetTupleName() const { return fTupleName; }
+};
+
+#endif // ROOT_RVISUALIZATIONHOLDER_HXX

--- a/gui/browsable/src/RVisualizationProvider.hxx
+++ b/gui/browsable/src/RVisualizationProvider.hxx
@@ -1,0 +1,38 @@
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RVISUALIZATIONPROVIDER_HXX
+#define ROOT_RVISUALIZATIONPROVIDER_HXX
+
+#include <ROOT/Browsable/RProvider.hxx>
+
+#include "RVisualizationHolder.hxx"
+
+#include <ROOT/RNTupleTreeMap.hxx>
+
+/** \class RVisualizationProvider
+\ingroup rbrowser
+\brief Provider for RNTuple TreeMap visualization on TCanvas
+\author Patryk Pilichowski
+\date 2025
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
+welcome!
+*/
+class RVisualizationProvider : public RProvider {
+public:
+   /** Create TreeMap visualization for RNTuple */
+   std::unique_ptr<ROOT::Experimental::RTreeMapPainter> CreateTreeMap(RVisualizationHolder *holder) const
+   {
+      if (!holder)
+         return nullptr;
+
+      return ROOT::Experimental::CreateTreeMapFromRNTuple(holder->GetFileName(), holder->GetTupleName());
+   }
+};
+
+#endif // ROOT_RVISUALIZATIONPROVIDER_HXX


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR adds the following functionality
- Use `ROOTTreeMap` library in `browsable` by including it in `gui/browsable/CMakeLists.txt`
- Visualization node in the RBrowser that paints treemap of the corresponding RNTuple on click

![1](https://i.imgur.com/Bdvi0HT.png)

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)
