### PR TITLE
[ntuple] Add some internal utilities to the storage layer

### DIFF
--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -32,13 +32,14 @@ class TVirtualStreamerInfo;
 
 namespace ROOT {
 
-namespace Internal {
-class RRawFile;
-}
-
 class RNTupleWriteOptions;
 
 namespace Internal {
+
+class RRawFile;
+
+TDirectory *GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer);
+
 /// Holds status information of an open ROOT file during writing
 struct RTFileControlBlock;
 
@@ -68,9 +69,6 @@ private:
    /// Used when the file turns out to be a TFile container. The ntuplePath variable is either the ntuple name
    /// or an ntuple name preceded by a directory (`myNtuple` or `foo/bar/myNtuple` or `/foo/bar/myNtuple`)
    RResult<RNTuple> GetNTupleProper(std::string_view ntuplePath);
-   /// Loads an RNTuple anchor from a TFile at the given file offset (unzipping it if necessary).
-   RResult<RNTuple>
-   GetNTupleProperAtOffset(std::uint64_t payloadOffset, std::uint64_t compSize, std::uint64_t uncompLen);
 
    /// Searches for a key with the given name and type in the key index of the directory starting at offsetDir.
    /// The offset points to the start of the TDirectory DATA section, without the key and without the name and title
@@ -84,6 +82,9 @@ public:
    explicit RMiniFileReader(ROOT::Internal::RRawFile *rawFile);
    /// Extracts header and footer location for the RNTuple identified by ntupleName
    RResult<RNTuple> GetNTuple(std::string_view ntupleName);
+   /// Loads an RNTuple anchor from a TFile at the given file offset (unzipping it if necessary).
+   RResult<RNTuple>
+   GetNTupleProperAtOffset(std::uint64_t payloadOffset, std::uint64_t compSize, std::uint64_t uncompLen);
    /// Reads a given byte range from the file into the provided memory buffer.
    /// If `nbytes > fMaxKeySize` it will perform chunked read from multiple blobs,
    /// whose addresses are listed at the end of the first chunk.
@@ -109,6 +110,8 @@ A stand-alone version of RNTuple can remove the TFile based writer.
 */
 // clang-format on
 class RNTupleFileWriter {
+   friend TDirectory *ROOT::Internal::GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer);
+
 public:
    /// The key length of a blob. It is always a big key (version > 1000) with class name RBlob.
    static constexpr std::size_t kBlobKeyLen = 42;
@@ -254,7 +257,7 @@ public:
    void WriteIntoReservedBlob(const void *buffer, size_t nbytes, std::int64_t offset);
    /// Ensures that the streamer info records passed as argument are written to the file
    void UpdateStreamerInfos(const ROOT::Internal::RNTupleSerializer::StreamerInfoMap_t &streamerInfos);
-   /// Writes the RNTuple key to the file so that the header and footer keys can be found
+   /// Writes the RNTuple key to the file so that the header and footer keys can be found.
    void Commit(int compression = RCompressionSetting::EDefaults::kUseGeneralPurpose);
 };
 

--- a/tree/ntuple/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/inc/ROOT/RPageNullSink.hxx
@@ -106,6 +106,10 @@ public:
    void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const final
+   {
+      return nullptr;
+   }
 };
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/inc/ROOT/RPageSinkBuf.hxx
@@ -152,6 +152,11 @@ public:
    void CommitDatasetImpl() final;
 
    RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
