### PR TITLE
[RF][HS3] Remove redundant check in variable export

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1016,11 +1016,6 @@ void RooJSONFactoryWSTool::exportVariable(const RooAbsArg *v, JSONNode &node)
       return;
    }
 
-   // this variable was already exported
-   if (findNamedChild(node, v->GetName())) {
-      return;
-   }
-
    JSONNode &var = appendNamedChild(node, v->GetName());
 
    if (cv) {


### PR DESCRIPTION
The check for already added variables was redundant, because in the `exportObject()` function we already check if a given argument was already exported, tracking this in a standard map.

This drastically reduces performance and memory usage, because the lookup in the JSON itself was very slow and memory hungry, because of some caching that nlohmann-json tries to do when looking up in array collections.

Fixes a problem reported by @kratsg. To be backported to the affected previous releases.