### PR TITLE
[ci] Also test DistRDF on Fedora 43

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora43.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora43.txt
@@ -3,6 +3,4 @@ builtin_zlib=ON
 builtin_zstd=ON
 experimental_adaptivecpp=ON
 pythia8=ON
-test_distrdf_dask=OFF
-test_distrdf_pyspark=OFF
 vdt=OFF

--- a/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
@@ -26,6 +26,4 @@ builtin_zstd=ON
 check_connection=ON
 cocoa=ON
 minuit2_omp=OFF
-test_distrdf_dask=ON
-test_distrdf_pyspark=ON
 x11=OFF

--- a/.github/workflows/root-ci-config/buildconfig/mac15.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac15.txt
@@ -24,7 +24,5 @@ builtin_zeromq=ON
 builtin_zstd=ON
 cocoa=ON
 minuit2_omp=OFF
-test_distrdf_dask=ON
-test_distrdf_pyspark=ON
 tmva-sofie=ON
 x11=OFF

--- a/.github/workflows/root-ci-config/buildconfig/mac26.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac26.txt
@@ -26,6 +26,4 @@ builtin_zstd=ON
 check_connection=ON
 cocoa=ON
 minuit2_omp=OFF
-test_distrdf_dask=ON
-test_distrdf_pyspark=ON
 x11=OFF


### PR DESCRIPTION
It's better to test also on the newest Fedora release, to make sure it still works with the newest Python and other packages.