### PR TITLE
[RF] Fix codegen of RooMultiVarGaussian

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -787,8 +787,8 @@ double bernsteinIntegral(double xlo, double xhi, double xmin, double xmax, Doubl
    return norm * (xmax - xmin);
 }
 
-template <typename DoubleArray>
-double multiVarGaussian(int n, DoubleArray x, DoubleArray mu, DoubleArray covI)
+template <typename XArray, typename MuArray, typename CovArray>
+double multiVarGaussian(int n, XArray x, MuArray mu, CovArray covI)
 {
    double result = 0.0;
 


### PR DESCRIPTION
The codegen implementation for this class was broken because the function only took one template parameter, which resulted in overload resolution failure when the passed argument types were different.

This is fixed now, and a unit test is added to prevent future regressions.

Also, a workaround around a Clad issue is removed from the tests, and the tolerance parameter of some tests is adjusted, because changing a prior test had an effect on the random number generation of the Landau tests.

FYI, @TomasDado 