### PR TITLE
[Python][UHI] Integrate the UHI testing suite

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -22,6 +22,10 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)
 ROOT_ADD_PYUNITTEST(uhi_plotting uhi_plotting.py GENERIC PYTHON_DEPS uhi numpy)
 ROOT_ADD_PYUNITTEST(uhi_indexing uhi_indexing.py GENERIC PYTHON_DEPS uhi numpy)
+if(Python3_VERSION VERSION_GREATER_EQUAL 3.9)
+    # Enable uhi testing helper for Python 3.9+
+    ROOT_ADD_PYUNITTEST(uhi_test_suite uhi_test_suite.py GENERIC PYTHON_DEPS uhi numpy)
+endif()
 
 # STL containers pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_stl_vector stl_vector.py)

--- a/bindings/pyroot/pythonizations/test/uhi_test_suite.py
+++ b/bindings/pyroot/pythonizations/test/uhi_test_suite.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import ROOT
+import uhi.testing.indexing
+from ROOT._pythonization._uhi import _temporarily_disable_add_directory
+
+
+def th1_eq(self, other):
+    if self is other:
+        return True
+    return (
+        isinstance(other, type(self))
+        and self.kind == other.kind
+        and np.array_equal(self.values(), other.values())
+        and np.array_equal(self.counts(), other.counts())
+        and np.array_equal(self.variances(), other.variances())
+        and all(a == b for a, b in zip(self.axes, other.axes))
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_th1_eq(monkeypatch):
+    """
+    Temporarily patch ROOT.TH1.__eq__ for tests
+    Since __eq__ pythonizations are not defined, the comparison
+    would fall back to object identity (`is`) and would fail
+    """
+    monkeypatch.setattr(ROOT.TH1, "__eq__", th1_eq)
+
+
+class TestIndexing1D(uhi.testing.indexing.Indexing1D[ROOT.TH1D]):
+    tag = ROOT.uhi
+
+    @classmethod
+    def make_histogram(cls) -> ROOT.TH1D:
+        """
+        Return a 1D histogram with 10 bins from 0 to 1. Each bin value increases
+        by 2 compared to the previous one, starting at 0. The underflow bin is 3,
+        and the overflow bin is 1.
+        Reference base class:
+        https://github.com/scikit-hep/uhi/blob/7d2cc3c169b51b5538e1380e66b892f451c28c1a/src/uhi/testing/indexing.py#L68
+        """
+        with _temporarily_disable_add_directory():
+            h = ROOT.TH1D("h", "h", 10, 0, 1)
+            h[...] = np.array([3.0, 0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 1.0])
+            return h
+
+
+class TestIndexing2D(uhi.testing.indexing.Indexing2D[ROOT.TH2D]):
+    tag = ROOT.uhi
+
+    @classmethod
+    def make_histogram(cls) -> ROOT.TH2D:
+        """
+        Return a 2D histogram with [2,5] bins. The contents are x+2y, where x and y
+        are the bin indices.
+        Reference base class:
+        https://github.com/scikit-hep/uhi/blob/7d2cc3c169b51b5538e1380e66b892f451c28c1a/src/uhi/testing/indexing.py#L391
+        """
+        with _temporarily_disable_add_directory():
+            h2 = ROOT.TH2D("h2", "h2", 2, 0, 2, 5, 0, 5)
+            x, y = np.mgrid[0:2, 0:5]
+            data = np.pad(x + 2 * y, 1, mode="constant")
+            h2[...] = data
+            return h2
+
+
+class TestIndexing3D(uhi.testing.indexing.Indexing3D[ROOT.TH3D]):
+    tag = ROOT.uhi
+
+    @classmethod
+    def make_histogram(cls) -> ROOT.TH3D:
+        """
+        Return a 3D histogram with [2,5,10] bins. The contents are x+2y+3z, where x,
+        y, and z are the bin indices.
+        Reference base class:
+        https://github.com/scikit-hep/uhi/blob/7d2cc3c169b51b5538e1380e66b892f451c28c1a/src/uhi/testing/indexing.py#L591
+        """
+        with _temporarily_disable_add_directory():
+            h3 = ROOT.TH3D("h3", "h3", 2, 0, 2, 5, 0, 5, 10, 0, 10)
+            x, y, z = np.mgrid[0:2, 0:5, 0:10]
+            data = np.pad(x + 2 * y + 3 * z, 1, mode="constant")
+            h3[...] = data
+            return h3
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main(args=[__file__]))


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
- This PR integrates the [UHI indexing test suite](https://uhi.readthedocs.io/en/latest/testing.html) for ROOT histograms by adding `Indexing1D`,  `Indexing2D` and `Indexing3D` test helpers specialized for `ROOT.TH1` histograms.

- For all tests to pass, a temporary equality patch (`__eq__)` for `ROOT.TH1` within the test context is implemented checking histogram values instead of default object identity.

- Since serialization is not yet implemented, the histograms are manually created and set in `make_histogram`.

## Checklist:

- [x] tested changes locally

