### PR TITLE
[CI] Don't upload build caches to S3 for Mac15 and Mac26.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -123,6 +123,25 @@ jobs:
       ${{ (github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && join( matrix.overrides, ', ' )) || '' }}
 
     steps:
+      - name: Node state
+        shell: bash -leo pipefail {0}
+        run: |
+          echo $PATH
+          which cmake || true
+          find /opt -name cmake -type f || true
+          find /usr -name cmake -type f || true
+          cmake --version || true
+          which c++ || true
+          c++ --version || true
+          uname -a || true
+          sw_vers || true
+          uptime || true
+          df || true
+          echo $SHELL
+          echo $0
+          python3 -m site || true
+          pkgutil --pkg-info=com.apple.pkg.CLTools_Executables || true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -203,8 +203,8 @@ jobs:
 
       - name: Update build cache after push to release branch
         shell: bash -leo pipefail {0}
-        if:   github.event_name == 'push'
-        run: ".github/workflows/root-ci-config/build_root.py 
+        if:   ${{ github.event_name == 'push' && !matrix.platform == 'mac15' && !matrix.platform == 'mac26' }}
+        run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      RelWithDebInfo
                     --platform       ${{ matrix.platform }}
                     --incremental    false


### PR DESCRIPTION
For Mac15 and Mac26, the source and build caches aren't used since 4c3335e, so there is no urgent need to generate them at all. Since the Mac VMs sometimes hang for several hours at the upload step, it seems less fragile to not upload or download anything.

