### PR TITLE
Remove unused dependency of TGCocoa on glew

### DIFF
--- a/graf2d/cocoa/CMakeLists.txt
+++ b/graf2d/cocoa/CMakeLists.txt
@@ -39,7 +39,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(GCocoa
     "-framework Cocoa"
     "-framework OpenGL"
     ${FREETYPE_LIBRARIES}
-    GLEW::GLEW
 )
 
 target_include_directories(GCocoa PRIVATE ${CMAKE_SOURCE_DIR}/graf3d/gl/inc)

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -13,8 +13,6 @@
 
 #include "TGCocoa.h"
 
-#include <GL/glew.h>
-
 #include "ROOTOpenGLView.h"
 #include "CocoaConstants.h"
 #include "TMacOSXSystem.h"
@@ -41,6 +39,7 @@
 
 #include <ApplicationServices/ApplicationServices.h>
 #include <OpenGL/OpenGL.h>
+#include <OpenGL/gl.h>
 #include <Cocoa/Cocoa.h>
 
 #include <algorithm>


### PR DESCRIPTION
This is part of the glew replacement campaign.