### PR TITLE
[v632][tutorials] Don't import TensorFlow in TMVA tutorials if tmva-pymva=OFF

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -22,21 +22,24 @@
 ## The difference between signal and background is in the gaussian width.
 ## The width for the background gaussian is slightly larger than the signal width by few % values
 
+import ROOT
+
 import os
 import importlib.util
 
+useKerasCNN = False
+
+if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
+    useKerasCNN = True
+
 opt = [1, 1, 1, 1, 1]
 useTMVACNN = opt[0] if len(opt) > 0  else False
-useKerasCNN = opt[1] if len(opt) > 1 else False
+useKerasCNN = opt[1] if len(opt) > 1 else useKerasCNN
 useTMVADNN = opt[2] if len(opt) > 2 else False
 useTMVABDT = opt[3] if len(opt) > 3 else False
 usePyTorchCNN = opt[4] if len(opt) > 4 else False
 
-tf_spec = importlib.util.find_spec("tensorflow")
-if tf_spec is None:
-    useKerasCNN = False
-    print("TMVA_CNN_Classificaton","Skip using Keras since tensorflow is not installed")
-else:
+if useKerasCNN:
     import tensorflow
 
 # PyTorch has to be imported before ROOT to avoid crashes because of clashing

--- a/tutorials/tmva/TMVA_RNN_Classification.py
+++ b/tutorials/tmva/TMVA_RNN_Classification.py
@@ -154,16 +154,14 @@ maxepochs = 10
 
 nTotEvts = 2000  # total events to be generated for signal or background
 
-useKeras = True
+useKeras = False
 
 useTMVA_RNN = True
 useTMVA_DNN = True
 useTMVA_BDT = False
 
-tf_spec = importlib.util.find_spec("tensorflow")
-if tf_spec is None:
-    useKeras = False
-    ROOT.Warning("TMVA_RNN_Classificaton","Skip using Keras since tensorflow is not installed")
+if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") == "yes":
+    useKeras = True
 
 
 rnn_types = ["RNN", "LSTM", "GRU"]


### PR DESCRIPTION
It's not needed in that case, and like this we avoid LLVM symbol clashes.

Backport of 6e6d7dc.