### PR TITLE
[ntuple] Merger: avoid resealing if not needed

### DIFF
--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -301,6 +301,7 @@ struct RResealFunc {
    ROOT::Internal::RPageAllocator &fPageAlloc;
    std::uint8_t *fBuffer;
    std::size_t fBufSize;
+   const ROOT::RNTupleWriteOptions &fWriteOpts;
 
    void operator()() const
    {
@@ -310,7 +311,7 @@ struct RResealFunc {
       sealConf.fPage = &page;
       sealConf.fBuffer = fBuffer;
       sealConf.fCompressionSettings = *fMergeOptions.fCompressionSettings;
-      sealConf.fWriteChecksum = fSealedPage.GetHasChecksum();
+      sealConf.fWriteChecksum = fWriteOpts.GetEnablePageChecksums();
       assert(fBufSize >= fSealedPage.GetDataSize() + fSealedPage.GetHasChecksum() * sizeof(std::uint64_t));
       auto refSealedPage = RPageSink::SealPage(sealConf);
       fSealedPage = refSealedPage;
@@ -916,6 +917,7 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
                   *fPageAlloc,
                   buffer.get(),
                   bufSize,
+                  mergeData.fDestination.GetWriteOptions()
                });
             } else {
                RTaskVisitor{fTaskGroup}(RChangeCompressionFunc{


### PR DESCRIPTION
Currently we either "fast merge" the page (i.e. we copy it as-is to the destination) or we reseal it if fast merging is not possible (which happens where the compression or the on-disk encoding don't match).
There is a middle ground where we can avoid resealing if only the page compression differs but not the on-disk encoding.
We were not currently leveraging this and doing the extra work of resealing the pages in all cases where just recompression could be done.

With this PR we introduce this middle ground case ("L2 merging", aka "recompress merging") which skips the resealing (thus the re-encoding) of the pages whenever possible.

([see here](https://codimd.web.cern.ch/s/xI6A5V4_w#) for the L2 terminology)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