+
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view newName, const ROOT::RNTupleWriteOptions &opts) const final
+   {
+      return std::make_unique<RPageSinkBuf>(fInnerSink->DeriveFor(newName, opts));
+   }
 }; // RPageSinkBuf
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -47,9 +47,9 @@ namespace ROOT {
 class RNTupleModel;
 
 namespace Internal {
-
-class RPageAllocator;
 class RColumn;
+class RMiniFileReader;
+class RPageAllocator;
 struct RNTupleModelChangeset;
 
 enum class EPageStorageType {
@@ -312,6 +312,10 @@ public:
    virtual const ROOT::RNTupleDescriptor &GetDescriptor() const = 0;
 
    virtual ROOT::NTupleSize_t GetNEntries() const = 0;
+
+   /// Creates a new RPageSink linked to the same underlying storage as this, writing to a new RNTuple called `newName`.
+   /// The existing sink will stay valid. The existing sink and the new one must not write concurrently.
+   virtual std::unique_ptr<RPageSink> DeriveFor(std::string_view newName, const RNTupleWriteOptions &opts) const = 0;
 
    /// Physically creates the storage container to hold the ntuple (e.g., a keys a TFile or an S3 bucket)
    /// Init() associates column handles to the columns referenced by the model
@@ -807,6 +811,8 @@ public:
    /// concurrently to other methods of the page source.
    virtual std::vector<std::unique_ptr<ROOT::Internal::RCluster>>
    LoadClusters(std::span<ROOT::Internal::RCluster::RKey> clusterKeys) = 0;
+
+   virtual RMiniFileReader *GetUnderlyingReader() { return nullptr; }
 
    /// Parallel decompression and unpacking of the pages in the given cluster. The unzipped pages are supposed
    /// to be preloaded in a page pool attached to the source. The method is triggered by the cluster pool's

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -141,6 +141,8 @@ protected:
 public:
    RPageSinkDaos(std::string_view ntupleName, std::string_view uri, const ROOT::RNTupleWriteOptions &options);
    ~RPageSinkDaos() override;
+
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const final;
 }; // class RPageSinkDaos
 
 // clang-format off

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -104,6 +104,10 @@ public:
    ~RPageSinkFile() override;
 
    void UpdateSchema(const ROOT::Internal::RNTupleModelChangeset &changeset, ROOT::NTupleSize_t firstEntry) final;
+
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view newName, const ROOT::RNTupleWriteOptions &opts) const final;
+
+   ROOT::Internal::RNTupleFileWriter *GetUnderlyingWriter() const { return fWriter.get(); }
 }; // class RPageSinkFile
 
 // clang-format off
@@ -155,6 +159,8 @@ private:
    std::unique_ptr<ROOT::Internal::RCluster>
    PrepareSingleCluster(const ROOT::Internal::RCluster::RKey &clusterKey, std::vector<RRawFile::RIOVec> &readRequests);
 
+   RMiniFileReader *GetUnderlyingReader() final { return &fReader; }
+
 protected:
    void LoadStructureImpl() final;
    ROOT::RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode mode) final;
@@ -178,6 +184,11 @@ public:
    RPageSourceFile(RPageSourceFile &&) = delete;
    RPageSourceFile &operator=(RPageSourceFile &&) = delete;
    ~RPageSourceFile() override;
+
+   /// Creates a new PageSourceFile using the same underlying file as this but referring to a different RNTuple,
+   /// represented by `anchor`.
+   std::unique_ptr<RPageSourceFile>
+   OpenWithDifferentAnchor(const RNTuple &anchor, const ROOT::RNTupleReadOptions &options = ROOT::RNTupleReadOptions());
 
    void
    LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) final;

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -1608,3 +1608,11 @@ void ROOT::Internal::RNTupleFileWriter::WriteTFileSkeleton(int defaultCompressio
       fileSimple.Write(&padding, sizeof(padding));
    fileSimple.fKeyOffset = fileSimple.fFilePos;
 }
+
+TDirectory *ROOT::Internal::GetUnderlyingDirectory(ROOT::Internal::RNTupleFileWriter &writer)
+{
+   if (auto *proper = std::get_if<ROOT::Internal::RNTupleFileWriter::RFileProper>(&writer.fFile)) {
+      return proper->fDirectory;
+   }
+   return nullptr;
+}

--- a/tree/ntuple/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/src/RNTupleParallelWriter.cxx
@@ -111,6 +111,10 @@ public:
    {
       throw ROOT::RException(R__FAIL("should never commit dataset via RPageSynchronizingSink"));
    }
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const final
+   {
+      throw ROOT::RException(R__FAIL("DeriveFor unavailable for RPageSynchronizingSink"));
+   }
 
    RSinkGuard GetSinkGuard() final { return RSinkGuard(fMutex); }
 };

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -483,6 +483,12 @@ void ROOT::Experimental::Internal::RPageSinkDaos::WriteNTupleAnchor()
       kDistributionKeyDefault, kAttributeKeyAnchor, kCidMetadata);
 }
 
