### PR TITLE
Enable XRootD redirection when opening file on EOS

### DIFF
--- a/io/io/src/RRawFile.cxx
+++ b/io/io/src/RRawFile.cxx
@@ -21,6 +21,28 @@
 #include "TPluginManager.h"
 #include "TROOT.h"
 
+// XRootD protocol redirection
+#ifdef R__UNIX
+
+#ifdef R__FBSD
+#include <sys/extattr.h>
+#else
+#include <sys/xattr.h>
+#endif
+
+#ifdef R__MACOSX
+/* On macOS getxattr takes two extra arguments that should be set to 0 */
+#define getxattr(path, name, value, size) getxattr(path, name, value, size, 0u, 0)
+#endif
+
+#ifdef R__FBSD
+#define getxattr(path, name, value, size) extattr_get_file(path, EXTATTR_NAMESPACE_USER, name, value, size)
+#endif
+
+#include "TEnv.h"
+
+#endif
+
 #include <algorithm>
 #include <cctype> // for towlower
 #include <cerrno>
@@ -68,6 +90,23 @@ ROOT::Internal::RRawFile::Create(std::string_view url, ROptions options)
 #ifdef _WIN32
       return std::unique_ptr<RRawFile>(new RRawFileWin(url, options));
 #else
+      // If URL is a file on an EOS FUSE mount, attempt redirection to XRootD protocol.
+      if (gEnv->GetValue("TFile.CrossProtocolRedirects", 1) == 1) {
+         // At the moment the url parameter can only be the file name
+         ssize_t len = getxattr(url.data(), "eos.url.xroot", nullptr, 0);
+         if (len > 0) {
+            std::string xurl(len, 0);
+            std::string fileNameFromUrl{url.data()};
+            if (getxattr(fileNameFromUrl.c_str(), "eos.url.xroot", &xurl[0], len) == len) {
+               // Sometimes the `getxattr` call may return an invalid URL due
+               // to the POSIX attribute not being yet completely filled by EOS.
+               if (auto baseName = fileNameFromUrl.substr(fileNameFromUrl.find_last_of("/") + 1);
+                   std::equal(baseName.crbegin(), baseName.crend(), xurl.crbegin())) {
+                  return Create(xurl, options);
+               }
+            }
+         }
+      }
       return std::unique_ptr<RRawFile>(new RRawFileUnix(url, options));
 #endif
    }


### PR DESCRIPTION
Fixes #20213

With these changes I can see the redirection happening when reading an RNTuple on EOS from lxplus (going from `ntpl001_staff.root` to `root://eoshome-v.cern.ch//eos/user/v/vpadulan/ntpl001_staff.root`

```
Breakpoint 1, ROOT::Internal::RRawFile::Create (url=..., options=...) at /tmp/vpadulan/root/io/io/src/RRawFile.cxx:88       
88         std::string transport = GetTransport(url);                                                                       
(gdb) n  
89         if (transport == "file") {
(gdb) p url                                                                                                                 
$1 = {_M_len = 18, _M_str = 0x4030a3 "ntpl001_staff.root"}  
[...]
103                    if (auto baseName = fileNameFromUrl.substr(fileNameFromUrl.find_last_of("/") + 1);
(gdb) 
105                       return Create(xurl, options);
(gdb) s
[...]
Breakpoint 1, ROOT::Internal::RRawFile::Create (url=..., options=...) at /tmp/vpadulan/root/io/io/src/RRawFile.cxx:88       
88         std::string transport = GetTransport(url);                                                                       
(gdb) n                                                                                                                     
89         if (transport == "file") {                                                                                       
(gdb) 
113        if (transport == "http" || transport == "https" ||
(gdb) p url
$8 = {_M_len = 64, _M_str = 0x136a790 "root://eoshome-v.cern.ch//eos/user/v/vpadulan/ntpl001_staff.root"}
(gdb) p transport
$9 = {static npos = 18446744073709551615, 
  _M_dataplus = {<std::allocator<char>> = {<std::__new_allocator<char>> = {<No data fields>}, <No data fields>}, 
    _M_p = 0x7fffffffa230 "root"}, _M_string_length = 4, {
    _M_local_buf = "root\000\177\000\000\220\242\377\377\377\177\000", _M_allocated_capacity = 139639930187634}}
(gdb) 
```

There might be more places where the redirection needs to happen though.