### PR TITLE
[skip-ci] TFormula doc fix

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -120,17 +120,17 @@ std::string doubleToString(double val)
     above also applies to the predefined parametrized functions like `gaus` and
     `expo`.
 
-    Comparisons operators are also supported `(&amp;&amp;, ||, ==, &lt;=, &gt;=, !)`
+    Comparisons operators are also supported `(&&, ||, ==, <=, >=, !)`
 
     Examples:
 
-    `sin(x*(x&lt;0.5 || x&gt;1))`
+    `sin(x*(x<0.5 || x>1))`
 
     If the result of a comparison is TRUE, the result is 1, otherwise 0.
 
     Already predefined names can be given. For example, if the formula
 
-    `TFormula old("old",sin(x*(x&lt;0.5 || x&gt;1)))`
+    `TFormula old("old",sin(x*(x<0.5 || x>1)))`
 
     one can assign a name to the formula. By default the name of the object = title = formula itself.
 
@@ -138,7 +138,7 @@ std::string doubleToString(double val)
 
     is equivalent to:
 
-    `TFormula new("new","x*sin(x*(x&lt;0.5 || x&gt;1))")`
+    `TFormula new("new","x*sin(x*(x<0.5 || x>1))")`
 
     The class supports unlimited number of variables and parameters.
     By default the names which can be used for the variables are `x,y,z,t` or


### PR DESCRIPTION
Special characters like &, <, > were replaced with HTML entities &amp;, &lt;, &gt;, respectively, on the TFormula documentation page.
Reported here: https://root-forum.cern.ch/t/special-characters-in-the-tformula-documentation/64396