### PR TITLE
[v636] Make sure we consistently use system openblas in SOFIE GNN tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/sofie_gnn.py
+++ b/bindings/pyroot/pythonizations/test/sofie_gnn.py
@@ -1,6 +1,10 @@
 import unittest
 import ROOT
 
+# Load system openblas library explicitly if available. This avoids pulling in
+# NumPys builtin openblas later, which will conflict with the system openblas.
+ROOT.gInterpreter.Load("libopenblaso.so")
+
 import numpy as np
 from numpy.testing import assert_almost_equal
 

--- a/tutorials/machine_learning/TMVA_SOFIE_GNN.py
+++ b/tutorials/machine_learning/TMVA_SOFIE_GNN.py
@@ -6,6 +6,10 @@
 
 import ROOT
 
+# Load system openblas library explicitly if available. This avoids pulling in
+# NumPys builtin openblas later, which will conflict with the system openblas.
+ROOT.gInterpreter.Load("libopenblaso.so")
+
 import numpy as np
 import graph_nets as gn
 from graph_nets import utils_tf


### PR DESCRIPTION
This avoids crashes because of mixing openblas versions on some platforms.

Backport of:

  * https://github.com/root-project/root/pull/19946