### PR TITLE
[core] also print cxx standard into start message

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -988,8 +988,8 @@ TString TApplication::GetSetup()
                                          gROOT->GetGitBranch(),
                                          gROOT->GetGitCommit()));
    }
-   lines.emplace_back(TString::Format("With %s",
-                                      gSystem->GetBuildCompilerVersionStr()));
+   lines.emplace_back(TString::Format("With %s std%ld",
+                                      gSystem->GetBuildCompilerVersionStr(), __cplusplus));
    lines.emplace_back("Binary directory: "+ gROOT->GetBinDir());
    lines.emplace_back("```");
    TString setup = "";

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -542,8 +542,8 @@ void TRint::PrintLogo(Bool_t lite)
                                             gROOT->GetGitBranch(),
                                             gROOT->GetGitCommit()));
       }
-      lines.emplace_back(TString::Format("With %s %%s",
-                                         gSystem->GetBuildCompilerVersionStr()));
+      lines.emplace_back(TString::Format("With %s std%ld %%s",
+                                         gSystem->GetBuildCompilerVersionStr(), __cplusplus));
       lines.emplace_back(TString("Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'%s"));
 
       // Find the longest line and its length:


### PR DESCRIPTION
This is useful, since some bug reports could be traced back to a specific cxx standard that can not be reproduced with others