### PR TITLE
Fix win warning in TFile.h

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -123,7 +123,7 @@ public:
    explicit TKeyMapIterable(TFile *file) : fFile(file) {}
 
    TIterator begin() const { return TIterator(fFile, 0); }
-   TIterator end() const { return TIterator(fFile, -1); }
+   TIterator end() const { return TIterator(fFile, (std::uint64_t) -1); }
 };
 
 } // namespace ROOT::Detail


### PR DESCRIPTION
Fix windows warning C4245: '=': conversion from 'int' to 'uint64_t'
