### PR TITLE
[Python] Raise minimum required Python version from 3.8 to 3.9

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [cp38-manylinux_x86_64, cp39-manylinux_x86_64, cp310-manylinux_x86_64, cp311-manylinux_x86_64, cp312-manylinux_x86_64, cp313-manylinux_x86_64]
+        target: [cp39-manylinux_x86_64, cp310-manylinux_x86_64, cp311-manylinux_x86_64, cp312-manylinux_x86_64, cp313-manylinux_x86_64]
     name: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4

--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -137,6 +137,8 @@ If you want to keep using `TList*` return values, you can write a small adapter 
 
 ## Python Interface
 
+ROOT dropped support for Python 3.8, meaning ROOT now requires at least Python 3.9.
+
 ### Deprecate the attribute pythonization of `TDirectory` in favor of item-getting syntax
 
 Since ROOT 6.32, the recommended way to get objects from a `TFile` or any `TDirectory` in general is via `__getitem__`:

--- a/bindings/distrdf/CMakeLists.txt
+++ b/bindings/distrdf/CMakeLists.txt
@@ -47,8 +47,6 @@ endforeach()
 add_custom_target(DistRDF ALL DEPENDS ${py_sources_in_localruntimedir})
 
 # Compile .py files
-# We include DistRDF in the build only if Python 3.8+ is used,
-# so we can directly use the main Python executable to compile the sources
 foreach(py_source ${py_sources})
   install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m py_compile ${localruntimedir}/${py_source})")
   install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${localruntimedir}/${py_source})")

--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -94,14 +94,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
   target_compile_options(CPyCppyy PRIVATE -Wno-cast-function-type)
 endif()
 
-# Disables warnings in Python 3.8 caused by the temporary extra filed for tp_print compatibility
-# (see https://github.com/python/cpython/blob/3.8/Include/cpython/object.h#L260).
-# Note that Python 3.8 is the lowers Python version that is still supported by
-# ROOT, so this compile option can be completely removed soon.
-if(NOT MSVC AND Python3_VERSION VERSION_LESS 3.9)
-  target_compile_options(CPyCppyy PRIVATE -Wno-missing-field-initializers)
-endif()
-
 target_compile_definitions(CPyCppyy PRIVATE NO_CPPYY_LEGACY_NAMESPACE)
 
 target_include_directories(CPyCppyy SYSTEM PUBLIC ${Python3_INCLUDE_DIRS})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -708,7 +708,7 @@ endif()
 if(tmva-pymva)
   list(APPEND python_components NumPy)
 endif()
-find_package(Python3 3.8 COMPONENTS ${python_components})
+find_package(Python3 3.9 COMPONENTS ${python_components})
 
 #---Check for OpenGL installation-------------------------------------------------------
 # OpenGL is required by various graf3d features that are enabled with opengl=ON,

--- a/test/PostInstall/CMakeLists.txt
+++ b/test/PostInstall/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_TESTING)
   set_tests_properties(run-hsimple   PROPERTIES FIXTURES_SETUP    HSIMPLE)
   set_tests_properties(read-hsimple  PROPERTIES FIXTURES_REQUIRED HSIMPLE)
 
-  find_package(Python3 3.8 REQUIRED)
+  find_package(Python3 3.9 REQUIRED)
   # Need to duplicate the import ROOT test because the PASS_REGULAR_EXPRESSION
   # property will disable checking the exit code of the test so import ROOT
   # might fail but ctest would not report it


### PR DESCRIPTION
Python 3.8 has been end-of-life for one year already. The last platform that used it was AlmaLinux 8, but also there it has reached end of life. Instead, RHEL has committed to support Python 3.12 until the end-of-life of RHEL 8 itself:
https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle

Therefore, our CI images for `alma8` also use Python 3.12 now.

And although Python 3.9 has also reached end-of-life now, we still need to support it because it's the system Python version on macOS.

See:
https://devguide.python.org/versions/