### PR TITLE
[InterOp] Fix a build failure when configuring offline

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -557,14 +557,10 @@ set(CPPINTEROP_USE_CLING ON CACHE BOOL "" FORCE)
 set(CPPINTEROP_USE_REPL OFF CACHE BOOL "" FORCE)
 
 #---Disable testing on InterOp if ROOT's testing is OFF (InterOp tests are enabled by default) -------------------------------------------------------
-ROOT_CHECK_CONNECTION("CPPINTEROP_ENABLE_TESTING=OFF")
-if(testing AND NOT NO_CONNECTION)
-  set(CPPINTEROP_ENABLE_TESTING ON CACHE BOOL "" FORCE)
+if(testing)
+  set(CPPINTEROP_ENABLE_TESTING ON CACHE BOOL "Enable gtest in CppInterOp")
 else()
-  if(NO_CONNECTION)
-    message(STATUS "No internet connection, disabling the `CppInterOp testing infrastructure` option")
-  endif()
-  set(CPPINTEROP_ENABLE_TESTING OFF CACHE BOOL "")
+  set(CPPINTEROP_ENABLE_TESTING OFF CACHE BOOL "Enable gtest in CppInterOp")
 endif()
 
 add_subdirectory(CppInterOp)

--- a/interpreter/CppInterOp/unittests/CMakeLists.txt
+++ b/interpreter/CppInterOp/unittests/CMakeLists.txt
@@ -4,7 +4,11 @@ enable_testing()
 
 # LLVM builds (not installed llvm) provides gtest.
 if (NOT TARGET GTest::gtest AND NOT TARGET gtest)
-  include(GoogleTest)
+  find_package(GTest)
+  if (NOT GTest_FOUND)
+    message(WARNING "CppInterOp could not find GTest. Provide the package or set CPPINTEROP_ENABLE_TESTING=OFF to disable this warning.")
+    return()
+  endif()
 endif()
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
With llvm's include(Googletest), CppInterOp might download its own
googletest, ignoring the system installation. This created several
problems:
- An existing system installation might be ignored.
- When used in ROOT with builtin gtest, a conflicting gtest might be
  downloaded.
- When ROOT is configured with fail-on-missing while offline, the
  configuration fails, because it is assumed that gtest needs to be
  downloaded. This is not the case, though, if gtest is present in the
  system.

Therefore:
- Test if the targets GTest::gtest or gtest exist. If found, no further
  actions are required.
- New: If not found, run find_package(GTest). If found, continue as normal.
- New: If not found, warn and disable the interop tests.

With the above, the logic in ROOT can be simplified:
- ROOT switches On/Off `CPPINTEROP_ENABLE_TESTING` based on whether `testing` is on or off.
- The internet connection check could be removed.