### PR TITLE
[core] Allow custom path for .rootrc instead of $HOME

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -58,6 +58,7 @@ export CLING_LDSYSPATH=ROOT_LDSYSPATH
 export CLING_CPPSYSINCL=$(LC_ALL=C c++ -xc++ -E -v /dev/null 2>&1 | sed -n '/^.include/,${/^ \/.*++/{p}}' | tr '\n' ':' | tr ' ' ':')
 ```
 This caching reduces sub-process creation during initialization and can be useful when multiple ROOT instances or binaries linked to ROOT are executed (less system-calls, cleaner debugging).
+* It is now possible to read a user configuration file (in jeargon, a "rootrc file") at startup in a custom path instead of the one in the home directory, by specifying its full path with the `ROOTENV_USER_PATH` environment variable.
 
 ## I/O
 

--- a/core/base/src/TEnv.cxx
+++ b/core/base/src/TEnv.cxx
@@ -388,14 +388,20 @@ TString TEnvRec::ExpandValue(const char *value)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a resource table and read the (possibly) three resource files,
-/// i.e.\ `$ROOTSYS/etc/system<name>` (or `ROOTETCDIR/system<name>`),
-/// `$HOME/<name>` and `$PWD/<name>`.
+/// i.e.\ `$ROOTSYS/etc/system<name>` or `ROOTETCDIR/system<name>` 
+/// (kEnvGlobal), `$HOME/<name>` or (kEnvUser),  and `$PWD/<name>` (kEnvLocal).
 /// ROOT always reads ".rootrc" (in TROOT::InitSystem()). You can
 /// read additional user defined resource files by creating additional TEnv
 /// objects. By setting the shell variable ROOTENV_NO_HOME=1 the reading of
 /// the `$HOME/<name>` resource file will be skipped. This might be useful in
 /// case the home directory resides on an auto-mounted remote file system
 /// and one wants to avoid the file system from being mounted.
+/// In case the environment variable ROOTENV_USER_PATH is specified, 
+/// and ROOTENV_NO_HOME is not set, then `$ROOTENV_USER_PATH/<name>` 
+/// is considered instead of `$HOME/<name>`.
+/// If environment variables have to be avoided, a `rootlogon.C` script 
+/// can be created where where the environment can be set through an
+/// invocation of TEnv::ReadFile.
 
 TEnv::TEnv(const char *name)
 {
@@ -412,14 +418,23 @@ TEnv::TEnv(const char *name)
       char *s = gSystem->ConcatFileName(TROOT::GetEtcDir(), sname);
       ReadFile(s, kEnvGlobal);
       delete [] s;
+
       if (!gSystem->Getenv("ROOTENV_NO_HOME")) {
-         s = gSystem->ConcatFileName(gSystem->HomeDirectory(), name);
-         ReadFile(s, kEnvUser);
-         delete [] s;
-         if (strcmp(gSystem->HomeDirectory(), gSystem->WorkingDirectory()))
+         if (const auto rootrcPath = gSystem->Getenv("ROOTENV_USER_PATH")) {
+            s = gSystem->ConcatFileName(rootrcPath, name);
+            ReadFile(s, kEnvUser);
+            delete[] s;
+         } else {
+            s = gSystem->ConcatFileName(gSystem->HomeDirectory(), name);
+            ReadFile(s, kEnvUser);
+            delete[] s;
+         }
+         if (strcmp(gSystem->HomeDirectory(), gSystem->WorkingDirectory())) {
             ReadFile(name, kEnvLocal);
-      } else
+         }
+      } else {
          ReadFile(name, kEnvLocal);
+      }
    }
 }
 

--- a/roottest/root/core/CMakeLists.txt
+++ b/roottest/root/core/CMakeLists.txt
@@ -1,5 +1,9 @@
 ROOTTEST_ADD_TESTDIRS()
 
+ROOTTEST_ADD_TEST(customRootrcPath
+                  MACRO customRootrcPath.C
+                  ENVIRONMENT ROOTENV_USER_PATH=${CMAKE_CURRENT_SOURCE_DIR}/customrootc)
+
 ROOTTEST_ADD_TEST(lifetime
                   MACRO lifetime.C
                   OUTREF lifetime.ref)

--- a/roottest/root/core/customRootrcPath.C
+++ b/roottest/root/core/customRootrcPath.C
@@ -1,0 +1,14 @@
+int customRootrcPath()
+{
+
+   if (!gSystem->Getenv("ROOTENV_USER_PATH")) {
+      cerr << "Error: env variable 'ROOTENV_USER_PATH' cannot be found." << endl;
+      return 1;
+   }
+
+   if (1 != gEnv->GetValue("customVal.customVal", (int)-1)) {
+      cerr << "Error: variable customVal is not 1" << endl;
+      return 2;
+   }
+   return 0;
+}

--- a/roottest/root/core/customrootc/.rootrc
+++ b/roottest/root/core/customrootc/.rootrc
@@ -1,0 +1,1 @@
+customVal.customVal: 1


### PR DESCRIPTION
via environment variable ROOTENV_USER_PATH.

Fixes #20132
