### PR TITLE
[core] Add core headers to private CMake target FILE_SETS

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -199,15 +199,15 @@ set(BASE_SOURCES
   src/TVirtualX.cxx
 )
 
-set(RELATIVE_BASE_INC_HEADERS ${BASE_HEADERS})
-list(TRANSFORM RELATIVE_BASE_INC_HEADERS PREPEND inc/)
+set(RELATIVE_INC_HEADERS ${BASE_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
 
 # only here complete list of headers can be propogated to parent cmake file
 set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${BASE_HEADERS})
 
 target_sources(Core PRIVATE ${BASE_SOURCES})
 
-if(NOT CMAKE_VERSION VERSION_LESS "3.23.0") # https://discourse.cmake.org/t/file-set-xyz-is-listed-in-interface-file-sets-of-w-but-has-not-been-exported/9131/3
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
   target_sources(
       Core
       PRIVATE
@@ -215,7 +215,8 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.23.0") # https://discourse.cmake.org/t/file
       TYPE HEADERS
       BASE_DIRS inc/ src/
       FILES
-          ${RELATIVE_BASE_INC_HEADERS}
+          ${RELATIVE_INC_HEADERS}
+          inc/LinkDef.h
           src/TListOfTypes.h
   )
 endif()

--- a/core/clib/CMakeLists.txt
+++ b/core/clib/CMakeLists.txt
@@ -8,10 +8,26 @@
 # CMakeLists.txt file for building ROOT core/clib package
 ############################################################################
 
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+set(CLIB_HEADERS
   strlcpy.h
   snprintf.h
   strtok.h
+)
+
+set(RELATIVE_INC_HEADERS ${CLIB_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+set(CLIB_RES_HEADERS
+  mmalloc.h
+  mmconfig.h
+  mmprivate.h
+)
+
+set(RELATIVE_RES_HEADERS ${CLIB_RES_HEADERS})
+list(TRANSFORM RELATIVE_RES_HEADERS PREPEND res/)
+
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+  ${CLIB_HEADERS}
 )
 
 ROOT_OBJECT_LIBRARY(Clib
@@ -30,6 +46,19 @@ ROOT_OBJECT_LIBRARY(Clib
   src/strlcat.c
   src/strlcpy.c
 )
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Clib
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/ res/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+          ${RELATIVE_RES_HEADERS}
+  )
+endif()
 
 target_include_directories(Clib
   PUBLIC

--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -25,6 +25,22 @@ ROOT_OBJECT_LIBRARY(ClingUtils
   src/TClingUtils.cxx
 )
 
+set(RELATIVE_RES_HEADERS RStl.h TClingUtils.h)
+list(TRANSFORM RELATIVE_RES_HEADERS PREPEND res/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      ClingUtils
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS res/ inc/
+      FILES
+          ${RELATIVE_RES_HEADERS}
+          inc/root_std_complex.h
+  )
+endif()
+
 if(NOT MSVC)
   target_compile_options(ClingUtils PRIVATE -Wno-error)
 endif()

--- a/core/cont/CMakeLists.txt
+++ b/core/cont/CMakeLists.txt
@@ -7,8 +7,7 @@
 ############################################################################
 # CMakeLists.txt file for building ROOT core/cont package
 ############################################################################
-
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+set(CONT_HEADERS
   ROOT/TSeq.hxx
   TArrayC.h
   TArrayD.h
@@ -39,6 +38,8 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TSortedList.h
   TVirtualCollectionProxy.h
 )
+
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${CONT_HEADERS})
 
 target_sources(Core PRIVATE
   src/TArrayC.cxx
@@ -71,6 +72,21 @@ target_sources(Core PRIVATE
 
 target_include_directories(Core
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
+
+set(RELATIVE_INC_HEADERS ${CONT_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+  )
+endif()
 
 ROOT_INSTALL_HEADERS()
 

--- a/core/dictgen/CMakeLists.txt
+++ b/core/dictgen/CMakeLists.txt
@@ -27,6 +27,36 @@ ROOT_OBJECT_LIBRARY(Dictgen
   XMLReader.cxx
 )
 
+set(DICTGEN_HEADERS
+  BaseSelectionRule.h
+  ClassSelectionRule.h
+  cygpath.h
+  DictSelectionReader.h
+  LinkdefReader.h
+  OptionParser.h
+  rootcling_impl.h
+  Scanner.h
+  SelectionRules.h
+  TModuleGenerator.h
+  VariableSelectionRule.h
+  XMLReader.h
+)
+
+set(RELATIVE_RES_HEADERS ${DICTGEN_HEADERS})
+list(TRANSFORM RELATIVE_RES_HEADERS PREPEND res/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Dictgen
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS res/
+      FILES
+          ${RELATIVE_RES_HEADERS}
+  )
+endif()
+
 # This directory contains files that include llvm, which can give warnings.
 if(NOT MSVC)
   target_compile_options(Dictgen PRIVATE -Wno-error)

--- a/core/foundation/CMakeLists.txt
+++ b/core/foundation/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/foundation package
 ############################################################################
 
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+set(FOUNDATION_HEADERS
   ESTLType.h
   RStringView.h
   TClassEdit.h
@@ -26,6 +26,8 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   ROOT/TypeTraits.hxx
 )
 
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${FOUNDATION_HEADERS})
+
 set(FOUNDATION_SOURCES
   src/FoundationUtils.cxx
   src/RConversionRuleParser.cxx
@@ -37,6 +39,8 @@ set(FOUNDATION_SOURCES
 )
 
 set(FOUNDATION_HEADER_DIRS inc/)
+
+
 
 target_sources(Core PRIVATE ${FOUNDATION_SOURCES})
 
@@ -61,6 +65,31 @@ set_target_properties(Foundation_Stage1 PROPERTIES
   COMPILE_FLAGS "${COMPILE_FLAGS} ${CLING_CXXFLAGS}"
   VISIBILITY_INLINES_HIDDEN "ON"
 )
+
+
+set(RELATIVE_INC_HEADERS ${FOUNDATION_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Foundation_Stage1
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+  )
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+  )
+endif()
 
 ROOT_INSTALL_HEADERS(${FOUNDATION_HEADER_DIRS})
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/gui/CMakeLists.txt
+++ b/core/gui/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/meta package
 ############################################################################
 
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+set(GUI_HEADERS
   GuiTypes.h
   TApplicationImp.h
   TBrowser.h
@@ -24,6 +24,10 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TToggleGroup.h
   TToggle.h
 )
+
+
+
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${GUI_HEADERS})
 
 target_sources(Core PRIVATE
   src/InitGui.cxx
@@ -45,5 +49,20 @@ target_sources(Core PRIVATE
 target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
+
+set(RELATIVE_INC_HEADERS ${GUI_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+  )
+endif()
 
 ROOT_INSTALL_HEADERS()

--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -25,13 +25,15 @@ target_link_libraries(Imt PRIVATE Thread INTERFACE Core)
 
 if(imt)
   target_link_libraries(Imt PRIVATE TBB::tbb)
-  
-  ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
+  set(IMT_HEADERS
     ROOT/TTaskGroup.hxx
     ROOT/RTaskArena.hxx
     ROOT/RSlotStack.hxx
     ROOT/TExecutor.hxx
     ROOT/TThreadExecutor.hxx
+  )
+  ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
+    ${IMT_HEADERS}
     LINKDEF
       LinkDef.h
     MODULE
@@ -52,8 +54,11 @@ if(imt)
 
   ROOT_ADD_TEST_SUBDIRECTORY(test)
 else()
-  ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
+  set(IMT_HEADERS
     ROOT/TExecutor.hxx
+  )
+  ROOT_GENERATE_DICTIONARY(G__Imt STAGE1
+    ${IMT_HEADERS}
     LINKDEF
       LinkDef.h
     MODULE
@@ -61,6 +66,22 @@ else()
     DEPENDENCIES
       Core
       ${MULTIPROC_LIB}
+  )
+endif()
+
+set(RELATIVE_INC_HEADERS ${IMT_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Imt
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+          inc/LinkDef.h
   )
 endif()
 

--- a/core/lz4/CMakeLists.txt
+++ b/core/lz4/CMakeLists.txt
@@ -9,5 +9,16 @@ target_link_libraries(Core PRIVATE xxHash::xxHash LZ4::LZ4)
 target_include_directories(Core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          inc/ZipLZ4.h
+  )
+endif()
 
 ROOT_INSTALL_HEADERS()

--- a/core/lzma/CMakeLists.txt
+++ b/core/lzma/CMakeLists.txt
@@ -13,5 +13,15 @@ target_sources(Core PRIVATE src/ZipLZMA.c)
 target_link_libraries(Core PRIVATE LibLZMA::LibLZMA)
 
 target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
-
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          inc/ZipLZMA.h
+  )
+endif()
 ROOT_INSTALL_HEADERS()

--- a/core/macosx/CMakeLists.txt
+++ b/core/macosx/CMakeLists.txt
@@ -35,6 +35,20 @@ if(cocoa)
 
   target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
 
+  if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+    target_sources(
+        Macosx
+        PRIVATE
+        FILE_SET private_header_files
+        TYPE HEADERS
+        BASE_DIRS inc/
+        FILES
+            inc/CocoaUtils.h
+            inc/TMacOSXSystem.h
+            inc/LinkDef.h
+    )
+  endif()
+
 endif()
 
 ROOT_INSTALL_HEADERS()

--- a/core/meta/CMakeLists.txt
+++ b/core/meta/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/meta package
 ############################################################################
 
-set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+set(META_HEADERS
   TBaseClass.h
   TClassGenerator.h
   TClass.h
@@ -52,6 +52,8 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TVirtualObject.h
 )
 
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${META_HEADERS})
+
 target_sources(Core PRIVATE
   src/TBaseClass.cxx
   src/TClass.cxx
@@ -93,5 +95,19 @@ target_include_directories(Core
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
+set(RELATIVE_INC_HEADERS ${META_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+  )
+endif()
 ROOT_INSTALL_HEADERS()
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -37,6 +37,37 @@ ROOT_OBJECT_LIBRARY(MetaCling
   TClingValue.cxx
 )
 
+set (METACLING_HEADERS
+  ClingRAII.h
+  TClingBaseClassInfo.h
+  TClingCallbacks.h
+  TClingCallFunc.h
+  TClingClassInfo.h
+  TClingDataMemberInfo.h
+  TClingDeclInfo.h
+  TClingDiagnostics.h
+  TCling.h
+  TClingMemberIter.h
+  TClingMethodArgInfo.h
+  TClingMethodInfo.h
+  TClingRdictModuleFileExtension.h
+  TClingTypedefInfo.h
+  TClingTypeInfo.h
+  TClingValue.h
+)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      MetaCling
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS ./
+      FILES
+          ${METACLING_HEADERS}
+  )
+endif()
+
 # This directory contains files that include llvm, which can give warnings.
 if(NOT MSVC)
   target_compile_options(MetaCling PRIVATE -Wno-error)

--- a/core/multiproc/CMakeLists.txt
+++ b/core/multiproc/CMakeLists.txt
@@ -12,16 +12,21 @@ if(WIN32)
   return()
 endif()
 
+
+set(MULTIPROC_HEADERS
+  MPCode.h
+  MPSendRecv.h
+  PoolUtils.h
+  TMPClient.h
+  TMPWorker.h
+  TMPWorkerExecutor.h
+  TProcPool.h
+  ROOT/TProcessExecutor.hxx
+)
+
 ROOT_STANDARD_LIBRARY_PACKAGE(MultiProc STAGE1
   HEADERS
-    MPCode.h
-    MPSendRecv.h
-    PoolUtils.h
-    TMPClient.h
-    TMPWorker.h
-    TMPWorkerExecutor.h
-    TProcPool.h
-    ROOT/TProcessExecutor.hxx
+    ${MULTIPROC_HEADERS}
   SOURCES
     src/MPSendRecv.cxx
     src/TMPClient.cxx
@@ -33,3 +38,19 @@ ROOT_STANDARD_LIBRARY_PACKAGE(MultiProc STAGE1
     Core
     Net
 )
+
+set(RELATIVE_INC_HEADERS ${MULTIPROC_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      MultiProc
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+          inc/LinkDef.h
+  )
+endif()

--- a/core/rint/CMakeLists.txt
+++ b/core/rint/CMakeLists.txt
@@ -8,11 +8,15 @@
 # CMakeLists.txt file for building ROOT core/rint package
 ############################################################################
 
+set(RINT_HEADERS
+  TRint.h
+  TTabCom.h
+)
+
 ROOT_STANDARD_LIBRARY_PACKAGE(Rint
   STAGE1
   HEADERS
-    TRint.h
-    TTabCom.h
+    ${RINT_HEADERS}
   SOURCES
     src/TRint.cxx
     src/TTabCom.cxx
@@ -23,5 +27,20 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Rint
 )
 
 target_include_directories(Core PRIVATE inc)
+set(RELATIVE_INC_HEADERS ${RINT_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Rint
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+          inc/LinkDef.h
+  )
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/testsupport/CMakeLists.txt
+++ b/core/testsupport/CMakeLists.txt
@@ -26,6 +26,19 @@ install(TARGETS ${libname}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${header_dir})
 set_property(GLOBAL APPEND PROPERTY ROOT_EXPORTED_TARGETS ${libname})
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      ${libname}
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/${header_dir}
+      FILES
+          inc/${header_dir}/TestSupport.hxx
+  )
+endif()
+
+
 # Make it usable inside and outside of ROOT under a single name if somebody writes their own tests using ROOT_ADD_GTEST
 add_library(ROOT::TestSupport ALIAS ${libname})
 

--- a/core/textinput/CMakeLists.txt
+++ b/core/textinput/CMakeLists.txt
@@ -36,4 +36,38 @@ target_include_directories(Core
     src
 )
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/ src/
+      FILES
+          inc/Getline.h
+          src/Getline_color.h
+          src/textinput/Callbacks.h
+          src/textinput/Callbacks.h
+          src/textinput/Color.h
+          src/textinput/Display.h
+          src/textinput/Editor.h
+          src/textinput/History.h
+          src/textinput/InputData.h
+          src/textinput/KeyBinding.h
+          src/textinput/Range.h
+          src/textinput/Reader.h
+          src/textinput/SignalHandler.h
+          src/textinput/StreamReader.h
+          src/textinput/StreamReaderUnix.h
+          src/textinput/StreamReaderWin.h
+          src/textinput/TerminalConfigUnix.h
+          src/textinput/TerminalDisplay.h
+          src/textinput/TerminalDisplayUnix.h
+          src/textinput/TerminalDisplayWin.h
+          src/textinput/Text.h
+          src/textinput/TextInputContext.h
+          src/textinput/TextInput.h
+  )
+endif()
+
 ROOT_INSTALL_HEADERS()

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -27,23 +27,27 @@ else()
   )
 endif()
 
+set(THREAD_HEADERS
+  TAtomicCount.h
+  TCondition.h
+  TConditionImp.h
+  TMutex.h
+  TMutexImp.h
+  TRWLock.h
+  TSemaphore.h
+  TThreadFactory.h
+  TThread.h
+  TThreadImp.h
+  TThreadPool.h
+  ROOT/TRWSpinLock.hxx
+  ROOT/TSpinMutex.hxx
+  ROOT/TThreadedObject.hxx
+)
+
 ROOT_STANDARD_LIBRARY_PACKAGE(Thread
   HEADERS
     ${PLATFORM_HEADERS}
-    TAtomicCount.h
-    TCondition.h
-    TConditionImp.h
-    TMutex.h
-    TMutexImp.h
-    TRWLock.h
-    TSemaphore.h
-    TThreadFactory.h
-    TThread.h
-    TThreadImp.h
-    TThreadPool.h
-    ROOT/TRWSpinLock.hxx
-    ROOT/TSpinMutex.hxx
-    ROOT/TThreadedObject.hxx
+    ${THREAD_HEADERS}
   SOURCES
     src/TCondition.cxx
     src/TConditionImp.cxx
@@ -68,6 +72,22 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Thread
 target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
+
+set(RELATIVE_INC_HEADERS ${PLATFORM_HEADERS} ${THREAD_HEADERS})
+list(TRANSFORM RELATIVE_INC_HEADERS PREPEND inc/)
+
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Thread
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          ${RELATIVE_INC_HEADERS}
+          inc/LinkDef.h
+  )
+endif()
 
 target_link_libraries(Thread PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 

--- a/core/unix/CMakeLists.txt
+++ b/core/unix/CMakeLists.txt
@@ -15,6 +15,18 @@ endif()
 set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TUnixSystem.h)
 target_sources(Core PRIVATE src/TUnixSystem.cxx)
 target_include_directories(Core PRIVATE inc ../clib/res)
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          inc/TUnixSystem.h
+          inc/LinkDef.h
+  )
+endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
   target_link_libraries(Core PRIVATE execinfo util)

--- a/core/winnt/CMakeLists.txt
+++ b/core/winnt/CMakeLists.txt
@@ -30,4 +30,20 @@ target_link_libraries(Core PRIVATE
 
 target_include_directories(Core PRIVATE inc)
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          inc/TWin32SplashThread.h
+          inc/TWinNTSystem.h
+          inc/Win32Constants.h
+          inc/Windows4Root.h
+          inc/LinkDef.h
+  )
+endif()
+
 ROOT_INSTALL_HEADERS()

--- a/core/zip/CMakeLists.txt
+++ b/core/zip/CMakeLists.txt
@@ -19,6 +19,22 @@ target_include_directories(Core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/ src/
+      FILES
+          inc/Compression.h
+          inc/RZip.h
+          src/Bits.h
+          src/Tailor.h
+          src/ZIP.h
+  )
+endif()
+
 ROOT_INSTALL_HEADERS()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/zstd/CMakeLists.txt
+++ b/core/zstd/CMakeLists.txt
@@ -8,4 +8,15 @@ target_link_libraries(Core PRIVATE ZSTD::ZSTD)
 
 target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
 
+if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
+  target_sources(
+      Core
+      PRIVATE
+      FILE_SET private_header_files
+      TYPE HEADERS
+      BASE_DIRS inc/
+      FILES
+          inc/ZipZSTD.h
+  )
+endif()
 ROOT_INSTALL_HEADERS()


### PR DESCRIPTION
This is a non-functional change, it only improves the IDE experience.

In the future, we could avoid copying headers to build-directory and verbose target_include_directory statements by just using the file_sets. Same with INSTALL, would go through headers.
This could ultimately go into the ROOT custom macros, but for the moment let's only do the minimal changes for the IDE and let the rest for later.
They are all added as private now, in the future we can distinguish private from public file-sets.
As well as DICT_HEADERS for dictionary generation. This might enhance dependency issues and build speed.

Follow-up of https://github.com/root-project/root/pull/18419

Work towards https://its.cern.ch/jira/browse/ROOT-10915