### PR TITLE
[ci] Don't set `CMAKE_BUILD_RPATH` on macOS

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac-beta.txt
@@ -1,4 +1,3 @@
-CMAKE_BUILD_RPATH=/usr/local/lib
 CMAKE_CXX_STANDARD=23
 builtin_cfitsio=ON
 builtin_cppzmq=ON

--- a/.github/workflows/root-ci-config/buildconfig/mac15.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac15.txt
@@ -1,4 +1,3 @@
-CMAKE_BUILD_RPATH=/usr/local/lib
 builtin_cfitsio=ON
 builtin_cppzmq=ON
 builtin_davix=ON

--- a/.github/workflows/root-ci-config/buildconfig/mac26.txt
+++ b/.github/workflows/root-ci-config/buildconfig/mac26.txt
@@ -1,4 +1,3 @@
-CMAKE_BUILD_RPATH=/usr/local/lib
 CMAKE_CXX_STANDARD=23
 builtin_cfitsio=ON
 builtin_cppzmq=ON


### PR DESCRIPTION
This was needed to find the Fortran libraries, but since 31613210d6 the RPATH is appended to in the CMake configuration code, so we don't need to pass "magic" CMAKE_* flags in the CI configuration on macOS anymore.