### PR TITLE
[main] rootls: fix/improve recursive printing

### DIFF
--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -282,7 +282,7 @@ static void PrintRNTuple(std::ostream &stream, const ROOT::RNTupleDescriptor &de
    std::size_t maxNameLen = 0, maxTypeLen = 0;
    std::vector<const ROOT::RFieldDescriptor *> fields;
    fields.reserve(rootField.GetLinkIds().size());
-   for (const auto &field: desc.GetFieldIterable(rootField.GetId())) {
+   for (const auto &field : desc.GetFieldIterable(rootField.GetId())) {
       fields.push_back(&field);
       maxNameLen = std::max(maxNameLen, field.GetFieldName().length());
       maxTypeLen = std::max(maxTypeLen, field.GetTypeName().length());
@@ -482,11 +482,11 @@ static void PrintNodesInColumns(std::ostream &stream, const RootLsTree &tree,
 
    const bool isTerminal = terminalSize.x + terminalSize.y > 0;
 
-   bool mustIndent = false;
+   auto curCol = 0u;
    for (auto i = 0u; i < nNodes; ++i) {
       NodeIdx childIdx = nodesBegin[i];
       const auto &child = tree.fNodes[childIdx];
-      if ((i % nCols) == 0 || mustIndent) {
+      if (curCol == 0) {
          PrintIndent(stream, indent);
       }
 
@@ -499,22 +499,39 @@ static void PrintNodesInColumns(std::ostream &stream, const RootLsTree &tree,
             stream << Color(kAnsiGreen);
       }
 
-      const bool isExtremal = !(((i + 1) % nCols) != 0 && i != nNodes - 1);
+      // Handle line breaks. Lines are broken in the following situations:
+      // - when the current column number reaches the max number of columns
+      // - when we are in recursive mode and the item is a directory with children
+      // - when we are in recursive mode and the NEXT item is a directory with children
+      
+      const bool isDirWithRecursiveDisplay = isDir && (flags & RootLsArgs::kRecursiveListing) && child.fNChildren > 0;
+
+      bool nextIsDirWithRecursiveDisplay = false;
+      if ((flags & RootLsArgs::kRecursiveListing) && i < nNodes - 1) {
+         NodeIdx nextChildIdx = nodesBegin[i + 1];
+         const auto &nextChild = tree.fNodes[nextChildIdx];
+         nextIsDirWithRecursiveDisplay =
+            nextChild.fNChildren > 0 && ClassInheritsFrom(nextChild.fClassName.c_str(), "TDirectory");
+      }
+
+      const bool isExtremal = (((curCol + 1) % nCols) == 0) || (i == nNodes - 1) || isDirWithRecursiveDisplay ||
+                              nextIsDirWithRecursiveDisplay;
       if (!isExtremal) {
-         stream << std::left << std::setw(colWidths[i % nCols]) << child.fName;
+         stream << std::left << std::setw(colWidths[curCol % nCols]) << child.fName;
       } else {
          stream << std::setw(1) << child.fName;
       }
       stream << Color(kAnsiNone);
 
-      if (isExtremal)
-         stream << "\n";
+      if (isExtremal) {
+         stream << '\n';
+         curCol = 0;
+      } else {
+         ++curCol;
+      }
 
-      if (isDir && (flags & RootLsArgs::kRecursiveListing)) {
-         if (!isExtremal)
-            stream << "\n";
+      if (isDirWithRecursiveDisplay) {
          PrintChildrenInColumns(stream, tree, childIdx, flags, indent + 2);
-         mustIndent = true;
       }
    }
 }

--- a/roottest/main/CMakeLists.txt
+++ b/roottest/main/CMakeLists.txt
@@ -91,6 +91,11 @@ ROOTTEST_ADD_TEST(RecursiveRootls2
                   OUTREF RecursiveRootls2.ref
                   ENVIRONMENT ${test_env})
 
+ROOTTEST_ADD_TEST(RecursiveRootls3
+                  COMMAND ${TOOLS_PREFIX}/rootls${exeext} -r subdirs.root
+                  OUTREF RecursiveRootls3.ref
+                  ENVIRONMENT ${test_env})
+
 ROOTTEST_ADD_TEST(RootlsRNTuple
                   COMMAND ${TOOLS_PREFIX}/rootls${exeext} -R RNTuple.root
                   OUTREF RootlsRNTuple.ref

--- a/roottest/main/RecursiveRootls3.ref
+++ b/roottest/main/RecursiveRootls3.ref
@@ -1,0 +1,6 @@
+sub
+  s1  s2
+  s3
+    t1
+      c
+sub2 sub3


### PR DESCRIPTION
The current algorithm didn't properly handle certain cases when the -r flag is used (namely, directories were not printed in a newline)

Example before:
```
dir  hprof  hpx  hpxpy
tof
  h0_0N  h0_1N  h0_2N  h0_3N  h0_4N  h0_5N  h0_6N  h0_7N  h0_8N  h0_9N  h1_0N  h1_1N  h1_2N  h1_3N  h1_4N  h1_5N  h1_6N  h1_7N  h1_8N  h1_9N  plane0
    h0_10N  h0_11N  h0_12N  h0_13N  h0_14N  h0_15N  h0_16N  h0_17N  h0_18N  h0_19N  h0_20N  h0_21N  h0_22N  h0_23N  h0_24N  h0_25N  h0_26N  h0_27N  h0_28N  h0_29N  h0_30N  h0_31N  h0_32N  h0_33N
    h0_34N  h0_35N  h0_36N  h0_37N  h0_38N  h0_39N  h0_40N  h0_41N  h0_42N  h0_43N  h0_44N  h0_45N  h0_46N  h0_47N  h0_48N  h0_49N
plane1
    h1_10N  h1_11N  h1_12N  h1_13N  h1_14N  h1_15N  h1_16N  h1_17N  h1_18N  h1_19N  h1_20N  h1_21N  h1_22N  h1_23N  h1_24N  h1_25N  h1_26N  h1_27N  h1_28N  h1_29N  h1_30N  h1_31N  h1_32N  h1_33N
    h1_34N  h1_35N  h1_36N  h1_37N  h1_38N  h1_39N  h1_40N  h1_41N  h1_42N  h1_43N  h1_44N  h1_45N  h1_46N  h1_47N  h1_48N  h1_49N
```

After:
```
dir  hprof  hpx  hpxpy
tof
  h0_0N  h0_1N  h0_2N  h0_3N  h0_4N  h0_5N  h0_6N  h0_7N  h0_8N  h0_9N  h1_0N  h1_1N  h1_2N  h1_3N  h1_4N  h1_5N  h1_6N  h1_7N  h1_8N  h1_9N
  plane0
    h0_10N  h0_11N  h0_12N  h0_13N  h0_14N  h0_15N  h0_16N  h0_17N  h0_18N  h0_19N  h0_20N  h0_21N  h0_22N  h0_23N  h0_24N  h0_25N  h0_26N  h0_27N  h0_28N  h0_29N  h0_30N  h0_31N  h0_32N  h0_33N
    h0_34N  h0_35N  h0_36N  h0_37N  h0_38N  h0_39N  h0_40N  h0_41N  h0_42N  h0_43N  h0_44N  h0_45N  h0_46N  h0_47N  h0_48N  h0_49N
  plane1
    h1_10N  h1_11N  h1_12N  h1_13N  h1_14N  h1_15N  h1_16N  h1_17N  h1_18N  h1_19N  h1_20N  h1_21N  h1_22N  h1_23N  h1_24N  h1_25N  h1_26N  h1_27N  h1_28N  h1_29N  h1_30N  h1_31N  h1_32N  h1_33N
    h1_34N  h1_35N  h1_36N  h1_37N  h1_38N  h1_39N  h1_40N  h1_41N  h1_42N  h1_43N  h1_44N  h1_45N  h1_46N  h1_47N  h1_48N  h1_49N
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


