### PR TITLE
[hist] Accept regular axis interval as `std::pair`

### DIFF
--- a/hist/histv7/benchmark/hist_benchmark_axes.cxx
+++ b/hist/histv7/benchmark/hist_benchmark_axes.cxx
@@ -9,7 +9,7 @@
 struct RAxes_Regular1 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::Internal::RAxes axes{{axis}};
    std::vector<double> fNumbers;
 
@@ -39,7 +39,7 @@ BENCHMARK_REGISTER_F(RAxes_Regular1, ComputeGlobalIndex)->Range(0, 32768);
 struct RAxes_Regular2 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::Internal::RAxes axes{{axis, axis}};
    std::vector<double> fNumbers;
 

--- a/hist/histv7/benchmark/hist_benchmark_engine.cxx
+++ b/hist/histv7/benchmark/hist_benchmark_engine.cxx
@@ -11,7 +11,7 @@
 struct RHistEngine_int_Regular1 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<int> engine{{axis}};
    std::vector<double> fNumbers;
 
@@ -41,7 +41,7 @@ BENCHMARK_REGISTER_F(RHistEngine_int_Regular1, Fill)->Range(0, 32768);
 struct RHistEngine_int_Regular2 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<int> engine{{axis, axis}};
    std::vector<double> fNumbers;
 
@@ -71,7 +71,7 @@ BENCHMARK_REGISTER_F(RHistEngine_int_Regular2, Fill)->Range(0, 32768);
 struct RHistEngine_float_Regular1 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<float> engine{{axis}};
    std::vector<double> fNumbers;
 
@@ -111,7 +111,7 @@ BENCHMARK_REGISTER_F(RHistEngine_float_Regular1, FillWeight)->Range(0, 32768);
 struct RHistEngine_float_Regular2 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<float> engine{{axis, axis}};
    std::vector<double> fNumbers;
 
@@ -151,7 +151,7 @@ BENCHMARK_REGISTER_F(RHistEngine_float_Regular2, FillWeight)->Range(0, 32768);
 struct RHistEngine_RBinWithError_Regular1 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<ROOT::Experimental::RBinWithError> engine{{axis}};
    std::vector<double> fNumbers;
 
