### PR TITLE
[cppyy] Do not run crashing test on macOS

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -1,6 +1,6 @@
 import py, sys, pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, pyunicode, IS_MAC_ARM
+from support import setup_make, pylong, pyunicode, IS_MAC, IS_MAC_ARM
 
 currpath = os.getcwd()
 test_dct = currpath + "/libdatatypesDict"
@@ -1260,7 +1260,7 @@ class TestDATATYPES:
         run(self, cppyy.gbl.sum_uc_data, buf, total)
         run(self, cppyy.gbl.sum_byte_data, buf, total)
 
-    @mark.xfail(run=not IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
+    @mark.xfail(run=not IS_MAC, reason = "Fails on all platforms; crashes on macOS with " \
     "libc++abi: terminating due to uncaught exception")
     def test26_function_pointers(self):
         """Function pointer passing"""


### PR DESCRIPTION
Since commit c12392d94b ("[cling] Remove duplicate EHFrameRegistrationPlugin"), this test is also crashing on mac14 with Intel processor. Since it is failing on all platforms, restrict further where it is run to get back green builds.

FYI @aaronj0 @guitargeek it is not fully clear to me what changed with above commit. Exception handling in general is working, from / through / into interpreted code, but for some reason the test is now crashing with
```
libc++abi: terminating due to uncaught exception of type std::__1::bad_function_call: std::exception
```
If you think it is crucial to understand what has changed for this particular (failing) test, please open a followup issue and assign to me, thanks.