### PR TITLE
[cppyy] Skip failing tests in `test_datatypes.py`

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -192,7 +192,7 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
+    @mark.skip()
     def test02_instance_data_write_access(self):
         """Test write access to instance public data and verify values"""
 
@@ -377,7 +377,7 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
+    @mark.skip()
     def test04_class_read_access(self):
         """Test read access to class public data and verify values"""
 
@@ -542,7 +542,7 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
+    @mark.skip()
     def test07_type_conversions(self):
         """Test conversions between builtin types"""
 
@@ -736,7 +736,7 @@ class TestDATATYPES:
         assert gbl.EnumSpace.AA == 1
         assert gbl.EnumSpace.BB == 2
 
-    @mark.xfail()
+    @mark.skip()
     def test11_typed_enums(self):
         """Determine correct types of enums"""
 
@@ -779,7 +779,7 @@ class TestDATATYPES:
         assert type(sc.vraioufaux.faux) == bool  # no bool as base class
         assert isinstance(sc.vraioufaux.faux, bool)
 
-    @mark.xfail()
+    @mark.skip()
     def test12_enum_scopes(self):
         """Enum accessibility and scopes"""
 
@@ -1108,7 +1108,7 @@ class TestDATATYPES:
 
         assert not d2
 
-    @mark.xfail()
+    @mark.skip()
     def test22_buffer_shapes(self):
         """Correctness of declared buffer shapes"""
 
@@ -1277,8 +1277,10 @@ class TestDATATYPES:
         if self.has_byte:
             run(self, cppyy.gbl.sum_byte_data, buf, total)
 
-    @mark.xfail(run=not IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception")
+    # @mark.xfail(run=not IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
+    # "libc++abi: terminating due to uncaught exception")
+    # Marked as skip to prevent propagation of failure to other tests
+    @mark.skip()
     def test26_function_pointers(self):
         """Function pointer passing"""
 
@@ -1560,7 +1562,7 @@ class TestDATATYPES:
                 p = (ctype * len(buf)).from_buffer(buf)
                 assert [p[j] for j in range(width*height)] == [2*j for j in range(width*height)]
 
-    @mark.xfail()
+    @mark.skip()
     def test31_anonymous_union(self):
         """Anonymous unions place there fields in the parent scope"""
 
@@ -1654,7 +1656,7 @@ class TestDATATYPES:
         assert type(p.data_c[0]) == float
         assert p.intensity == 5.
 
-    @mark.xfail()
+    @mark.skip()
     def test32_anonymous_struct(self):
         """Anonymous struct creates an unnamed type"""
 
@@ -1703,7 +1705,7 @@ class TestDATATYPES:
 
         assert 'foo' in dir(ns.libuntitled1_ExportedSymbols().kotlin.root.com.justamouse.kmmdemo)
 
-    @mark.xfail()
+    @mark.skip()
     def test33_pointer_to_array(self):
         """Usability of pointer to array"""
 
@@ -2059,7 +2061,7 @@ class TestDATATYPES:
             r2 = ns.make_R2()
             assert r2.s.x == 1
 
-    @mark.xfail()
+    @mark.skip()
     def test41_complex_numpy_arrays(self):
         """Usage of complex numpy arrays"""
 
@@ -2107,7 +2109,7 @@ class TestDATATYPES:
             Ccl = func(Acl, Bcl, 2)
             assert complex(Ccl) == pyCcl
 
-    @mark.xfail()
+    @mark.skip()
     def test42_mixed_complex_arithmetic(self):
         """Mixin of Python and C++ std::complex in arithmetic"""
 
@@ -2121,7 +2123,7 @@ class TestDATATYPES:
         assert c*(c*c) == p*(p*p)
         assert (c*c)*c == (p*p)*p
 
-    @mark.xfail()
+    @mark.skip()
     def test43_ccharp_memory_handling(self):
         """cppyy side handled memory of C strings"""
 
@@ -2238,7 +2240,7 @@ class TestDATATYPES:
         b = ns.B()
         assert b.body1.name == b.body2.name
 
-    @mark.xfail()
+    @mark.skip()
     def test46_small_int_enums(self):
         """Proper typing of small int enums"""
 
@@ -2293,7 +2295,7 @@ class TestDATATYPES:
         assert ns.func_int8()  == -1
         assert ns.func_uint8() == 255
 
-    @mark.xfail()
+    @mark.skip()
     def test47_hidden_name_enum(self):
         """Usage of hidden name enum"""
 


### PR DESCRIPTION
Some that are expected to fail should better be skipped, and not run with expected failures.

That's because running the failing tests can leave the Python error indicator in an unclear state, which can cause also other subsequent tests to fail that would otherwise pass.