### PR TITLE
[IO] Modernize TFileCacheRead: Replace NULL with nullptr

### DIFF
--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -2660,7 +2660,7 @@ void TBufferFile::WriteObjectClass(const void *actualObjectStart, const TClass *
 
    if (!actualObjectStart) {
 
-      // save kNullTag to represent NULL pointer
+      // save kNullTag to represent nullptr pointer
       *this << (UInt_t) kNullTag;
 
    } else {

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -809,7 +809,7 @@ Int_t TBufferJSON::ExportToFile(const char *filename, const TObject *obj, const 
       const char *objbuf = json.Data();
       Long_t objlen = json.Length();
 
-      unsigned long objcrc = R__crc32(0, NULL, 0);
+      unsigned long objcrc = R__crc32(0, nullptr, 0);
       objcrc = R__crc32(objcrc, (const unsigned char *)objbuf, objlen);
 
       // 10 bytes (ZIP header), compressed data, 8 bytes (CRC and original length)
@@ -889,7 +889,7 @@ Int_t TBufferJSON::ExportToFile(const char *filename, const void *obj, const TCl
       const char *objbuf = json.Data();
       Long_t objlen = json.Length();
 
-      unsigned long objcrc = R__crc32(0, NULL, 0);
+      unsigned long objcrc = R__crc32(0, nullptr, 0);
       objcrc = R__crc32(objcrc, (const unsigned char *)objbuf, objlen);
 
       // 10 bytes (ZIP header), compressed data, 8 bytes (CRC and original length)

--- a/io/io/src/TFileCacheRead.cxx
+++ b/io/io/src/TFileCacheRead.cxx
@@ -796,7 +796,7 @@ void TFileCacheRead::SetEnablePrefetchingImpl(Bool_t setPrefetching)
       }
    } else if (fPrefetch && !fEnablePrefetching) {
        SafeDelete(fPrefetch);
-       fPrefetch = NULL;
+       fPrefetch = nullptr;
    }
 
    //environment variable used to switch to the new method of reading asynchronously

--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -338,10 +338,10 @@ TMapFile::TMapFile(const char *name, const char *title, Option_t *option,
       fFd = (Longptr_t) CreateFile(fname,                    // pointer to name of the file
                      GENERIC_WRITE | GENERIC_READ,       // access (read-write) mode
                      FILE_SHARE_WRITE | FILE_SHARE_READ, // share mode
-                     NULL,                               // pointer to security attributes
+                     nullptr,                               // pointer to security attributes
                      OPEN_ALWAYS,                        // how to create
                      FILE_ATTRIBUTE_TEMPORARY,           // file attributes
-                     (HANDLE) NULL);                     // handle to file with attributes to copy
+                     (HANDLE) nullptr);                     // handle to file with attributes to copy
 #endif
       if (fFd == (Longptr_t)INVALID_HANDLE_VALUE) {
          SysError("TMapFile", "file %s can not be opened", fname);
@@ -355,10 +355,10 @@ TMapFile::TMapFile(const char *name, const char *title, Option_t *option,
       fFd = (Longptr_t) CreateFile(fname,                    // pointer to name of the file
                      GENERIC_READ,                       // access (read-write) mode
                      FILE_SHARE_WRITE | FILE_SHARE_READ, // share mode
-                     NULL,                               // pointer to security attributes
+                     nullptr,                               // pointer to security attributes
                      OPEN_EXISTING,                      // how to create
                      FILE_ATTRIBUTE_TEMPORARY,           // file attributes
-                     (HANDLE) NULL);                     // handle to file with attributes to copy
+                     (HANDLE) nullptr);                     // handle to file with attributes to copy
 #endif
       if (fFd == (Longptr_t)INVALID_HANDLE_VALUE) {
          SysError("TMapFile", "file %s can not be opened for reading", fname);
@@ -864,7 +864,7 @@ void TMapFile::CreateSemaphore(int pid)
    char buffer[] ="ROOT_Semaphore_xxxxxxxx";
    int lbuf = strlen(buffer);
    if (!pid) fSemaphore = getpid();
-   fhSemaphore = (ULongptr_t)CreateMutex(NULL,FALSE,itoa(fSemaphore,&buffer[lbuf-8],16));
+   fhSemaphore = (ULongptr_t)CreateMutex(nullptr,FALSE,itoa(fSemaphore,&buffer[lbuf-8],16));
    if (fhSemaphore == 0) fSemaphore = (Longptr_t)INVALID_HANDLE_VALUE;
 #endif
 #endif

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5391,7 +5391,7 @@ void TStreamerInfo::PrintValue(const char *name, char *pointer, Int_t i, Int_t l
    } else        {
       if (i < 0) {
          if (pointer==0) {
-            printf("NULL\n");
+            printf("nullptr\n");
          } else {
             const static TClassRef stringClass("string");
             if (fClass == stringClass) {

--- a/io/io/test/RIoUring.cxx
+++ b/io/io/test/RIoUring.cxx
@@ -58,7 +58,7 @@ TEST(RawUring, NopRoundTrip)
    // can make sqes
    struct io_uring_sqe *sqe;
    sqe = io_uring_get_sqe(&ring);
-   ASSERT_NE(sqe, (io_uring_sqe*) NULL);
+   ASSERT_NE(sqe, (io_uring_sqe*) nullptr);
 
    // can submit sqes to the ring
    io_uring_prep_nop(sqe);

--- a/io/mpi/src/TMPIFile.cxx
+++ b/io/mpi/src/TMPIFile.cxx
@@ -501,7 +501,7 @@ void TMPIFile::SplitMPIComm()
    Int_t flag;
    MPI_Initialized(&flag);
    if (!flag) {
-      MPI_Init(NULL, NULL);
+      MPI_Init(nullptr, nullptr);
    }
    // get global size and current global rank
    MPI_Comm_size(MPI_COMM_WORLD, &fMPIGlobalSize);

--- a/io/sql/src/TSQLFile.cxx
+++ b/io/sql/src/TSQLFile.cxx
@@ -53,7 +53,7 @@ Up to now following member are supported:
   -# Object as data member. In that case object is saved in normal way to data base and column
     will contain id of this object.
   -# Pointer on object. Same as before. In case if object was already stored, just its id
-    will be placed in the column. For NULL pointer 0 is used.
+    will be placed in the column. For nullptr pointer 0 is used.
   -# TString. Now column with limited width like VARCAHR(255) in MySQL is used.
     Later this will be improved to support maximum possible strings
   -# Anything else. Data will be converted to raw format and saved in _streamer_ table.

--- a/io/sql/src/TSQLStructure.cxx
+++ b/io/sql/src/TSQLStructure.cxx
@@ -41,7 +41,7 @@ to database server.
 #include <iostream>
 
 namespace sqlio {
-const Int_t Ids_NullPtr = 0;       // used to identify NULL pointer in tables
+const Int_t Ids_NullPtr = 0;       // used to identify nullptr pointer in tables
 const Int_t Ids_RootDir = 0;       // dir:id, used for keys stored in root directory.
 const Int_t Ids_TSQLFile = 0;      // keyid for TSQLFile entry in keys list
 const Int_t Ids_StreamerInfos = 1; // keyid used to store StreamerInfos in ROOT directory

--- a/io/xml/src/TXMLSetup.cxx
+++ b/io/xml/src/TXMLSetup.cxx
@@ -291,6 +291,6 @@ Int_t TXMLSetup::AtoI(const char *sbuf, Int_t def, const char *errinfo)
    if (sbuf)
       return atoi(sbuf);
    if (errinfo)
-      std::cerr << "<Error in TXMLSetup::AtoI>" << errinfo << " not valid integer: sbuf <NULL>" << std::endl;
+      std::cerr << "<Error in TXMLSetup::AtoI>" << errinfo << " not valid integer: sbuf <nullptr>" << std::endl;
    return def;
 }


### PR DESCRIPTION
# This Pull request:
Replaces legacy C-style `NULL` with modern C++ `nullptr` in `io/io/src/TFileCacheRead.cxx` to improve type safety and code consistency.

## Changes or fixes:
- Replaced `fPrefetch = NULL` with `fPrefetch = nullptr`.
- Verified that `fPrefetch` is a pointer type (`TFilePrefetch*`).

## Checklist:
- [x] tested changes locally (compiled target RIO successfully)
- [ ] updated the docs (if necessary)
