### PR TITLE
Fix warnings when compiling with Clang 21

### DIFF
--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -191,7 +191,7 @@ protected:
 
 public: // Public Interface
 
-   virtual ~TCling();
+   ~TCling() final;
    TCling(const char* name, const char* title, const char* const argv[], void *interpLibHandle);
 
    void    AddIncludePath(const char* path) final;
@@ -219,11 +219,11 @@ public: // Public Interface
    const char* GetClassSharedLibs(const char* cls, bool skipCore = true) final;
    const char* GetSharedLibDeps(const char* lib, bool tryDyld = false) final;
    const char* GetIncludePath() final;
-   virtual const char* GetSTLIncludePath() const final;
+   const char* GetSTLIncludePath() const final;
    TObjArray*  GetRootMapFiles() const final { return fRootmapFiles; }
    unsigned long long GetInterpreterStateMarker() const final { return fTransactionCount;}
-   virtual void Initialize() final;
-   virtual void ShutDown() final;
+   void    Initialize() final;
+   void    ShutDown() final;
    void    InspectMembers(TMemberInspector&, const void* obj, const TClass* cl, Bool_t isTransient) final;
    Bool_t  IsLoaded(const char* filename) const final;
    Bool_t  IsLibraryLoaded(const char* libname) const final;
@@ -252,7 +252,7 @@ public: // Public Interface
                           const char** classesHeaders,
                           Bool_t lateRegistration = false,
                           Bool_t hasCxxModule = false) final;
-   virtual void AddAvailableIndentifiers(TSeqCollection& Idents) final;
+   void    AddAvailableIndentifiers(TSeqCollection& Idents) final;
    void    RegisterTClassUpdate(TClass *oldcl,DictFuncPtr_t dict) final;
    void    UnRegisterTClassUpdate(const TClass *oldcl) final;
 
@@ -301,7 +301,7 @@ public: // Public Interface
    DeclId_t GetFunctionWithValues(ClassInfo_t *cl, const char* method, const char* params, Bool_t objectIsConst = kFALSE) final;
    DeclId_t GetFunctionTemplate(ClassInfo_t *cl, const char *funcname) final;
    void     GetFunctionOverloads(ClassInfo_t *cl, const char *funcname, std::vector<DeclId_t>& res) const final;
-   virtual void     LoadFunctionTemplates(TClass* cl) const final;
+   void     LoadFunctionTemplates(TClass* cl) const final;
 
    std::vector<std::string> GetUsingNamespaces(ClassInfo_t *cl) const final;
 
@@ -369,7 +369,7 @@ public: // Public Interface
 
    // core/meta helper functions.
    EReturnType MethodCallReturnType(TFunction *func) const final;
-   virtual void GetFunctionName(const clang::Decl *decl, std::string &name) const;
+   void GetFunctionName(const clang::Decl *decl, std::string &name) const;
    bool DiagnoseIfInterpreterException(const std::exception &e) const final;
 
    // CallFunc interface

--- a/roofit/roofitcore/inc/RooFit/ModelConfig.h
+++ b/roofit/roofitcore/inc/RooFit/ModelConfig.h
@@ -67,7 +67,7 @@ public:
    /// Set a workspace that owns all the necessary components for the analysis.
    void SetWS(RooWorkspace &ws) override;
    //// alias for SetWS(...)
-   virtual void SetWorkspace(RooWorkspace &ws) { SetWS(ws); }
+   void SetWorkspace(RooWorkspace &ws) { SetWS(ws); }
 
    /// Remove the existing reference to a workspace and replace it with this new one.
    void ReplaceWS(RooWorkspace *ws) override
@@ -77,28 +77,28 @@ public:
    }
 
    /// Set the proto DataSet, add to the workspace if not already there
-   virtual void SetProtoData(RooAbsData &data)
+   void SetProtoData(RooAbsData &data)
    {
       ImportDataInWS(data);
       SetProtoData(data.GetName());
    }
 
    /// Set the Pdf, add to the workspace if not already there
-   virtual void SetPdf(const RooAbsPdf &pdf)
+   void SetPdf(const RooAbsPdf &pdf)
    {
       ImportPdfInWS(pdf);
       SetPdf(pdf.GetName());
    }
 
    /// Set the Prior Pdf, add to the workspace if not already there
