### PR TITLE
Prevent TSVG::Text crash when wrong font id specified [6.36]

### DIFF
--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1793,7 +1793,8 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
    Float_t ftsize;
 
    Int_t font  = abs(fTextFont)/10;
-   if (font > 42 || font < 1) font = 1;
+   if (font > 15 || font < 1)
+      font = 1;
    if (wh < hh) {
       ftsize = fTextSize*fXsize*gPad->GetAbsWNDC();
    } else {


### PR DESCRIPTION
Font outside 1..15 range not exists in SVG and does not supported
When used - ROOT crashes

Backported from https://github.com/root-project/root/pull/20111
