### PR TITLE
[hist] prevent Unzoom from Zooming in

### DIFF
--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -1268,7 +1268,7 @@ void TAxis::UnZoom()
 
    //unzoom object owning this axis
    SetRange(0,0);
-   TH1 *hobj1 = GetParent() && GetParent()->InheritsFrom(TH1::Class()) ? static_cast<TH1 *>(GetParent()) : nullptr;
+   TH1 *hobj1 = dynamic_cast<TH1 *>(GetParent());
    if (!strstr(GetName(),"xaxis")) {
       if (!hobj1) return;
       if (hobj1->GetDimension() == 2) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Default drawing histogram option is to leave a YMARGIN range of 10% in YMAX. So if you call Unzoom, it was calling GetMaximum, which calculated the exact maximum, and then called SetMaximum, thus overwriting the stored value. Use instead GetMaximumStored to prevent recalculation if not set by user.

Also add sanity check before casting

Reproducer:

```
TH1F h("h", "", 100, 0, 10);
h->Fill(2);
h.Draw();
h.GetYaxis()->UnZoom(); // This zooms in rather than out.
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

