### PR TITLE
Help ROOT I/O of class in streamer field test

### DIFF
--- a/tree/ntuple/test/StreamerField.hxx
+++ b/tree/ntuple/test/StreamerField.hxx
@@ -67,20 +67,26 @@ class IgnoreUnsplitComment {
 // Test streamer field with polymorphic type
 
 struct PolyBase {
-   virtual ~PolyBase() {}
+   virtual ~PolyBase() = default;
    int x;
+   ClassDef(PolyBase, 3);
 };
 
 struct PolyA : public PolyBase {
+   ~PolyA() override = default;
    int a;
+   ClassDefOverride(PolyA, 3);
 };
 
 struct PolyB : public PolyBase {
+   ~PolyB() override = default;
    int b;
+   ClassDefOverride(PolyB, 3);
 };
 
 struct PolyContainer {
    std::unique_ptr<PolyBase> fPoly;
+   ClassDefNV(PolyContainer, 3);
 };
 
 template <typename T>


### PR DESCRIPTION
Attempt at fixing failures such as seen on MacOS beta:

```
  Error in <CloseStreamerInfoROOTFile>: Unique pointer unique_ptr<PolyBase,default_delete<PolyBase> > has zero data members.
```

See e.g. https://github.com/root-project/root/actions/runs/19197912794/job/54881579525?pr=20353#step:6:5580
