### PR TITLE
[ntuple] automatic evolution from fixed-size array to RVec

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -197,15 +197,20 @@ public:
          }
       }
 
+      RFieldZero fieldZero;
+      ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, true);
+      fieldZero.Attach(std::move(fField));
       try {
-         ROOT::Internal::CallConnectPageSourceOnField(*fField, source);
+         ROOT::Internal::CallConnectPageSourceOnField(fieldZero, source);
       } catch (const ROOT::RException &err) {
+         fField = std::move(fieldZero.ReleaseSubfields()[0]);
          auto onDiskType = source.GetSharedDescriptorGuard()->GetFieldDescriptor(fField->GetOnDiskId()).GetTypeName();
          std::string msg = "RNTupleDS: invalid type \"" + fField->GetTypeName() + "\" for column \"" +
                            fDataSource->fFieldId2QualifiedName[fField->GetOnDiskId()] + "\" with on-disk type \"" +
                            onDiskType + "\"";
          throw std::runtime_error(msg);
       }
+      fField = std::move(fieldZero.ReleaseSubfields()[0]);
 
       if (fValuePtr) {
          // When the reader reconnects to a new file, the fValuePtr is already set

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -208,7 +208,7 @@ protected:
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
    void ReadInClusterImpl(RNTupleLocalIndex localIndex, void *to) final;
 
-   void BeforeConnectPageSource(ROOT::Internal::RPageSource &pageSource) final;
+   std::unique_ptr<RFieldBase> BeforeConnectPageSource(ROOT::Internal::RPageSource &pageSource) final;
    void ReconcileOnDiskField(const RNTupleDescriptor &desc) final;
 
 public:
@@ -263,7 +263,7 @@ protected:
    // Returns the list of seen streamer infos
    ROOT::RExtraTypeInfoDescriptor GetExtraTypeInfo() const final;
 
-   void BeforeConnectPageSource(ROOT::Internal::RPageSource &source) final;
+   std::unique_ptr<RFieldBase> BeforeConnectPageSource(ROOT::Internal::RPageSource &source) final;
    void ReconcileOnDiskField(const RNTupleDescriptor &desc) final;
 
 public:

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -83,6 +83,8 @@ public:
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 
    bool GetAllowFieldSubstitutions() const { return fAllowFieldSubstitutions; }
+   /// Moves all subfields into the returned vector.
+   std::vector<std::unique_ptr<RFieldBase>> ReleaseSubfields();
 };
 
 /// Used in RFieldBase::Check() to record field creation failures.

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -111,6 +111,13 @@ public:
 
 /// The type-erased field for a RVec<Type>
 class RRVecField : public RFieldBase {
+   friend class RArrayAsRVecField; // to call ResizeRVec()
+
+   // Ensures that the RVec pointed to by rvec has at least nItems valid elements
+   // Returns the possibly new "begin pointer" of the RVec, i.e. the pointer to the data area.
+   static unsigned char *
+   ResizeRVec(void *rvec, std::size_t nItems, std::size_t itemSize, const RFieldBase *itemField, RDeleter *itemDeleter);
+
 public:
    /// the RRVecDeleter is also used by RArrayAsRVecField and therefore declared public
    class RRVecDeleter : public RDeleter {

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -154,6 +154,7 @@ protected:
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
    std::size_t ReadBulkImpl(const RBulkSpec &bulkSpec) final;
 
+   std::unique_ptr<RFieldBase> BeforeConnectPageSource(ROOT::Internal::RPageSource &pageSource) final;
    void ReconcileOnDiskField(const RNTupleDescriptor &desc) final;
 
    void CommitClusterImpl() final { fNWritten = 0; }

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -514,7 +514,13 @@ protected:
    /// Called by ConnectPageSource() before connecting; derived classes may override this as appropriate, e.g.
    /// for the application of I/O rules. In the process, the field at hand or its subfields may be marked as
    /// "artifical", i.e. introduced by schema evolution and not backed by on-disk information.
-   virtual void BeforeConnectPageSource(ROOT::Internal::RPageSource & /* source */) {}
+   /// May return a field substitute that fits the on-disk schema as a replacement for the field at hand.
+   /// A field substitute must read into the same in-memory layout than the original field and field substitutions
+   /// must not be cyclic.
+   virtual std::unique_ptr<RFieldBase> BeforeConnectPageSource(ROOT::Internal::RPageSource & /* source */)
+   {
+      return nullptr;
+   }
 
    /// For non-artificial fields, check compatibility of the in-memory field and the on-disk field. In the process,
    /// the field at hand may change its on-disk ID or perform other tasks related to automatic schema evolution.

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -85,6 +85,7 @@ This is and can only be partially enforced through C++.
 */
 // clang-format on
 class RFieldBase {
+   friend class RFieldZero;                                    // to reset fParent pointer in ReleaseSubfields()
    friend class ROOT::Experimental::Detail::RRawPtrWriteEntry; // to call Append()
    friend struct ROOT::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Internal::RFieldRepresentationModifier; // used for unit tests

--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -93,7 +93,7 @@ private:
    /// The model is generated from the RNTuple metadata on storage.
    explicit RNTupleReader(std::unique_ptr<Internal::RPageSource> source, const ROOT::RNTupleReadOptions &options);
 
-   void ConnectModel(ROOT::RNTupleModel &model);
+   void ConnectModel(ROOT::RNTupleModel &model, bool allowFieldSubstitutions);
    RNTupleReader *GetDisplayReader();
    void InitPageSource(bool enableMetrics);
 

--- a/tree/ntuple/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleView.hxx
@@ -89,6 +89,8 @@ protected:
    static std::unique_ptr<ROOT::RFieldBase>
    CreateField(ROOT::DescriptorId_t fieldId, Internal::RPageSource &pageSource, std::string_view typeName = "")
    {
+      RFieldZero fieldZero;
+      Internal::SetAllowFieldSubstitutions(fieldZero, true);
       std::unique_ptr<ROOT::RFieldBase> field;
       {
          const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
@@ -103,8 +105,9 @@ protected:
          }
       }
       field->SetOnDiskId(fieldId);
-      ROOT::Internal::CallConnectPageSourceOnField(*field, pageSource);
-      return field;
+      fieldZero.Attach(std::move(field));
+      ROOT::Internal::CallConnectPageSourceOnField(fieldZero, pageSource);
+      return std::move(fieldZero.ReleaseSubfields()[0]);
    }
 
    RNTupleViewBase(std::unique_ptr<ROOT::RFieldBase> field, ROOT::RNTupleGlobalRange range)

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -31,6 +31,11 @@
 #include <type_traits>
 #include <unordered_set>
 
+void ROOT::Internal::SetAllowFieldSubstitutions(RFieldZero &fieldZero, bool val)
+{
+   fieldZero.fAllowFieldSubstitutions = val;
+}
+
 std::unique_ptr<ROOT::RFieldBase> ROOT::RFieldZero::CloneImpl(std::string_view /*newName*/) const
 {
    auto result = std::make_unique<RFieldZero>();

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -44,6 +44,15 @@ std::unique_ptr<ROOT::RFieldBase> ROOT::RFieldZero::CloneImpl(std::string_view /
    return result;
 }
 
+std::vector<std::unique_ptr<ROOT::RFieldBase>> ROOT::RFieldZero::ReleaseSubfields()
+{
+   std::vector<std::unique_ptr<ROOT::RFieldBase>> result;
+   std::swap(fSubfields, result);
+   for (auto &f : result)
+      f->fParent = nullptr;
+   return result;
+}
+
 void ROOT::RFieldZero::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitFieldZero(*this);

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -945,8 +945,12 @@ void ROOT::RFieldBase::ConnectPageSink(ROOT::Internal::RPageSink &pageSink, ROOT
 
 void ROOT::RFieldBase::ConnectPageSource(ROOT::Internal::RPageSource &pageSource)
 {
-   if (dynamic_cast<ROOT::RFieldZero *>(this))
-      throw RException(R__FAIL("invalid attempt to connect zero field to page source"));
+   if (dynamic_cast<ROOT::RFieldZero *>(this)) {
+      for (auto &f : fSubfields)
+         f->ConnectPageSource(pageSource);
+      return;
+   }
+
    if (fState != EState::kUnconnected)
       throw RException(R__FAIL("invalid attempt to connect an already connected field to a page source"));
 

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -440,7 +440,7 @@ void ROOT::RClassField::AddReadCallbacksFromIORule(const TSchemaRule *rule)
    });
 }
 
-void ROOT::RClassField::BeforeConnectPageSource(ROOT::Internal::RPageSource &pageSource)
+std::unique_ptr<ROOT::RFieldBase> ROOT::RClassField::BeforeConnectPageSource(ROOT::Internal::RPageSource &pageSource)
 {
    std::vector<const TSchemaRule *> rules;
    // On-disk members that are not targeted by an I/O rule; all other sub fields of the in-memory class
@@ -507,6 +507,8 @@ void ROOT::RClassField::BeforeConnectPageSource(ROOT::Internal::RPageSource &pag
          CallSetArtificialOn(*field);
       }
    }
+
+   return nullptr;
 }
 
 void ROOT::RClassField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
@@ -979,9 +981,10 @@ void ROOT::RStreamerField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex, std::byte>(desc);
 }
 
