### PR TITLE
[hist] Implement `RHistEngine::SetBinContent`

### DIFF
--- a/hist/histv7/doc/DesignImplementation.md
+++ b/hist/histv7/doc/DesignImplementation.md
@@ -58,11 +58,12 @@ Special arguments are passed last.
 Examples include
 ```cpp
 template <typename... A> void Fill(const std::tuple<A...> &args, RWeight w);
-template <std::size_t N> void SetBinContent(const std::array<RBinIndex, N> &indices, const BinContentType &content);
+template <std::size_t N, typename V> void SetBinContent(const std::array<RBinIndex, N> &indices, const V &value);
 ```
-The same works for the variadic function templates that will check the type of the last argument.
+Note that we accept mandatory arguments with a template type as well to allow automatic conversion.
 
-For profiles, we accept the value with a template type as well to allow automatic conversion to `double`, for example from `int`.
+Variadic function templates receive all arguments in a single function parameter pack.
+For optional arguments, the function will check the type of the last argument to determine if it was passed.
 
 ## Miscellaneous
 

--- a/hist/histv7/test/hist_engine.cxx
+++ b/hist/histv7/test/hist_engine.cxx
@@ -71,6 +71,55 @@ TEST(RHistEngine, GetBinContentNotFound)
    EXPECT_THROW(engine.GetBinContent(Bins), std::invalid_argument);
 }
 
+TEST(RHistEngine, SetBinContent)
+{
+   static constexpr std::size_t Bins = 20;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<int> engine({axis});
+
+   const RBinIndex index(7);
+   engine.SetBinContent(index, 42);
+   EXPECT_EQ(engine.GetBinContent(index), 42);
+
+   const std::array<RBinIndex, 1> indices = {index};
+   engine.SetBinContent(indices, 43);
+   EXPECT_EQ(engine.GetBinContent(indices), 43);
+
+   // This also works if the value must be converted to the bin content type.
+   RHistEngine<float> engineF({axis});
+   engineF.SetBinContent(index, 42);
+   EXPECT_EQ(engineF.GetBinContent(index), 42);
+
+   engineF.SetBinContent(indices, 43);
+   EXPECT_EQ(engineF.GetBinContent(indices), 43);
+}
+
+TEST(RHistEngine, SetBinContentInvalidNumberOfArguments)
+{
+   static constexpr std::size_t Bins = 20;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<int> engine1({axis});
+   ASSERT_EQ(engine1.GetNDimensions(), 1);
+   RHistEngine<int> engine2({axis, axis});
+   ASSERT_EQ(engine2.GetNDimensions(), 2);
+
+   EXPECT_NO_THROW(engine1.SetBinContent(1, 0));
+   EXPECT_THROW(engine1.SetBinContent(1, 2, 0), std::invalid_argument);
+
+   EXPECT_THROW(engine2.SetBinContent(1, 0), std::invalid_argument);
+   EXPECT_NO_THROW(engine2.SetBinContent(1, 2, 0));
+   EXPECT_THROW(engine2.SetBinContent(1, 2, 3, 0), std::invalid_argument);
+}
+
+TEST(RHistEngine, SetBinContentNotFound)
+{
+   static constexpr std::size_t Bins = 20;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<int> engine({axis});
+
+   EXPECT_THROW(engine.SetBinContent(Bins, 0), std::invalid_argument);
+}
+
 TEST(RHistEngine, Add)
 {
    static constexpr std::size_t Bins = 20;

--- a/hist/histv7/test/hist_user.cxx
+++ b/hist/histv7/test/hist_user.cxx
@@ -6,6 +6,12 @@
 struct User {
    double fValue = 0;
 
+   User &operator=(double value)
+   {
+      fValue = value;
+      return *this;
+   }
+
    User &operator++()
    {
       fValue++;
@@ -118,4 +124,20 @@ TEST(RHistEngineUser, FillWeight)
    EXPECT_EQ(engine.GetBinContent(RBinIndex(8)).fValue, 0.8);
    std::array<RBinIndex, 1> indices = {9};
    EXPECT_EQ(engine.GetBinContent(indices).fValue, 0.9);
+}
+
+TEST(RHistEngineUser, SetBinContent)
+{
+   // Setting uses operator=
+   static constexpr std::size_t Bins = 20;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<User> engine({axis});
+
+   const RBinIndex index(7);
+   engine.SetBinContent(index, 42);
+   EXPECT_EQ(engine.GetBinContent(index).fValue, 42);
+
+   const std::array<RBinIndex, 1> indices = {index};
+   engine.SetBinContent(indices, 43);
+   EXPECT_EQ(engine.GetBinContent(indices).fValue, 43);
 }


### PR DESCRIPTION
This needs one indirection to construct the `std::array` of indices with the right (number of) elements.