### PR TITLE
[v636] Remove Fedora 41 from the CI

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora41.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora41.txt
@@ -1,5 +1,0 @@
-builtin_vdt=On
-builtin_zlib=ON
-builtin_zstd=ON
-ccache=On
-tmva=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -358,7 +358,6 @@ jobs:
         # Common configs: {Release,Debug,RelWithDebInfo)
         # Build options: https://root.cern/install/build_from_source/#all-build-options
         include:
-          - image: fedora41
           - image: fedora42
             overrides: ["CMAKE_CXX_STANDARD=23"]
           - image: alma8


### PR DESCRIPTION
It's already removed from `master` to free up resources, as it is only one month away from end-of-life.