### PR TITLE
[RF] Avoid resetting the workspace of ModelConfig in HistFactory

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -797,7 +797,6 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     auto protoOwner = std::make_unique<RooWorkspace>(channel_name.c_str(), (channel_name+" workspace").c_str());
     RooWorkspace &proto = *protoOwner;
     auto proto_config = make_unique<ModelConfig>("ModelConfig", &proto);
-    proto_config->SetWorkspace(proto);
 
     // preprocess functions
     for(auto const& func : fPreprocessFunctions){


### PR DESCRIPTION
Re-setting the workspace can be dangerous for IO reasons, and this is why the new ROOT now emits a warning when this happens.

There is one place in HistFactory that triggered this warning, where the Workspace was redundantly set in the constructor and with the `ModelConfig::SetWorkspace()` function, with the same workspace.

See also:
  * https://github.com/root-project/root/pull/19999