### PR TITLE
[RF] harmonize function name between normal and copy constructor

### DIFF
--- a/roofit/roofitcore/src/RooEffProd.cxx
+++ b/roofit/roofitcore/src/RooEffProd.cxx
@@ -45,7 +45,7 @@ RooEffProd::RooEffProd(const char *name, const char *title,
 RooEffProd::RooEffProd(const RooEffProd& other, const char* name) :
   RooAbsPdf(other, name),
   _pdf("pdf",this,other._pdf),
-  _eff("acc",this,other._eff)
+  _eff("eff",this,other._eff)
 {
 }
 


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/20324