### PR TITLE
[RF] JIT all generated code in one `gInterpreter` call

### DIFF
--- a/roofit/roofitcore/inc/RooFit/CodegenContext.h
+++ b/roofit/roofitcore/inc/RooFit/CodegenContext.h
@@ -117,6 +117,7 @@ public:
    std::vector<double> const &xlArr() { return _xlArr; }
 
    void collectFunction(std::string const &name);
+   std::string const &collectedCode() { return _collectedCode; }
    std::vector<std::string> const &collectedFunctions() { return _collectedFunctions; }
 
    std::string
@@ -207,6 +208,7 @@ private:
    std::unordered_map<RooFit::UniqueId<RooAbsCollection>::Value_t, std::string> _listNames;
    std::vector<double> _xlArr;
    std::vector<std::string> _collectedFunctions;
+   std::string _collectedCode;
 };
 
 template <>


### PR DESCRIPTION
This speeds up RooFit codegen by about 20 %.