### PR TITLE
Directly include OpenGL in gl2ps

### DIFF
--- a/graf3d/gl/src/gl2ps/gl2ps.h
+++ b/graf3d/gl/src/gl2ps/gl2ps.h
@@ -38,7 +38,15 @@
 #include <cstdio>
 #include <cstdlib>
 
-#include "../TGLIncludes.h"
+#ifdef WIN32
+#include "Windows4Root.h"
+#endif
+
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
+#include <GL/gl.h>
+#endif
 
 #define GL2PSDLL_API
 


### PR DESCRIPTION
The OpenGL ROOT wrapper headers like TGLIncludes are deprecated, and not using them internally in ROOT makes the migration from Glew to Glad easier.