### PR TITLE
[webgui] Fix selection of working directory in RFileDialog

### DIFF
--- a/gui/browserv7/src/RFileDialog.cxx
+++ b/gui/browserv7/src/RFileDialog.cxx
@@ -337,7 +337,7 @@ void RFileDialog::ProcessMsg(unsigned connid, const std::string &arg)
 
 void RFileDialog::SetWorkingPath(const std::string &path)
 {
-   auto p = Browsable::RElement::ParsePath(path);
+   auto p = Browsable::RSysFile::GetWorkingPath(path);
    auto elem = fBrowsable.GetSubElement(p);
    if (elem) {
       fBrowsable.SetWorkingPath(p);


### PR DESCRIPTION
One should use Browsable::RSysFile::GetWorkingPath to produce path
