### PR TITLE
Remove unused variable in `stressGraphics.cxx`

### DIFF
--- a/test/stressGraphics.cxx
+++ b/test/stressGraphics.cxx
@@ -113,7 +113,6 @@
 #include "TView.h"
 
 
-const int kMaxNumTests = 1000;
 const int  kFineSvgTest = 10; // SVG file can slightly vary
 const int  kSkipSvgTest = 100; // do not perform SVG test
 


### PR DESCRIPTION
Fixes this warning:

```
unused variable 'kMaxNumTests' [-Wunused-const-variable]
```