### PR TITLE
[v636][RF] Fix RooAbsCollection::contentsString() for empty collections

### DIFF
--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1154,7 +1154,9 @@ std::string RooAbsCollection::contentsString() const
     retVal += ",";
   }
 
-  retVal.erase(retVal.end()-1);
+  if (!retVal.empty()) {
+    retVal.erase(retVal.end()-1);
+  }
 
   return retVal;
 }


### PR DESCRIPTION
Closes #20189.