### PR TITLE
[ntuple] remove GetCollectionInfo() from collection fields

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -182,16 +182,6 @@ public:
    size_t GetValueSize() const final { return fProxy->Sizeof(); }
    size_t GetAlignment() const final { return alignof(std::max_align_t); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
-   void
-   GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
-   }
-   void
-   GetCollectionInfo(RNTupleLocalIndex localIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(localIndex, collectionStart, size);
-   }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -163,16 +163,6 @@ public:
    size_t GetValueSize() const final;
    size_t GetAlignment() const final;
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
-   void
-   GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
-   }
-   void
-   GetCollectionInfo(RNTupleLocalIndex localIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(localIndex, collectionStart, size);
-   }
 };
 
 template <typename ItemT>
@@ -256,16 +246,6 @@ public:
    size_t GetValueSize() const final { return sizeof(std::vector<char>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
-   void
-   GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
-   }
-   void
-   GetCollectionInfo(RNTupleLocalIndex localIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(localIndex, collectionStart, size);
-   }
 };
 
 template <typename ItemT>
@@ -316,16 +296,6 @@ public:
    size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
    size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
-   void
-   GetCollectionInfo(ROOT::NTupleSize_t globalIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
-   }
-   void
-   GetCollectionInfo(RNTupleLocalIndex localIndex, RNTupleLocalIndex *collectionStart, ROOT::NTupleSize_t *size) const
-   {
-      fPrincipalColumn->GetCollectionInfo(localIndex, collectionStart, size);
-   }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -345,7 +345,7 @@ std::size_t ROOT::RRVecField::ReadBulkImpl(const RBulkSpec &bulkSpec)
    // Get size of the first RVec of the bulk
    RNTupleLocalIndex firstItemIndex;
    ROOT::NTupleSize_t collectionSize;
-   this->GetCollectionInfo(bulkSpec.fFirstIndex, &firstItemIndex, &collectionSize);
+   fPrincipalColumn->GetCollectionInfo(bulkSpec.fFirstIndex, &firstItemIndex, &collectionSize);
    *beginPtr = itemValueArray;
    *sizePtr = collectionSize;
    *capacityPtr = -1;

--- a/tree/ntuple/test/ntuple_emulated.cxx
+++ b/tree/ntuple/test/ntuple_emulated.cxx
@@ -680,20 +680,13 @@ TEST(RNTupleEmulated, CollectionProxy)
    EXPECT_NE(field.GetTraits() & RFieldBase::kTraitEmulatedField, 0);
    EXPECT_EQ(field.GetValueSize(), sizeof(std::vector<char>));
 
-   const auto *vec = dynamic_cast<const ROOT::RVectorField *>(&field);
-   ASSERT_NE(vec, nullptr);
-   RNTupleLocalIndex collectionStart;
-   ROOT::NTupleSize_t size;
-   vec->GetCollectionInfo(0, &collectionStart, &size);
-   EXPECT_EQ(collectionStart.GetClusterId(), 0);
-   EXPECT_EQ(collectionStart.GetIndexInCluster(), 0);
-   EXPECT_EQ(size, 100);
-   vec->GetCollectionInfo(1, &collectionStart, &size);
-   EXPECT_EQ(collectionStart.GetClusterId(), 0);
-   EXPECT_EQ(collectionStart.GetIndexInCluster(), 100);
-   EXPECT_EQ(size, 0);
-
+   auto vec = std::static_pointer_cast<std::vector<char>>(reader->GetModel().GetDefaultEntry().GetPtr<void>("proxyC"));
    reader->LoadEntry(0);
+   EXPECT_EQ(100u, vec->size());
+   EXPECT_EQ(0x42, vec->at(0));
+   EXPECT_EQ(0x42, vec->at(99));
+   reader->LoadEntry(1);
+   EXPECT_EQ(0u, vec->size());
 }
 
 TEST(RNTupleEmulated, MergeEmulated)


### PR DESCRIPTION
Several collection fields still had a public GetCollectionInfo() method. It was an oversight not to remove them earlier. These methods are unneeded and potentially dangerous to expose.