### PR TITLE
[ci] Use alma10 for coverage build

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -98,7 +98,7 @@ jobs:
       INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') }}
 
     container:
-      image: registry.cern.ch/root-ci/alma9:buildready
+      image: registry.cern.ch/root-ci/alma10:buildready
       options: '--security-opt label=disable --rm'
 
     steps:
@@ -109,11 +109,8 @@ jobs:
         run: 'if [ -d /py-venv/ROOT-CI/bin/ ]; then . /py-venv/ROOT-CI/bin/activate && echo PATH=$PATH >> $GITHUB_ENV; fi'
 
       # This should be part of the container image
-      - name: Install cov packages
-        run: |
-          dnf -y update
-          dnf -y install lcov
-          pip3 install "gcovr<8.4"
+      - name: Install gcovr
+        run: pip3 install "gcovr<8.4"
 
       # This checks out the merge commit if this is a PR
       - name: Checkout
@@ -141,7 +138,7 @@ jobs:
       - name: Apply option override from matrix for this job
         env:
           OVERRIDE: "coverage=ON"
-          FILE: .github/workflows/root-ci-config/buildconfig/alma9.txt
+          FILE: .github/workflows/root-ci-config/buildconfig/alma10.txt
         shell: bash
         run: |
           set -x
@@ -156,7 +153,7 @@ jobs:
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      Debug
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    $INCREMENTAL
                     --coverage       true
                     --base_ref       ${{ github.base_ref }}
@@ -171,7 +168,7 @@ jobs:
         run: ".github/workflows/root-ci-config/build_root.py
                     --binaries       ${{ inputs.binaries }}
                     --buildtype      ${{ inputs.buildtype }}
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    ${{ inputs.incremental }}
                     --coverage       true
                     --base_ref       ${{ inputs.base_ref }}
@@ -185,7 +182,7 @@ jobs:
         if:   github.event_name == 'schedule'
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype      Debug
-                    --platform       alma9
+                    --platform       alma10
                     --incremental    false
                     --coverage       true
                     --base_ref       ${{ github.ref_name }}


### PR DESCRIPTION
It has a newer compiler which should not show the incorrect missed lines documented in https://github.com/root-project/root/issues/20047.