### PR TITLE
[ntuplebrowse] Add treemap visualization in classic ntuplebrowser

### DIFF
--- a/config/mimes.unix.in
+++ b/config/mimes.unix.in
@@ -255,6 +255,11 @@ pattern = RNTuple-leaf
 icon = leaf_s.xpm leaf_t.xpm
 action = ->Browse()
 
+[root/rntuple-visualization]
+pattern = RNTuple-visualization
+icon = bld_listtree.xpm
+action = ->Browse()
+
 # actions used by GuiBuilder
 [root/textbutton]
 pattern = TGTextButton

--- a/config/mimes.win32.in
+++ b/config/mimes.win32.in
@@ -255,6 +255,11 @@ pattern = RNTuple-leaf
 icon = leaf_s.xpm leaf_t.xpm
 action = ->Browse()
 
+[root/rntuple-visualization]
+pattern = RNTuple-visualization
+icon = bld_listtree.xpm
+action = ->Browse()
+
 # actions used by GuiBuilder
 [root/textbutton]
 pattern = TGTextButton

--- a/tree/ntuplebrowse/CMakeLists.txt
+++ b/tree/ntuplebrowse/CMakeLists.txt
@@ -26,6 +26,7 @@ DEPENDENCIES
   Graf
   Hist
   ROOTNTuple
+  ROOTTreeMap
 )
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/tree/ntuplebrowse/src/RNTupleClassicBrowse.cxx
+++ b/tree/ntuplebrowse/src/RNTupleClassicBrowse.cxx
@@ -17,6 +17,8 @@
 #include <ROOT/RNTupleDrawVisitor.hxx>
 #include <ROOT/RNTupleDescriptor.hxx>
 #include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RTreeMapPainter.hxx>
+#include <ROOT/RNTupleInspector.hxx>
 
 #include <TBrowser.h>
 #include <TObject.h>
@@ -91,6 +93,32 @@ public:
    const char *GetTitle() const final { return fTypeName.c_str(); }
 };
 
+class RVisualizationBrowsable : public TObject {
+private:
+   std::unique_ptr<ROOT::Experimental::RNTupleInspector> fInspector;
+   std::unique_ptr<ROOT::Experimental::RTreeMapPainter> fTreeMap;
+
+public:
+   RVisualizationBrowsable(const ROOT::RNTuple &ntuple)
+      : fInspector(ROOT::Experimental::RNTupleInspector::Create(ntuple))
+   {
+   }
+   void Browse(TBrowser *b) final
+   {
+      if (!b || !gPad)
+         return;
+      gPad->GetListOfPrimitives()->Clear();
+      fTreeMap = ROOT::Experimental::RTreeMapPainter::ImportRNTuple(*fInspector);
+      fTreeMap->Paint("");
+      gPad->Update();
+   }
+
+   const char *GetIconName() const final { return "RNTuple-visualization"; }
+   bool IsFolder() const final { return false; }
+   const char *GetName() const final { return "Visualization"; }
+   const char *GetTitle() const final { return "TreeMap visualization of RNTuple structure and disk usage"; }
+};
+
 } // anonymous namespace
 
 void ROOT::Internal::BrowseRNTuple(const void *ntuple, TBrowser *b)
@@ -100,6 +128,7 @@ void ROOT::Internal::BrowseRNTuple(const void *ntuple, TBrowser *b)
 
    std::shared_ptr<ROOT::RNTupleReader> reader = RNTupleReader::Open(*static_cast<const ROOT::RNTuple *>(ntuple));
    const auto &desc = reader->GetDescriptor();
+   b->Add(new RVisualizationBrowsable(*static_cast<const ROOT::RNTuple *>(ntuple)), "Visualization");
    for (const auto &f : desc.GetTopLevelFields()) {
       b->Add(new RFieldBrowsable(reader, f.GetId()), f.GetFieldName().c_str());
    }

--- a/tree/ntuplebrowse/test/ntuple_browse.cxx
+++ b/tree/ntuplebrowse/test/ntuple_browse.cxx
@@ -72,6 +72,6 @@ TEST(RNTupleBrowse, Simple)
 
    ROOT::Internal::BrowseRNTuple(ntpl.get(), b);
 
-   ASSERT_EQ(1u, imp->fAdded.size());
-   EXPECT_EQ("f", imp->fAdded[0]);
+   ASSERT_EQ(2u, imp->fAdded.size());
+   EXPECT_EQ("f", imp->fAdded[1]);
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
- Add the icon for RNTuple-visualization node in `config/mimes.unix.in` and `config/mimes.win32.in`
- Visualization node represented by `RVisualizationBrowsable` class, which visualizes the corresponding ntuple on click as a treemap
- Use RTreeMap classes from included `ROOTTreeMap` module for treemap visualization
- Adapting the `ntuple_browse` test to the changes

![node](https://i.imgur.com/gJelmnh.png)
![viz](https://i.imgur.com/9xAGrRY.png)

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)