-   virtual void SetPriorPdf(const RooAbsPdf &pdf)
+   void SetPriorPdf(const RooAbsPdf &pdf)
    {
       ImportPdfInWS(pdf);
       SetPriorPdf(pdf.GetName());
    }
 
    /// Specify parameters of the PDF.
-   virtual void SetParameters(const RooArgSet &set)
+   void SetParameters(const RooArgSet &set)
    {
       if (!SetHasOnlyParameters(set, "ModelConfig::SetParameters"))
          return;
@@ -107,7 +107,7 @@ public:
    }
 
    /// Specify parameters of interest.
-   virtual void SetParametersOfInterest(const RooArgSet &set)
+   void SetParametersOfInterest(const RooArgSet &set)
    {
       if (!SetHasOnlyParameters(set, "ModelConfig::SetParametersOfInterest"))
          return;
@@ -116,7 +116,7 @@ public:
 
    /// Specify parameters
    /// using a list of comma-separated list of arguments already in the workspace.
-   virtual void SetParameters(const char *argList)
+   void SetParameters(const char *argList)
    {
       if (!GetWS())
          return;
@@ -125,10 +125,10 @@ public:
 
    /// Specify parameters of interest
    /// using a comma-separated list of arguments already in the workspace.
-   virtual void SetParametersOfInterest(const char *argList) { SetParameters(argList); }
+   void SetParametersOfInterest(const char *argList) { SetParameters(argList); }
 
    /// Specify the nuisance parameters (parameters that are not POI).
-   virtual void SetNuisanceParameters(const RooArgSet &set)
+   void SetNuisanceParameters(const RooArgSet &set)
    {
       if (!SetHasOnlyParameters(set, "ModelConfig::SetNuisanceParameters"))
          return;
@@ -138,7 +138,7 @@ public:
 
    /// Specify the nuisance parameters
    /// using a comma-separated list of arguments already in the workspace.
-   virtual void SetNuisanceParameters(const char *argList)
+   void SetNuisanceParameters(const char *argList)
    {
       if (!GetWS())
          return;
@@ -146,7 +146,7 @@ public:
    }
 
    /// Specify the constraint parameters
-   virtual void SetConstraintParameters(const RooArgSet &set)
+   void SetConstraintParameters(const RooArgSet &set)
    {
       if (!SetHasOnlyParameters(set, "ModelConfig::SetConstrainedParameters"))
          return;
@@ -155,7 +155,7 @@ public:
    }
    /// Specify the constraint parameters
    /// through a comma-separated list of arguments already in the workspace.
-   virtual void SetConstraintParameters(const char *argList)
+   void SetConstraintParameters(const char *argList)
    {
       if (!GetWS())
          return;
@@ -163,7 +163,7 @@ public:
    }
 
    /// Specify the observables.
-   virtual void SetObservables(const RooArgSet &set)
+   void SetObservables(const RooArgSet &set)
    {
       if (!SetHasOnlyParameters(set, "ModelConfig::SetObservables"))
          return;
@@ -172,27 +172,27 @@ public:
    }
    /// specify the observables
    /// through a comma-separated list of arguments already in the workspace.
-   virtual void SetObservables(const char *argList)
+   void SetObservables(const char *argList)
    {
       if (!GetWS())
          return;
       SetObservables(GetWS()->argSet(argList));
    }
 
-   virtual void SetConditionalObservables(const RooArgSet &set);
+   void SetConditionalObservables(const RooArgSet &set);
    /// Specify the conditional observables
    /// through a comma-separated list of arguments already in the workspace.
-   virtual void SetConditionalObservables(const char *argList)
+   void SetConditionalObservables(const char *argList)
    {
       if (!GetWS())
          return;
       SetConditionalObservables(GetWS()->argSet(argList));
    }
 
-   virtual void SetGlobalObservables(const RooArgSet &set);
+   void SetGlobalObservables(const RooArgSet &set);
    /// Specify the global observables
    /// through a comma-separated list of arguments already in the workspace.
-   virtual void SetGlobalObservables(const char *argList)
+   void SetGlobalObservables(const char *argList)
    {
       if (!GetWS())
          return;
@@ -202,7 +202,7 @@ public:
    void SetExternalConstraints(const RooArgSet &set);
    /// Specify the external constraints
    /// through a comma-separated list of arguments already in the workspace.
-   virtual void SetExternalConstraints(const char *argList)
+   void SetExternalConstraints(const char *argList)
    {
       if (!GetWS())
          return;
@@ -211,10 +211,10 @@ public:
 
    /// Set parameter values for a particular hypothesis if using a common PDF
    /// by saving a snapshot in the workspace.
-   virtual void SetSnapshot(const RooArgSet &set);
+   void SetSnapshot(const RooArgSet &set);
 
    /// Specify the name of the PDF in the workspace to be used.
-   virtual void SetPdf(const char *name)
+   void SetPdf(const char *name)
    {
       if (!GetWS())
          return;
@@ -231,7 +231,7 @@ public:
    }
 
    /// Specify the name of the PDF in the workspace to be used.
-   virtual void SetPriorPdf(const char *name)
+   void SetPriorPdf(const char *name)
    {
       if (!GetWS())
          return;
@@ -248,7 +248,7 @@ public:
    }
 
    /// Specify the name of the dataset in the workspace to be used.
-   virtual void SetProtoData(const char *name)
+   void SetProtoData(const char *name)
    {
       if (!GetWS())
          return;

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -29,10 +29,10 @@ public:
   TObject* clone(const char* newname=nullptr) const override { return new RooStringVar(*this,newname); }
 
   // Parameter value and error accessors
-  virtual operator TString() {return TString(_string.c_str()); }
+  operator TString() {return TString(_string.c_str()); }
   const char* getVal() const { clearValueDirty(); return _string.c_str(); }
   void setVal(const char* newVal) { _string = newVal ? newVal : ""; setValueDirty(); }
-  virtual RooAbsArg& operator=(const char* newVal) { setVal(newVal); return *this; }
+  RooAbsArg& operator=(const char* newVal) { setVal(newVal); return *this; }
 
   // We implement a fundamental type of AbsArg that can be stored in a dataset
   bool isFundamental() const override { return true; }
@@ -62,7 +62,7 @@ public:
 protected:
   // Internal consistency checking (needed by RooDataSet)
   bool isValid() const override { return true; }
-  virtual bool isValidString(const char*, bool /*printError=false*/) const { return true; }
+  bool isValidString(const char*, bool /*printError=false*/) const { return true; }
 
   void syncCache(const RooArgSet* /*nset*/ = nullptr) override { }
   void copyCache(const RooAbsArg* source, bool valueOnly=false, bool setValDiry=true) override;

--- a/tree/ntuple/test/ntuple_parallel_writer.cxx
+++ b/tree/ntuple/test/ntuple_parallel_writer.cxx
@@ -93,12 +93,12 @@ TEST(RNTupleParallelWriter, RawPtrWriteEntry)
       // Create two RNTupleFillContext to prepare clusters in parallel.
       auto c1 = writer->CreateFillContext();
       auto e1 = c1->CreateRawPtrWriteEntry();
-      float pt1;
+      float pt1 = 0.f;
       e1->BindRawPtr("pt", &pt1);
 
       auto c2 = writer->CreateFillContext();
       auto e2 = c2->CreateRawPtrWriteEntry();
-      float pt2;
+      float pt2 = 0.f;
       e2->BindRawPtr("pt", &pt2);
 
       // Fill one entry per context and commit a cluster each.


### PR DESCRIPTION
Fixing warnings like:
```txt
In file included from /home/rembserj/code/root/root_src/core/metacling/src/TClingCallFunc.cxx:32:
/home/rembserj/code/root/root_src/core/metacling/src/TCling.h:372:17: warning: virtual method 'GetFunctionName' is inside a 'final' class and can never be overridden [-Wunnecessary-virtual-specifier]
  372 |    virtual void GetFunctionName(const clang::Decl *decl, std::string &name) const;
      |                 ^
1 warning generated.
```
or
```
/home/rembserj/code/root/root_src/tree/ntuple/test/ntuple_parallel_writer.cxx:97:29: warning: variable 'pt1' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
   97 |       e1->BindRawPtr("pt", &pt1);
      |
```