### PR TITLE
Revert "requirements.txt: make sure that cpu version of PyTorch gets installed"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,3 @@ mplhep
 nbconvert>=7.4.0
 pytest
 setuptools
-
-# Look for CPU-only versions of PyTorch to avoid pulling CUDA in the CI docker images.
--f https://download.pytorch.org/whl/cpu/torch_stable.html


### PR DESCRIPTION
This reverts commit 800f97c0c64d7e3968d00d694e4f40dd8cd0ab3c. It doesn't work, pip still pulls in the CUDA dependencies. A proper solution has been implemented during image building.