### PR TITLE
[RF] Add base-case overload for `RooAbsReal::matchArgs` implementation

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -437,6 +437,8 @@ protected:
     return result;
   }
 
+  bool matchArgs(const RooArgSet &allDeps, RooArgSet &analDeps, const RooArgProxy &a) const;
+
   bool matchArgs(const RooArgSet& allDeps, RooArgSet& numDeps,
          const RooArgSet& set) const ;
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3122,6 +3122,17 @@ RooFit::OwningPtr<RooAbsArg> RooAbsReal::createFundamental(const char* newname) 
   return RooFit::makeOwningPtr<RooAbsArg>(std::move(fund));
 }
 
+
+bool RooAbsReal::matchArgs(const RooArgSet &allDeps, RooArgSet &analDeps, const RooArgProxy &a) const
+{
+   TList nameList;
+   nameList.Add(new TObjString(a.absArg()->GetName()));
+   bool result = matchArgsByName(allDeps, analDeps, nameList);
+   nameList.Delete();
+   return result;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Utility function for use in getAnalyticalIntegral(). If the
 /// contents of 'refset' occur in set 'allDeps' then the arguments


### PR DESCRIPTION
In user frameworks based on RooFit, there were linker errors with ROOT `master`:

```txt
undefined reference to RooAbsReal::matchArgs(RooArgSet const&, RooArgSet&, RooArgProxy const&) const
```

This can be fixed by treating the case of no extra arguments to the variadic `matchArgs` function as a separate overload, so it get consistently not inlined.

Thanks @cburgard for noticing and reporting!

Follows up on 85186f3d8e8fea3, which implemented `RooAbsReal::matchArgs` with variadic templates.