### PR TITLE
[ntuple] fix bool-backed enums

### DIFF
--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -538,6 +538,7 @@ ROOT::REnumField::REnumField(std::string_view fieldName, TEnum *enump)
    }
 
    switch (enump->GetUnderlyingType()) {
+   case kBool_t: Attach(std::make_unique<RField<Bool_t>>("_0")); break;
    case kChar_t: Attach(std::make_unique<RField<Char_t>>("_0")); break;
    case kUChar_t: Attach(std::make_unique<RField<UChar_t>>("_0")); break;
    case kShort_t: Attach(std::make_unique<RField<Short_t>>("_0")); break;

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -22,6 +22,8 @@
 
 enum CustomEnum { kCustomEnumVal = 7 };
 // TODO(jblomer): use standard integer types for specifying the underlying width; requires TEnum fix.
+enum class CustomEnumBool : bool {
+};
 enum class CustomEnumInt8 : char {};
 enum class CustomEnumUInt8 : unsigned char {};
 enum class CustomEnumInt16 : short int {};

--- a/tree/ntuple/test/CustomStructLinkDef.h
+++ b/tree/ntuple/test/CustomStructLinkDef.h
@@ -1,6 +1,7 @@
 #ifdef __CLING__
 
 #pragma link C++ enum CustomEnum;
+#pragma link C++ enum CustomEnumBool;
 #pragma link C++ enum CustomEnumInt8;
 #pragma link C++ enum CustomEnumUInt8;
 #pragma link C++ enum CustomEnumInt16;

--- a/tree/ntuple/test/ntuple_types.cxx
+++ b/tree/ntuple/test/ntuple_types.cxx
@@ -47,8 +47,9 @@ TEST(RNTuple, EnumBasics)
    EXPECT_EQ(kCustomEnumVal, reader->GetModel().GetDefaultEntry().GetPtr<std::vector<CustomEnum>>("ve")->at(1));
 }
 
-using EnumClassInts = ::testing::Types<CustomEnumInt8, CustomEnumUInt8, CustomEnumInt16, CustomEnumUInt16,
-                                       CustomEnumInt32, CustomEnumUInt32, CustomEnumInt64, CustomEnumUInt64>;
+using EnumClassInts =
+   ::testing::Types<CustomEnumBool, CustomEnumInt8, CustomEnumUInt8, CustomEnumInt16, CustomEnumUInt16, CustomEnumInt32,
+                    CustomEnumUInt32, CustomEnumInt64, CustomEnumUInt64>;
 
 template <typename EnumT>
 class EnumClass : public ::testing::Test {


### PR DESCRIPTION
Enables bool as an underlying type for custom enums, which was previously overlooked.

Follow-up of #19907 
