### PR TITLE
[gui] Avoid several crashes when the images are not found

### DIFF
--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -420,6 +420,8 @@ void TGX11::ClearPixmap(Drawable *pix)
 
 void TGX11::ClearWindow()
 {
+   if (!gCws) return;
+   
    if (!gCws->fIsPixmap && !gCws->fDoubleBuffer) {
       XSetWindowBackground((Display*)fDisplay, gCws->fDrawing, GetColor(0).fPixel);
       XClearWindow((Display*)fDisplay, gCws->fDrawing);

--- a/gui/gui/src/TGListTree.cxx
+++ b/gui/gui/src/TGListTree.cxx
@@ -2551,7 +2551,7 @@ const TGGC &TGListTree::GetColorGC()
 const TGPicture *TGListTree::GetOpenPic()
 {
    if (!fgOpenPic)
-      fgOpenPic = gClient->GetPicture("ofolder_t.xpm");
+      fgOpenPic = gClient->GetPictureOrEmpty("ofolder_t.xpm");
    ((TGPicture *)fgOpenPic)->AddReference();
    return fgOpenPic;
 }
@@ -2562,7 +2562,7 @@ const TGPicture *TGListTree::GetOpenPic()
 const TGPicture *TGListTree::GetClosedPic()
 {
    if (!fgClosedPic)
-      fgClosedPic = gClient->GetPicture("folder_t.xpm");
+      fgClosedPic = gClient->GetPictureOrEmpty("folder_t.xpm");
    ((TGPicture *)fgClosedPic)->AddReference();
    return fgClosedPic;
 }
@@ -2573,7 +2573,7 @@ const TGPicture *TGListTree::GetClosedPic()
 const TGPicture *TGListTree::GetCheckedPic()
 {
    if (!fgCheckedPic)
-      fgCheckedPic = gClient->GetPicture("checked_t.xpm");
+      fgCheckedPic = gClient->GetPictureOrEmpty("checked_t.xpm");
    ((TGPicture *)fgCheckedPic)->AddReference();
    return fgCheckedPic;
 }
@@ -2584,7 +2584,7 @@ const TGPicture *TGListTree::GetCheckedPic()
 const TGPicture *TGListTree::GetUncheckedPic()
 {
    if (!fgUncheckedPic)
-      fgUncheckedPic = gClient->GetPicture("unchecked_t.xpm");
+      fgUncheckedPic = gClient->GetPictureOrEmpty("unchecked_t.xpm");
    ((TGPicture *)fgUncheckedPic)->AddReference();
    return fgUncheckedPic;
 }

--- a/gui/gui/src/TGTextEditor.cxx
+++ b/gui/gui/src/TGTextEditor.cxx
@@ -240,7 +240,7 @@ TGTextEditor::TGTextEditor(const char *filename, const TGWindow *p, UInt_t w,
       fToolBar->RemoveFrame(fComboCmd);
       fLabel->UnmapWindow();
       fToolBar->RemoveFrame(fLabel);
-      fToolBar->GetButton(kM_FILE_EXIT)->SetState(kButtonDisabled);
+      if (auto btn = fToolBar->GetButton(kM_FILE_EXIT); btn) btn->SetState(kButtonDisabled);
       fToolBar->Layout();
    }
    if (filename) {
@@ -412,10 +412,10 @@ void TGTextEditor::Build()
    AddFrame(new TGHorizontal3DLine(this),
             new TGLayoutHints(kLHintsTop | kLHintsExpandX, 0,0,2,2));
 
-   fToolBar->GetButton(kM_EDIT_CUT)->SetState(kButtonDisabled);
-   fToolBar->GetButton(kM_EDIT_COPY)->SetState(kButtonDisabled);
-   fToolBar->GetButton(kM_EDIT_DELETE)->SetState(kButtonDisabled);
-   fToolBar->GetButton(kM_EDIT_PASTE)->SetState(kButtonDisabled);
+   if (auto btn = fToolBar->GetButton(kM_EDIT_CUT); btn) btn->SetState(kButtonDisabled);
+   if (auto btn = fToolBar->GetButton(kM_EDIT_COPY); btn) btn->SetState(kButtonDisabled);
+   if (auto btn = fToolBar->GetButton(kM_EDIT_DELETE); btn) btn->SetState(kButtonDisabled);
+   if (auto btn = fToolBar->GetButton(kM_EDIT_PASTE); btn) btn->SetState(kButtonDisabled);
 
    fTextEdit = new TGTextEdit(this, 10, 10, 1);
    if (gClient->GetStyle() < 2) {
@@ -866,8 +866,8 @@ Bool_t TGTextEditor::HandleTimer(TTimer *t)
    }
    else {
       fMenuEdit->EnableEntry(kM_EDIT_PASTE);
-      if (fToolBar->GetButton(kM_EDIT_PASTE)->GetState() == kButtonDisabled)
-         fToolBar->GetButton(kM_EDIT_PASTE)->SetState(kButtonUp);
+      if (auto btn = fToolBar->GetButton(kM_EDIT_PASTE); btn && btn->GetState() == kButtonDisabled)
+         btn->SetState(kButtonUp);
    }
    // check if text is selected in the editor
    if (fTextEdit->IsMarked()) {
@@ -884,8 +884,8 @@ Bool_t TGTextEditor::HandleTimer(TTimer *t)
       fMenuEdit->DisableEntry(kM_EDIT_CUT);
       fMenuEdit->DisableEntry(kM_EDIT_COPY);
       fMenuEdit->DisableEntry(kM_EDIT_DELETE);
-      if (fToolBar->GetButton(kM_EDIT_CUT)->GetState() == kButtonUp) {
-         fToolBar->GetButton(kM_EDIT_CUT)->SetState(kButtonDisabled);
+      if (auto btn = fToolBar->GetButton(kM_EDIT_CUT); btn && btn->GetState() == kButtonUp) {
+         btn->SetState(kButtonDisabled);
          fToolBar->GetButton(kM_EDIT_COPY)->SetState(kButtonDisabled);
          fToolBar->GetButton(kM_EDIT_DELETE)->SetState(kButtonDisabled);
       }


### PR DESCRIPTION
Opening the classic browser when some pictures are missing causes crashes due to missing checks. With this PR the browser will simply not display the missing elements (and it still works somewhat fine) in such cases.
