### PR TITLE
[RF] Add protection in RooAbsCollection::contentsString() for empty string

### DIFF
--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1154,7 +1154,9 @@ std::string RooAbsCollection::contentsString() const
     retVal += ",";
   }
 
-  retVal.erase(retVal.end()-1);
+  if (!retVal.empty()) {
+    retVal.erase(retVal.end()-1);
+  }
 
   return retVal;
 }


### PR DESCRIPTION
# This Pull request:
Adds a protection against an empty string in RooAbsCollection::contentsString() to prevent an invalid string creation.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #20189

