### PR TITLE
[tmva][sofie] install onnxscript from within LinearModelGenerator

### DIFF
--- a/tmva/sofie/test/LinearModelGenerator.py
+++ b/tmva/sofie/test/LinearModelGenerator.py
@@ -8,19 +8,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import importlib
-import subprocess
-import sys
-
-package_name = "onnxscript"
-
-try:
-    importlib.import_module(package_name)
-except ImportError:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package_name])
-finally:
-    globals()[package_name] = importlib.import_module(package_name)
-
 result = []
 
 class Net(nn.Module):
@@ -136,7 +123,8 @@ def main():
                 model,
                 xinput,
                 name + ".onnx",
-                export_params=True
+                export_params=True,
+                dynamo=False
         )
 
    if loadModel :


### PR DESCRIPTION
This PR tries to install onnxscript from within the `LinearModelGenertor.py` file if the package does not already exist to avoid failures in the CI.