### PR TITLE
[tutorials] fix default path in webcanv/trinagle.cxx [skip-ci]

### DIFF
--- a/tutorials/visualisation/webcanv/triangle.cxx
+++ b/tutorials/visualisation/webcanv/triangle.cxx
@@ -79,7 +79,7 @@ void triangle(bool ignore_jsmodule = false)
       if (pos != std::string::npos)
          fdir.resize(pos);
       else
-         fdir = gROOT->GetTutorialsDir() + std::string("/webcanv/");
+         fdir = gROOT->GetTutorialsDir() + std::string("/visualisation/webcanv/");
 
       // location required to load files
       // also it is name of modules path used in importmap


### PR DESCRIPTION
Was not changed after moving tutorial in `visualisation` subfolder