### PR TITLE
[v632][RF] Consistent minimizer defaults in `RooAbsPdf::fitTo()`

### DIFF
--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -243,7 +243,7 @@ struct MinimizerConfig {
    int maxCalls = -1;
    int doOffset = -1;
    int parallelize = 0;
-   bool enableParallelGradient = true;
+   bool enableParallelGradient = false;
    bool enableParallelDescent = false;
    bool timingAnalysis = false;
    const RooArgSet *minosSet = nullptr;
@@ -412,8 +412,7 @@ std::unique_ptr<RooAbsReal> createNLLNew(RooAbsPdf &pdf, RooAbsData &data, std::
 
 } // namespace
 
-namespace RooFit {
-namespace FitHelpers {
+namespace RooFit::FitHelpers {
 
 void defineMinimizationOptions(RooCmdConfig &pc)
 {
@@ -437,11 +436,11 @@ void defineMinimizationOptions(RooCmdConfig &pc)
    pc.defineInt("doSumW2", "SumW2Error", 0, minimizerDefaults.doSumW2);
    pc.defineInt("doAsymptoticError", "AsymptoticError", 0, minimizerDefaults.doAsymptotic);
    pc.defineInt("maxCalls", "MaxCalls", 0, minimizerDefaults.maxCalls);
-   pc.defineInt("doOffset", "OffsetLikelihood", 0, 0);
-   pc.defineInt("parallelize", "Parallelize", 0, 0); // Three parallelize arguments
-   pc.defineInt("enableParallelGradient", "ParallelGradientOptions", 0, 0);
-   pc.defineInt("enableParallelDescent", "ParallelDescentOptions", 0, 0);
-   pc.defineInt("timingAnalysis", "TimingAnalysis", 0, 0);
+   pc.defineInt("doOffset", "OffsetLikelihood", 0, minimizerDefaults.doOffset);
+   pc.defineInt("parallelize", "Parallelize", 0, minimizerDefaults.parallelize); // Three parallelize arguments
+   pc.defineInt("enableParallelGradient", "ParallelGradientOptions", 0, minimizerDefaults.enableParallelGradient);
+   pc.defineInt("enableParallelDescent", "ParallelDescentOptions", 0, minimizerDefaults.enableParallelDescent);
+   pc.defineInt("timingAnalysis", "TimingAnalysis", 0, minimizerDefaults.timingAnalysis);
    pc.defineString("mintype", "Minimizer", 0, minimizerDefaults.minType.c_str());
    pc.defineString("minalg", "Minimizer", 1, minimizerDefaults.minAlg.c_str());
    pc.defineSet("minosSet", "Minos", 0, minimizerDefaults.minosSet);
@@ -1058,7 +1057,6 @@ std::unique_ptr<RooFitResult> fitTo(RooAbsReal &real, RooAbsData &data, const Ro
    return RooFit::FitHelpers::minimize(real, *nll, data, pc);
 }
 
-} // namespace FitHelpers
-} // namespace RooFit
+} // namespace RooFit::FitHelpers
 
 /// \endcond


### PR DESCRIPTION
Backport to close #20083.