### PR TITLE
[RF] Fix wrong usage of `std::ostringstream` in RooProdPdf

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1438,7 +1438,8 @@ std::string RooProdPdf::makeRGPPName(const char* pfx, const RooArgSet& term, con
 {
   // Make an appropriate automatic name for a RooGenProdProj object in getPartIntList()
 
-  std::ostringstream os(pfx);
+  std::ostringstream os;
+  os << pfx;
   os << "[";
 
   // Encode component names


### PR DESCRIPTION
After getting confused for some time why some fits don't work with the new CPU backend, I found one of the problems: the `std::ostringstream` was used incorrectly since 916a180 (commit from 10 years ago).

The `std::ostringstream` constructor arguments do not initialize the stream with that string — the argument sets the open mode, not the contents.

This can be seen with this little example in the interpreter.

```txt
root [0] const char *pfx = "hello";
root [1] std::ostringstream os(pfx);
root [2] os << " world";
root [3] os.str()
(std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::__string_type) " world"
root [4] .q
```

The result is that the prefix doesn't get added, and hence it can happen that many nodes in the computation graph can have the same name, breaking the assumptions of the new RooFit evaluation backend.