### PR TITLE
[ci] Use AlmaLinux 10 for ARM build

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -403,7 +403,7 @@ jobs:
             is_special: true
             property: march_native
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "builtin_zlib=ON", "builtin_zstd=ON"]
-          - image: alma9
+          - image: alma10
             is_special: true
             property: arm64
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "builtin_zlib=ON", "builtin_zstd=ON"]


### PR DESCRIPTION
This is to test the newer GCC 14 on ARM.

Should also add coverage for #14446.

Two commits with fixes to h2root and RVec tests are also added to avoid these test failures on alma10 ARM without any further changes:
```txt
TEST FAILURES:
317:gtest-math-vecops-vecops-rvec
1998:roottest-root-hist-h2root
```