+std::unique_ptr<ROOT::Internal::RPageSink>
+ROOT::Experimental::Internal::RPageSinkDaos::DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const
+{
+   throw ROOT::RException(R__FAIL("this method is not available for the DAOS backend"));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::Internal::RPageSourceDaos::RPageSourceDaos(std::string_view ntupleName, std::string_view uri,

--- a/tree/ntuple/test/ntuple_endian.cxx
+++ b/tree/ntuple/test/ntuple_endian.cxx
@@ -59,6 +59,11 @@ protected:
    void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const final
+   {
+      R__ASSERT(false);
+      return nullptr;
+   }
 
 public:
    RPageSinkMock(const RColumnElementBase &elt) : RPageSink("test", ROOT::RNTupleWriteOptions()), fElement(elt)

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -54,6 +54,11 @@ protected:
    void CommitStagedClusters(std::span<RStagedCluster>) final {}
    void CommitClusterGroup() final {}
    void CommitDatasetImpl() final {}
+   std::unique_ptr<RPageSink> DeriveFor(std::string_view, const ROOT::RNTupleWriteOptions &) const final
+   {
+      R__ASSERT(false);
+      return nullptr;
+   }
 
 public:
    RPageSinkMock(const ROOT::RNTupleWriteOptions &options) : RPageSink("test", options) {}
@@ -1144,4 +1149,63 @@ TEST(RPageSourceFile, NameFromAnchor)
    EXPECT_EQ(source->GetNTupleName(), "");
    source->Attach();
    EXPECT_EQ(source->GetNTupleName(), "ntpl");
+}
+
+TEST(RPageSourceFile, OpenDifferentAnchor)
+{
+   FileRaii fileGuard("test_ntuple_open_diff_anchor.root");
+
+   auto model = RNTupleModel::Create();
+   auto pF = model->MakeField<float>("f");
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   {
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl1", *file);
+      for (auto i = 0; i < 100; ++i) {
+         *pF = i;
+         writer->Fill();
+      }
+   }
+   {
+      model = RNTupleModel::Create();
+      auto pI = model->MakeField<int>("i");
+      auto pC = model->MakeField<char>("c");
+
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl2", *file);
+      for (auto i = 0; i < 20; ++i) {
+         *pI = i;
+         *pC = i;
+         writer->Fill();
+      }
+   }
+
+   auto source = std::make_unique<RPageSourceFile>("ntpl1", fileGuard.GetPath(), RNTupleReadOptions());
+   source->Attach();
+   EXPECT_EQ(source->GetNEntries(), 100);
+   {
+      auto desc = source->GetSharedDescriptorGuard();
+      EXPECT_NE(desc->FindFieldId("f"), ROOT::kInvalidDescriptorId);
+   }
+
+   auto anchor2 = file->Get<ROOT::RNTuple>("ntpl2");
+   ASSERT_NE(anchor2, nullptr);
+   auto source2 = source->OpenWithDifferentAnchor(*anchor2);
+   source2->Attach();
+   EXPECT_EQ(source2->GetNTupleName(), "ntpl2");
+   EXPECT_EQ(source2->GetNEntries(), 20);
+   {
+      auto desc2 = source2->GetSharedDescriptorGuard();
+      EXPECT_EQ(desc2->FindFieldId("f"), ROOT::kInvalidDescriptorId);
+      EXPECT_NE(desc2->FindFieldId("i"), ROOT::kInvalidDescriptorId);
+      EXPECT_NE(desc2->FindFieldId("c"), ROOT::kInvalidDescriptorId);
+   }
+
+   source.reset();
+   // source2 should still be valid after dropping the first source.
+   EXPECT_EQ(source2->GetNEntries(), 20);
+   {
+      auto desc2 = source2->GetSharedDescriptorGuard();
+      EXPECT_EQ(desc2->FindFieldId("f"), ROOT::kInvalidDescriptorId);
+      EXPECT_NE(desc2->FindFieldId("i"), ROOT::kInvalidDescriptorId);
+      EXPECT_NE(desc2->FindFieldId("c"), ROOT::kInvalidDescriptorId);
+   }
 }


### PR DESCRIPTION
**NOTE**: this PR has been split into multiple ones:
- #21007
- #21010
- #21063

Add a bunch of functions to poke through the abstraction of the storage classes (specifically, to get the underlying TDirectory and RMiniFileReader).  These functionalities (all Internal) will be needed by the RNTuple Attributes (see [the full PR](https://github.com/root-project/root/pull/19153) for details)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

