### PR TITLE
[v630][ci] Set `tmva-sofie=OFF` also on `alma8`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -1,4 +1,3 @@
 builtin_gtest=ON
 builtin_nlohmannjson=ON
-builtin_vdt=On
-tmva-sofie=On
+builtin_vdt=ON


### PR DESCRIPTION
Disabled on most other platforms, and with the recent release of PyTorch 2.9.0 three days ago, tests started failing too on `alma8`.

On `alma9` it is still working, because that platform still uses Python 3.9, which is not supported by PyTorch 2.9.0 and therefore the update was not a problem.