### PR TITLE
[cmake][win] Change the default `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/cmake/modules/SetUpWindows.cmake
+++ b/cmake/modules/SetUpWindows.cmake
@@ -18,6 +18,15 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 
 elseif(MSVC)
+
+  if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    # Change the default install from "C:/Program Files/${PROJECT_NAME}" to
+    # "C:/${PROJECT_NAME}-${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION}"
+    # to prevent having (unsupported) spaces in the install PATH
+    set (CMAKE_INSTALL_PREFIX "C:/${PROJECT_NAME}-${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION}"
+         CACHE PATH "default install path" FORCE)
+  endif()
+
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(ARCH "-wd4267")
     set(ROOT_ARCHITECTURE win64)


### PR DESCRIPTION
Change the default install prefix from `C:/Program Files/${PROJECT_NAME}` to
`C:/${PROJECT_NAME}-${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION}`
to prevent having (unsupported) spaces in the install PATH