-void ROOT::RStreamerField::BeforeConnectPageSource(ROOT::Internal::RPageSource &source)
+std::unique_ptr<ROOT::RFieldBase> ROOT::RStreamerField::BeforeConnectPageSource(ROOT::Internal::RPageSource &source)
 {
    source.RegisterStreamerInfos();
+   return nullptr;
 }
 
 void ROOT::RStreamerField::ReconcileOnDiskField(const RNTupleDescriptor &desc)

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -424,6 +424,22 @@ void ROOT::RRVecField::GenerateColumns(const ROOT::RNTupleDescriptor &desc)
    GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
 }
 
+std::unique_ptr<ROOT::RFieldBase> ROOT::RRVecField::BeforeConnectPageSource(Internal::RPageSource &pageSource)
+{
+   if (GetOnDiskId() == kInvalidDescriptorId)
+      return nullptr;
+
+   const auto descGuard = pageSource.GetSharedDescriptorGuard();
+   const auto &fieldDesc = descGuard->GetFieldDescriptor(GetOnDiskId());
+   if (fieldDesc.GetTypeName().rfind("std::array<", 0) == 0) {
+      auto substitute = std::make_unique<RArrayAsRVecField>(
+         GetFieldName(), fSubfields[0]->Clone(fSubfields[0]->GetFieldName()), fieldDesc.GetNRepetitions());
+      substitute->SetOnDiskId(GetOnDiskId());
+      return substitute;
+   }
+   return nullptr;
+}
+
 void ROOT::RRVecField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
 {
    EnsureMatchingOnDiskField(desc.GetFieldDescriptor(GetOnDiskId()), kDiffTypeName);

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -208,6 +208,7 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
    auto &fieldZero = ROOT::Internal::GetFieldZeroOfModel(*fModel);
    auto fieldZeroId = desc->GetFieldZeroId();
    fieldZero.SetOnDiskId(fieldZeroId);
+   ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, true);
 
    for (auto &field : fieldZero.GetMutableSubfields()) {
       auto onDiskId = desc->FindFieldId(field->GetQualifiedFieldName(), fieldZeroId);
@@ -223,6 +224,7 @@ void ROOT::Experimental::RNTupleSingleProcessor::Connect()
 
       ROOT::Internal::CallConnectPageSourceOnField(*field, *fPageSource);
    }
