### PR TITLE
Remove Snapshot info about change in default compression settings

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -53,6 +53,8 @@ The following people have contributed to this new version:
 
 ## RDataFrame
 
+- The message shown in ROOT 6.38 to inform users about change of default compression setting used by Snapshot (was 101 before 6.38, became 505 in 6.38) is now removed.
+
 ## Python Interface
 
 ## Command-line utilities

--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -615,9 +615,3 @@ Rint.Canvas.HighLightColor:      5
 #                          1 All Branches (default)
 # Can be overridden by the environment variable ROOT_TTREECACHE_PREFILL
 # TTreeCache.Prefill: 1
-
-# Set whether to show or suppress an info message coming from RDataFrame
-# Snapshot informing the user on the change of default output dataset
-# compression settings introduced in ROOT 6.38 (1 means show the info, 0 means
-# suppress, 1 by default).
-# ROOT.RDF.Snapshot.Info: 1

--- a/roottest/root/dataframe/.rootrc
+++ b/roottest/root/dataframe/.rootrc
@@ -1,5 +1,3 @@
 # First two lines are taken from ROOTTEST_ADD_TESTDIRS in RootMacros.cmake
 Rint.History:  .root_hist
 ACLiC.LinkLibs:  1
-# Suppress the info message from Snapshot to prevent test failures
-ROOT.RDF.Snapshot.Info: 0

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -45,13 +45,6 @@
 #include "TProfile2D.h"
 #include "TStatistic.h"
 
-// TODO: Needed to show the info message in Snapshot, remove in 6.40
-#include "ROOT/RLogger.hxx"
-#include "ROOT/RVersion.hxx"
-#include "TEnv.h"
-#include <cstdlib>
-#include <cstring>
-
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>
@@ -1328,26 +1321,6 @@ public:
                                                  const ColumnNames_t &columnList,
                                                  const RSnapshotOptions &options = RSnapshotOptions())
    {
-      // TODO: Remove before releasing 6.40.00
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 40, 0)
-      static_assert(false && "Remove information about change of Snapshot defaut compression settings.");
-#endif
-      [[maybe_unused]] static bool once = []() {
-         if (const char *suppress = std::getenv("ROOT_RDF_SNAPSHOT_INFO"))
-            if (std::strcmp(suppress, "0") == 0)
-               return true;
-         if (const char *suppress = gEnv->GetValue("ROOT.RDF.Snapshot.Info", "1"))
-            if (std::strcmp(suppress, "0") == 0)
-               return true;
-         RLogScopedVerbosity showInfo{ROOT::Detail::RDF::RDFLogChannel(), ROOT::ELogLevel::kInfo};
-         R__LOG_INFO(ROOT::Detail::RDF::RDFLogChannel())
-            << "\n\tIn ROOT 6.38, the default compression settings of Snapshot have been changed from 101 (ZLIB with "
-               "compression level 1, the TTree default) to 505 (ZSTD with compression level 5). This change may result "
-               "in smaller Snapshot output dataset size by default. In order to suppress this message, set "
-               "'ROOT_RDF_SNAPSHOT_INFO=0' in your environment or set 'ROOT.RDF.Snapshot.Info: 0' in your .rootrc "
-               "file.";
-         return true;
-      }();
       // like columnList but with `#var` columns removed
       auto colListNoPoundSizes = RDFInternal::FilterArraySizeColNames(columnList, "Snapshot");
       // like columnListWithoutSizeColumns but with aliases resolved


### PR DESCRIPTION
It was scheduled for removal after 6.38.
