### PR TITLE
[tutorials] Return void instead of TCanvas* in histogram tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -550,13 +550,6 @@ set(returncode_1 math/fit/fit2a.C
                  visualisation/graphics/tmathtext.C visualisation/graphics/tmathtext2.C
                  visualisation/graphs/gr106_exclusiongraph.C
                  visualisation/graphs/gr016_struct.C
-                 hist/hist102_TH2_contour_list.C
-                 hist/hist006_TH1_bar_charts.C
-                 hist/hist037_TH2Poly_boxes.C
-                 hist/hist060_TH1_stats.C
-                 hist/hist014_TH1_cumulative.C
-                 hist/hist004_TH1_labels.C
-                 hist/hist036_TH2_labels.C
                  analysis/tree/h1analysis.C
                  math/chi2test.C
                  math/r/SimpleFitting.C)

--- a/tutorials/hist/hist004_TH1_labels.C
+++ b/tutorials/hist/hist004_TH1_labels.C
@@ -11,7 +11,7 @@
 /// \date November 2024
 /// \author Rene Brun
 
-TCanvas *hist004_TH1_labels()
+void hist004_TH1_labels()
 {
    // Create the histogram
    const std::array people{"Jean",    "Pierre", "Marie",    "Odile",   "Sebastien", "Fons",  "Rene",
@@ -56,6 +56,4 @@ TCanvas *hist004_TH1_labels()
    pt->AddText(" \">\"   to sort by decreasing values");
    pt->AddText(" \"<\"   to sort by increasing values");
    pt->Draw();
-
-   return c1;
 }

--- a/tutorials/hist/hist006_TH1_bar_charts.C
+++ b/tutorials/hist/hist006_TH1_bar_charts.C
@@ -9,7 +9,7 @@
 /// \date November 2024
 /// \author Rene Brun
 
-TCanvas *hist006_TH1_bar_charts()
+void hist006_TH1_bar_charts()
 {
    // Try to open first the file cernstaff.root in tutorials/io/tree directory
    TString filedir = gROOT->GetTutorialDir();
@@ -28,14 +28,14 @@ TCanvas *hist006_TH1_bar_charts()
    auto file = std::unique_ptr<TFile>(TFile::Open(filename, "READ"));
    if (!file) {
       Error("hist006_TH1_bar_charts", "file cernstaff.root not found");
-      return nullptr;
+      return;
    }
 
    // Retrieve the TTree named "T" contained in the file
    auto tree = file->Get<TTree>("T");
    if (!tree) {
       Error("hist006_TH1_bar_charts", "Tree T is not present in file %s", file->GetName());
-      return nullptr;
+      return;
    }
    tree->SetFillColor(45);
 
@@ -88,6 +88,4 @@ TCanvas *hist006_TH1_bar_charts()
    legend->Draw();
 
    c1->cd();
-
-   return c1;
 }

--- a/tutorials/hist/hist014_TH1_cumulative.C
+++ b/tutorials/hist/hist014_TH1_cumulative.C
@@ -17,7 +17,7 @@
 #include "TCanvas.h"
 #include "TRandom.h"
 
-TCanvas *hist014_TH1_cumulative()
+void hist014_TH1_cumulative()
 {
    TH1 *h = new TH1D("h", "h", 100, -5., 5.);
    gRandom->SetSeed();
@@ -37,6 +37,4 @@ TCanvas *hist014_TH1_cumulative()
    c->cd(2);
    hc->Draw();
    c->Update();
-
-   return c;
 }

--- a/tutorials/hist/hist036_TH2_labels.C
+++ b/tutorials/hist/hist036_TH2_labels.C
@@ -9,7 +9,7 @@
 /// \date July 2016
 /// \author Rene Brun
 
-TCanvas *hist036_TH2_labels()
+void hist036_TH2_labels()
 {
    const Int_t nx = 12;
    const Int_t ny = 20;
@@ -44,5 +44,4 @@ TCanvas *hist036_TH2_labels()
    pt->AddText(" \">\"   to sort by decreasing values");
    pt->AddText(" \"<\"   to sort by increasing values");
    pt->Draw();
-   return c1;
 }

--- a/tutorials/hist/hist037_TH2Poly_boxes.C
+++ b/tutorials/hist/hist037_TH2Poly_boxes.C
@@ -10,7 +10,7 @@
 /// \date August 2016
 /// \author Olivier Couet
 
-TCanvas *hist037_TH2Poly_boxes()
+void hist037_TH2Poly_boxes()
 {
    TCanvas *ch2p2 = new TCanvas("ch2p2", "ch2p2", 600, 400);
    gStyle->SetPalette(57);
@@ -44,5 +44,4 @@ TCanvas *hist037_TH2Poly_boxes()
    }
 
    h2p->Draw("COLZ");
-   return ch2p2;
 }

--- a/tutorials/hist/hist060_TH1_stats.C
+++ b/tutorials/hist/hist060_TH1_stats.C
@@ -13,7 +13,7 @@
 /// \date August 2016
 /// \author  Olivier Couet
 
-TCanvas *hist060_TH1_stats()
+void hist060_TH1_stats()
 {
    // Create and plot a test histogram with stats
    TCanvas *se = new TCanvas;
@@ -44,5 +44,4 @@ TCanvas *hist060_TH1_stats()
    h->SetStats(0);
 
    se->Modified();
-   return se;
 }

--- a/tutorials/hist/hist102_TH2_contour_list.C
+++ b/tutorials/hist/hist102_TH2_contour_list.C
@@ -20,7 +20,7 @@
 
 Double_t SawTooth(Double_t x, Double_t WaveLen);
 
-TCanvas *hist102_TH2_contour_list()
+void hist102_TH2_contour_list()
 {
 
    const Double_t PI = TMath::Pi();
@@ -91,7 +91,7 @@ TCanvas *hist102_TH2_contour_list()
 
    if (!conts) {
       printf("*** No Contours Were Extracted!\n");
-      return nullptr;
+      return;
    }
 
    TList *contLevel = nullptr;
@@ -157,7 +157,6 @@ TCanvas *hist102_TH2_contour_list()
    printf("\n\n\tExtracted %d Contours and %d Graphs \n", TotalConts, nGraphs);
    gStyle->SetTitleW(0.);
    gStyle->SetTitleH(0.);
-   return c1;
 }
 
 Double_t SawTooth(Double_t x, Double_t WaveLen)


### PR DESCRIPTION
# This Pull request:
Update the histogram tutorials to return `void` instead of a `TCanvas*`, which is also the convention used in other ROOT tutorials.

This is required for testing in the Python wheels workflow #19600 since running `root tutorial.C` in this context returns code `255` , causing `pytest` to flag the test as failed.

See failure message:
```bash
FAILED test/wheels/test_tutorials.py::test_cpp_tutorial[hist004_TH1_labels.C] - subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.11.14/x64/bin/root', '-b', '-q', '/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/ROOT/tutorials/hist/hist004_TH1_labels.C']' returned non-zero exit status 255.
```

## Checklist:

- [x] tested changes locally