+   ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, false);
 }
 
 void ROOT::Experimental::RNTupleSingleProcessor::AddEntriesToJoinTable(Internal::RNTupleJoinTable &joinTable,

--- a/tree/ntuple/src/RNTupleReader.cxx
+++ b/tree/ntuple/src/RNTupleReader.cxx
@@ -22,9 +22,10 @@
 
 #include <TROOT.h>
 
-void ROOT::RNTupleReader::ConnectModel(ROOT::RNTupleModel &model)
+void ROOT::RNTupleReader::ConnectModel(ROOT::RNTupleModel &model, bool allowFieldSubstitutions)
 {
    auto &fieldZero = ROOT::Internal::GetFieldZeroOfModel(model);
+   ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, allowFieldSubstitutions);
    // We must not use the descriptor guard to prevent recursive locking in field.ConnectPageSource
    ROOT::DescriptorId_t fieldZeroId = fSource->GetSharedDescriptorGuard()->GetFieldZeroId();
    fieldZero.SetOnDiskId(fieldZeroId);
@@ -38,6 +39,7 @@ void ROOT::RNTupleReader::ConnectModel(ROOT::RNTupleModel &model)
       }
       ROOT::Internal::CallConnectPageSourceOnField(*field, *fSource);
    }
+   ROOT::Internal::SetAllowFieldSubstitutions(fieldZero, false);
 }
 
 void ROOT::RNTupleReader::InitPageSource(bool enableMetrics)
