### PR TITLE
[core] Fix libCling linking with `-Bsymbolic`

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -225,6 +225,13 @@ if(APPLE)
   target_link_libraries(Cling PUBLIC -Wl,-w -Wl,-bind_at_load -Wl,-undefined,dynamic_lookup)
 elseif(NOT MSVC)
   target_link_libraries(Cling PUBLIC -Wl,--unresolved-symbols=ignore-in-object-files)
+  # Require the linker to resolve the symbol internally and prevent
+  # conflicts when linked with another software using also LLVM like in
+  # the problem reported for Julia in
+  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
+  # and by ALICE in https://github.com/root-project/root/issues/19889
+  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
+  target_link_libraries(Cling PUBLIC -Wl,-Bsymbolic)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -130,12 +130,8 @@ else()
   set(CMAKE_C_VISIBILITY_PRESET hidden)
 endif()
 if (NOT MSVC AND NOT APPLE)
-  # Requires the linker to resolve the symbol internally and prevents
-  # conflicts when linked with another software using also LLVM like in
-  # the problem reported for Julia in
-  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
-  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
-  string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
+  # Allow the compiler to optimize knowing that symbols defined in libCling.so
+  # are not interposed.
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS "-fno-semantic-interposition")
 endif()
 set(CMAKE_VISIBILITY_INLINES_HIDDEN "ON")


### PR DESCRIPTION
The code was in `interpreter/CMakeLists.txt`, but the definition of libCling is in `core/metacling`. After moving, symbols are correctly resolved by the linker and not anymore during dynamic loading.

Fixes #19889