### PR TITLE
[ntuple] deprecate small helpers in RFieldDescriptor

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -189,15 +189,10 @@ public:
    std::uint32_t GetColumnCardinality() const { return fColumnCardinality; }
    std::optional<std::uint32_t> GetTypeChecksum() const { return fTypeChecksum; }
    bool IsProjectedField() const { return fProjectionSourceId != ROOT::kInvalidDescriptorId; }
-   /// Tells if the field describes a user-defined class rather than a fundamental type, a collection, or one of the
-   /// natively supported stdlib classes.
-   /// The dictionary does not need to be available for this method.
-   bool IsCustomClass() const;
-   /// Tells if the field describes a user-defined enum type.
-   /// The dictionary does not need to be available for this method.
-   /// Needs the full descriptor to look up sub fields.
-   bool IsCustomEnum(const RNTupleDescriptor &desc) const;
-   bool IsStdAtomic() const;
+
+   bool IsCustomClass() const R__DEPRECATED(6, 42, "removed from public interface");
+   bool IsCustomEnum(const RNTupleDescriptor &desc) const R__DEPRECATED(6, 42, "removed from public interface");
+   bool IsStdAtomic() const R__DEPRECATED(6, 42, "removed from public interface");
 };
 
 // clang-format off
@@ -1768,6 +1763,14 @@ inline RNTupleDescriptor CloneDescriptorSchema(const RNTupleDescriptor &desc)
 {
    return desc.CloneSchema();
 }
+
+/// Tells if the field describes a user-defined enum type.
+/// The dictionary does not need to be available for this method.
+/// Needs the full descriptor to look up sub fields.
+bool IsCustomEnumFieldDesc(const RNTupleDescriptor &desc, const RFieldDescriptor &fieldDesc);
+
+/// Tells if the field describes a std::atomic<T> type
+bool IsStdAtomicFieldDesc(const RFieldDescriptor &fieldDesc);
 
 } // namespace Internal
 

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -117,7 +117,7 @@ void ROOT::RSimpleField<T>::ReconcileIntegralField(const RNTupleDescriptor &desc
    EnsureMatchingOnDiskField(desc, kDiffTypeName);
 
    const RFieldDescriptor &fieldDesc = desc.GetFieldDescriptor(GetOnDiskId());
-   if (fieldDesc.IsCustomEnum(desc)) {
+   if (Internal::IsCustomEnumFieldDesc(desc, fieldDesc)) {
       SetOnDiskId(desc.FindFieldId("_0", GetOnDiskId()));
       return;
    }

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -959,7 +959,8 @@ void ROOT::RFieldBase::ConnectPageSource(ROOT::Internal::RPageSource &pageSource
       // Note that we have to do this before calling BeforeConnectPageSource(), which already may compare the field
       // to its on-disk description.
       const auto &desc = pageSource.GetSharedDescriptorGuard().GetRef();
-      if (!dynamic_cast<RAtomicField *>(this) && desc.GetFieldDescriptor(GetOnDiskId()).IsStdAtomic()) {
+      if (!dynamic_cast<RAtomicField *>(this) &&
+          Internal::IsStdAtomicFieldDesc(desc.GetFieldDescriptor(GetOnDiskId()))) {
          SetOnDiskId(desc.GetFieldDescriptor(GetOnDiskId()).GetLinkIds()[0]);
       }
    }

--- a/tree/ntuple/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/src/RNTupleDescriptor.cxx
@@ -170,27 +170,12 @@ bool ROOT::RFieldDescriptor::IsCustomClass() const
 
 bool ROOT::RFieldDescriptor::IsCustomEnum(const RNTupleDescriptor &desc) const
 {
-   if (fStructure != ROOT::ENTupleStructure::kPlain)
-      return false;
-   if (fTypeName.rfind("std::", 0) == 0)
-      return false;
-
-   auto subFieldId = desc.FindFieldId("_0", fFieldId);
-   if (subFieldId == kInvalidDescriptorId)
-      return false;
-
-   static const std::string gIntTypeNames[] = {"bool",         "char",          "std::int8_t",  "std::uint8_t",
-                                               "std::int16_t", "std::uint16_t", "std::int32_t", "std::uint32_t",
-                                               "std::int64_t", "std::uint64_t"};
-   return std::find(std::begin(gIntTypeNames), std::end(gIntTypeNames),
-                    desc.GetFieldDescriptor(subFieldId).GetTypeName()) != std::end(gIntTypeNames);
+   return Internal::IsCustomEnumFieldDesc(desc, *this);
 }
 
 bool ROOT::RFieldDescriptor::IsStdAtomic() const
 {
-   if (fStructure != ROOT::ENTupleStructure::kPlain)
-      return false;
-   return (fTypeName.rfind("std::atomic<", 0) == 0);
+   return Internal::IsStdAtomicFieldDesc(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1506,4 +1491,29 @@ ROOT::Experimental::RNTupleAttrSetDescriptor ROOT::Experimental::RNTupleAttrSetD
    desc.fAnchorLocator = fAnchorLocator;
    desc.fName = fName;
    return desc;
+}
+
+bool ROOT::Internal::IsCustomEnumFieldDesc(const RNTupleDescriptor &desc, const RFieldDescriptor &fieldDesc)
+{
+   if (fieldDesc.GetStructure() != ROOT::ENTupleStructure::kPlain)
+      return false;
+   if (fieldDesc.GetTypeName().rfind("std::", 0) == 0)
+      return false;
+
+   auto subFieldId = desc.FindFieldId("_0", fieldDesc.GetId());
+   if (subFieldId == kInvalidDescriptorId)
+      return false;
+
+   static const std::string gIntTypeNames[] = {"bool",         "char",          "std::int8_t",  "std::uint8_t",
+                                               "std::int16_t", "std::uint16_t", "std::int32_t", "std::uint32_t",
+                                               "std::int64_t", "std::uint64_t"};
+   return std::find(std::begin(gIntTypeNames), std::end(gIntTypeNames),
+                    desc.GetFieldDescriptor(subFieldId).GetTypeName()) != std::end(gIntTypeNames);
+}
+
+bool ROOT::Internal::IsStdAtomicFieldDesc(const RFieldDescriptor &fieldDesc)
+{
+   if (fieldDesc.GetStructure() != ROOT::ENTupleStructure::kPlain)
+      return false;
+   return (fieldDesc.GetTypeName().rfind("std::atomic<", 0) == 0);
 }


### PR DESCRIPTION
The query methods `IsCustomClass`, `IsCustomEnum`, and `IsStdAtomic` are rather arbitrary and should not have been added to the public interface. They only make sense in the internal context in which they are used.

Removed for v6.42.
