### PR TITLE
[hist] Remove casts in `TH[23]L::AddBinContent`

### DIFF
--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -3684,7 +3684,7 @@ void TH2L::AddBinContent(Int_t bin)
 void TH2L::AddBinContent(Int_t bin, Double_t w)
 {
    Long64_t newval = fArray[bin] + Long64_t(w);
-   if (newval > -LLONG_MAX && newval < LLONG_MAX) {fArray[bin] = Int_t(newval); return;}
+   if (newval > -LLONG_MAX && newval < LLONG_MAX) {fArray[bin] = newval; return;}
    if (newval < -LLONG_MAX) fArray[bin] = -LLONG_MAX;
    if (newval >  LLONG_MAX) fArray[bin] =  LLONG_MAX;
 }

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -4344,7 +4344,7 @@ void TH3L::AddBinContent(Int_t bin)
 void TH3L::AddBinContent(Int_t bin, Double_t w)
 {
    Long64_t newval = fArray[bin] + Long64_t(w);
-   if (newval > -LLONG_MAX && newval < LLONG_MAX) {fArray[bin] = Int_t(newval); return;}
+   if (newval > -LLONG_MAX && newval < LLONG_MAX) {fArray[bin] = newval; return;}
    if (newval < -LLONG_MAX) fArray[bin] = -LLONG_MAX;
    if (newval >  LLONG_MAX) fArray[bin] =  LLONG_MAX;
 }


### PR DESCRIPTION
They would truncate the count to 32 bits.