### PR TITLE
[skip-ci][hist] Remove mentions of SetBinContent

### DIFF
--- a/hist/histv7/doc/CodeArchitecture.md
+++ b/hist/histv7/doc/CodeArchitecture.md
@@ -68,7 +68,7 @@ Objects of this type are passed by value.
 
 A single bin index, which is just an integer for normal bins.
 `Underflow()` and `Overflow()` are special values and not ordered with respect to others.
-Objects of this type are passed by value; most notably to `GetBinContent` and `SetBinContent`.
+Objects of this type are passed by value; most notably to `GetBinContent`.
 
 ### `RBinIndexRange`
 

--- a/hist/histv7/doc/DesignImplementation.md
+++ b/hist/histv7/doc/DesignImplementation.md
@@ -55,10 +55,9 @@ This will copy the arguments, which is fine in this case because `RBinIndex` is 
 ### Special Arguments
 
 Special arguments are passed last.
-Examples include
+For example
 ```cpp
 template <typename... A> void Fill(const std::tuple<A...> &args, RWeight w);
-template <std::size_t N> void SetBinContent(const std::array<RBinIndex, N> &indices, const BinContentType &content);
 ```
 The same works for the variadic function templates that will check the type of the last argument.
 


### PR DESCRIPTION
We decided to not add this method to the public interface because it has unclear semantics for a number of cases, in particular related to global histogram statistics. While it might be fine to allow it in `RHistEngine`, it would also be confusing to then not have it in `RHist`.