### PR TITLE
[gui] Add browsable RNTupleItem

### DIFF
--- a/gui/browsable/CMakeLists.txt
+++ b/gui/browsable/CMakeLists.txt
@@ -26,6 +26,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTBrowsable
     ROOT/Browsable/TObjectElement.hxx
     ROOT/Browsable/TObjectHolder.hxx
     ROOT/Browsable/TObjectItem.hxx
+    ROOT/Browsable/RNTupleItem.hxx
   SOURCES
     src/RElement.cxx
     src/RGroup.cxx

--- a/gui/browsable/inc/LinkDef.h
+++ b/gui/browsable/inc/LinkDef.h
@@ -30,5 +30,6 @@
 
 #pragma link C++ class ROOT::Browsable::RItem+;
 #pragma link C++ class ROOT::Browsable::RSysFileItem+;
+#pragma link C++ class ROOT::Browsable::RNTupleItem+;
 
 #endif

--- a/gui/browsable/inc/ROOT/Browsable/RNTupleItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RNTupleItem.hxx
@@ -1,0 +1,56 @@
+/*************************************************************************
+ * Copyright (C) 1995-2025, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_Browsable_RNTupleItem
+#define ROOT7_Browsable_RNTupleItem
+
+#include <ROOT/Browsable/RItem.hxx>
+
+namespace ROOT {
+namespace Browsable {
+
+/** \class RNTupleItem
+\ingroup rbrowser
+\brief Representation of an RNTuple item in the browser
+\author Patryk Tymoteusz Pilichowski
+*/
+
+class RNTupleItem : public RItem {
+public:
+   enum ECategory {
+      kField,
+      kVisualization
+   };
+
+   RNTupleItem() = default;
+   RNTupleItem(const std::string &_name, int _nchilds = 0, const std::string &_icon = "", ECategory _category = kField)
+      : RItem(_name, _nchilds, _icon), category(_category)
+   {
+   }
+   // must be here, one needs virtual table for correct streaming of sub-classes
+   virtual ~RNTupleItem() = default;
+
+   bool IsVisualization() const { return category == kVisualization; }
+   bool IsField() const { return category == kField; }
+
+   bool Compare(const RItem *b, const std::string &s) const override
+   {
+      auto tuple_b = dynamic_cast<const RNTupleItem *>(b);
+      if (tuple_b != nullptr && (IsVisualization() || tuple_b->IsVisualization()))
+         return IsVisualization();
+      return RItem::Compare(b, s);
+   }
+
+protected:
+   ECategory category{kField};
+};
+
+} // namespace Browsable
+} // namespace ROOT
+
+#endif

--- a/gui/browsable/src/RNTupleBrowseProvider.cxx
+++ b/gui/browsable/src/RNTupleBrowseProvider.cxx
@@ -10,6 +10,7 @@
 #include <ROOT/Browsable/RProvider.hxx>
 #include <ROOT/Browsable/RLevelIter.hxx>
 #include <ROOT/Browsable/RItem.hxx>
+#include <ROOT/Browsable/RNTupleItem.hxx>
 
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleBrowseUtils.hxx>
@@ -76,7 +77,7 @@ public:
    /** Create item with TreeMap icon */
    std::unique_ptr<RItem> CreateItem() const override
    {
-      auto item = std::make_unique<RItem>(GetName(), 0, "sap-icon://Chart-Tree-Map");
+      auto item = std::make_unique<RNTupleItem>(GetName(), 0, "sap-icon://Chart-Tree-Map");
       item->SetTitle(GetTitle());
       return item;
    }
@@ -132,7 +133,8 @@ public:
    /** Create item with visualization folder icon */
    std::unique_ptr<RItem> CreateItem() const override
    {
-      auto item = std::make_unique<RItem>(GetName(), 1, "sap-icon://show");
+      auto item =
+         std::make_unique<RNTupleItem>(GetName(), 1, "sap-icon://show", RNTupleItem::ECategory::kVisualization);
       item->SetTitle(GetTitle());
       return item;
    }
@@ -184,7 +186,7 @@ public:
    std::unique_ptr<RItem> CreateItem() override
    {
       if (fCounter == 0) {
-         auto item = std::make_unique<RItem>("TreeMap", 0, "sap-icon://Chart-Tree-Map");
+         auto item = std::make_unique<RNTupleItem>("TreeMap", 0, "sap-icon://Chart-Tree-Map");
          item->SetTitle("TreeMap visualization of RNTuple structure and disk usage");
          return item;
       }
@@ -306,7 +308,7 @@ public:
 
    std::unique_ptr<RItem> CreateItem() const override
    {
-      auto item = std::make_unique<RItem>(GetName(), -1, "sap-icon://table-chart");
+      auto item = std::make_unique<RNTupleItem>(GetName(), -1, "sap-icon://table-chart");
       item->SetTitle(GetTitle());
       return item;
    }
@@ -382,7 +384,8 @@ public:
    std::unique_ptr<RItem> CreateItem() override
    {
       if (fHasVisualization && fCounter == 0) {
-         auto item = std::make_unique<RItem>("Visualization", 1, "sap-icon://show");
+         auto item = std::make_unique<RNTupleItem>("Visualization", 1, "sap-icon://show",
+                                                   RNTupleItem::ECategory::kVisualization);
          item->SetTitle("Visualization tools and options for RNTuple data");
          return item;
       }
@@ -396,8 +399,8 @@ public:
 
       const auto &field = fNtplReader->GetDescriptor().GetFieldDescriptor(fProvidedFieldIds[fieldIndex]);
 
-      auto item =
-         std::make_unique<RItem>(field.GetFieldName(), nchilds, nchilds > 0 ? "sap-icon://split" : "sap-icon://e-care");
+      auto item = std::make_unique<RNTupleItem>(field.GetFieldName(), nchilds,
+                                                nchilds > 0 ? "sap-icon://split" : "sap-icon://e-care");
 
       item->SetTitle("RField name "s + field.GetFieldName() + " type "s + field.GetTypeName());
       return item;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR adds `RNTupleItem` class which overrides `Compare` method to ensure correct order in RBrowser (visualization element always appears before fields)

cc @silverweed 

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)


