### PR TITLE
Fix rootssh connection issues on MacOS [skip-ci]

### DIFF
--- a/config/rootssh
+++ b/config/rootssh
@@ -55,13 +55,17 @@ elif [[ "$1" == "--as-listener--" ]] ; then
    #remember processid to be able kill it
    nc_procid=$!
 
-   # protect socket and log file from reading
-   chmod -f 0700 $listener_socket $listener_socket.log
+   # protect log file from reading
+   chmod -f 0700 $listener_socket.log
 
-   # remove netcat listening on socket
+   # cleanup netcat listening on socket at the end
    trap "kill -SIGINT $nc_procid >/dev/null 2>&1; rm -f $listener_socket.log" 0 1 2 3 6
 
    while [[ ($flag -ne 0) && (-f $listener_socket.log) ]] ; do
+      # protect socket from reading
+      if [ -S $listener_socket ] ; then
+         chmod -f 0700 $listener_socket
+      fi
 
       line=$(sed "${NUM}q;d" $listener_socket.log)
 


### PR DESCRIPTION
# This Pull request:
Fixes root connection issues on MacOS.

## Changes or fixes:
Changed rootssh not to create the $listener_socket prior to calling nc.
nc BSD, which is used on MacOS, cannot connect to existing Unix sockets.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

# This PR
Fixes rootssh connection issues on MacOS.

