### PR TITLE
[RDF] Bring back a removed snapshot method

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1242,6 +1242,15 @@ public:
       return newInterface;
    }
 
+   template <typename... ColumnTypes>
+   [[deprecated("Snapshot is not any more a template. You can safely remove the template parameters.")]]
+   RResultPtr<RInterface<RLoopManager>>
+   Snapshot(std::string_view treename, std::string_view filename, const ColumnNames_t &columnList,
+            const RSnapshotOptions &options = RSnapshotOptions())
+   {
+      return Snapshot(treename, filename, columnList, options);
+   }
+
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Save selected columns to disk, in a new TTree or RNTuple `treename` in file `filename`.
    /// \param[in] treename The name of the output TTree or RNTuple.


### PR DESCRIPTION
As discussed on the ROOT Users workshop, entirely removing interfaces after one single ROOT release leaves users with broken code without any hints on how to solve the problem. Instead, a minimal placeholder should remain, which gives directions on how solve the error. In that spirit, the templated snapshot overload is brought back and marked deprecated.

This partly reverts commit 4da10a206fedc7c6b482ead3acd92f481c7fa35c.
