### PR TITLE
[RelNotes] Add initial contributors section to 6.38 release notes

### DIFF
--- a/README/ReleaseNotes/empty.md
+++ b/README/ReleaseNotes/empty.md
@@ -32,7 +32,7 @@ The following people have contributed to this new version:
  Bernhard Manfred Gruber,\
  Enrico Guiraud,
  Jonas Hahnfeld, CERN/Goethe University Frankfurt,\
- Fernando Hueso Gonzalez, University of Valencia\
+ Fernando Hueso Gonzalez, IFIC (CSIC-University of Valencia),\
  Attila Krasznahorkay, CERN/EP-ADP-OS,\
  Wim Lavrijsen, LBL,\
  Dennis Klein, GSI,\

--- a/README/ReleaseNotes/v636/index.md
+++ b/README/ReleaseNotes/v636/index.md
@@ -63,7 +63,7 @@ The following people have contributed to this new version:
  Silia Taider, CERN/EP-SFT,\
  Florian Uhlig, GSI,\
  Devajith Valaparambil Sreeramaswamy, CERN/EP-SFT,\
- Vassil Vasilev, Princeton,\
+ Vassil Vassilev, Princeton,\
  Dongliang Zhang, University of Science and Technology of China
 
 ## Deprecation and Removal

--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -1,3 +1,38 @@
+% ROOT Version 6.38 Release Notes
+% 2025-11
+<a name="TopOfPage"></a>
+
+## Introduction
+
+For more information, see:
+
+[http://root.cern](http://root.cern)
+
+The following people have contributed to this new version:
+
+ Bertrand Bellenot, CERN/EP-SFT,\
+ Jakob Blomer, CERN/EP-SFT,\
+ Lukas Breitwieser, CERN/EP-SFT,\
+ Philippe Canal, FNAL,\
+ Olivier Couet, CERN/EP-SFT,\
+ Marta Czurylo, CERN/EP-SFT,\
+ Florine de Geus, CERN/EP-SFT and University of Twente,\
+ Jonas Hahnfeld, CERN/EP-SFT and Goethe University Frankfurt,\
+ Fernando Hueso Gonzalez, IFIC (CSIC-University of Valencia),\
+ Stephan Hageboeck, CERN/EP-SFT,\
+ Aaron Jomy, CERN/EP-SFT,\
+ Sergey Linev, GSI Darmstadt,\
+ Lorenzo Moneta, CERN/EP-SFT,\
+ Vincenzo Eduardo Padulano, CERN/EP-SFT,\
+ Giacomo Parolini, CERN/EP-SFT,\
+ Danilo Piparo, CERN/EP-SFT,\
+ Jonas Rembser, CERN/EP-SFT,\
+ Sanjiban Sengupta, CERN/EP-SFT and Manchester University,\
+ Silia Taider, CERN/EP-SFT,\
+ Florian Uhlig, GSI,\
+ Devajith Valaparambil Sreeramaswamy, CERN/EP-SFT,\
+ Vassil Vassilev, Princeton
+
 ## Deprecation and Removal
 
 * The `RooDataSet` constructors to construct a dataset from a part of an existing dataset were deprecated in ROOT 6.36 and are now removed. This is to avoid interface duplication. Please use `RooAbsData::reduce()` instead, or if you need to change the weight column, use the universal constructor with the `Import()`, `Cut()`, and `WeightVar()` arguments.


### PR DESCRIPTION
The list is far from complete and should be completed by the release managers before the 6.38 release.

But it's good to already have an initial skeleton, so we can easily ask new contributors to add themselves with their preferred name and affiliation following the template.