### PR TITLE
[cling] Remove duplicate `EHFrameRegistrationPlugin`

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -19,8 +19,6 @@
 #include <clang/Basic/TargetOptions.h>
 #include <clang/Frontend/CompilerInstance.h>
 
-#include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
-#include <llvm/ExecutionEngine/Orc/EHFrameRegistrationPlugin.h>
 #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
@@ -505,8 +503,6 @@ IncrementalJIT::IncrementalJIT(
       unsigned PageSize = cantFail(sys::Process::getPageSize());
       auto ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(
           ES, std::make_unique<ClingJITLinkMemoryManager>(PageSize));
-      ObjLinkingLayer->addPlugin(std::make_unique<EHFrameRegistrationPlugin>(
-          ES, std::make_unique<InProcessEHFrameRegistrar>()));
       return ObjLinkingLayer;
     }
 


### PR DESCRIPTION
During the LLVM 20 development cycle, upstream commit https://github.com/llvm/llvm-project/commit/d0052ebbe2e2f691ec42cad3c8613ef387abc53f now installs the plugin during platform setup. This happens even with a custom `ObjectLinkingLayerCreator` as we do it, which lead to two plugins being added and registering the eh-frames twice. This causes assertions in libgcc during shutdown.

Closes #20063