### PR TITLE
[core] Add "kWhite" and "kBlack" to the special TColorNumber map

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -55,6 +55,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_iterable ttree_iterable.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_setbranchaddress ttree_setbranchaddress.py PYTHON_DEPS numpy)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_ttree_branch ttree_branch.py PYTHON_DEPS numpy)
 
+# TColor-related pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcolor tcolor.py)
+
 # TH1 and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_operators th1_operators.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_th1_fillN th1_fillN.py PYTHON_DEPS numpy)

--- a/bindings/pyroot/pythonizations/test/tcolor.py
+++ b/bindings/pyroot/pythonizations/test/tcolor.py
@@ -1,0 +1,71 @@
+import unittest
+
+import ROOT
+
+# All values of the EColor enum
+ecolor_values = [
+    "kAsh",
+    "kAzure",
+    "kBlack",
+    "kBlue",
+    "kBrown",
+    "kCyan",
+    "kGrape",
+    "kGray",
+    "kGreen",
+    "kMagenta",
+    "kOrange",
+    "kP10Ash",
+    "kP10Blue",
+    "kP10Brown",
+    "kP10Cyan",
+    "kP10Gray",
+    "kP10Green",
+    "kP10Orange",
+    "kP10Red",
+    "kP10Violet",
+    "kP10Yellow",
+    "kP6Blue",
+    "kP6Grape",
+    "kP6Gray",
+    "kP6Red",
+    "kP6Violet",
+    "kP6Yellow",
+    "kP8Azure",
+    "kP8Blue",
+    "kP8Cyan",
+    "kP8Gray",
+    "kP8Green",
+    "kP8Orange",
+    "kP8Pink",
+    "kP8Red",
+    "kPink",
+    "kRed",
+    "kSpring",
+    "kTeal",
+    "kViolet",
+    "kWhite",
+    "kYellow",
+]
+
+
+class TColorTests(unittest.TestCase):
+    """
+    Tests related to TColor.
+    """
+
+    # Tests
+    def test_implicit_tcolor_from_string(self):
+        """Test that we can set colors using Python strings."""
+
+        lgnd = ROOT.TLegend(0.53, 0.73, 0.87, 0.87)
+
+        for string_val in ecolor_values:
+            enum_val = getattr(ROOT, string_val)
+            lgnd.SetFillColor(string_val)
+            # Check consistency
+            assert enum_val == lgnd.GetFillColor()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -3696,9 +3696,15 @@ void TColor::InvertPalette()
 TColorNumber::TColorNumber(std::string const &color)
 {
    using Map = std::unordered_map<std::string, Int_t>;
-   // Color dictionary to define matplotlib conventions
-   static Map colorMap{{"r", kRed},   {"b", kBlue},  {"g", kGreen},   {"y", kYellow},
-                       {"w", kWhite}, {"k", kBlack}, {"m", kMagenta}, {"c", kCyan}};
+   // Color dictionary to define matplotlib conventions and other special colors.
+   // We can't use TColor::GetColorByName() with "kWhite" and "kBlack", as
+   // these are the only identifiers that are an enum values, but there is no
+   // corresponding color with the same name in the global list of colors.
+   // That's why they are looked up in this special map instead.
+   static Map colorMap{
+      {"r", kRed},   {"b", kBlue},    {"g", kGreen}, {"y", kYellow},     {"w", kWhite},
+      {"k", kBlack}, {"m", kMagenta}, {"c", kCyan},  {"kWhite", kWhite}, {"kBlack", kBlack},
+   };
    auto found = colorMap.find(color);
    if (found != colorMap.end()) {
       fNumber = found->second;


### PR DESCRIPTION
There is a map in the TColorNumber constructor to get colors by special name. The "kWhite" and "kBlack" keys have to be added there, as these are the only color names that don't have have a corresponding entry in the global list of colors.

Unfortunately, we can't add "kWhite" and "kBlack" to the global list of colors, because the indices corresponding to these enum values are alredy taken by "background" and "black". And using different indices would break the 1-to-1 correspondence between the color enum integer values and the global color names. That's why we just treat them as special colors in the TColorNumber constructor.

You can verify that kBlack and kWhite are special with this code:

```c++
// all the EColor enum values
   #define COLOR_LIST \
   X(kWhite)       \
   X(kBlack)       \
   X(kGray)        \
   X(kRed)         \
   X(kGreen)       \
   X(kBlue)        \
   X(kYellow)      \
   X(kMagenta)     \
   X(kCyan)        \
   X(kOrange)      \
   X(kSpring)      \
   X(kTeal)        \
   X(kAzure)       \
   X(kViolet)      \
   X(kPink)        \
   X(kGrape)       \
   X(kBrown)       \
   X(kAsh)         \
   X(kP6Blue)      \
   X(kP6Yellow)    \
   X(kP6Red)       \
   X(kP6Grape)     \
   X(kP6Gray)      \
   X(kP6Violet)    \
   X(kP8Blue)      \
   X(kP8Orange)    \
   X(kP8Red)       \
   X(kP8Pink)      \
   X(kP8Green)     \
   X(kP8Cyan)      \
   X(kP8Azure)     \
   X(kP8Gray)      \
   X(kP10Blue)     \
   X(kP10Yellow)   \
   X(kP10Red)      \
   X(kP10Gray)     \
   X(kP10Violet)   \
   X(kP10Brown)    \
   X(kP10Orange)   \
   X(kP10Green)    \
   X(kP10Ash)      \
   X(kP10Cyan)

   #define X(color) std::cout << TColor::GetColorByName(#color) << "  " << color << std::endl;
   COLOR_LIST
   #undef X
```
The output will be:
```txt
-1  0
-1  1
920  920
632  632
416  416
600  600
400  400
616  616
432  432
800  800
820  820
840  840
860  860
880  880
900  900
100  100
101  101
102  102
103  103
104  104
105  105
106  106
107  107
108  108
109  109
110  110
111  111
112  112
113  113
114  114
115  115
116  116
117  117
118  118
119  119
120  120
121  121
122  122
123  123
124  124
125  125
126  126
```