### PR TITLE
[Tutorials] Fix uhi test timeouts in matplotlib.

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -37,11 +37,12 @@ else()                       # testing using an installation
   enable_testing()
 endif()
 
-# Set the environment for the tutorials, which is the eventual ROOT_environ
+# - Set the environment for the tutorials, which is the eventual ROOT_environ
 # plus some environment variables related to limiting the number of threads
 # used by NumPy.
 # See: https://stackoverflow.com/questions/30791550/limit-number-of-threads-in-numpy
-set(TUTORIAL_ENV ${ROOT_environ} OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1)
+# - For matplotlib, disable a blocking event loop on show() using a non-interactive backend
+set(TUTORIAL_ENV ${ROOT_environ} OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 MPLBACKEND=AGG)
 
 #---Copy the CTestCustom.cmake file into the build directory--------
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)


### PR DESCRIPTION
On some Mac VMs, `matplotlib.show()` was entering an interactive event loop, which caused four uhi tutorials to time out. By switching matplotlib to the PNG backend, `show()` is skipped as follows:
```
  hist015_TH1_read_and_draw_uhi.py:88: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
    plt.show()
```

The affected tutorials were:
```
2025-10-22T09:19:00.5968120Z    1339 - tutorial-hist-hist003_TH1_draw_uhi-py (Timeout)   python_runtime_deps tutorial
2025-10-22T09:19:00.5968650Z    1341 - tutorial-hist-hist007_TH1_liveupdate_uhi-py (Timeout) python_runtime_deps tutorial
2025-10-22T09:19:00.5969030Z    1343 - tutorial-hist-hist010_TH1_two_scales_uhi-py (Timeout) python_runtime_deps tutorial
2025-10-22T09:19:00.5969410Z    1345 - tutorial-hist-hist015_TH1_read_and_draw_uhi-py (Timeout) python_runtime_deps tutorial
```