### PR TITLE
[ntuple] Properly set the NTupleName in sources created from anchors

### DIFF
--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -301,7 +301,7 @@ ROOT::Internal::RPageSourceFile::CreateFromAnchor(const RNTuple &anchor, const R
 
    auto pageSource = std::make_unique<RPageSourceFile>("", std::move(rawFile), options);
    pageSource->fAnchor = anchor;
-   pageSource->fNTupleName = pageSource->fDescriptorBuilder.GetDescriptor().GetName();
+   // NOTE: fNTupleName gets set only upon Attach().
    return pageSource;
 }
 
@@ -365,6 +365,11 @@ ROOT::RNTupleDescriptor ROOT::Internal::RPageSourceFile::AttachImpl(RNTupleSeria
    RNTupleSerializer::DeserializeFooter(unzipBuf, fAnchor->GetLenFooter(), fDescriptorBuilder);
 
    auto desc = fDescriptorBuilder.MoveDescriptor();
+
+   // fNTupleName is empty if and only if we created this source via CreateFromAnchor. If that's the case, this is the
+   // earliest we can set the name.
+   if (fNTupleName.empty())
+      fNTupleName = desc.GetName();
 
    std::vector<unsigned char> buffer;
    for (const auto &cgDesc : desc.GetClusterGroupIterable()) {

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1128,3 +1128,20 @@ TEST(RPageSinkFile, StreamerInfo)
    }
    FAIL() << "not all streamer infos found! ";
 }
+
+TEST(RPageSourceFile, NameFromAnchor)
+{
+   FileRaii fileGuard("test_ntuple_storage_namefromanchor.root");
+   {
+      auto model = RNTupleModel::Create();
+      RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+   }
+
+   auto file = std::make_unique<TFile>(fileGuard.GetPath().c_str(), "READ");
+   auto anchor = file->Get<ROOT::RNTuple>("ntpl");
+   auto source = RPageSourceFile::CreateFromAnchor(*anchor, {});
+   // When creating a source from anchor, its name doesn't get set until we Attach it.
+   EXPECT_EQ(source->GetNTupleName(), "");
+   source->Attach();
+   EXPECT_EQ(source->GetNTupleName(), "ntpl");
+}


### PR DESCRIPTION
The previous code would always set the name to the empty string as the descriptor builder was not initialized yet by that point.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


