### PR TITLE
Cleanup also current file in TChain::GetEntries 

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -50,6 +50,7 @@ private:
    void
    ParseTreeFilename(const char *name, TString &filename, TString &treename, TString &query, TString &suffix) const;
    Long64_t RefreshFriendAddresses();
+   TTreeCache *CleanupCurrentFileAndTree();
 
 protected:
    void InvalidateCurrentTree();

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -567,14 +567,9 @@ void TTreeReader::Restart()
    fProxiesSet = false; // we might get more value readers, meaning new proxies.
    fEntry = -1;
    if (const auto curFile = fTree->GetCurrentFile()) {
-      if (!fTree->GetTree()) {
-         fTree->LoadTree(0);
-      }
-      if (fTree->GetTree()) {
-         if (auto tc = fTree->GetTree()->GetReadCache(curFile, true)) {
-            tc->DropBranch("*", true);
-            tc->ResetCache();
-         }
+      if (auto tc = fTree->GetTree()->GetReadCache(curFile, true)) {
+         tc->DropBranch("*", true);
+         tc->ResetCache();
       }
    }
 }

--- a/tree/treeplayer/test/regressions.cxx
+++ b/tree/treeplayer/test/regressions.cxx
@@ -263,3 +263,31 @@ TEST(TTreeFormulaRegressions, WrongName)
       EXPECT_EQ(t.Draw("s.Eta()", ""), -1);
    }
 }
+
+// https://github.com/root-project/root/issues/19814
+TEST(TTreeReaderRegressions, UninitializedChain)
+{
+   auto filename = "eve19814.root";
+   auto treename = "events";
+   auto brname = "x";
+   const int refval = 19814;
+   {
+      TFile f(filename, "RECREATE");
+      TTree t(treename, "");
+      int x = refval;
+      t.Branch(brname, &x);
+      t.Fill();
+      f.Write();
+   }
+   {
+      TChain ch(treename);
+      ch.Add(filename);
+      TTreeReader reader(&ch);
+      reader.SetEntriesRange(0, ch.GetEntries());
+      EXPECT_EQ(reader.GetEntries(), 1);
+      TTreeReaderValue<int> x(reader, brname);
+      EXPECT_TRUE(reader.Next());
+      EXPECT_EQ(*x, refval);
+   }
+   gSystem->Unlink(filename);
+}

--- a/tree/treeplayer/test/regressions.cxx
+++ b/tree/treeplayer/test/regressions.cxx
@@ -263,31 +263,3 @@ TEST(TTreeFormulaRegressions, WrongName)
       EXPECT_EQ(t.Draw("s.Eta()", ""), -1);
    }
 }
-
-// https://github.com/root-project/root/issues/19814
-TEST(TTreeReaderRegressions, UninitializedChain)
-{
-   auto filename = "eve19814.root";
-   auto treename = "events";
-   auto brname = "x";
-   const int refval = 19814;
-   {
-      TFile f(filename, "RECREATE");
-      TTree t(treename, "");
-      int x = refval;
-      t.Branch(brname, &x);
-      t.Fill();
-      f.Write();
-   }
-   {
-      TChain ch(treename);
-      ch.Add(filename);
-      TTreeReader reader(&ch);
-      reader.SetEntriesRange(0, ch.GetEntries());
-      EXPECT_EQ(reader.GetEntries(), 1);
-      TTreeReaderValue<int> x(reader, brname);
-      EXPECT_TRUE(reader.Next());
-      EXPECT_EQ(*x, refval);
-   }
-   gSystem->Unlink(filename);
-}


### PR DESCRIPTION
Followup to https://github.com/root-project/root/pull/19817

In the method we need to check if the current TTree has a TTreeCache associated with the current file. The previous logic was getting the pointer to the current file but calling LoadTree afterwards, which deleted the current file and switched it for a new instance. In turn, this would cause bad reads as highlighted by a run of the associated unit test with the address sanitizer:

```
==18501==ERROR: AddressSanitizer: heap-use-after-free on address 0x61800004be60 at pc 0x000108735e2c bp 0x00016b501950 sp 0x00016b501948
READ of size 8 at 0x61800004be60 thread T0
    #0 0x000108735e28 in TFile::GetCacheRead(TObject const*) const TFile.cxx:1262
    https://github.com/root-project/root/issues/1 0x00010a6e0758 in TTree::GetReadCache(TFile*) const TTree.cxx:6403
    https://github.com/root-project/root/pull/2 0x00010a6e79c0 in TTree::GetReadCache(TFile*, bool) TTree.cxx:6416
    https://github.com/root-project/root/pull/3 0x00010acd2f58 in TTreeReader::Restart() TTreeReader.cxx:574
    https://github.com/root-project/root/pull/4 0x00010acd2634 in TTreeReader::SetEntriesRange(long long, long long) TTreeReader.cxx:550
    https://github.com/root-project/root/pull/5 0x0001048fd23c in main test_ttreereader_uninitialized_chain.cpp:28
    https://github.com/root-project/root/pull/6 0x000190a96b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)

0x61800004be60 is located 480 bytes inside of 824-byte region [0x61800004bc80,0x61800004bfb8)
freed by thread T0 here:
    #0 0x00010c757b0c in _ZdlPv+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x4bb0c)
    https://github.com/root-project/root/issues/1 0x000107556f6c in TStorage::ObjectDealloc(void*) TStorage.cxx:325
    https://github.com/root-project/root/pull/2 0x0001074a8a68 in TObject::operator delete(void*) TObject.cxx:1189
    https://github.com/root-project/root/pull/3 0x000108732650 in TFile::~TFile() TFile.cxx:569
    https://github.com/root-project/root/pull/4 0x00010a5c6e04 in TChain::LoadTree(long long) TChain.cxx:1449
    https://github.com/root-project/root/pull/5 0x00010acd2dfc in TTreeReader::Restart() TTreeReader.cxx:571
    https://github.com/root-project/root/pull/6 0x00010acd2634 in TTreeReader::SetEntriesRange(long long, long long) TTreeReader.cxx:550
    https://github.com/root-project/root/pull/7 0x0001048fd23c in main test_ttreereader_uninitialized_chain.cpp:28
    https://github.com/root-project/root/pull/8 0x000190a96b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)

previously allocated by thread T0 here:
    #0 0x00010c7576e4 in _Znwm+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x4b6e4)
    https://github.com/root-project/root/issues/1 0x000107556eec in TStorage::ObjectAlloc(unsigned long) TStorage.cxx:293
    https://github.com/root-project/root/pull/2 0x0001056ee26c in TObject::operator new(unsigned long) TObject.h:187
    https://github.com/root-project/root/pull/3 0x00010875b3c8 in TFile::Open(char const*, char const*, char const*, int, int) TFile.cxx:3956
    https://github.com/root-project/root/pull/4 0x00010a5c71a0 in TChain::LoadTree(long long) TChain.cxx:1481
    https://github.com/root-project/root/pull/5 0x00010a5c0f04 in TChain::GetEntries() const TChain.cxx:910
    https://github.com/root-project/root/pull/6 0x0001048fd224 in main test_ttreereader_uninitialized_chain.cpp:28
    https://github.com/root-project/root/pull/7 0x000190a96b94 in start+0x17b8 (dyld:arm64e+0xfffffffffff3ab94)
```

Change the logic to instead load the tree beforehand, so the pointer to the file will be the correct one.


Fixes CI failures such as https://github.com/root-project/root/actions/runs/17610706130/job/50031825233?pr=19860#step:6:4762
