### PR TITLE
[df] Silence Snapshot info message in unittest folder

### DIFF
--- a/tree/dataframe/test/.rootrc
+++ b/tree/dataframe/test/.rootrc
@@ -1,0 +1,1 @@
+ROOT.RDF.Snapshot.Info: 0

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -157,3 +157,5 @@ if(pyroot)
     ROOT_ADD_PYUNITTEST(dataframe_merge_results dataframe_merge_results.py)
   endif()
 endif()
+
+configure_file(.rootrc . COPYONLY)


### PR DESCRIPTION
The unittests do not fail because of this message, but it just adds verbosity to the CI log which is unnecessary.
