### PR TITLE
[webgui] fix screenshot functionality

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -297,6 +297,13 @@ RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
 
    ProcessGeometry(exec, args);
 
+   std::string extra = args.GetExtraArgs();
+   if (!extra.empty()) {
+      auto p = exec.find("$url");
+      if (p != std::string::npos)
+         exec.insert(p, extra + " ");
+   }
+
    std::string rmdir = MakeProfile(exec, args.IsBatchMode() || args.IsHeadless());
 
    std::string tmpfile;
@@ -685,11 +692,6 @@ void RWebDisplayHandle::ChromeCreator::ProcessGeometry(std::string &exec, const 
       if (!geometry.empty()) geometry.append(" ");
       geometry.append("--window-position="s + std::to_string(args.GetX() >= 0 ? args.GetX() : 0) + ","s +
                                            std::to_string(args.GetY() >= 0 ? args.GetY() : 0));
-   }
-
-   if (!args.GetExtraArgs().empty()) {
-      if (!geometry.empty()) geometry.append(" ");
-      geometry.append(args.GetExtraArgs());
    }
 
    exec = std::regex_replace(exec, std::regex("\\$geometry"), geometry);

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -1396,9 +1396,13 @@ try_again:
 
    auto handle = RWebDisplayHandle::Display(args);
 
-   if (!handle) {
-      R__LOG_DEBUG(0, WebGUILog()) << "Cannot start " << args.GetBrowserName() << " to produce image " << fdebug;
-      return false;
+   // ensure file is created by browser draw
+   if (use_browser_draw && handle) {
+      Int_t batch_timeout = gEnv->GetValue("WebGui.BatchTimeout", 30) * 10;
+      while (gSystem->AccessPathName(wait_file_name.Data()) && (--batch_timeout > 0)) {
+         gSystem->ProcessEvents();
+         gSystem->Sleep(100);
+      }
    }
 
    // delete temporary HTML file
@@ -1409,12 +1413,18 @@ try_again:
          gSystem->Unlink(html_name.Data());
    }
 
-   if (!wait_file_name.IsNull() && gSystem->AccessPathName(wait_file_name.Data())) {
-      R__LOG_ERROR(WebGUILog()) << "Fail to produce image " << fdebug;
+   if (!handle) {
+      R__LOG_DEBUG(0, WebGUILog()) << "Cannot start " << args.GetBrowserName() << " to produce image " << fdebug;
       return false;
    }
 
    if (use_browser_draw) {
+
+      if (gSystem->AccessPathName(wait_file_name.Data())) {
+         R__LOG_ERROR(WebGUILog()) << "Fail to produce image " << fdebug;
+         return false;
+      }
+
       if (fmts[0] == "s.pdf")
          ::Info("ProduceImages", "PDF file %s with %d pages has been created", fnames[0].c_str(), (int) jsons.size());
       else {

--- a/js/files/canv_batch.htm
+++ b/js/files/canv_batch.htm
@@ -152,14 +152,16 @@
 
    drawNext(0).then(() => {
 
-      appendResult(null, '###batch###job###done###');
+      if (!keep_as_is) {
+         appendResult(null, '###batch###job###done###');
 
-      current_dom?.remove();
+         current_dom?.remove();
+      }
 
       // remove main script from dump
       document.getElementById('main').remove();
 
-      if (JSROOT.browser.isFirefox && window && (typeof window.dump == "function")) {
+      if (JSROOT.browser.isFirefox && window && (typeof window.dump == "function") && !keep_as_is) {
          window.dump(document.body.innerHTML);
          window.close();
       }


### PR DESCRIPTION
With chrome and firefox browser one can use screenshot functionality.
It activated when canvas stored in file like `file.screenshot.png` or `file.screenshot.pdf`
In such case --screenshot arg add to args

Problem appeared when `fork:` start to be used for batch jobs. 
In such case screenshot does not appears immedeately but with some timeout.
Now this handled correctly - ROOT will wait some time for it.

Also repair handling of screenshot in firefox - extra args were not handled properly.

Correctly delete HTML file only after browser processing really finished.
