### PR TITLE
[v632][RF] Fix RooAbsCollection::contentsString() for empty collections

### DIFF
--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1143,7 +1143,9 @@ std::string RooAbsCollection::contentsString() const
     retVal += ",";
   }
 
-  retVal.erase(retVal.end()-1);
+  if (!retVal.empty()) {
+    retVal.erase(retVal.end()-1);
+  }
 
   return retVal;
 }


### PR DESCRIPTION
Closes #20189.