### PR TITLE
[v638][ci] Remove Fedora Rawhide build

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/rawhide.txt
+++ b/.github/workflows/root-ci-config/buildconfig/rawhide.txt
@@ -1,6 +1,0 @@
-builtin_zlib=ON
-builtin_zstd=ON
-pythia8=ON
-test_distrdf_dask=OFF
-test_distrdf_pyspark=OFF
-vdt=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -413,11 +413,6 @@ jobs:
             property: "clang Ninja"
             overrides: ["CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++"]
             cmake_generator: Ninja
-          # Fedora Rawhide with Python debug build
-          - image: rawhide
-            is_special: true
-            property: "Fedora pydebug"
-            overrides: ["CMAKE_CXX_STANDARD=23"]
           # Disable GPU builds until the DNS problem is solved  
           # - image: ubuntu2404-cuda
           #   is_special: true


### PR DESCRIPTION
We want the release branch CI to be stable, and moving targets like the Fedora Rawhide platform should not be part of it.