### PR TITLE
Fix setting precision for matrix values in TGDMLWrite::CreateMatrixN

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -2036,6 +2036,7 @@ XMLNodePointer_t TGDMLWrite::CreateRotationN(const char *name, Xyz rotation, con
 XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
 {
    std::stringstream vals;
+   vals << std::setprecision(fFltPrecision);
    size_t cols = matrix->GetCols();
    size_t rows = matrix->GetRows();
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "matrix", nullptr);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
https://github.com/root-project/root/issues/20342


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/20342

