### PR TITLE
[ci] Disable `builtin_vc` on `mac15`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac15.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac15.txt
@@ -16,7 +16,6 @@ builtin_openssl=ON
 builtin_pcre=ON
 builtin_tbb=ON
 builtin_unuran=ON
-builtin_vc=ON
 builtin_vdt=ON
 builtin_veccore=ON
 builtin_xrootd=ON


### PR DESCRIPTION
It fails to build with the latest SDK because of missing includes and was already off for `mac26` and `mac-beta` (probably for that reason).