### PR TITLE
[v636][ci] Disable `builtin_vc` on `mac15`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac15.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac15.txt
@@ -15,7 +15,6 @@ builtin_openssl=ON
 builtin_pcre=ON
 builtin_tbb=ON
 builtin_unuran=ON
-builtin_vc=ON
 builtin_vdt=ON
 builtin_veccore=ON
 builtin_xrootd=ON


### PR DESCRIPTION
Backport of #20062 to fix CI failures.