### PR TITLE
[browserv7] RBrowser: avoid crashing if web=off

### DIFF
--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -301,6 +301,9 @@ RBrowser::RBrowser(bool use_rcanvas)
    fTimer = std::make_unique<RBrowserTimer>(10, kTRUE, *this);
 
    fWebWindow = RWebWindow::Create();
+   if (!fWebWindow)
+      return;
+   
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
    std::string sortby = gEnv->GetValue("WebGui.Browser.SortBy", "name"),


### PR DESCRIPTION
If you run `root --web=off` and try to create a RBrowser, you will get a segmentation fault because RWebWindow fails to be created. This PR avoids that and instead early returns.

