### PR TITLE
Always add `-Wl,-rpath` to output of `root-config --libs`

### DIFF
--- a/config/root-config.in
+++ b/config/root-config.in
@@ -331,11 +331,9 @@ case $arch in
 freebsd*)
    auxcflags="-pthread $auxcflags"
    auxlibs="-pthread $auxlibs"
+   auxlibs="-Wl,-rpath,$libdir $auxlibs"
 
    for f in $features ; do
-      if test "x$f" = "xrpath" ; then
-         auxlibs="-Wl,-rpath,$libdir $auxlibs"
-      fi
       if test "x$f" = "xlibcxx" ; then
          auxcflags="-stdlib=libc++ $auxcflags"
          auxlibs="-stdlib=libc++ $auxlibs"
@@ -345,11 +343,9 @@ freebsd*)
 openbsd* | linux*)
    auxcflags="-pthread $auxcflags"
    auxlibs="-pthread $auxlibs"
+   auxlibs="-Wl,-rpath,$libdir $auxlibs"
 
    for f in $features ; do
-      if test "x$f" = "xrpath" ; then
-         auxlibs="-Wl,-rpath,$libdir $auxlibs"
-      fi
       if test "x$f" = "xlibcxx" ; then
          auxcflags="-stdlib=libc++ $auxcflags"
          auxlibs="-stdlib=libc++ $auxlibs"
@@ -359,10 +355,9 @@ openbsd* | linux*)
 macosx*)
    auxcflags="-pthread $auxcflags"
    auxlibs="-lpthread $auxlibs"
+   auxlibs="-Wl,-rpath,$libdir $auxlibs"
+
    for f in $features ; do
-      if test "x$f" = "xrpath" ; then
-         auxlibs="-Wl,-rpath,$libdir $auxlibs"
-      fi
       if test "x$f" = "xlibcxx" ; then
          auxcflags="-stdlib=libc++ $auxcflags"
          auxlibs="-stdlib=libc++ $auxlibs"


### PR DESCRIPTION
Follows up on 26d24de5db60, where the `rpath` configuration path was made the default and can't be disabled anymore.

This means that the `rpath` CMake configuration option is gone, but there was still some code that checked it, which I missed to update.

Addresses https://github.com/root-project/root/pull/19501#issuecomment-3153732504.