### PR TITLE
[hist] Check argument types during `ComputeGlobalIndex`

### DIFF
--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -204,7 +204,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \par See also
@@ -231,7 +232,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \param[in] weight the weight for this entry
@@ -262,7 +264,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \par See also

--- a/hist/histv7/inc/ROOT/RHistEngine.hxx
+++ b/hist/histv7/inc/ROOT/RHistEngine.hxx
@@ -223,7 +223,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \par See also
@@ -257,7 +258,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \param[in] weight the weight for this entry
@@ -298,7 +300,8 @@ public:
    /// If one of the arguments is outside the corresponding axis and flow bins are disabled, the entry will be silently
    /// discarded.
    ///
-   /// Throws an exception if the number of arguments does not match the axis configuration.
+   /// Throws an exception if the number of arguments does not match the axis configuration, or if an argument cannot be
+   /// converted for the axis type at run-time.
    ///
    /// \param[in] args the arguments for each axis
    /// \par See also

--- a/hist/histv7/inc/ROOT/RRegularAxis.hxx
+++ b/hist/histv7/inc/ROOT/RRegularAxis.hxx
@@ -35,6 +35,10 @@ outside the axis will be silently discarded.
 Feedback is welcome!
 */
 class RRegularAxis final {
+public:
+   using ArgumentType = double;
+
+private:
    /// The number of normal bins
    std::size_t fNNormalBins;
    /// The lower end of the axis interval

--- a/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
+++ b/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
@@ -37,6 +37,10 @@ outside the axis will be silently discarded.
 Feedback is welcome!
 */
 class RVariableBinAxis final {
+public:
+   using ArgumentType = double;
+
+private:
    /// The (ordered) edges of the normal bins
    std::vector<double> fBinEdges;
    /// Whether underflow and overflow bins are enabled

--- a/hist/histv7/test/hist_axes.cxx
+++ b/hist/histv7/test/hist_axes.cxx
@@ -203,3 +203,21 @@ TEST(RAxes, ComputeGlobalIndexInvalidNumberOfArguments)
    EXPECT_NO_THROW(axes2.ComputeGlobalIndex(indices2));
    EXPECT_THROW(axes2.ComputeGlobalIndex(indices3), std::invalid_argument);
 }
+
+TEST(RAxes, ComputeGlobalIndexInvalidArgumentType)
+{
+   static constexpr std::size_t BinsX = 20;
+   const RRegularAxis regularAxis(BinsX, {0, BinsX});
+   static constexpr std::size_t BinsY = 30;
+   std::vector<double> bins;
+   for (std::size_t i = 0; i < BinsY; i++) {
+      bins.push_back(i);
+   }
+   bins.push_back(BinsY);
+   const RVariableBinAxis variableBinAxis(bins);
+   const RAxes axes({regularAxis, variableBinAxis});
+
+   EXPECT_NO_THROW(axes.ComputeGlobalIndex(std::make_tuple(1, 2)));
+   EXPECT_THROW(axes.ComputeGlobalIndex(std::make_tuple("1", 2)), std::invalid_argument);
+   EXPECT_THROW(axes.ComputeGlobalIndex(std::make_tuple(1, "2")), std::invalid_argument);
+}


### PR DESCRIPTION
This prepares for future axis types that accept different argument types (in particular `RCategoricalAxis`), where we can only decide at run-time if the parameters match the axis configuration. However, because the type check is evaluated at compile-time, there is no performance penalty for cases where the type is convertible.