### PR TITLE
[core] Use version script to hide symbols in libCling

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -229,6 +229,8 @@ if(NOT APPLE AND NOT MSVC)
   # and by ALICE in https://github.com/root-project/root/issues/19889
   # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
   target_link_libraries(Cling PRIVATE -Wl,-Bsymbolic)
+  target_link_libraries(Cling PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libCling.script)
+  set_target_properties(Cling PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libCling.script)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)

--- a/core/metacling/src/libCling.script
+++ b/core/metacling/src/libCling.script
@@ -1,0 +1,13 @@
+{
+  global:
+    CreateInterpreter;
+    DestroyInterpreter;
+    TCling__*;
+    _Z26TCling__TEST_isInvalidDeclP11ClassInfo_t;
+    TROOT__*;
+    ROOT_rootcling_Driver;
+    _ZN5cling*;
+    cling_runtime_internal_throwIfInvalidPointer;
+  local:
+    *;
+};


### PR DESCRIPTION
We already use `-fvisibility=hidden` and `-fvisibility-inlines-hidden` to generate symbols that are not exported from the shared object. However, these two options don't apply for non-inline template instantiations, which can still cause problems when a STL container is instantiated with an LLVM type that may change size between LLVM versions.

Related to https://github.com/root-project/root/issues/19889