### PR TITLE
[webgui] handle ClearOnClose for pending connections

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -85,11 +85,11 @@ public:
    void AddTCanvas() { AddInitWidget("tcanvas"); }
    void AddRCanvas() { AddInitWidget("rcanvas"); }
 
-   /// show Browser in specified place
    void Show(const RWebDisplayArgs &args = "", bool always_start_new_browser = false);
 
-   /// hide Browser
    void Hide();
+
+   void Sync();
 
    std::string GetWindowUrl(bool remote);
 

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -303,7 +303,7 @@ RBrowser::RBrowser(bool use_rcanvas)
    fWebWindow = RWebWindow::Create();
    if (!fWebWindow)
       return;
-   
+
    fWebWindow->SetDefaultPage("file:rootui5sys/browser/browser.html");
 
    std::string sortby = gEnv->GetValue("WebGui.Browser.SortBy", "name"),
@@ -591,6 +591,15 @@ void RBrowser::Hide()
 {
    if (fWebWindow)
       fWebWindow->CloseConnections();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Run widget Sync method - processing pending actions
+
+void RBrowser::Sync()
+{
+   if (fWebWindow)
+      fWebWindow->Sync();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -72,6 +72,7 @@ private:
       unsigned fConnId{0};                 ///<! connection id (unique inside the window)
       bool fHeadlessMode{false};           ///<! indicate if connection represent batch job
       bool fWasFirst{false};               ///<! indicate if this was first connection, will be reinjected also on first place
+      bool fWasEstablished{false};         ///<! indicate if connection was established at least once
       std::string fKey;                    ///<! key value supplied to the window (when exists)
       int fKeyUsed{0};                     ///<! key value used to verify connection
       std::string fNewKey;                 ///<! new key if connection request reload

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -51,6 +51,7 @@ private:
    bool fUseHttpThrd{false};              ///<! use special thread for THttpServer
    bool fUseSenderThreads{false};         ///<! use extra threads for sending data from RWebWindow to clients
    float fLaunchTmout{30.};               ///<! timeout in seconds to start browser process, default 30s
+   float fReconnectTmout{15.};            ///<! timeout in seconds to reconnect connection, default 15s
    bool fExternalProcessEvents{false};    ///<! indicate that there are external process events engine
    std::unique_ptr<TExec> fAssgnExec;     ///<! special exec to assign thread id via ProcessEvents
    WebWindowShowCallback_t fShowCallback; ///<! function called for each RWebWindow::Show call
@@ -64,6 +65,9 @@ private:
 
    /// Returns timeout for launching new browser process
    float GetLaunchTmout() const { return fLaunchTmout; }
+
+   /// Returns timeout for launching new browser process
+   float GetReconnectTmout() const { return fReconnectTmout; }
 
    void Unregister(RWebWindow &win);
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -647,6 +647,8 @@ void RWebWindow::CheckPendingConnections()
 
    ConnectionsList_t selected;
 
+   bool do_clear_on_close = false;
+
    {
       std::lock_guard<std::mutex> grd(fConnMutex);
 
@@ -663,7 +665,12 @@ void RWebWindow::CheckPendingConnections()
       };
 
       fPendingConn.erase(std::remove_if(fPendingConn.begin(), fPendingConn.end(), pred), fPendingConn.end());
+
+      do_clear_on_close = (selected.size() > 0) && (fPendingConn.size() == 0) && (fConn.size() == 0);
    }
+
+   if (do_clear_on_close)
+      fClearOnClose.reset();
 }
 
 

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -914,7 +914,7 @@ bool RWebWindow::ProcessWS(THttpCallArg &arg)
 
       if (conn) {
          bool do_clear_on_close = false;
-         if (!conn->fNewKey.empty()) {
+         if (!conn->fNewKey.empty() && (fMgr->GetReconnectTmout() > 0)) {
             // case when same handle want to be reused by client with new key
             std::lock_guard<std::mutex> grd(fConnMutex);
             conn->fKeyUsed = 0;

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -785,7 +785,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 ///      WebGui.FirefoxProfilePath: file path to Firefox profile
 ///      WebGui.FirefoxRandomProfile: usage of random Firefox profile "no" - disabled, "yes" - enabled (default)
 ///      WebGui.LaunchTmout: time required to start process in seconds (default 30 s)
-///      WebGui.ReconnectTmout: time to reconnect for already existing connection (default 15 s)
+///      WebGui.ReconnectTmout: time to reconnect for already existing connection, if negative - no reconnecting possible (default 15 s)
 ///      WebGui.CefTimer: periodic time to run CEF event loop (default 10 ms)
 ///      WebGui.CefUseViews: "yes" - enable / "no" - disable usage of CEF views frameworks (default is platform/version dependent)
 ///      WebGui.OperationTmout: time required to perform WebWindow operation like execute command or update drawings

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -510,6 +510,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
    int fcgi_thrds = gEnv->GetValue("WebGui.FastCgiThreads", 10);
    const char *fcgi_serv = gEnv->GetValue("WebGui.FastCgiServer", "");
    fLaunchTmout = gEnv->GetValue("WebGui.LaunchTmout", 30.);
+   fReconnectTmout = gEnv->GetValue("WebGui.ReconnectTmout", 15.);
    bool assign_loopback = gWebWinLoopbackMode;
    const char *http_bind = gEnv->GetValue("WebGui.HttpBind", "");
    bool use_secure = RWebWindowWSHandler::GetBoolEnv("WebGui.UseHttps", 0) == 1;
@@ -784,6 +785,7 @@ std::string RWebWindowsManager::GetUrl(RWebWindow &win, bool remote, std::string
 ///      WebGui.FirefoxProfilePath: file path to Firefox profile
 ///      WebGui.FirefoxRandomProfile: usage of random Firefox profile "no" - disabled, "yes" - enabled (default)
 ///      WebGui.LaunchTmout: time required to start process in seconds (default 30 s)
+///      WebGui.ReconnectTmout: time to reconnect for already existing connection (default 15 s)
 ///      WebGui.CefTimer: periodic time to run CEF event loop (default 10 ms)
 ///      WebGui.CefUseViews: "yes" - enable / "no" - disable usage of CEF views frameworks (default is platform/version dependent)
 ///      WebGui.OperationTmout: time required to perform WebWindow operation like execute command or update drawings


### PR DESCRIPTION
`RWebWindow::ClearOnClose` let destroy handle when all connections are closed by widget - or when widget is destroyed.

But if pending connection is not reconnected and finally removed, `ClearOnClose` was not emptied. 
Therefore add such check when pending connections processed.

Add separate timeout for reconnecting of pending connections.
Default is 15 seconds - while in such case browser process already exists and only JavaScript has to be reinitialized.
Can be changed via ` WebGui.ReconnectTmout` rootrc parameter.

If such timeout zero or negative - connection is not possible to reconnect.

