### PR TITLE
[cmake][win] Fix error in root_compile_macro

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2368,8 +2368,9 @@ macro(ROOTTEST_COMPILE_MACRO filename)
     list(APPEND RootMacroDirDefines "-e;#define ${d}")
   endforeach()
 
+  cmake_path(CONVERT "${CMAKE_CURRENT_BINARY_DIR}" TO_NATIVE_PATH_LIST NATIVE_BINARY_DIR)
   set(root_compile_macro ${CMAKE_COMMAND} -E env
-      ROOT_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}"
+      ROOT_LIBRARY_PATH="${NATIVE_BINARY_DIR}"
       ROOT_INCLUDE_PATH="${CMAKE_CURRENT_BINARY_DIR}:${DEFAULT_ROOT_INCLUDE_PATH}"
       ${ROOT_root_CMD}
       -e "gSystem->SetBuildDir(\"${CMAKE_CURRENT_BINARY_DIR}\", true)"


### PR DESCRIPTION
Fix potential error message in root_compile_macro, like:
Error in <TUrl::TUrl>: "C:/root-dev/build/x64/relwithdebinfo/roottest/root/io/newstl" malformed, URL must contain "://"