### PR TITLE
[v6.36][ntuple] enforce correct subfield name in untyped collection

### DIFF
--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -488,7 +488,7 @@ ROOT::RVectorField::RVectorField(std::string_view fieldName, std::unique_ptr<RFi
 std::unique_ptr<ROOT::RVectorField>
 ROOT::RVectorField::CreateUntyped(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField)
 {
-   return std::unique_ptr<ROOT::RVectorField>(new RVectorField(fieldName, std::move(itemField), true));
+   return std::unique_ptr<ROOT::RVectorField>(new RVectorField(fieldName, itemField->Clone("_0"), true));
 }
 
 std::unique_ptr<ROOT::RFieldBase> ROOT::RVectorField::CloneImpl(std::string_view newName) const

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -318,8 +318,8 @@ ROOT::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSchema()
 
       c.fFieldName = "_collection" + std::to_string(iLeafCountCollection);
       auto recordField = std::make_unique<ROOT::RRecordField>("_0", std::move(c.fLeafFields));
-      c.fRecordField = recordField.get();
       auto collectionField = ROOT::RVectorField::CreateUntyped(c.fFieldName, std::move(recordField));
+      c.fRecordField = static_cast<RRecordField *>(collectionField->GetMutableSubfields()[0]);
       fModel->AddField(std::move(collectionField));
 
       // Add projected fields for all leaf count arrays


### PR DESCRIPTION
Collection items must have "_0" as item field name, which can be violated in RVectorField::CreateUntyped().

(cherry picked from commit 2f8d30d048dd9cfc2393241b54e50fce685273f0)

Backport from #20007 

