### PR TITLE
Rework TChain::GetEntries to avoid side-effects 

### DIFF
--- a/roottest/root/tree/chain/execChainElementStatus.C
+++ b/roottest/root/tree/chain/execChainElementStatus.C
@@ -26,7 +26,9 @@ void testGetEntries() {
    TChain ch("tester");
    AddFiles(ch);
 
-   ch.GetEntries();
+   // The test is meant to traverse the entire dataset to populate
+   // the information of each TChainElement correctly.
+   ch.LoadTree(TTree::kMaxEntries - 1);
 
    Print(ch);
 

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -905,14 +905,24 @@ Long64_t TChain::GetEntries() const
       // and `LoadTree` will be no-op.
       if (kLoadTree & fFriendLockStatus)
          return fEntries;
-      const auto readEntry = fReadEntry;
-      auto *thisChain = const_cast<TChain *>(this);
-      thisChain->LoadTree(TTree::kMaxEntries - 1);
-      thisChain->InvalidateCurrentTree();
-      if (readEntry >= 0)
-         thisChain->LoadTree(readEntry);
-      else
-         thisChain->fReadEntry = readEntry;
+      Long64_t totalEntries{};
+      for (auto chainEl : ROOT::Detail::TRangeStaticCast<TChainElement>(fFiles)) {
+         if (chainEl->GetEntries() != TTree::kMaxEntries) {
+            totalEntries += chainEl->GetEntries();
+            continue;
+         }
+         TDirectory::TContext ctxt;
+         std::unique_ptr<TFile> curFile{TFile::Open(chainEl->GetTitle(), "READ_WITHOUT_GLOBALREGISTRATION")};
+         if (!curFile || curFile->IsZombie()) {
+            continue;
+         }
+         std::unique_ptr<TTree> curTree{curFile->Get<TTree>(chainEl->GetName())};
+         if (!curTree) {
+            continue;
+         }
+         totalEntries += curTree->GetEntries();
+      }
+      const_cast<TChain *>(this)->fEntries = totalEntries;
    }
    return fEntries;
 }

--- a/tree/tree/src/TChainElement.cxx
+++ b/tree/tree/src/TChainElement.cxx
@@ -30,7 +30,7 @@ TChainElement::TChainElement() : TNamed(),fBaddress(nullptr),fBaddressType(0),
 {
    fNPackets   = 0;
    fPackets    = nullptr;
-   fEntries    = 0;
+   fEntries    = TTree::kMaxEntries;
    fPacketSize = 100;
    fStatus     = -1;
    ResetBit(kHasBeenLookedUp);
@@ -45,7 +45,7 @@ TChainElement::TChainElement(const char *name, const char *title)
 {
    fNPackets   = 0;
    fPackets    = nullptr;
-   fEntries    = 0;
+   fEntries    = TTree::kMaxEntries;
    fPacketSize = 100;
    fStatus     = -1;
    ResetBit(kHasBeenLookedUp);

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -567,14 +567,9 @@ void TTreeReader::Restart()
    fProxiesSet = false; // we might get more value readers, meaning new proxies.
    fEntry = -1;
    if (const auto curFile = fTree->GetCurrentFile()) {
-      if (!fTree->GetTree()) {
-         fTree->LoadTree(0);
-      }
-      if (fTree->GetTree()) {
-         if (auto tc = fTree->GetTree()->GetReadCache(curFile, true)) {
-            tc->DropBranch("*", true);
-            tc->ResetCache();
-         }
+      if (auto tc = fTree->GetTree()->GetReadCache(curFile, true)) {
+         tc->DropBranch("*", true);
+         tc->ResetCache();
       }
    }
 }

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -566,12 +566,20 @@ void TTreeReader::Restart()
    fDirector->SetReadEntry(-1);
    fProxiesSet = false; // we might get more value readers, meaning new proxies.
    fEntry = -1;
-   if (const auto curFile = fTree->GetCurrentFile()) {
-      if (auto tc = fTree->GetTree()->GetReadCache(curFile, true)) {
-         tc->DropBranch("*", true);
-         tc->ResetCache();
-      }
-   }
+   // Find if there is an active TTreeCache and reset it if so
+   if (!fTree)
+      return;
+   const auto curFile = fTree->GetCurrentFile();
+   if (!curFile)
+      return;
+   auto curTree = fTree->GetTree();
+   if (!curTree)
+      return;
+   auto tc = curTree->GetReadCache(curFile, true);
+   if (!tc)
+      return;
+   tc->DropBranch("*", true);
+   tc->ResetCache();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/test/regressions.cxx
+++ b/tree/treeplayer/test/regressions.cxx
@@ -263,3 +263,31 @@ TEST(TTreeFormulaRegressions, WrongName)
       EXPECT_EQ(t.Draw("s.Eta()", ""), -1);
    }
 }
+
+// https://github.com/root-project/root/issues/19814
+TEST(TTreeReaderRegressions, UninitializedChain)
+{
+   auto filename = "eve19814.root";
+   auto treename = "events";
+   auto brname = "x";
+   const int refval = 19814;
+   {
+      TFile f(filename, "RECREATE");
+      TTree t(treename, "");
+      int x = refval;
+      t.Branch(brname, &x);
+      t.Fill();
+      f.Write();
+   }
+   {
+      TChain ch(treename);
+      ch.Add(filename);
+      TTreeReader reader(&ch);
+      reader.SetEntriesRange(0, ch.GetEntries());
+      EXPECT_EQ(reader.GetEntries(), 1);
+      TTreeReaderValue<int> x(reader, brname);
+      EXPECT_TRUE(reader.Next());
+      EXPECT_EQ(*x, refval);
+   }
+   gSystem->Unlink(filename);
+}

--- a/tree/treeplayer/test/regressions.cxx
+++ b/tree/treeplayer/test/regressions.cxx
@@ -263,31 +263,3 @@ TEST(TTreeFormulaRegressions, WrongName)
       EXPECT_EQ(t.Draw("s.Eta()", ""), -1);
    }
 }
-
-// https://github.com/root-project/root/issues/19814
-TEST(TTreeReaderRegressions, UninitializedChain)
-{
-   auto filename = "eve19814.root";
-   auto treename = "events";
-   auto brname = "x";
-   const int refval = 19814;
-   {
-      TFile f(filename, "RECREATE");
-      TTree t(treename, "");
-      int x = refval;
-      t.Branch(brname, &x);
-      t.Fill();
-      f.Write();
-   }
-   {
-      TChain ch(treename);
-      ch.Add(filename);
-      TTreeReader reader(&ch);
-      reader.SetEntriesRange(0, ch.GetEntries());
-      EXPECT_EQ(reader.GetEntries(), 1);
-      TTreeReaderValue<int> x(reader, brname);
-      EXPECT_TRUE(reader.Next());
-      EXPECT_EQ(*x, refval);
-   }
-   gSystem->Unlink(filename);
-}


### PR DESCRIPTION
Fixes #19814 and also the recent CI failures such as https://github.com/root-project/root/actions/runs/17610706130/job/50031825233?pr=19860#step:6:4762

The second commit contains the main change: reworking the `TChain::GetEntries` method. The issue with it was that it was causing one side-effect too many: the last opened file was not being properly closed. This in turn triggered the if condition in `TTreeReader::Restart` and the segfaults due to bad memory accesses. This is an alternative solution to https://github.com/root-project/root/pull/19866 . The advantage IMHO is that it requires changing fewer places and better conveys the intent of the method: a for loop opening the files as opposed to calling LoadTree until all files have been opened. On top of course of having far less side-effects (AFAICT none).