### PR TITLE
[ntuple] unpublish RRVecField internals

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -111,15 +111,13 @@ public:
 
 /// The type-erased field for a RVec<Type>
 class RRVecField : public RFieldBase {
-   friend class RArrayAsRVecField; // to call ResizeRVec()
+   friend class RArrayAsRVecField; // to use the RRVecDeleter and to call ResizeRVec()
 
    // Ensures that the RVec pointed to by rvec has at least nItems valid elements
    // Returns the possibly new "begin pointer" of the RVec, i.e. the pointer to the data area.
    static unsigned char *
    ResizeRVec(void *rvec, std::size_t nItems, std::size_t itemSize, const RFieldBase *itemField, RDeleter *itemDeleter);
 
-public:
-   /// the RRVecDeleter is also used by RArrayAsRVecField and therefore declared public
    class RRVecDeleter : public RDeleter {
    private:
       std::size_t fItemAlignment;


### PR DESCRIPTION
change visibility from public to private in RRVecField for members that should have been private all along.
