### PR TITLE
Implement `TAnnotation::SavePrimitive`

### DIFF
--- a/graf2d/gpad/inc/TAnnotation.h
+++ b/graf2d/gpad/inc/TAnnotation.h
@@ -30,6 +30,7 @@ public:
    void Paint(Option_t *option="") override;
    void PaintAnnotation(Double_t x, Double_t y, Double_t z, Double_t angle, Double_t size, const Char_t *text);
    void Print(Option_t *option="") const override;
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    void SetZ(double z) { fZ = z; } // *MENU*
    double GetZ() const { return fZ; }

--- a/graf2d/gpad/src/TAnnotation.cxx
+++ b/graf2d/gpad/src/TAnnotation.cxx
@@ -131,3 +131,21 @@ void TAnnotation::Print(Option_t *) const
    if (GetTextAngle() != 0 ) printf(" Angle=%f",GetTextAngle());
    printf("\n");
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Save primitives in this pad on the C++ source file out.
+
+void TAnnotation::SavePrimitive(std::ostream &out, Option_t *option)
+{
+   SavePrimitiveConstructor(
+      out, Class(), "annotation",
+      TString::Format("%g, %g, %g, \"%s\"", fX, fY, fZ, TString(GetTitle()).ReplaceSpecialCppChars().Data()), kFALSE);
+
+   SaveTextAttributes(out, "annotation", 11, 0, 1, 62, 0.05);
+   SaveLineAttributes(out, "annotation", 1, 1, 1);
+
+   if (TestBit(kTextNDC))
+      out << "   annotation->SetNDC();\n";
+
+   SavePrimitiveDraw(out, "annotation", option);
+}


### PR DESCRIPTION
Was stored before as `TLatex` object without Z coordinate
