### PR TITLE
[core] Avoid anonymous version tag in libCling version script

### DIFF
--- a/core/metacling/src/libCling.script
+++ b/core/metacling/src/libCling.script
@@ -8,6 +8,4 @@ LIBCLING_1_0 {
     ROOT_rootcling_Driver;
     _ZN5cling*;
     cling_runtime_internal_throwIfInvalidPointer;
-  local:
-    *;
 };


### PR DESCRIPTION
Follows up on 4f29a50 by adding a version name to the libCling version script.

This avoids build errors like the following in pedantic environments:

```txt
[ 29%] Linking CXX shared library ../../../lib/libCling.so
/nix/store/416ykpc2bksb90sd1ia8cybxb3p83mrd-binutils-2.44/bin/ld: anonymous version tag cannot be combined with other version tags
collect2: error: ld returned 1 exit status
make[2]: *** [core/metacling/src/CMakeFiles/Cling.dir/build.make:338: lib/libCling.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:7467: core/metacling/src/CMakeFiles/Cling.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```