### PR TITLE
[core] Reduce size of libCling

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -236,6 +236,10 @@ if(NOT APPLE AND NOT MSVC)
   # After inlining and hiding symbols, some of them are not referenced anymore
   # and can be collected by the linker, reducing the library size.
   target_link_libraries(Cling PRIVATE -Wl,--gc-sections)
+  # Additionally, for Release builds, strip the binary to remove symbol tables.
+  add_custom_command(TARGET Cling POST_BUILD
+    COMMAND $<$<CONFIG:Release>:${CMAKE_STRIP}>
+    ARGS $<TARGET_FILE:Cling>)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)


### PR DESCRIPTION
Garbage collect unused sections and strip the library after build, reducing its size from 120 MB to 88 MB in a `Release` configuration with GCC. See the individual commit messages for more details.

FYI @vepadulano maybe interesting for the Python wheels, though we will grow in size again with each LLVM upgrade...