### PR TITLE
[cling] Enable cling to be built with Emscripten

### DIFF
--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -118,7 +118,7 @@ else()
   endif()
 endif()
 
-if( NOT "NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
+if( NOT "NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD AND NOT EMSCRIPTEN)
   message(FATAL_ERROR "NVPTX backend is not activated\n"
     "Please enable it via -DLLVM_TARGETS_TO_BUILD=\"host;NVPTX\"")
 endif()

--- a/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalCUDADeviceCompiler.cpp
@@ -92,13 +92,13 @@ namespace cling {
       llvm::errs() << "Could not create PTX interpreter instance\n";
       return;
     }
-
+#ifndef __EMSCRIPTEN__
     // initialize NVPTX backend
     LLVMInitializeNVPTXTargetInfo();
     LLVMInitializeNVPTXTarget();
     LLVMInitializeNVPTXTargetMC();
     LLVMInitializeNVPTXAsmPrinter();
-
+#endif
     m_Init = true;
   }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This change enables cling to be built with Emscripten. The Emscripten build of cling doesn't currently work, but these changes allow it to build. If this goes in I will begin debugging what changes are needed to enable it to function in a web browser and node through CppInterOp, which has an Emscripten ci (including tests).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