@@ -191,7 +191,7 @@ BENCHMARK_REGISTER_F(RHistEngine_RBinWithError_Regular1, FillWeight)->Range(0, 3
 struct RHistEngine_RBinWithError_Regular2 : public benchmark::Fixture {
    // The objects are stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    ROOT::Experimental::RHistEngine<ROOT::Experimental::RBinWithError> engine{{axis, axis}};
    std::vector<double> fNumbers;
 

--- a/hist/histv7/benchmark/hist_benchmark_regular.cxx
+++ b/hist/histv7/benchmark/hist_benchmark_regular.cxx
@@ -8,7 +8,7 @@
 struct RRegularAxis : public benchmark::Fixture {
    // The axis is stored and constructed in the fixture to avoid compiler optimizations in the benchmark body taking
    // advantage of the (constant) constructor parameters.
-   ROOT::Experimental::RRegularAxis axis{20, 0.0, 1.0};
+   ROOT::Experimental::RRegularAxis axis{20, {0.0, 1.0}};
    std::vector<double> fNumbers;
 
    // Avoid GCC warning

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -27,7 +27,7 @@ A histogram for aggregation of data along multiple dimensions.
 
 Every call to \ref Fill(const A &... args) "Fill" increments the bin content and is reflected in global statistics:
 \code
-ROOT::Experimental::RHist<int> hist(10, 5, 15);
+ROOT::Experimental::RHist<int> hist(10, {5, 15});
 hist.Fill(8.5);
 // hist.GetBinContent(ROOT::Experimental::RBinIndex(3)) will return 1
 \endcode
@@ -70,12 +70,12 @@ public:
    /// Construct a one-dimensional histogram engine with a regular axis.
    ///
    /// \param[in] nNormalBins the number of normal bins, must be > 0
-   /// \param[in] low the lower end of the axis interval (inclusive)
-   /// \param[in] high the upper end of the axis interval (exclusive), must be > low
+   /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \par See also
-   /// the \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, double low, double high, bool enableFlowBins)
+   /// the
+   /// \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins)
    /// "constructor of RRegularAxis"
-   RHist(std::size_t nNormalBins, double low, double high) : RHist({RRegularAxis(nNormalBins, low, high)}) {}
+   RHist(std::size_t nNormalBins, std::pair<double, double> interval) : RHist({RRegularAxis(nNormalBins, interval)}) {}
 
    /// The copy constructor is deleted.
    ///

--- a/hist/histv7/inc/ROOT/RHistEngine.hxx
+++ b/hist/histv7/inc/ROOT/RHistEngine.hxx
@@ -32,7 +32,7 @@ A histogram data structure to bin data along multiple dimensions.
 Every call to \ref Fill(const A &... args) "Fill" bins the data according to the axis configuration and increments the
 bin content:
 \code
-ROOT::Experimental::RHistEngine<int> hist(10, 5, 15);
+ROOT::Experimental::RHistEngine<int> hist(10, {5, 15});
 hist.Fill(8.5);
 // hist.GetBinContent(ROOT::Experimental::RBinIndex(3)) will return 1
 \endcode
@@ -75,12 +75,13 @@ public:
    /// Construct a one-dimensional histogram engine with a regular axis.
    ///
    /// \param[in] nNormalBins the number of normal bins, must be > 0
-   /// \param[in] low the lower end of the axis interval (inclusive)
-   /// \param[in] high the upper end of the axis interval (exclusive), must be > low
+   /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \par See also
-   /// the \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, double low, double high, bool enableFlowBins)
+   /// the
+   /// \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins)
    /// "constructor of RRegularAxis"
-   RHistEngine(std::size_t nNormalBins, double low, double high) : RHistEngine({RRegularAxis(nNormalBins, low, high)})
+   RHistEngine(std::size_t nNormalBins, std::pair<double, double> interval)
+      : RHistEngine({RRegularAxis(nNormalBins, interval)})
    {
    }
 

--- a/hist/histv7/inc/ROOT/RRegularAxis.hxx
+++ b/hist/histv7/inc/ROOT/RRegularAxis.hxx
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 class TBuffer;
 
@@ -49,20 +50,19 @@ public:
    /// Construct a regular axis object.
    ///
    /// \param[in] nNormalBins the number of normal bins, must be > 0
-   /// \param[in] low the lower end of the axis interval (inclusive)
-   /// \param[in] high the upper end of the axis interval (exclusive), must be > low
+   /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \param[in] enableFlowBins whether to enable underflow and overflow bins
-   RRegularAxis(std::size_t nNormalBins, double low, double high, bool enableFlowBins = true)
-      : fNNormalBins(nNormalBins), fLow(low), fHigh(high), fEnableFlowBins(enableFlowBins)
+   RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins = true)
+      : fNNormalBins(nNormalBins), fLow(interval.first), fHigh(interval.second), fEnableFlowBins(enableFlowBins)
    {
       if (nNormalBins == 0) {
          throw std::invalid_argument("nNormalBins must be > 0");
       }
-      if (low >= high) {
-         std::string msg = "high must be > low, but " + std::to_string(low) + " >= " + std::to_string(high);
+      if (fLow >= fHigh) {
+         std::string msg = "high must be > low, but " + std::to_string(fLow) + " >= " + std::to_string(fHigh);
          throw std::invalid_argument(msg);
       }
-      fInvBinWidth = nNormalBins / (high - low);
+      fInvBinWidth = nNormalBins / (fHigh - fLow);
    }
 
    std::size_t GetNNormalBins() const { return fNNormalBins; }

--- a/hist/histv7/test/hist_axes.cxx
+++ b/hist/histv7/test/hist_axes.cxx
@@ -9,7 +9,7 @@
 TEST(RAxes, Constructor)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -37,7 +37,7 @@ TEST(RAxes, Constructor)
 TEST(RAxes, Equality)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -69,7 +69,7 @@ TEST(RAxes, Equality)
 TEST(RAxes, ComputeTotalNBins)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -86,7 +86,7 @@ TEST(RAxes, ComputeTotalNBins)
 TEST(RAxes, ComputeGlobalIndex)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -132,7 +132,7 @@ TEST(RAxes, ComputeGlobalIndex)
 TEST(RAxes, ComputeGlobalIndexNoFlowBins)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX, /*enableFlowBins=*/false);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX}, /*enableFlowBins=*/false);
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -179,7 +179,7 @@ TEST(RAxes, ComputeGlobalIndexNoFlowBins)
 TEST(RAxes, ComputeGlobalIndexInvalidNumberOfArguments)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    const RAxes axes1({axis});
    ASSERT_EQ(axes1.GetNDimensions(), 1);
    const RAxes axes2({axis, axis});