@@ -68,7 +70,7 @@ ROOT::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::RNTupleModel> model,
    }
    fModel->Freeze();
    InitPageSource(options.GetEnableMetrics());
-   ConnectModel(*fModel);
+   ConnectModel(*fModel, false /* allowFieldSubstitutions */);
 }
 
 ROOT::RNTupleReader::RNTupleReader(std::unique_ptr<ROOT::Internal::RPageSource> source,
@@ -136,7 +138,7 @@ const ROOT::RNTupleModel &ROOT::RNTupleReader::GetModel()
    if (!fModel) {
       fModel = fSource->GetSharedDescriptorGuard()->CreateModel(
          fCreateModelOptions.value_or(ROOT::RNTupleDescriptor::RCreateModelOptions{}));
-      ConnectModel(*fModel);
+      ConnectModel(*fModel, true /* allowFieldSubstitutions */);
    }
    return *fModel;
 }

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -92,6 +92,7 @@ ROOT_ADD_GTEST(ntuple_extended ntuple_extended.cxx LIBRARIES ROOTNTuple MathCore
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(ntuple_largefile1 ntuple_largefile1.cxx LIBRARIES ROOTNTuple MathCore)
   ROOT_ADD_GTEST(ntuple_largefile2 ntuple_largefile2.cxx LIBRARIES ROOTNTuple MathCore)
+  ROOT_ADD_GTEST(ntuple_largevector ntuple_largevector.cxx LIBRARIES ROOTNTuple)
 endif()
 ROOT_ADD_GTEST(ntuple_randomaccess ntuple_randomaccess.cxx LIBRARIES ROOTNTuple MathCore)
 

--- a/tree/ntuple/test/ntuple_evolution_shape.cxx
+++ b/tree/ntuple/test/ntuple_evolution_shape.cxx
@@ -956,6 +956,50 @@ struct RenamedIntermediateDerived : public RenamedIntermediate2 {
    }
 }
 
