### PR TITLE
[docs] Merge documentation of MathMore and MathCore.

### DIFF
--- a/math/mathcore/doc/index.md
+++ b/math/mathcore/doc/index.md
@@ -1,4 +1,4 @@
-\defgroup MathCore  MathCore
+\defgroup MathCore  Core Math Functionality (MathCore)
 \ingroup Math
 \brief The Core Mathematical Library of %ROOT.
 

--- a/math/mathcore/inc/Math/Integrator.h
+++ b/math/mathcore/inc/Math/Integrator.h
@@ -26,17 +26,13 @@
 #include <vector>
 #include <string>
 
-
 /**
 @defgroup NumAlgo Numerical Algorithms
 
 Numerical Algorithm classes from the \ref MathCore and \ref MathMore libraries.
 
 @ingroup MathCore
-@ingroup MathMore
-
 */
-
 
 /**
 

--- a/math/mathcore/inc/Math/Math.h
+++ b/math/mathcore/inc/Math/Math.h
@@ -45,11 +45,6 @@
 #define M_PI_4     0.78539816339744830961566084582      // Pi/4
 #endif
 
-/**
-   \namespace ROOT
-   Namespace for new ROOT classes and functions
- */
-
 namespace ROOT {
 
 /**

--- a/math/mathcore/inc/Math/PdfFuncMathCore.h
+++ b/math/mathcore/inc/Math/PdfFuncMathCore.h
@@ -8,8 +8,6 @@
  *                                                                    *
  **********************************************************************/
 
-
-
 /**
 
 Probability density functions, cumulative distribution functions
@@ -23,15 +21,11 @@ user must calculate the shift themselves if they wish.
 
 MathCore provides the majority of the probability density functions, of the
 cumulative distributions and of the quantiles (inverses of the cumulatives).
-Additional distributions are also provided by the
-<A HREF="../../MathMore/html/group__StatFunc.html">MathMore</A> library.
+Additional distributions are also provided by the \ref MathMore library.
 
 
 @defgroup StatFunc Statistical functions
-
 @ingroup  MathCore
-@ingroup  MathMore
-
 */
 
 #ifndef ROOT_Math_PdfFuncMathCore
@@ -58,12 +52,11 @@ namespace Math {
    *
    */
 
-   /** @name Probability Density Functions from MathCore
-   *   Additional PDF's are provided in the MathMore library
-   *   (see PDF functions from MathMore)
-   */
+/** @name Probability Density Functions from MathCore
+ *   Additional PDFs are provided in the MathMore library when the GSL is available.
+ */
 
-  //@{
+//@{
 
   /**
 

--- a/math/mathcore/inc/Math/SpecFuncMathCore.h
+++ b/math/mathcore/inc/Math/SpecFuncMathCore.h
@@ -8,8 +8,6 @@
  *                                                                    *
  **********************************************************************/
 
-
-
 /**
 
 Special mathematical functions.
@@ -23,7 +21,6 @@ N1687=04-0127, September 10, 2004</A>
 
 @defgroup SpecFunc Special functions
 @ingroup MathCore
-@ingroup MathMore
 
 */
 

--- a/math/mathmore/doc/index.md
+++ b/math/mathmore/doc/index.md
@@ -1,11 +1,16 @@
 \defgroup MathMore  MathMore
-\ingroup Math
-\brief The Mathematical library providing some advanced functionality and based on GSL.
+\ingroup MathCore
+\brief The Mathematical library providing GSL extensions to MathCore.
 
 **MathMore** provides an advanced collection of functions and C++ classes for HEP numerical
-computing. This is an extension of the functionality provided by the \ref MathCore. The
-current set includes classes and functions for:
+computing. This is an extension of the functionality provided by the \ref MathCore, which becomes
+available when a GSL library is found in the system. It can be enabled/disabled
+when configuring %ROOT using `cmake -Dmathmore=On/Off`.
+MathMore links with the GSL static libraries, so note that its license differs from ROOT's usual license,
+since the GSL is distributed under the GNU General Public License. On some platforms (like Linux x86-64), GSL
+needs to be compiled with the option `--with-pic`.
 
+MathMore provides extensions to the following MathCore groups:
 *   \ref SpecFunc, with all the major functions (Bessel functions, Legendre polynomial, etc..)
 *   \ref StatFunc, Mathematical functions used in statistics such as probability density
      functions, cumulative distributions functions and their inverse (quantiles).
@@ -30,10 +35,3 @@ file of GSL can be downloaded from the [GSL Web site](http://www.gnu.org/softwar
 or (for version 1.8) from [here](http://seal.web.cern.ch/seal/MathLibs/gsl-1.8.tar.gz).
 Windows binaries, compiled using Visual Studio 7.1 can be downloaded from
 [this location](http://seal.web.cern.ch/seal/MathLibs/GSL-1.8.zip).
-
-MathMore (and its %ROOT CINT dictionary) can be built within %ROOT whenever a GSL library
-is found in the system. Optionally the GSL library and header file location can be specified
-in the %ROOT configure script with _configure --with-gsl-incdir=... --with-gsl-libdir=..._
-MathMore links with the GSL static libraries. On some platform (like Linux x86-64)  GSL
-needs to be compiled with the option _--with-pic_.
-The source code of MathMore is distributed under the GNU General Public License

--- a/math/mathmore/inc/Math/QuasiRandom.h
+++ b/math/mathmore/inc/Math/QuasiRandom.h
@@ -35,12 +35,10 @@
 
 /**
    @defgroup QuasiRandom QuasiRandom number generators and distributions
-   Classes for generating QuasiRandom numbers and based on GSL 
+   Classes for generating QuasiRandom numbers and based on GSL.
+   \note MathMore needs to be enabled for these integrator to be available.
    @ingroup Random
-   @ingroup MathMore
 */
-
-
 
 namespace ROOT {
 namespace Math {


### PR DESCRIPTION
Since the documentation of both math groups share the same subgroups, doxygen fails to create a stable index that can be navigated. One gets thrown around between MathCore and MathMore in an unpredictable way. Here, groups such as probability density functions and smiliar are only listed in MathCore, and MathMore is moved as a subgroup into MathCore.

It is explained what MathMore is, how it can be (de-)activated, and why it's separate from MathCore.

Fix #7440

