### PR TITLE
[skip-ci][tutorials] refactor roofit tutorial

### DIFF
--- a/tutorials/roofit/roofit/rf615_simulation_based_inference.py
+++ b/tutorials/roofit/roofit/rf615_simulation_based_inference.py
@@ -33,8 +33,8 @@
 ## \date July 2024
 ## \author Robin Syring
 
-import ROOT
 import numpy as np
+import ROOT
 from sklearn.neural_network import MLPClassifier
 
 # The samples used for training the classifier in this tutorial / rescale for more accuracy
@@ -45,8 +45,7 @@ ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.WARNING)
 
 
 # Morphing as a baseline
-def morphing(setting):
-
+def morphing(setting, workspace):
     # Define binning for morphing
     grid = ROOT.RooMomentMorphFuncND.Grid(ROOT.RooBinning(4, 0.0, 4.0))
     x_var.setBins(50)
@@ -199,7 +198,7 @@ nllr_learned = pdf_learned.createNLL(obs_data)
 ROOT.SetOwnership(nllr_learned, True)
 
 # Compute the morphed nll
-morphing(ROOT.RooMomentMorphFuncND.Linear)
+morphing(ROOT.RooMomentMorphFuncND.Linear, workspace)
 nll_morph = workspace["morph"].createNLL(obs_data)
 ROOT.SetOwnership(nll_morph, True)
 


### PR DESCRIPTION
[This failure](https://github.com/root-project/root/actions/runs/18940952328/job/54110599747) appeared when testing the python wheels in #19600:

```shell
    legend2.SetFillColor("kWhite")
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: none of the 2 overloaded methods succeeded. Full details:
  void TAttFill::SetFillColor(TColorNumber) =>
    TypeError: could not convert argument 1
  short conversion expects an integer object
```