+TEST(RNTupleEvolution, ArrayAsVector)
+{
+   FileRaii fileGuard("test_ntuple_evolution_array_as_vector.root");
+
+   ExecInFork([&] {
+      // The child process writes the file and exits, but the file must be preserved to be read by the parent.
+      fileGuard.PreserveFile();
+
+      ASSERT_TRUE(gInterpreter->Declare(R"(
+struct ArrayAsVector {
+   std::array<int, 2> fArr = {1, 2};
+   int x = 3;
+};
+)"));
+
+      auto model = RNTupleModel::Create();
+      model->AddField(RFieldBase::Create("f", "ArrayAsVector").Unwrap());
+
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      writer->Fill();
+
+      writer.reset();
+   });
+
+   ASSERT_TRUE(gInterpreter->Declare(R"(
+struct ArrayAsVector {
+   ROOT::RVec<short> fArr;
+   int x;
+};
+)"));
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   ASSERT_EQ(1, reader->GetNEntries());
+
+   void *ptr = reader->GetModel().GetDefaultEntry().GetPtr<void>("f").get();
+   DeclarePointer("ArrayAsVector", "ptrArrayAsVector", ptr);
+
+   reader->LoadEntry(0);
+   EXPECT_EVALUATE_EQ("ptrArrayAsVector->x", 3);
+   EXPECT_EVALUATE_EQ("ptrArrayAsVector->fArr.size()", 2);
+   EXPECT_EVALUATE_EQ("ptrArrayAsVector->fArr[0]", 1);
+   EXPECT_EVALUATE_EQ("ptrArrayAsVector->fArr[1]", 2);
+}
+
 TEST(RNTupleEvolution, StreamerField)
 {
    FileRaii fileGuard("test_ntuple_evolution_streamer_field.root");

--- a/tree/ntuple/test/ntuple_largevector.cxx
+++ b/tree/ntuple/test/ntuple_largevector.cxx
@@ -1,0 +1,45 @@
+#include "ntuple_test.hxx"
+
+#include <limits>
+
+TEST(RNTuple, DISABLED_LargeVector)
+{
+   FileRaii fileGuard("test_ntuple_large_vector.root");
+
+   // write out a vector too large for RVec
+   {
+      auto m = RNTupleModel::Create();
+      auto vec = m->MakeField<std::vector<int8_t>>("v");
+      auto writer = RNTupleWriter::Recreate(std::move(m), "r", fileGuard.GetPath());
+      vec->push_back(1);
+      writer->Fill();
+      vec->resize(std::numeric_limits<std::int32_t>::max());
+      writer->Fill();
+      vec->push_back(2);
+      writer->Fill();
+      vec->clear();
+      writer->Fill();
+   }
+
+   ROOT::RNTupleReadOptions options;
+   options.SetClusterCache(ROOT::RNTupleReadOptions::EClusterCache::kOff);
+   auto reader = RNTupleReader::Open("r", fileGuard.GetPath(), options);
+   ASSERT_EQ(4u, reader->GetNEntries());
+
+   auto viewRVec = reader->GetView<ROOT::RVec<int8_t>>("v");
+   EXPECT_EQ(1u, viewRVec(0).size());
+   EXPECT_EQ(1, viewRVec(0).at(0));
+   const auto &v1 = viewRVec(1);
+   EXPECT_EQ(std::numeric_limits<std::int32_t>::max(), v1.size());
+   EXPECT_EQ(1, v1.at(0));
+   EXPECT_EQ(0, v1.at(1000));
+   EXPECT_THROW(viewRVec(2), ROOT::RException);
+   EXPECT_TRUE(viewRVec(3).empty());
+
+   auto viewVector = reader->GetView<std::vector<int8_t>>("v");
+   const auto &v3 = viewVector(2);
+   EXPECT_EQ(static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max()) + 1, v3.size());
+   EXPECT_EQ(1, v3.at(0));
+   EXPECT_EQ(0, v3.at(1000));
+   EXPECT_EQ(2, v3.at(std::numeric_limits<std::int32_t>::max()));
+}


### PR DESCRIPTION
In contrast to other automatic evolution mechanisms, this one cannot use `ReconcileOnDiskField()` because for proper support the type of the field itself must change. In principle, we could stuff all the logic into RRecField, but it would be quite messy. We also discussed adding a "virtual column" for the fixed-size indexes; this doesn't work, however, because the index column stores offsets and not vector lengths, and it is also used to translate between global and local indexing.

Thus, this PR adds the infrastructure to replace fields of just created field hierarchies (models). This is legit as long as the fields weren't exposed to the user yet, where the user, e.g., could have already created entries. As a result, the automatic evolution from fixed-size to RVec (and later std::vector) won't work with imposed models. But it does work for views and models reconstructed from disk, which are the most common use cases.

The infrastructure will also be used to switch between streamer field and class field.