### PR TITLE
[CMake] Bump the minimum required version to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
 if(WIN32)
   # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD
@@ -42,7 +42,7 @@ foreach(policy ${policy_new})
   endif()
 endforeach()
 
-set(policy_old CMP0116)
+set(policy_old CMP0116 CMP0126)
 foreach(policy ${policy_old})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} OLD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
 if(WIN32)
   # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD
@@ -41,6 +41,13 @@ set(policy_new CMP0072 CMP0076 CMP0077 CMP0079
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)
+  endif()
+endforeach()
+
+set(policy_old CMP0126)
+foreach(policy ${policy_old})
+  if(POLICY ${policy})
+    cmake_policy(SET ${policy} OLD)
   endif()
 endforeach()
 

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1323,13 +1323,6 @@ if (testing OR testsupport)
       message(SEND_ERROR "Missing installation of GTest subcomponent ${LIBNAME}")
     endif()
   endforeach()
-  # Starting from cmake 3.23, the GTest targets will have stable names.
-  # ROOT was updated to use those, but for older CMake versions, we have to declare the aliases:
-  foreach(LIBNAME gtest_main gmock_main gtest gmock)
-    if(NOT TARGET GTest::${LIBNAME} AND TARGET ${LIBNAME})
-      add_library(GTest::${LIBNAME} ALIAS ${LIBNAME})
-    endif()
-  endforeach()
 endif()
 
 #------------------------------------------------------------------------------------

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1115,13 +1115,6 @@ if (testing OR testsupport)
       message(SEND_ERROR "Missing installation of GTest subcomponent ${LIBNAME}")
     endif()
   endforeach()
-  # Starting from cmake 3.23, the GTest targets will have stable names.
-  # ROOT was updated to use those, but for older CMake versions, we have to declare the aliases:
-  foreach(LIBNAME gtest_main gmock_main gtest gmock)
-    if(NOT TARGET GTest::${LIBNAME} AND TARGET ${LIBNAME})
-      add_library(GTest::${LIBNAME} ALIAS ${LIBNAME})
-    endif()
-  endforeach()
 endif()
 
 #------------------------------------------------------------------------------------

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -207,18 +207,16 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${BASE_HEADERS})
 
 target_sources(Core PRIVATE ${BASE_SOURCES})
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0") # https://discourse.cmake.org/t/file-set-xyz-is-listed-in-interface-file-sets-of-w-but-has-not-been-exported/9131/3
-  target_sources(
-      Core
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ src/
-      FILES
-          ${RELATIVE_BASE_INC_HEADERS}
-          src/TListOfTypes.h
-  )
-endif()
+target_sources(
+    Core
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ src/
+    FILES
+        ${RELATIVE_BASE_INC_HEADERS}
+        src/TListOfTypes.h
+)
 
 target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>

