### PR TITLE
[tmva] Fix Clang 21 compiler warnings in RBatchLoader

### DIFF
--- a/tmva/tmva/inc/TMVA/BatchGenerator/RBatchGenerator.hxx
+++ b/tmva/tmva/inc/TMVA/BatchGenerator/RBatchGenerator.hxx
@@ -144,7 +144,7 @@ public:
       fChunkLoader =
          std::make_unique<RChunkLoader<Args...>>(f_rdf, fNumEntries, fEntries, fChunkSize, fBlockSize, fValidationSplit,
                                                  fCols, vecSizes, vecPadding, fShuffle, fSetSeed);
-      fBatchLoader = std::make_unique<RBatchLoader>(fChunkSize, fBatchSize, fNumChunkCols);
+      fBatchLoader = std::make_unique<RBatchLoader>(fBatchSize, fNumChunkCols);
 
       // split the dataset into training and validation sets
       fChunkLoader->SplitDataset();


### PR DESCRIPTION
Follow up on #20071.

Fix the following compiler warnings:
```txt
/home/rembserj/code/root/root_src/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx:46:16: warning: private field 'fChunkSize' is not used [-Wunused-private-field]
   46 |    std::size_t fChunkSize;
      |                ^
/home/rembserj/code/root/root_src/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx:49:16: warning: private field 'fMaxBatches' is not used [-Wunused-private-field]
   49 |    std::size_t fMaxBatches;
      |                ^
/home/rembserj/code/root/root_src/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx:50:16: warning: private field 'fTrainingRemainderRow' is not used [-Wunused-private-field]
   50 |    std::size_t fTrainingRemainderRow = 0;
      |                ^
/home/rembserj/code/root/root_src/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx:51:16: warning: private field 'fValidationRemainderRow' is not used [-Wunused-private-field]
   51 |    std::size_t fValidationRemainderRow = 0;
      |                ^
```

Also, use inline namespaces for code brevity and remove some comments that trigger clang-format to not run on the doc string, although it only suggests harmless line breaks that don't change how the rendered doxygen looks like.