### PR TITLE
[cmake] Fix builtin usage of GLEW

### DIFF
--- a/builtins/glew/CMakeLists.txt
+++ b/builtins/glew/CMakeLists.txt
@@ -24,7 +24,7 @@ unset(GLEW_FOUND CACHE)
 unset(GLEW_FOUND PARENT_SCOPE)
 set(GLEW_FOUND TRUE CACHE BOOL "" FORCE)
 
-# chnage variable and cache to ensure that cmake use builtin version
+# change variable and cache to ensure that cmake use builtin version
 set(GLEW_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/inc PARENT_SCOPE)
 set(GLEW_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/inc PARENT_SCOPE)
 


### PR DESCRIPTION
On Mac platform without installed GLEW one gets error by first invocation of cmake:

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
/Users/user/git/root/graf3d/gl/GLEW_INCLUDE_DIR
   used as include directory in directory /Users/user/git/root/graf3d/gl
```

Problem that setting cache variable is not enough to overwrite already existing variable
So set variables as well.