--- a/hist/histv7/standalone.cmake
+++ b/hist/histv7/standalone.cmake
@@ -13,8 +13,8 @@ target_include_directories(ROOTHist INTERFACE
 target_compile_features(ROOTHist INTERFACE cxx_std_17)
 
 # Install header files manually: PUBLIC_HEADER has the disadvantage that CMake
-# flattens the directory structure on install, and FILE_SETs are only available
-# with CMake v3.23.
+# flattens the directory structure on install
+# TO-DO: use FILE_SETs instead
 install(FILES ${histv7_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ROOT)
 
 include(CTest)

--- a/roofit/batchcompute/CMakeLists.txt
+++ b/roofit/batchcompute/CMakeLists.txt
@@ -117,30 +117,28 @@ set(shared_object_sources src/RooBatchCompute.cxx src/ComputeFunctions.cxx)
 ROOT_LINKER_LIBRARY(RooBatchCompute_GENERIC ${shared_object_sources} TYPE SHARED DEPENDENCIES RooBatchCompute)
 target_compile_options(RooBatchCompute_GENERIC  PRIVATE ${common-flags} -DRF_ARCH=GENERIC)
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooBatchCompute
+target_sources(
+    RooBatchCompute
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS res/
+    FILES
+        res/RooBatchCompute.h
+)
+target_sources(
+      RooBatchCompute_GENERIC
       PRIVATE
       FILE_SET private_header_files
       TYPE HEADERS
-      BASE_DIRS res/
+      BASE_DIRS src/ res/
       FILES
-          res/RooBatchCompute.h
-  )
-  target_sources(
-        RooBatchCompute_GENERIC
-        PRIVATE
-        FILE_SET private_header_files
-        TYPE HEADERS
-        BASE_DIRS src/ res/
-        FILES
-            res/RooBatchComputeTypes.h
-            res/RooHeterogeneousMath.h
-            res/RooNaNPacker.h
-            src/Batches.h
-            src/RooVDTHeaders.h
-  )
-endif()
+          res/RooBatchComputeTypes.h
+          res/RooHeterogeneousMath.h
+          res/RooNaNPacker.h
+          src/Batches.h
+          src/RooVDTHeaders.h
+)
 
 # Windows platform and ICC compiler need special code and testing, thus the feature has not been implemented yet for these.
 if (ROOT_PLATFORM MATCHES "linux|macosx" AND CMAKE_SYSTEM_PROCESSOR MATCHES x86_64 AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -190,17 +188,15 @@ if (cuda)
   endif()
 
   target_compile_options(RooBatchCompute_CUDA  PRIVATE -lineinfo --expt-relaxed-constexpr)
-  if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-    target_sources(
-        RooBatchCompute_CUDA
-        PRIVATE
-        FILE_SET private_header_files
-        TYPE HEADERS
-        BASE_DIRS src/
-        FILES
-            src/CudaInterface.h
-    )
-  endif()
+  target_sources(
+      RooBatchCompute_CUDA
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS src/
+      FILES
+          src/CudaInterface.h
+  )
 endif()
 
 if(vdt OR builtin_vdt)

--- a/roofit/batchcompute/CMakeLists.txt
+++ b/roofit/batchcompute/CMakeLists.txt
@@ -18,30 +18,28 @@ set(shared_object_sources src/RooBatchCompute.cxx src/ComputeFunctions.cxx)
 ROOT_LINKER_LIBRARY(RooBatchCompute_GENERIC ${shared_object_sources} TYPE SHARED DEPENDENCIES RooBatchCompute)
 target_compile_options(RooBatchCompute_GENERIC  PRIVATE ${common-flags} -DRF_ARCH=GENERIC)
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooBatchCompute
+target_sources(
+    RooBatchCompute
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS res/
+    FILES
+        res/RooBatchCompute.h
+)
+target_sources(
+      RooBatchCompute_GENERIC
       PRIVATE
       FILE_SET private_header_files
       TYPE HEADERS
-      BASE_DIRS res/
+      BASE_DIRS src/ res/
       FILES
-          res/RooBatchCompute.h
-  )
-  target_sources(
-        RooBatchCompute_GENERIC
-        PRIVATE
-        FILE_SET private_header_files
-        TYPE HEADERS
-        BASE_DIRS src/ res/
-        FILES
-            res/RooBatchComputeTypes.h
-            res/RooHeterogeneousMath.h
-            res/RooNaNPacker.h
-            src/Batches.h
-            src/RooVDTHeaders.h
-  )
-endif()
+          res/RooBatchComputeTypes.h
+          res/RooHeterogeneousMath.h
+          res/RooNaNPacker.h
+          src/Batches.h
+          src/RooVDTHeaders.h
+)
 
 # Windows platform and ICC compiler need special code and testing, thus the feature has not been implemented yet for these.
 if (ROOT_PLATFORM MATCHES "linux|macosx" AND CMAKE_SYSTEM_PROCESSOR MATCHES x86_64 AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -68,17 +66,15 @@ if (cuda)
   set(shared_object_sources_cu src/RooBatchCompute.cu src/ComputeFunctions.cu src/CudaInterface.cu)
   ROOT_LINKER_LIBRARY(RooBatchCompute_CUDA  ${shared_object_sources_cu} TYPE SHARED DEPENDENCIES RooBatchCompute)
   target_compile_options(RooBatchCompute_CUDA  PRIVATE -lineinfo --expt-relaxed-constexpr)
-  if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-    target_sources(
-        RooBatchCompute_CUDA
-        PRIVATE
-        FILE_SET private_header_files
-        TYPE HEADERS
-        BASE_DIRS src/
-        FILES
-            src/CudaInterface.h
-    )
-  endif()
+  target_sources(
+      RooBatchCompute_CUDA
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS src/
+      FILES
+          src/CudaInterface.h
+  )
 endif()
 
 if(vdt OR builtin_vdt)

--- a/roofit/codegen/CMakeLists.txt
+++ b/roofit/codegen/CMakeLists.txt
@@ -22,17 +22,15 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCodegen
     HistFactory
 )
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitCodegen
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/
-      FILES
-          # LinkDef.h # empty, not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
-          inc/RooFit/CodegenImpl.h
-  )
-endif()
+target_sources(
+    RooFitCodegen
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/
+    FILES
+        # LinkDef.h # empty, not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
+        inc/RooFit/CodegenImpl.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/codegen/CMakeLists.txt
+++ b/roofit/codegen/CMakeLists.txt
@@ -22,15 +22,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCodegen
     HistFactory
 )
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitCodegen
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/
-      FILES
-          # LinkDef.h # empty, not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
-          inc/RooFit/CodegenImpl.h
-  )
-endif()
+target_sources(
+    RooFitCodegen
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/
+    FILES
+        # LinkDef.h # empty, not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
+        inc/RooFit/CodegenImpl.h
+)

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -99,18 +99,16 @@ install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${prepareHistFactory_script}
 
 set(RELATIVE_INC_HEADERS ${HISTFACTORY_HEADERS} ${HISTFACTORY_XML_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      HistFactory
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          inc/LinkDef.h # seemingly not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
-          inc/HFMsgService.h # not part of list above
-  )
-endif()
+target_sources(
+    HistFactory
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        inc/LinkDef.h # seemingly not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
+        inc/HFMsgService.h # not part of list above
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -39,20 +39,18 @@ target_link_libraries(RooFitHS3 PRIVATE nlohmann_json::nlohmann_json)
 
 set(RELATIVE_INC_HEADERS ${ROOFITHS3_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitHS3
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ src/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          # LinkDef.h # seemingly not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
-          src/Domains.h
-          src/JSONIOUtils.h
-          src/static_execute.h
-  )
-endif()
+target_sources(
+    RooFitHS3
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ src/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        # LinkDef.h # seemingly not being used by ROOT_STANDARD_LIBRARY_PACKAGE call
+        src/Domains.h
+        src/JSONIOUtils.h
+        src/static_execute.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofit/CMakeLists.txt
+++ b/roofit/roofit/CMakeLists.txt
@@ -174,18 +174,16 @@ endif()
 
 set(RELATIVE_INC_HEADERS ${ROOFIT_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFit
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ src/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          inc/LinkDef1.h
-          src/RooFit/Detail/Algorithms.h
-  )
-endif()
+target_sources(
+    RooFit
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ src/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        inc/LinkDef1.h
+        src/RooFit/Detail/Algorithms.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -527,45 +527,43 @@ endif()
 
 set(RELATIVE_INC_HEADERS ${ROOFITCORE_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitCore
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ res/ src/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          inc/LinkDef.h
-          inc/RooFit/UniqueId.h # Was not being included in ROOT_STL_PACKAGE call
-          src/RooConvIntegrandBinding.h
-          src/RooFormula.h
-          src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
-          src/RooMCIntegrator.h
-          src/RooFoamGenerator.h
-          src/RooAbsMinimizerFcn.h
-          src/RooSentinel.h
-          src/RooAcceptReject.h
-          src/TreeReadBuffer.h
-          src/ConstraintHelpers.h
-          src/RooRombergIntegrator.h
-          src/RooBinIntegrator.h
-          ${RooFitMPTestStatisticsHeaders}
-          ${LegacyEvalBackendHeaders}
-          src/RooFit/BatchModeDataHelpers.h
-          src/RooMinimizerFcn.h
-          src/RooAbsNumGenerator.h
-          src/FitHelpers.h
-          src/RooGenProdProj.h
-          src/RooNumGenFactory.h
-          src/RooGrid.h
-          src/RooAddHelpers.h
-          src/RooAdaptiveIntegratorND.h
-          src/ValueChecking.h
-          src/RooImproperIntegrator1D.h
-          res/RooFitImplHelpers.h
-          res/RooUnitTest.h
-  )
-endif()
+target_sources(
+    RooFitCore
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ res/ src/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        inc/LinkDef.h
+        inc/RooFit/UniqueId.h # Was not being included in ROOT_STL_PACKAGE call
+        src/RooConvIntegrandBinding.h
+        src/RooFormula.h
+        src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
+        src/RooMCIntegrator.h
+        src/RooFoamGenerator.h
+        src/RooAbsMinimizerFcn.h
+        src/RooSentinel.h
+        src/RooAcceptReject.h
+        src/TreeReadBuffer.h
+        src/ConstraintHelpers.h
+        src/RooRombergIntegrator.h
+        src/RooBinIntegrator.h
+        ${RooFitMPTestStatisticsHeaders}
+        ${LegacyEvalBackendHeaders}
+        src/RooFit/BatchModeDataHelpers.h
+        src/RooMinimizerFcn.h
+        src/RooAbsNumGenerator.h
+        src/FitHelpers.h
+        src/RooGenProdProj.h
+        src/RooNumGenFactory.h
+        src/RooGrid.h
+        src/RooAddHelpers.h
+        src/RooAdaptiveIntegratorND.h
+        src/ValueChecking.h
+        src/RooImproperIntegrator1D.h
+        res/RooFitImplHelpers.h
+        res/RooUnitTest.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -526,47 +526,46 @@ endif()
 
 set(RELATIVE_INC_HEADERS ${ROOFITCORE_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitCore
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ res/ src/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          inc/LinkDef.h
-          inc/RooFit/UniqueId.h # Was not being included in ROOT_STL_PACKAGE call
-          src/RooConvIntegrandBinding.h
-          src/RooFormulaUtils.h
-          src/RooFormulaEvaluator.h
-          src/RooTFormulaEvaluator.h
-          src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
-          src/RooMCIntegrator.h
-          src/RooFoamGenerator.h
-          src/RooAbsMinimizerFcn.h
-          src/RooSentinel.h
-          src/RooAcceptReject.h
-          src/TreeReadBuffer.h
-          src/ConstraintHelpers.h
-          src/RooRombergIntegrator.h
-          src/RooBinIntegrator.h
-          ${RooFitMPTestStatisticsHeaders}
-          ${LegacyEvalBackendHeaders}
-          src/RooFit/BatchModeDataHelpers.h
-          src/RooMinimizerFcn.h
-          src/RooAbsNumGenerator.h
-          src/FitHelpers.h
-          src/RooGenProdProj.h
-          src/RooNumGenFactory.h
-          src/RooGrid.h
-          src/RooAddHelpers.h
-          src/RooAdaptiveIntegratorND.h
-          src/ValueChecking.h
-          src/RooImproperIntegrator1D.h
-          res/RooFitImplHelpers.h
-          res/RooUnitTest.h
-  )
-endif()
+
+target_sources(
+    RooFitCore
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ res/ src/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        inc/LinkDef.h
+        inc/RooFit/UniqueId.h # Was not being included in ROOT_STL_PACKAGE call
+        src/RooConvIntegrandBinding.h
+        src/RooFormulaUtils.h
+        src/RooFormulaEvaluator.h
+        src/RooTFormulaEvaluator.h
+        src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
+        src/RooMCIntegrator.h
+        src/RooFoamGenerator.h
+        src/RooAbsMinimizerFcn.h
+        src/RooSentinel.h
+        src/RooAcceptReject.h
+        src/TreeReadBuffer.h
+        src/ConstraintHelpers.h
+        src/RooRombergIntegrator.h
+        src/RooBinIntegrator.h
+        ${RooFitMPTestStatisticsHeaders}
+        ${LegacyEvalBackendHeaders}
+        src/RooFit/BatchModeDataHelpers.h
+        src/RooMinimizerFcn.h
+        src/RooAbsNumGenerator.h
+        src/FitHelpers.h
+        src/RooGenProdProj.h
+        src/RooNumGenFactory.h
+        src/RooGrid.h
+        src/RooAddHelpers.h
+        src/RooAdaptiveIntegratorND.h
+        src/ValueChecking.h
+        src/RooImproperIntegrator1D.h
+        res/RooFitImplHelpers.h
+        res/RooUnitTest.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roostats/CMakeLists.txt
+++ b/roofit/roostats/CMakeLists.txt
@@ -140,8 +140,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooStats
 
 set(RELATIVE_INC_HEADERS ${ROOSTATS_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
+target_sources(
       RooStats
       PRIVATE
       FILE_SET private_header_files
@@ -150,7 +149,6 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
       FILES
           ${RELATIVE_INC_HEADERS}
           inc/LinkDef.h # seemingly this is not being used in ROOT_STANDARD_LIBRARY_PACKAGE call
-  )
-endif()
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/xroofit/CMakeLists.txt
+++ b/roofit/xroofit/CMakeLists.txt
@@ -40,21 +40,19 @@ target_include_directories(RooFitXRooFit PRIVATE inc/RooFit)
 
 set(RELATIVE_INC_HEADERS ${XROOFIT_HEADERS})
 list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
-  target_sources(
-      RooFitXRooFit
-      PRIVATE
-      FILE_SET private_header_files
-      TYPE HEADERS
-      BASE_DIRS inc/ src/
-      FILES
-          ${RELATIVE_INC_HEADERS}
-          inc/LinkDef.h
-          inc/RooFit/xRooFit/Config.h # was not part of XROOFIT_HEADERS
-          src/PythonInterface.h
-          src/coutCapture.h
-          src/xRooFitVersion.h
-  )
-endif()
+target_sources(
+    RooFitXRooFit
+    PRIVATE
+    FILE_SET private_header_files
+    TYPE HEADERS
+    BASE_DIRS inc/ src/
+    FILES
+        ${RELATIVE_INC_HEADERS}
+        inc/LinkDef.h
+        inc/RooFit/xRooFit/Config.h # was not part of XROOFIT_HEADERS
+        src/PythonInterface.h
+        src/coutCapture.h
+        src/xRooFitVersion.h
+)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
This version of CMake was released in March 2022
https://github.com/Kitware/CMake/releases/tag/v3.23.0

This version is required to use FILE_SETs, which could help towards https://github.com/root-project/root/issues/16327 and https://github.com/root-project/root/pull/18419.