### PR TITLE
[ntuple] add exporter option to decompress pages

### DIFF
--- a/tree/ntupleutil/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleExporter.hxx
@@ -50,6 +50,8 @@ public:
          kIncludeChecksums = 0x1,
          /// If enabled, the exporter will report the current progress on the stderr
          kShowProgressBar = 0x2,
+         /// If enabled, uncompress (but don't unpack) the page (mutually exclusive with kIncludeChecksums)
+         kDecompress = 0x04,
 
          kDefaults = kShowProgressBar
       };


### PR DESCRIPTION
Helps for compression studies: to experiment with different compression algorithms, we want to compare packed but uncompressed pages (i.e., different to just uncompressing the file with hadd and exporting the uncompressed file).
