### PR TITLE
[RF] Fix rf619_discrete_profiling tutorial in overview page

### DIFF
--- a/tutorials/roofit/roofit/index.md
+++ b/tutorials/roofit/roofit/index.md
@@ -124,7 +124,7 @@ Explore the tutorials below to discover the main features of RooFit. A more inde
 | rf610_visualerror.C| rf610_visualerror.py | Visualization of errors from a covariance matrix.|
 | rf611_weightedfits.C| | Parameter uncertainties for weighted unbinned ML fits.|
 | rf612_recoverFromInvalidParameters.C| rf612_recoverFromInvalidParameters.py | Recover from regions where the function is not defined.|
-| rf619_discrete_profile.C | rf619_discrete_profiling.py | Switch between multiple models using RooMultiPdf and select the best one with the discrete profiling method. |
+| rf619_discrete_profiling.C | rf619_discrete_profiling.py | Switch between multiple models using RooMultiPdf and select the best one with the discrete profiling method. |
 
 \anchor roofit_special_pdfs
 ## Special Pdf's


### PR DESCRIPTION
This fixes a missing link in the RooFit tutorials page: https://root.cern/doc/master/group__tutorial__roofit__main.html