### PR TITLE
[RF] Don't do dirty state propagation if more than 2 params changed

### DIFF
--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -53,6 +53,7 @@ private:
    RooAbsReal *_funct = nullptr;
    std::unique_ptr<ROOT::Math::IBaseFunctionMultiDim> _multiGenFcn;
    mutable std::vector<double> _gradientOutput;
+   mutable std::vector<double> _cachedInput;
 };
 
 #endif


### PR DESCRIPTION
The "dirty state propagation" is the mechanism that figures out which parts of the computation graph need to be re-evaluated.

It can be quite expensive if all the parameters in the model are changed at once, for example in the Minuit 2 line search step.

Changing only 1 or 2 parameters is common during numerical differentiation. But in the minimizer algorithms like Minuit 2, we can generally assume that if more than 2 parameter changed, then all of them are changed. Therefore, we should implement some mechanism that skips the dirty flag propagation in that case. This will greatly speed up fits with many parameters, especially when using AD, where the line search dominates the runtime. For ATLAS Higgs combinations, a speedup of 2x for minimization is expected.

To make some initial studies, this draft PR is opened with a relatively hacky way to implement this, using global state in RooFit.