### PR TITLE
Tests: add DEFAULT_ROOT_INCLUDE_PATH where needed

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2370,7 +2370,7 @@ macro(ROOTTEST_COMPILE_MACRO filename)
 
   set(root_compile_macro ${CMAKE_COMMAND} -E env
       ROOT_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}"
-      ROOT_INCLUDE_PATH="${CMAKE_CURRENT_BINARY_DIR}"
+      ROOT_INCLUDE_PATH="${CMAKE_CURRENT_BINARY_DIR}:${DEFAULT_ROOT_INCLUDE_PATH}"
       ${ROOT_root_CMD}
       -e "gSystem->SetBuildDir(\"${CMAKE_CURRENT_BINARY_DIR}\", true)"
       ${RootMacroDirDefines}

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -20,11 +20,11 @@ if(DEFINED ROOT_SOURCE_DIR)  # Testing using the binary tree
     set(ROOT_environ PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}
                      ${ld_library_path}=${CMAKE_BINARY_DIR}/lib:$ENV{${ld_library_path}}
                      ROOTSYS=${CMAKE_BINARY_DIR}
-                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree
+                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree:${DEFAULT_ROOT_INCLUDE_PATH}
                      PYTHONPATH=${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH})
   else()
     set(ROOT_environ ROOTSYS=${CMAKE_BINARY_DIR}
-                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree
+                     ROOT_INCLUDE_PATH=${CMAKE_BINARY_DIR}/tutorials/io/tree:${DEFAULT_ROOT_INCLUDE_PATH}
                      PYTHONPATH=${CMAKE_BINARY_DIR}/bin;$ENV{PYTHONPATH})
   endif()
 else()                       # testing using an installation


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes the tests environments for tests introduced in #19667 when running with externally build VC

Maybe fixes also other tests that are still failing.

## Checklist:

- [x] tested changes locally