--- a/hist/histv7/test/hist_engine.cxx
+++ b/hist/histv7/test/hist_engine.cxx
@@ -11,7 +11,7 @@ static_assert(std::is_nothrow_move_assignable_v<RHistEngine<int>>);
 TEST(RHistEngine, Constructor)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -32,7 +32,7 @@ TEST(RHistEngine, Constructor)
    // Both axes include underflow and overflow bins.
    EXPECT_EQ(engine.GetTotalNBins(), (BinsX + 2) * (BinsY + 2));
 
-   engine = RHistEngine<int>(BinsX, 0, BinsX);
+   engine = RHistEngine<int>(BinsX, {0, BinsX});
    ASSERT_EQ(engine.GetNDimensions(), 1);
    auto *regular = std::get_if<RRegularAxis>(&engine.GetAxes()[0]);
    ASSERT_TRUE(regular != nullptr);
@@ -44,7 +44,7 @@ TEST(RHistEngine, Constructor)
 TEST(RHistEngine, GetBinContentInvalidNumberOfArguments)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    const RHistEngine<int> engine1({axis});
    ASSERT_EQ(engine1.GetNDimensions(), 1);
    const RHistEngine<int> engine2({axis, axis});
@@ -61,7 +61,7 @@ TEST(RHistEngine, GetBinContentInvalidNumberOfArguments)
 TEST(RHistEngine, GetBinContentNotFound)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    const RHistEngine<int> engine({axis});
 
    EXPECT_THROW(engine.GetBinContent(Bins), std::invalid_argument);
@@ -70,7 +70,7 @@ TEST(RHistEngine, GetBinContentNotFound)
 TEST(RHistEngine, Add)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engineA({axis});
    RHistEngine<int> engineB({axis});
    RHistEngine<int> engineC({axis});
@@ -105,8 +105,8 @@ TEST(RHistEngine, AddDifferent)
 {
    // The equality operators of RAxes and the axis objects are already unit-tested separately, so here we only check one
    // case with different the number of bins.
-   RHistEngine<int> engineA(10, 0, 1);
-   RHistEngine<int> engineB(20, 0, 1);
+   RHistEngine<int> engineA(10, {0, 1});
+   RHistEngine<int> engineB(20, {0, 1});
 
    EXPECT_THROW(engineA.Add(engineB), std::invalid_argument);
 }
@@ -114,7 +114,7 @@ TEST(RHistEngine, AddDifferent)
 TEST(RHistEngine, Clear)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engine({axis});
 
    engine.Fill(-100);
@@ -135,7 +135,7 @@ TEST(RHistEngine, Clear)
 TEST(RHistEngine, Clone)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engineA({axis});
 
    engineA.Fill(-100);
@@ -168,7 +168,7 @@ TEST(RHistEngine, Clone)
 TEST(RHistEngine, Fill)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engine({axis});
 
    engine.Fill(-100);
@@ -187,7 +187,7 @@ TEST(RHistEngine, Fill)
 TEST(RHistEngine, FillDiscard)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins, /*enableFlowBins=*/false);
+   const RRegularAxis axis(Bins, {0, Bins}, /*enableFlowBins=*/false);
    RHistEngine<int> engine({axis});
 
    engine.Fill(-100);
