### PR TITLE
[skip-CI] [docs] Fix RNTupleWriter example

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -71,7 +71,7 @@ auto model = ROOT::RNTupleModel::Create();
 auto pFoo = model->MakeField<int>("foo");
 
 /// 2. Create writer from the model.
-auto writer = ROOT::RNTupleReader::Recreate(std::move(model), "myNTuple", "some/file.root");
+auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "myNTuple", "some/file.root");
 
 /// 3. Write into it.
 for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
Fix reference to RNTupleWriter::Recreate in example usage

# This Pull request:

## Changes or fixes:
An accidental reference to `RNTupleReader::Recreate` in the example usage of `RNTupleWriter`, which should be `RNTupleWriter::Recreate`.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)