### PR TITLE
[RF] Return reference to actual RooAbsReal in `RooPolyVar::x()` getter

### DIFF
--- a/roofit/roofitcore/inc/RooPolyVar.h
+++ b/roofit/roofitcore/inc/RooPolyVar.h
@@ -34,7 +34,7 @@ public:
    Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = nullptr) const override;
    double analyticalIntegral(Int_t code, const char *rangeName = nullptr) const override;
 
-   RooRealProxy const &x() const { return _x; }
+   RooAbsReal const &x() const { return _x.arg(); }
    RooArgList const &coefList() const { return _coefList; }
    int lowestOrder() const { return _lowestOrder; }
 


### PR DESCRIPTION
Just like in any other getter for the inputs of RooFit functions, the `RooPolyVar::x()` getter should return the underlying RooAbsReal, instead of the internal proxy.

Closes #20293.

Thanks to @Phmonski for noticing this!