@@ -204,9 +204,9 @@ TEST(RHistEngine, FillDiscard)
 TEST(RHistEngine, FillOnlyInner)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engine({axis});
-   const RRegularAxis axisNoFlowBins(Bins, 0, Bins, /*enableFlowBins=*/false);
+   const RRegularAxis axisNoFlowBins(Bins, {0, Bins}, /*enableFlowBins=*/false);
    RHistEngine<int> engineNoFlowBins({axisNoFlowBins});
 
    for (std::size_t i = 0; i < Bins; i++) {
@@ -225,7 +225,7 @@ TEST(RHistEngine, FillOnlyInner)
 TEST(RHistEngine, FillTuple)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engine({axis});
 
    engine.Fill(std::make_tuple(-100));
@@ -247,7 +247,7 @@ TEST(RHistEngine, FillTuple)
 TEST(RHistEngine, FillInvalidNumberOfArguments)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<int> engine1({axis});
    ASSERT_EQ(engine1.GetNDimensions(), 1);
    RHistEngine<int> engine2({axis, axis});
@@ -264,7 +264,7 @@ TEST(RHistEngine, FillInvalidNumberOfArguments)
 TEST(RHistEngine, FillWeight)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<float> engine({axis});
 
    engine.Fill(-100, RWeight(0.25));
@@ -283,7 +283,7 @@ TEST(RHistEngine, FillWeight)
 TEST(RHistEngine, FillTupleWeight)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<float> engine({axis});
 
    engine.Fill(std::make_tuple(-100), RWeight(0.25));
@@ -305,7 +305,7 @@ TEST(RHistEngine, FillTupleWeight)
 TEST(RHistEngine, FillWeightInvalidNumberOfArguments)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<float> engine1({axis});
    ASSERT_EQ(engine1.GetNDimensions(), 1);
    RHistEngine<float> engine2({axis, axis});
@@ -322,7 +322,7 @@ TEST(RHistEngine, FillWeightInvalidNumberOfArguments)
 TEST(RHistEngine, FillTupleWeightInvalidNumberOfArguments)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<float> engine1({axis});
    ASSERT_EQ(engine1.GetNDimensions(), 1);
    RHistEngine<float> engine2({axis, axis});
@@ -339,7 +339,7 @@ TEST(RHistEngine, FillTupleWeightInvalidNumberOfArguments)
 TEST(RHistEngine_RBinWithError, Add)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<RBinWithError> engineA({axis});
    RHistEngine<RBinWithError> engineB({axis});
 
@@ -362,7 +362,7 @@ TEST(RHistEngine_RBinWithError, Add)
 TEST(RHistEngine_RBinWithError, Fill)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<RBinWithError> engine({axis});
 
    for (std::size_t i = 0; i < Bins; i++) {
@@ -379,7 +379,7 @@ TEST(RHistEngine_RBinWithError, Fill)
 TEST(RHistEngine_RBinWithError, FillWeight)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHistEngine<RBinWithError> engine({axis});
 
    for (std::size_t i = 0; i < Bins; i++) {

--- a/hist/histv7/test/hist_hist.cxx
+++ b/hist/histv7/test/hist_hist.cxx
@@ -14,7 +14,7 @@ static_assert(std::is_nothrow_move_assignable_v<RHistEngine<int>>);
 TEST(RHist, Constructor)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis regularAxis(Bins, 0, Bins);
+   const RRegularAxis regularAxis(Bins, {0, Bins});
 
    RHist<int> hist({regularAxis, regularAxis});
    EXPECT_EQ(hist.GetNDimensions(), 2);
@@ -26,7 +26,7 @@ TEST(RHist, Constructor)
    // Both axes include underflow and overflow bins.
    EXPECT_EQ(hist.GetTotalNBins(), (Bins + 2) * (Bins + 2));
 
-   hist = RHist<int>(Bins, 0, Bins);
+   hist = RHist<int>(Bins, {0, Bins});
    ASSERT_EQ(hist.GetNDimensions(), 1);
    auto *regular = std::get_if<RRegularAxis>(&hist.GetAxes()[0]);
    ASSERT_TRUE(regular != nullptr);
@@ -38,7 +38,7 @@ TEST(RHist, Constructor)
 TEST(RHist, Add)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHist<int> histA({axis});
    RHist<int> histB({axis});
 
@@ -55,7 +55,7 @@ TEST(RHist, Add)
 TEST(RHist, Clear)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHist<int> hist({axis});
 
    hist.Fill(8.5);
@@ -71,7 +71,7 @@ TEST(RHist, Clear)
 TEST(RHist, Clone)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHist<int> histA({axis});
 
    histA.Fill(8.5);
@@ -95,7 +95,7 @@ TEST(RHist, Clone)
 TEST(RHist, Fill)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHist<int> hist({axis});
 
    hist.Fill(8.5);
@@ -114,7 +114,7 @@ TEST(RHist, Fill)
 TEST(RHist, FillWeight)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    RHist<float> hist({axis});
 
    hist.Fill(8.5, RWeight(0.8));

--- a/hist/histv7/test/hist_io.cxx
+++ b/hist/histv7/test/hist_io.cxx
@@ -18,7 +18,7 @@ static void ExpectThrowOnWriteObject(const T &obj)
 TEST(RRegularAxis, Streamer)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    ExpectThrowOnWriteObject(axis);
 }
 
@@ -38,7 +38,7 @@ TEST(RVariableBinAxis, Streamer)
 TEST(RAxes, Streamer)
 {
    static constexpr std::size_t BinsX = 20;
-   const RRegularAxis regularAxis(BinsX, 0, BinsX);
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
    static constexpr std::size_t BinsY = 30;
    std::vector<double> bins;
    for (std::size_t i = 0; i < BinsY; i++) {
@@ -54,7 +54,7 @@ TEST(RAxes, Streamer)
 TEST(RHistEngine, Streamer)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
 
    // We don't request a dictionary for RHistEngine<unsigned char>, and we generally don't recommend such narrow bin
    // content types. If used, the RAxes member will prevent streaming.
@@ -98,7 +98,7 @@ TEST(RHistStats, Streamer)
 TEST(RHist, Streamer)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
 
    const RHist<int> histI({axis});
    ExpectThrowOnWriteObject(histI);

--- a/hist/histv7/test/hist_regular.cxx
+++ b/hist/histv7/test/hist_regular.cxx
@@ -7,31 +7,31 @@
 TEST(RRegularAxis, Constructor)
 {
    static constexpr std::size_t Bins = 20;
-   RRegularAxis axis(Bins, 0, Bins);
+   RRegularAxis axis(Bins, {0, Bins});
    EXPECT_EQ(axis.GetNNormalBins(), Bins);
    EXPECT_EQ(axis.GetTotalNBins(), Bins + 2);
    EXPECT_EQ(axis.GetLow(), 0);
    EXPECT_EQ(axis.GetHigh(), Bins);
    EXPECT_TRUE(axis.HasFlowBins());
 
-   axis = RRegularAxis(Bins, 0, Bins, /*enableFlowBins=*/false);
+   axis = RRegularAxis(Bins, {0, Bins}, /*enableFlowBins=*/false);
    EXPECT_EQ(axis.GetNNormalBins(), Bins);
    EXPECT_EQ(axis.GetTotalNBins(), Bins);
    EXPECT_FALSE(axis.HasFlowBins());
 
-   EXPECT_THROW(RRegularAxis(0, 0, Bins), std::invalid_argument);
-   EXPECT_THROW(RRegularAxis(Bins, 1, 1), std::invalid_argument);
+   EXPECT_THROW(RRegularAxis(0, {0, Bins}), std::invalid_argument);
+   EXPECT_THROW(RRegularAxis(Bins, {1, 1}), std::invalid_argument);
 }
 
 TEST(RRegularAxis, Equality)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axisA(Bins, 0, Bins);
-   const RRegularAxis axisANoFlowBins(Bins, 0, Bins, /*enableFlowBins=*/false);
-   const RRegularAxis axisA2(Bins, 0, Bins);
-   const RRegularAxis axisB(Bins / 2, 0, Bins);
-   const RRegularAxis axisC(Bins, 0, Bins / 2);
-   const RRegularAxis axisD(Bins, Bins / 2, Bins);
+   const RRegularAxis axisA(Bins, {0, Bins});
+   const RRegularAxis axisANoFlowBins(Bins, {0, Bins}, /*enableFlowBins=*/false);
+   const RRegularAxis axisA2(Bins, {0, Bins});
+   const RRegularAxis axisB(Bins / 2, {0, Bins});
+   const RRegularAxis axisC(Bins, {0, Bins / 2});
+   const RRegularAxis axisD(Bins, {Bins / 2, Bins});
 
    EXPECT_TRUE(axisA == axisA);
    EXPECT_TRUE(axisA == axisA2);
@@ -53,8 +53,8 @@ TEST(RRegularAxis, Equality)
 TEST(RRegularAxis, ComputeLinearizedIndex)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
-   const RRegularAxis axisNoFlowBins(Bins, 0, Bins, /*enableFlowBins=*/false);
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RRegularAxis axisNoFlowBins(Bins, {0, Bins}, /*enableFlowBins=*/false);
 
    // Underflow
    static constexpr double NegativeInfinity = -std::numeric_limits<double>::infinity();
@@ -116,8 +116,8 @@ TEST(RRegularAxis, ComputeLinearizedIndex)
 TEST(RRegularAxis, GetLinearizedIndex)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
-   const RRegularAxis axisNoFlowBins(Bins, 0, Bins, /*enableFlowBins=*/false);
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RRegularAxis axisNoFlowBins(Bins, {0, Bins}, /*enableFlowBins=*/false);
 
    {
       const auto underflow = RBinIndex::Underflow();
@@ -169,7 +169,7 @@ TEST(RRegularAxis, GetLinearizedIndex)
 TEST(RRegularAxis, GetNormalRange)
 {
    static constexpr std::size_t Bins = 20;
-   const RRegularAxis axis(Bins, 0, Bins);
+   const RRegularAxis axis(Bins, {0, Bins});
    const auto index0 = RBinIndex(0);
    const auto index1 = RBinIndex(1);
    const auto indexBins = RBinIndex(Bins);
@@ -218,7 +218,7 @@ TEST(RRegularAxis, GetFullRange)
    static constexpr std::size_t Bins = 20;
 
    {
-      const RRegularAxis axis(Bins, 0, Bins);
+      const RRegularAxis axis(Bins, {0, Bins});
       const auto full = axis.GetFullRange();
       EXPECT_EQ(full.GetBegin(), RBinIndex::Underflow());
       EXPECT_EQ(full.GetEnd(), RBinIndex());
@@ -226,7 +226,7 @@ TEST(RRegularAxis, GetFullRange)
    }
 
    {
-      const RRegularAxis axisNoFlowBins(Bins, 0, Bins, /*enableFlowBins=*/false);
+      const RRegularAxis axisNoFlowBins(Bins, {0, Bins}, /*enableFlowBins=*/false);
       const auto full = axisNoFlowBins.GetFullRange();
       EXPECT_EQ(full.GetBegin(), RBinIndex(0));
       EXPECT_EQ(full.GetEnd(), RBinIndex(Bins));

--- a/tutorials/hist/histv7/hist001_RHist_basics.C
+++ b/tutorials/hist/histv7/hist001_RHist_basics.C
@@ -56,7 +56,7 @@ static void DrawHistogram(const ROOT::Experimental::RHist<int> &hist)
 void hist001_RHist_basics()
 {
    // Create an axis that can be used for multiple histograms.
-   ROOT::Experimental::RRegularAxis axis(40, 0, 20);
+   ROOT::Experimental::RRegularAxis axis(40, {0, 20});
 
    // Create a first histograms and fill with random values.
    ROOT::Experimental::RHist<int> hist1({axis});


### PR DESCRIPTION
This forces the user to make a distinction between the number of bins and the axis interval.