### PR TITLE
[RF] Fix allowed range for RooPoisson parameters

### DIFF
--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -14,7 +14,6 @@ Poisson pdf
 
 #include "RooPoisson.h"
 #include "RooRandom.h"
-#include "RooMath.h"
 #include "RooNaNPacker.h"
 #include "RooBatchCompute.h"
 #include "RooHelpers.h"
@@ -22,14 +21,18 @@ Poisson pdf
 #include <RooFit/Detail/MathFuncs.h>
 
 #include <array>
+#include <limits>
 
- ////////////////////////////////////////////////////////////////////////////////
- /// Constructor
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor
 
- RooPoisson::RooPoisson(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, bool noRounding)
-    : RooAbsPdf(name, title), x("x", "x", this, _x), mean("mean", "mean", this, _mean), _noRounding(noRounding)
- {
-    RooHelpers::checkRangeOfParameters(this, {&static_cast<RooAbsReal &>(_x), &static_cast<RooAbsReal &>(_mean)}, 0.);
+RooPoisson::RooPoisson(const char *name, const char *title, RooAbsReal::Ref _x, RooAbsReal::Ref _mean, bool noRounding)
+   : RooAbsPdf(name, title), x("x", "x", this, _x), mean("mean", "mean", this, _mean), _noRounding(noRounding)
+{
+   RooHelpers::checkRangeOfParameters(
+      /*callingClass=*/this, /*pars=*/{&x.arg(), &mean.arg()}, /*min=*/0.,
+      /*max=*/std::numeric_limits<double>::infinity(),
+      /*limitsInAllowedRange=*/true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Notably, the limits of `[0, inf]` should be included in the allowed range.

This should be backported to 6.38 to avoid a warning that would otherwise happen all over HistFactory.

This follows up on cde3b9beb900d9.