### PR TITLE
[RF][HF] Error out in HistFactory in case of duplicate channel names

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -71,6 +71,7 @@
 #include <fstream>
 #include <iomanip>
 #include <memory>
+#include <set>
 #include <utility>
 
 constexpr double alphaLow = -5.0;
@@ -1476,6 +1477,11 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
      }
      if (chs.size()  <  ch_names.size() ) {
         Error("MakeCombinedModel","Input vector of workspace has an invalid size - return a nullptr");
+        return nullptr;
+     }
+     std::set<std::string> ch_names_set{ch_names.begin(), ch_names.end()};
+     if (ch_names.size() != ch_names_set.size()) {
+        Error("MakeCombinedModel", "Input vector of channel names has duplicate names - return a nullptr");
         return nullptr;
      }
 


### PR DESCRIPTION
Duplicate channel names are not allowed, because it would result in name collisions for the channel pdfs.

Also make the logging more consistent in a separate commit.

FYI, @TomasDado 