### PR TITLE
[jupyter] use zipping for stored json

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -57,10 +57,12 @@ _jsCode = """
    function process_{jsDivId}() {{
       function drawPlot(Core) {{
          Core.settings.HandleKeys = false;
-         const obj = Core.parse({jsonContent});
-         Core.draw("{jsDivId}", obj, "{jsDrawOptions}");
+         Core.unzipJSON({jsonLength},'{jsonZip}').then(json => {{
+            const obj = Core.parse(json);
+            Core.draw('{jsDivId}', obj, '{jsDrawOptions}');
+         }});
       }}
-      const servers = ['/static/', 'https://root.cern/js/7.9.1/', 'https://jsroot.gsi.de/7.9.1/'],
+      const servers = ['/static/', 'https://jsroot.gsi.de/dev/', 'https://root.cern/js/dev/'],
             path = 'build/jsroot';
       if (typeof JSROOT !== 'undefined')
          drawPlot(JSROOT);
@@ -586,6 +588,7 @@ class NotebookDrawer(object):
 
         width = _jsCanvasWidth
         height = _jsCanvasHeight
+        jsonzip = ROOT.TBufferJSON.zipJSON(json)
         options = "all"
 
         if self.isCanvas:
@@ -603,7 +606,7 @@ class NotebookDrawer(object):
             options = ""
 
         thisJsCode = _jsCode.format(
-            jsCanvasWidth=width, jsCanvasHeight=height, jsonContent=json, jsDrawOptions=options, jsDivId=divId
+            jsCanvasWidth=width, jsCanvasHeight=height, jsonLength=len(json), jsonZip=jsonzip, jsDrawOptions=options, jsDivId=divId
         )
         return thisJsCode
 

--- a/io/io/inc/TBufferJSON.h
+++ b/io/io/inc/TBufferJSON.h
@@ -77,6 +77,8 @@ public:
       return ConvertToJSON(obj, TClass::GetClass<T>(), compact, member_name);
    }
 
+   static TString zipJSON(const char *json);
+
    template <class T>
    static Bool_t FromJSON(T *&obj, const char *json)
    {

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -542,6 +542,28 @@ TString TBufferJSON::ConvertToJSON(const TObject *obj, Int_t compact, const char
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// zip JSON string and convert into base64 string
+/// to be used with JSROOT unzipJSON() function
+/// Main application - embed large JSON code into jupyter notebooks
+
+TString TBufferJSON::zipJSON(const char *json)
+{
+   std::string buf;
+
+   int srcsize = (int) strlen(json);
+
+   buf.resize(srcsize + 500);
+
+   int tgtsize = buf.length();
+
+   int nout = 0;
+
+   R__zipMultipleAlgorithm(ROOT::RCompressionSetting::ELevel::kDefaultZLIB, &srcsize, (char *)json, &tgtsize, (char *) buf.data(), &nout, ROOT::RCompressionSetting::EAlgorithm::kZLIB);
+
+   return TBase64::Encode(buf.data(), nout);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set level of space/newline/array compression
 /// Lower digit of compact parameter define formatting rules
 ///  - kNoCompress = 0  - no any compression, human-readable form

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,6 +1,5 @@
 # JSROOT changelog
 
-
 ## Changes in dev
 1. RNtuple support, thanks to Kriti Mahajan (https://github.com/Krmjn09)
 1. Implement RTreeMapPainter to display RNTuple structure, thanks to Patryk Pilichowski (https://github.com/magnustymoteus)
@@ -11,6 +10,7 @@
 1. Support dark mode when store images
 1. With 'Shift' key pressed whole graph is moved by dragging action
 1. Support `Xall` and `Yall` as projections width #340
+1. Implement `unzipJSON()` function for data embeding in jupyter
 1. Support reading TBranch from old ROOT files with custom streamers
 1. Upgrade three.js r174 -> r180
 1. Upgrade lil-gui.mjs 0.19.2 -> 0.20.0
@@ -25,6 +25,7 @@
 1. Fix - TTree::Draw with strings
 1. Fix - first color in palette drawing #365
 1. Fix - toggle vertical/horizontal palette via context menu
+1. Fix - latex parsing error of `#delta_{0}_suffix` string
 
 
 ## Changes in 7.9.1

--- a/js/modules/base/BasePainter.mjs
+++ b/js/modules/base/BasePainter.mjs
@@ -646,6 +646,14 @@ class BasePainter {
 
       rect.changed = false;
 
+      if (!rect.width && !rect.height && !main.empty() && main.attr('style')) {
+         const ws = main.style('width'), hs = main.style('height');
+         if (isStr(ws) && isStr(hs) && ws.match(/^\d+px$/) && hs.match(/^\d+px$/)) {
+            rect.width = parseInt(ws.slice(0, ws.length-2));
+            rect.height = parseInt(hs.slice(0, hs.length-2));
+         }
+      }
+
       if (old_h && old_w && (old_h > 0) && (old_w > 0)) {
          if ((old_h !== rect.height) || (old_w !== rect.width))
             rect.changed = (check_level > 1) || (rect.width / old_w < 0.99) || (rect.width / old_w > 1.01) || (rect.height / old_h < 0.99) || (rect.height / old_h > 1.01);

--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -705,6 +705,7 @@ function parseLatex(node, arg, label, curr) {
 
       const extractLowUp = name => {
          const res = {};
+
          if (name) {
             label = '{' + label;
             res[name] = extractSubLabel(name === 'low' ? '_' : '^');
@@ -712,16 +713,16 @@ function parseLatex(node, arg, label, curr) {
          }
 
          while (label) {
-            if (label[0] === '_') {
+            if ((label[0] === '_') && !res.low) {
                label = label.slice(1);
-               res.low = !res.low ? extractSubLabel('_') : -1;
+               res.low = extractSubLabel('_');
                if (res.low === -1) {
-                  console.log(`error with ${found.name} low limit`);
+                  console.log(`error with ${found.name} low limit ${label}`);
                   return false;
                }
-            } else if (label[0] === '^') {
+            } else if ((label[0] === '^') && !res.up) {
                label = label.slice(1);
-               res.up = !res.up ? extractSubLabel('^') : -1;
+               res.up = extractSubLabel('^');
                if (res.up === -1) {
                   console.log(`error with ${found.name} upper limit ${label}`);
                   return false;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -4,7 +4,7 @@ const version_id = 'dev',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '18/09/2025',
+version_date = '24/09/2025',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -1559,7 +1559,8 @@ function createHistogram(typename, nbinsx, nbinsy, nbinsz) {
  * @desc Title may include axes titles, provided with ';' symbol like "Title;x;y;z" */
 
 function setHistogramTitle(histo, title) {
-   if (!histo) return;
+   if (!histo || !isStr(title))
+      return;
    if (title.indexOf(';') < 0)
       histo.fTitle = title;
    else {

--- a/js/modules/draw/RTreeMapTooltip.mjs
+++ b/js/modules/draw/RTreeMapTooltip.mjs
@@ -12,7 +12,10 @@ class RTreeMapTooltip {
    }
 
    cleanup() {
-      if (this.tooltip !== null) document.body.removeChild(this.tooltip);
+      if (this.tooltip !== null) {
+         document.body.removeChild(this.tooltip);
+         this.tooltip = null;
+      }
    }
 
    createTooltip()
@@ -51,7 +54,7 @@ class RTreeMapTooltip {
 
    hideTooltip()
    {
-      if (this.tooltip) 
+      if (this.tooltip)
          this.tooltip.style.opacity = '0';
    }
 
@@ -63,13 +66,13 @@ class RTreeMapTooltip {
       content += `<i>${(isLeaf ? 'Column' : 'Field')}</i><br>`;
       content += `Size: ${this.painter.getDataStr(node.fSize)}<br>`;
 
-      if (isLeaf && node.fType !== undefined) 
+      if (isLeaf && node.fType !== undefined)
          content += `Type: ${node.fType}<br>`;
-      
 
-      if (!isLeaf) 
+
+      if (!isLeaf)
          content += `Children: ${node.fNChildren}<br>`;
-      
+
 
       const obj = this.painter.getObject();
       if (obj.fNodes && obj.fNodes.length > 0) {

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -823,7 +823,7 @@ class TPadPainter extends ObjectPainter {
       this.createAttFill({ attr: this.#pad });
 
       if ((rect.width <= lmt) || (rect.height <= lmt)) {
-         if (this.hasSnapId()) {
+         if (!this.hasSnapId()) {
             svg.style('display', 'none');
             console.warn(`Hide canvas while geometry too small w=${rect.width} h=${rect.height}`);
          }

--- a/js/modules/hist2d/TScatterPainter.mjs
+++ b/js/modules/hist2d/TScatterPainter.mjs
@@ -38,8 +38,9 @@ class TScatterPainter extends TGraphPainter {
   /** @summary Draw axis histogram
     * @private */
    async drawAxisHisto() {
-      const need_histo = !this.getHistogram(),
-            histo = this.createHistogram(need_histo, need_histo);
+      const set_x = this.isDummyHistogram('x'),
+            set_y = this.isDummyHistogram('y'),
+            histo = this.createHistogram(set_x, set_y);
       return TH2Painter.draw(this.getDrawDom(), histo, this.getOptions().Axis + ';IGNORE_PALETTE');
    }
 

--- a/js/modules/io.mjs
+++ b/js/modules/io.mjs
@@ -1,7 +1,7 @@
 import { createHttpRequest, BIT, internals, settings, browser,
          create, getMethods, addMethods, isNodeJs, isObject, isFunc, isStr,
          clTObject, clTNamed, clTString, clTObjString, clTKey, clTFile, clTList, clTMap, clTObjArray, clTClonesArray,
-         clTAttLine, clTAttFill, clTAttMarker, clTStyle, clTImagePalette,
+         clTAttLine, clTAttFill, clTAttMarker, clTStyle, clTImagePalette, atob_func,
          clTPad, clTCanvas, clTAttCanvas, clTPolyMarker3D, clTF1, clTF12, clTF2 } from './core.mjs';
 
 const clTStreamerElement = 'TStreamerElement', clTStreamerObject = 'TStreamerObject',
@@ -4044,6 +4044,27 @@ function openFile(arg, opts) {
    return file._open();
 }
 
+/** @summary Unzip JSON string
+ * @desc Should be used for buffer produced with TBufferJSON::zipJSON() method
+ * @param tgtsize - original length of json string
+ * @param src - string with data returned by TBufferJSON::zipJSON
+ * @return {Promise} with unzipped string */
+
+async function unzipJSON(tgtsize, src) {
+   const bindata = atob_func(src),
+         buf = new ArrayBuffer(bindata.length),
+         bufView = new DataView(buf);
+   for (let i = 0; i < bindata.length; i++)
+      bufView.setUint8(i, bindata.charCodeAt(i));
+
+   return R__unzip(bufView, tgtsize).then(resView => {
+      let resstr = '';
+      for (let i = 0; i < tgtsize; i++)
+         resstr += String.fromCharCode(resView.getUint8(i));
+      return resstr;
+   });
+}
+
 // special way to assign methods when streaming objects
 addClassMethods(clTNamed, CustomStreamers[clTNamed]);
 addClassMethods(clTObjString, CustomStreamers[clTObjString]);
@@ -4055,5 +4076,5 @@ export { kChar, kShort, kInt, kLong, kFloat, kCounter,
    kBase, kOffsetL, kOffsetP, kObject, kAny, kObjectp, kObjectP, kTString,
    kAnyP, kStreamer, kStreamLoop, kSTLp, kSTL, kBaseClass,
    clTStreamerInfoList, clTDirectory, clTDirectoryFile, nameStreamerInfo, clTBasket,
-   R__unzip, addUserStreamer, createStreamerElement, createMemberStreamer,
+   R__unzip, unzipJSON, addUserStreamer, createStreamerElement, createMemberStreamer,
    openFile, reconstructObject, FileProxy, TBuffer };

--- a/js/modules/main.mjs
+++ b/js/modules/main.mjs
@@ -35,7 +35,7 @@ export { draw, redraw, makeSVG, makeImage, addDrawFunc, setDefaultDrawOpt } from
 
 export * from './gpad/TCanvasPainter.mjs';
 
-export { openFile, FileProxy, addUserStreamer } from './io.mjs';
+export { openFile, FileProxy, addUserStreamer, unzipJSON } from './io.mjs';
 
 export * from './gui/display.mjs';
 


### PR DESCRIPTION
Up to now plain json code embed into ipython notebooks.
This is very inefficient and can make notebook huge.
Especially because of fact that notebook stored as json - so any double-quote `"` symbol should be escaped.

Therefore use standard compression function of ROOT and then base64 encoding to produce string suitable for embeding. This done in `TBufferJSON::zipJSON()` method.

On JSROOT side just provide correspondent `unzipJSON()` function.

And modify jupyter `utils.py` code to use such functionality.

