### PR TITLE
[browsable] Change v7 draw as default for treemap visualization

### DIFF
--- a/gui/browsable/src/RNTupleBrowseProvider.cxx
+++ b/gui/browsable/src/RNTupleBrowseProvider.cxx
@@ -68,13 +68,10 @@ public:
    }
 
    /** Default action is to draw the treemap */
-   EActionKind GetDefaultAction() const override { return kActDraw6; /*temporary, replace with kActDraw7; */ }
+   EActionKind GetDefaultAction() const override { return kActDraw7; }
 
    /** Check if visualization is capable of being drawn */
-   bool IsCapable(EActionKind kind) const override
-   {
-      return kind == kActDraw6;
-   }
+   bool IsCapable(EActionKind kind) const override { return kind == kActDraw6 || kind == kActDraw7; }
 
    /** Create item with TreeMap icon */
    std::unique_ptr<RItem> CreateItem() const override
@@ -476,4 +473,3 @@ public:
    ~RNTupleBrowseProvider() override { RegisterNTupleFunc(nullptr); }
 
 } newRNTupleBrowseProvider;
-


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Make `kActDraw7` default for drawing `RTreeMapElement` on `RBrowser`

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

