### PR TITLE
[cmake][macOS] Auto-detect `CMAKE_OSX_SYSROOT` when not set [v6.32]

### DIFF
--- a/cmake/modules/SetUpMacOS.cmake
+++ b/cmake/modules/SetUpMacOS.cmake
@@ -44,6 +44,20 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
     endif()
   endif()
 
+  if(NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL "")
+    execute_process(COMMAND xcrun --sdk macosx --show-sdk-path
+      OUTPUT_VARIABLE SDK_PATH
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT EXISTS "${SDK_PATH}")
+      message(FATAL_ERROR "Could not detect macOS SDK path")
+    endif()
+
+    set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "SDK path" FORCE)
+  endif()
+  message(STATUS "Using SDK path: ${CMAKE_OSX_SYSROOT}")
+
   if(MACOSX_VERSION VERSION_GREATER 10.6)
     set(MACOSX_SSL_DEPRECATED ON)
   endif()


### PR DESCRIPTION
This will fix a build error when building with the latest CMake (4.0) version

(cherry picked from commit 6bd0dbad38bb524491c5109bc408942246db8b50, backport of https://github.com/root-project/root/pull/18318 to hopefully fix build on `mac26`)