### PR TITLE
[Tutorials] Don't explicitly state the filename for doxygen.

### DIFF
--- a/tutorials/io/experimental/rfile001_basics.C
+++ b/tutorials/io/experimental/rfile001_basics.C
@@ -1,5 +1,7 @@
-/// \file tutorials/io/experimental/rfile001_basics.py
-/// \ingroup Base ROOT7 tutorial_io
+/// \file
+/// \ingroup ROOT7 tutorial_io
+/// Demonstrate the basic usage of RFile.
+///
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2025-11-06
 /// \macro_code

--- a/tutorials/io/experimental/rfile001_basics.py
+++ b/tutorials/io/experimental/rfile001_basics.py
@@ -1,5 +1,7 @@
-# \file tutorials/io/experimental/rfile001_basics.py
-# \ingroup Base ROOT7 tutorial_io
+# \file
+# \ingroup ROOT7 tutorial_io
+# Demonstrate the basic usage of RFile.
+#
 # \author Giacomo Parolini <giacomo.parolini@cern.ch>
 # \date 2025-11-06
 # \macro_code


### PR DESCRIPTION
If the documentation block refers to the current file, doxygen doesn't need its path or name. This might fix a filename collision. Also added a short description to be shown in the doxygen overview.

Furthermore, removed the tutorial from the group of `Base` classes. It didn't seem to fit here:
<img width="273" height="409" alt="image" src="https://github.com/user-attachments/assets/e2d1a3d7-a04b-45eb-bd09-9b41fb62dcfa" />
