### PR TITLE
Mutable polynomial roots

### DIFF
--- a/math/mathmore/inc/Math/Polynomial.h
+++ b/math/mathmore/inc/Math/Polynomial.h
@@ -116,20 +116,20 @@ public:
       equation is very small. In that case it might be more robust to use the numerical method, by calling directly FindNumRoots()
 
    */
-   const std::vector<std::complex <double> > & FindRoots();
+   const std::vector<std::complex <double> > & FindRoots() const;
 
    /**
       Find the only the real polynomial roots.
       For n <= 4, the roots are found analytically while for larger order an iterative numerical method is used
       The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
-   std::vector<double > FindRealRoots();
+   std::vector<double > FindRealRoots() const;
 
    /**
       Find the polynomial roots using always an iterative numerical methods
       The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
-   const std::vector<std::complex <double> > & FindNumRoots();
+   const std::vector<std::complex <double> > & FindNumRoots() const;
 
    /**
       Order of Polynomial
@@ -166,8 +166,7 @@ private:
    mutable std::vector<double> fDerived_params;
 
    // roots
-
-   std::vector< std::complex < double > > fRoots;
+   mutable std::vector< std::complex < double > > fRoots;
 
 };
 

--- a/math/mathmore/src/Polynomial.cxx
+++ b/math/mathmore/src/Polynomial.cxx
@@ -148,7 +148,7 @@ IGenFunction * Polynomial::Clone() const {
 }
 
 
-const std::vector< std::complex <double> > &  Polynomial::FindRoots(){
+const std::vector< std::complex <double> > &  Polynomial::FindRoots() const {
 
 
     // check if order is correct
@@ -234,7 +234,7 @@ const std::vector< std::complex <double> > &  Polynomial::FindRoots(){
   }
 
 
-std::vector< double >  Polynomial::FindRealRoots(){
+std::vector< double >  Polynomial::FindRealRoots() const {
   FindRoots();
   std::vector<double> roots;
   roots.reserve(fOrder);
@@ -244,7 +244,7 @@ std::vector< double >  Polynomial::FindRealRoots(){
   }
   return roots;
 }
-const std::vector< std::complex <double> > &  Polynomial::FindNumRoots(){
+const std::vector< std::complex <double> > &  Polynomial::FindNumRoots() const {
 
 
     // check if order is correct


### PR DESCRIPTION
# This Pull request:

Hi @lmoneta @vepadulano ; we may benefit from introducing a `mutable` keyword to `fRoots` in the Polynomial.h methods. I would be grateful if you could consider such changes as described below.


## Changes or fixes:
I applied a mutable keywords to `fRoots` allowing to use FindRoots in const context. Such keyword was already applied along the same line to `fDerived_params` variable in `math/mathmore/inc/Math/Polynomial.h`.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

## Tests:

I ran the ROOT battery of tests with couple of issues (related to some stress test, vectorization & simultions), but those also happened on my Mac M3 ARM before my modifications. If you have any concern, I believe it wouldn't be an issue to run it in a more standard dev context.
```
cmake -DCMAKE_BUILD_TYPE=Debug -Dtesting=ON -Droottest=ON -Dmathmore=ON ../polynomial-patch
make -j8
ctest -j8
```

Regarding the Polynomial class modifications, my use case output remains unchanged. (I use polynomials to compute digital filtering, biquad, etc..) I also paid attention in particular to those related to polynomials: `gtest-hist-hist-testTProfile2Poly`, etc..
```
1015/3593 Test  #155: gtest-graf2d-primitivesv7-graf2dprimitivesv7testUnit ..............................................   Passed    0.39 sec
          Start  158: gtest-hist-hist-testTProfile2Poly
1016/3593 Test  #156: gtest-graf3d-eve7-graf3deve7testUnit ..............................................................   Passed    0.46 sec
          Start  159: gtest-hist-hist-testTFractionFitter
1017/3593 Test  #159: gtest-hist-hist-testTFractionFitter ...............................................................   Passed    0.39 sec
          Start  160: gtest-hist-hist-testTH2PolyBinError
1018/3593 Test  #160: gtest-hist-hist-testTH2PolyBinError ...............................................................   Passed    0.30 sec
          Start  161: gtest-hist-hist-testTH2PolyAdd
1019/3593 Test   #84: pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-rdataframe-histo-profile ....................   Passed   13.81 sec
          Start  162: gtest-hist-hist-testTH2PolyGetNumberOfBins
1020/3593 Test  #162: gtest-hist-hist-testTH2PolyGetNumberOfBins ........................................................   Passed    0.24 sec
          Start  163: gtest-hist-hist-testTHn
1021/3593 Test  #161: gtest-hist-hist-testTH2PolyAdd ....................................................................   Passed    0.51 sec
[...]

1198/3593 Test  #337: gtest-roofit-roofit-vectorisedPDFs-testNestedPDFs .................................................   Passed    1.91 sec
          Start  341: gtest-roofit-roofit-vectorisedPDFs-testBukin
1199/3593 Test  #340: gtest-roofit-roofit-vectorisedPDFs-testLandau .....................................................   Passed    0.80 sec
          Start  342: gtest-roofit-roofit-vectorisedPDFs-testChebychev
1200/3593 Test  #341: gtest-roofit-roofit-vectorisedPDFs-testBukin ......................................................   Passed    1.27 sec
          Start  343: gtest-roofit-roofit-vectorisedPDFs-testPolynomial
1201/3593 Test  #338: gtest-roofit-roofit-vectorisedPDFs-testProductPdf .................................................   Passed    3.06 sec
          Start  344: gtest-roofit-roofit-vectorisedPDFs-testBernstein
1202/3593 Test  #339: gtest-roofit-roofit-vectorisedPDFs-testJohnson ....................................................   Passed    3.47 sec
          Start  345: gtest-roofit-roofit-vectorisedPDFs-testArgusBG
1203/3593 Test  #343: gtest-roofit-roofit-vectorisedPDFs-testPolynomial .................................................   Passed    1.00 sec
          Start  346: gtest-roofit-roofit-vectorisedPDFs-testBifurGauss
1204/3593 Test  #344: gtest-roofit-roofit-vectorisedPDFs-testBernstein ..................................................   Passed    1.18 sec
          Start  347: gtest-roofit-roofit-vectorisedPDFs-testBreitWigner
1205/3593 Test  #345: gtest-roofit-roofit-vectorisedPDFs-testArgusBG ....................................................   Passed    0.71 sec
          Start  348: gtest-roofit-roofit-vectorisedPDFs-testCBShape
```