### PR TITLE
[CMake] Fix an RPath issue

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -26,6 +26,14 @@ add_custom_target(rconfigure ALL DEPENDS ${CMAKE_BINARY_DIR}/include/RConfigure.
 
 ROOT_LINKER_LIBRARY(Core BUILTINS LZMA)
 
+# This sets RUNPATH for libCore, which enables it to dlopen any ROOT library in its directory.
+# If omitted, Core might try to load libraries from a ROOT that's installed in the system.
+if(APPLE)
+  set_property(TARGET Core APPEND PROPERTY BUILD_RPATH @loader_path)
+elseif(NOT WIN32)
+  set_property(TARGET Core APPEND PROPERTY BUILD_RPATH $ORIGIN)
+endif()
+
 generateHeader(Core
   ${CMAKE_SOURCE_DIR}/core/base/src/root-argparse.py
   ${CMAKE_BINARY_DIR}/ginclude/TApplicationCommandLineOptionsHelp.h


### PR DESCRIPTION
Usually, CMake automatically sets RUNPATH when target_link_libraries is
used. However, since Core doesn't have other ROOT dependencies, its
RUNPATH might only contain external dependencies or remain empty.
To enable Core to find other ROOT libraries, its current location is
added to its BUILD_RPATH.
If this isn't done, dlopen might find ROOT libraries which are installed in system locations.