### PR TITLE
[clad] Bump clad to v2.2.

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -74,7 +74,7 @@ if (DEFINED CLAD_SOURCE_DIR)
   list(APPEND _clad_extra_settings SOURCE_DIR ${CLAD_SOURCE_DIR})
 else()
   list(APPEND _clad_extra_settings GIT_REPOSITORY https://github.com/vgvassilev/clad.git)
-  list(APPEND _clad_extra_settings GIT_TAG v2.1)
+  list(APPEND _clad_extra_settings GIT_TAG v2.2)
 endif()
 
 ## list(APPEND _clad_patches_list "patch1.patch" "patch2.patch")


### PR DESCRIPTION
Clad 2.2, delivers improvements to differentiation pipelines, feature coverage, and language compatibility. It now supports clang versions 11–21, includes better handling of pointer, tensor, and reference types, and adds conversion operator and `std::reference_wrapper` support. Forward mode gains experimental OpenMP differentiation, while reverse mode introduces loop checkpointing, elidable reverse passes, and enhanced handling of complex expressions and memory operations. CUDA support expands with new Thrust operations, device vector support, and a logistic regression demo. The release also improves thread safety through lock-controlled tape access, refines error handling and diagnostics, and simplifies attribute-based memory management.
