### PR TITLE
[CPyCppyy] Correctly handle static method calls via derived instance

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPClassMethod.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPClassMethod.cxx
@@ -34,8 +34,8 @@ PyObject* CPyCppyy::CPPClassMethod::Call(CPPInstance*&
     int nargs = (int)CPyCppyy_PyArgs_GET_SIZE(args, nargsf);
     if ((!self || (PyObject*)self == Py_None) && nargs) {
         PyObject* arg0 = CPyCppyy_PyArgs_GET_ITEM(args, 0);
-        if ((CPPInstance_Check(arg0) && ((CPPInstance*)arg0)->ObjectIsA() == GetScope()) && \
-                (fArgsRequired <= nargs-1)) {
+        if (CPPInstance_Check(arg0) && fArgsRequired <= nargs - 1 &&
+            Cppyy::IsSubtype(reinterpret_cast<CPPInstance *>(arg0)->ObjectIsA(), GetScope())) {
             args   += 1;     // drops first argument
             nargsf -= 1;
         }

--- a/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
@@ -377,5 +377,33 @@ class TestOVERLOADS:
         assert cppyy.gbl.test12_foo(1) == cppyy.gbl.call_test12_foo()
         assert cppyy.gbl.test12_bar(1) == cppyy.gbl.call_test12_bar()
 
+
+    def test13_static_call_from_derived_instance(self):
+        """Test calling a static member function via a derived instance."""
+
+        import cppyy
+
+        cppyy.cppdef("""
+            class Base {
+            public:
+                static int StaticMethod() {
+                    return 42;
+                }
+            };
+
+            class Derived : public Base {
+            };
+        """)
+
+        d = cppyy.gbl.Derived()
+
+        # Call static method through base class directly
+        result_direct = cppyy.gbl.Base.StaticMethod()
+
+        # Call static method through instance
+        result_instance = d.StaticMethod()
+
+        assert result_instance == result_direct
+
 if __name__ == "__main__":
     exit(pytest.main(args=['-sv', '-ra', __file__]))


### PR DESCRIPTION
The mechanism to strip away the "self" argument from the call to a static method checks the type of "self", matching the exact type.

However, it should also remove the "self" if it is an instance of a derived type, because in C++ it is also possible to call static methods via instances of derived types.

A unit test was also added.

Closes #20463.