### PR TITLE
[ci] Pin `gcovr` < 8.4

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           dnf -y update
           dnf -y install lcov
-          pip3 install gcovr
+          pip3 install "gcovr<8.4"
 
       # This checks out the merge commit if this is a PR
       - name: Checkout


### PR DESCRIPTION
There are some changes in `gcovr` version 8.4 that currently result in incorrect missed lines. Pin to a lower version for the time being.

Closes #20047