### PR TITLE
[v626][ci] Set `gfal=OFF` for all almas

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma8.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma8.txt
@@ -1,3 +1,4 @@
 builtin_gtest=ON
 builtin_nlohmannjson=ON
 builtin_vdt=ON
+gfal=OFF

--- a/.github/workflows/root-ci-config/buildconfig/alma9.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9.txt
@@ -1,3 +1,4 @@
 BLA_VENDOR=OpenBLAS
 builtin_vdt=ON
+gfal=OFF
 tmva-cpu=OFF


### PR DESCRIPTION
This is done for compatibility reasons, because gfal2 is not available on the standard AlmaLinux docker images. The `gfal` features are still tested on the Ubuntus.