### PR TITLE
[CI] Don't use incremental builds for Mac15 and Mac26.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -165,7 +165,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           HOME: /Users/sftnight
-          INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') }}
+          INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') && !matrix.platform == 'mac15' && !matrix.platform == 'mac26'}}
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
         run: ".github/workflows/root-ci-config/build_root.py 
                     --buildtype       RelWithDebInfo


### PR DESCRIPTION
Due to the mix of VMs and bare machines, incremental builds fail with link or compile errors.

Let's see if it's fast enough to run full builds.

**Update**:
The VMs for Mac15 and Mac26 finished in 30 m. That's twice as fast as the ones doing incremental builds. 🚀
For me that's good enough to stop trying to do incremental builds.

