### PR TITLE
[unix] add icpx to compiler options

### DIFF
--- a/cmake/unix/compiledata.sh
+++ b/cmake/unix/compiledata.sh
@@ -86,6 +86,11 @@ icc)
    COMPILERVERSSTR="Intel icc $cxxTemp"
    COMPILERVERS="icc"
    ;;
+icpx)
+   cxxTemp=`$CXX -dumpfullversion -dumpversion`
+   COMPILERVERSSTR="Intel oneAPI icpx $cxxTemp"
+   COMPILERVERS="icpx"
+   ;;
 clang++*)
    cxxTemp=`$CXX -dumpfullversion -dumpversion`
    COMPILERVERSSTR="`$CXX --version 2>&1 | grep -i clang | sed -n '1p'`"


### PR DESCRIPTION
https://root-forum.cern.ch/t/compiler-information-for-intel-llvm-not-shown-in-banner/64231