### PR TITLE
[tmva][sofie] add onnxscript to pypi requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pandas
 dm-sonnet # used for GNNs
 graph_nets
 onnx
+onnxscript
 
 # TMVA: PyMVA interfaces
 scikit-learn


### PR DESCRIPTION
This PR fixes the CI issue of unable to import onnxscript while running some of the SOFIE tests.