### PR TITLE
[Python] Avoid need for manual `__len__` pythonizations by implementing size()

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tarray.py
@@ -48,10 +48,7 @@ def pythonize_tarray(klass, name):
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == 'TArray':
-        # Support `len(a)` as `a.GetSize()`
-        klass.__len__ = klass.GetSize
-    else:
+    if not name == 'TArray':
         # Add checked __getitem__. It has to be directly added to the TArray
         # subclasses, which have a default __getitem__.
         # The new __getitem__ allows to throw pythonic IndexError when index

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
@@ -98,9 +98,6 @@ def pythonize_tcollection(klass):
     # Parameters:
     # klass: class to be pythonized
 
-    # Support `len(c)` as `c.GetEntries()`
-    klass.__len__ = klass.GetEntries
-
     # Add Python lists methods
     klass.append = klass.Add
     klass.remove = _remove_pyz

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tstring.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tstring.py
@@ -16,9 +16,6 @@ def pythonize_tstring(klass):
     # Parameters:
     # klass: class to be pythonized
 
-    # Support `len(s)` as `s.Length()`
-    klass.__len__ = klass.Length
-
     # Add string representation
     klass.__str__  = klass.Data
     klass.__repr__ = lambda self: "'{}'".format(self)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tvector3.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tvector3.py
@@ -18,9 +18,6 @@ def pythonize_tvector3(klass):
     # Parameters:
     # klass: class to be pythonized
 
-    # `len(v)` is always 3
-    klass.__len__ = lambda _: 3
-
     # Add checked __getitem__.
     # Allows to throw pythonic IndexError when index is out of range
     # and to iterate over the vector.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tvectort.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tvectort.py
@@ -18,9 +18,6 @@ def pythonize_tvectort(klass):
     # Parameters:
     # klass: class to be pythonized
 
-    # Support `len(v)` as `v.GetNoElements()`
-    klass.__len__ = klass.GetNoElements
-
     # Add checked __getitem__.
     # Allows to throw pythonic IndexError when index is out of range
     # and to iterate over the vector.

--- a/core/base/inc/TString.h
+++ b/core/base/inc/TString.h
@@ -423,6 +423,7 @@ public:
    Bool_t       IsWhitespace() const   { return (Length() == CountChar(' ')); }
    Ssiz_t       Last(char c) const;
    Ssiz_t       Length() const         { return IsLong() ? GetLongSize() : GetShortSize(); }
+   inline std::size_t size() const { return Length(); }
    Bool_t       MaybeRegexp() const;
    Bool_t       MaybeWildcard() const;
    TString      MD5() const;

--- a/core/cont/inc/TArray.h
+++ b/core/cont/inc/TArray.h
@@ -47,6 +47,8 @@ public:
    Int_t          GetSize() const { return fN; }
    virtual void   Set(Int_t n) = 0;
 
+   inline std::size_t size() const { return GetSize(); }
+
    virtual Double_t GetAt(Int_t i) const = 0;
    virtual void   SetAt(Double_t v, Int_t i) = 0;
 

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -177,6 +177,7 @@ public:
    TObject           *operator()(const char *name) const;
    TObject           *FindObject(const TObject *obj) const override;
    virtual Int_t      GetEntries() const { return GetSize(); }
+   inline std::size_t size() const { return GetEntries(); }
    const char        *GetName() const override;
    virtual TObject  **GetObjectRef(const TObject *obj) const = 0;
    /// Return the *capacity* of the collection, i.e. the current total amount of space that has been allocated so far.

--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -40,6 +40,9 @@ public:
    ~TVector3() override = default;
    // Destructor
 
+   /// The length is always 3. For compatibility with the standard library.
+   constexpr std::size_t size() const { return 3; }
+
    Double_t operator () (int) const;
    inline Double_t operator [] (int) const;
    // Get components by index (Geant4).


### PR DESCRIPTION
We prefer C++ code that get pythonized automatically by the heuristics in `cppyy`. One of these heuristics is the automatic implementation of `__len__` in terms of the `size()` method on the C++ side.