### PR TITLE
[v626][ci] Set `tmva-sofie=OFF` for all platforms

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -1,4 +1,3 @@
 builtin_gtest=ON
 builtin_nlohmannjson=ON
-builtin_vdt=On
-tmva-sofie=On
+builtin_vdt=ON


### PR DESCRIPTION
It was only switched to `ON` on `alma8`, and with the recent release of PyTorch 2.9.0 three days ago, tests started failing too on that platform.