### PR TITLE
[ntuple] fix automatic schema evolution into map

### DIFF
--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -936,8 +936,7 @@ std::unique_ptr<ROOT::RFieldBase> ROOT::RMapField::CloneImpl(std::string_view ne
 
 void ROOT::RMapField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
 {
-   static const std::vector<std::string> prefixesRegular = {"std::map<", "std::unordered_map<", "std::set<",
-                                                            "std::unordered_set<"};
+   static const std::vector<std::string> prefixesRegular = {"std::map<", "std::unordered_map<"};
 
    EnsureMatchingOnDiskField(desc, kDiffTypeName).ThrowOnError();
 

--- a/tree/ntuple/test/ntuple_evolution_type.cxx
+++ b/tree/ntuple/test/ntuple_evolution_type.cxx
@@ -628,8 +628,8 @@ TEST(RNTupleEvolution, Collections)
    ReadCollectionFail<std::map<short int, short int>, true>("proxyOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::map<short int, short int>, true>("vectorOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::map<short int, short int>, true>("rvecOfPairs", fileGuard.GetPath());
-   ReadCollection<std::map<short int, short int>, true>("setOfPairs", fileGuard.GetPath());
-   ReadCollection<std::map<short int, short int>, true>("unordered_setOfPairs", fileGuard.GetPath());
+   ReadCollectionFail<std::map<short int, short int>, true>("setOfPairs", fileGuard.GetPath());
+   ReadCollectionFail<std::map<short int, short int>, true>("unordered_setOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::map<short int, short int>, true>("multisetOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::map<short int, short int>, true>("unordered_multisetOfPairs", fileGuard.GetPath());
    ReadCollection<std::map<short int, short int>, true>("unordered_map", fileGuard.GetPath());
@@ -640,8 +640,8 @@ TEST(RNTupleEvolution, Collections)
    ReadCollectionFail<std::unordered_map<short int, short int>, true>("proxyOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::unordered_map<short int, short int>, true>("vectorOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::unordered_map<short int, short int>, true>("rvecOfPairs", fileGuard.GetPath());
-   ReadCollection<std::unordered_map<short int, short int>, true>("setOfPairs", fileGuard.GetPath());
-   ReadCollection<std::unordered_map<short int, short int>, true>("unordered_setOfPairs", fileGuard.GetPath());
+   ReadCollectionFail<std::unordered_map<short int, short int>, true>("setOfPairs", fileGuard.GetPath());
+   ReadCollectionFail<std::unordered_map<short int, short int>, true>("unordered_setOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::unordered_map<short int, short int>, true>("multisetOfPairs", fileGuard.GetPath());
    ReadCollectionFail<std::unordered_map<short int, short int>, true>("unordered_multisetOfPairs", fileGuard.GetPath());
    ReadCollection<std::unordered_map<short int, short int>, true>("map", fileGuard.GetPath());


### PR DESCRIPTION
Don't evolve an on-disk std::set<std::pair<...>> into a std::map<...>, because the uniqueness of the pair does not imply uniqueness of the key.
