### PR TITLE
[interpreter] Update expected LLVM version number to 20

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT builtin_clang)
 endif()
 
 #--Set the LLVM version required for ROOT-----------------------------------------------------------
-set(ROOT_LLVM_VERSION_REQUIRED_MAJOR 18)
+set(ROOT_LLVM_VERSION_REQUIRED_MAJOR 20)
 
 #---Define the way we want to build and what of llvm/clang/cling------------------------------------
 set(LLVM_ENABLE_RTTI ON CACHE BOOL "")


### PR DESCRIPTION
This is needs to be kept in sync for building with `builtin_llvm=OFF`.