### PR TITLE
[RF][HS3] Remove unused constructor

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -160,12 +160,6 @@ struct Var {
     * @param n Number of bins.
     */
    Var(int n) : nbins(n), min(0), max(n) {}
-
-   /**
-    * @brief Constructor for Var from JSONNode.
-    * @param val JSONNode containing variable information.
-    */
-   Var(const JSONNode &val);
 };
 
 /**
@@ -255,34 +249,6 @@ JSONNode const *getVariablesNode(JSONNode const &rootNode)
    if (out == nullptr)
       return nullptr;
    return &((*out)["parameters"]);
-}
-
-Var::Var(const JSONNode &val)
-{
-   if (val.find("edges")) {
-      for (auto const &child : val.children()) {
-         this->edges.push_back(child.val_double());
-      }
-      this->nbins = this->edges.size();
-      this->min = this->edges[0];
-      this->max = this->edges[this->nbins - 1];
-   } else {
-      if (!val.find("nbins")) {
-         this->nbins = 1;
-      } else {
-         this->nbins = val["nbins"].val_int();
-      }
-      if (!val.find("min")) {
-         this->min = 0;
-      } else {
-         this->min = val["min"].val_double();
-      }
-      if (!val.find("max")) {
-         this->max = 1;
-      } else {
-         this->max = val["max"].val_double();
-      }
-   }
 }
 
 std::string genPrefix(const JSONNode &p, bool trailing_underscore)


### PR DESCRIPTION
Follow up on the previous commit 4c545d7e116, removing a constructor of an internal class that is now unused.

Emergency PR because this fixes the CI failures on the Debians with `dev=ON`.

What is surprising is that the errors didn't appear in the PR that made the constructor unused:
https://github.com/root-project/root/pull/20276/checks

Maybe it's because of the incremental builds, but I'm not sure.