### PR TITLE
[main] add missing newlines in logging

### DIFF
--- a/main/src/rootbrowse.cxx
+++ b/main/src/rootbrowse.cxx
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
       gErrorIgnoreLevel = kError;
       file = std::unique_ptr<TFile>(TFile::Open(std::string(args.fFileName).c_str(), "READ"));
       if (!file || file->IsZombie()) {
-         Err() << "File " << args.fFileName << " does not exist or is unreadable.";
+         Err() << "File " << args.fFileName << " does not exist or is unreadable.\n";
          return 1;
       }
       gErrorIgnoreLevel = kUnset;

--- a/main/src/rootls.cxx
+++ b/main/src/rootls.cxx
@@ -380,7 +380,7 @@ static void PrintNodesDetailed(std::ostream &stream, const RootLsTree &tree,
                const auto &desc = reader->GetDescriptor();
                PrintRNTuple(stream, desc, indent + 2, desc.GetFieldZero());
             } else {
-               Err() << "failed to read RNTuple object: " << child.fName;
+               Err() << "failed to read RNTuple object: " << child.fName << "\n";
             }
          }
       }
@@ -686,7 +686,7 @@ static RootLsArgs ParseArgs(const char **args, int nArgs)
 
    opts.Parse(args, nArgs);
    for (const auto &err : opts.GetErrors())
-      Err() << err;
+      Err() << err << "\n";
 
    if (opts.GetSwitch("help")) {
       outArgs.fPrintUsageAndExit = RootLsArgs::EPrintUsage::kLong;


### PR DESCRIPTION
Followup of #20516: forgot to add newlines to the logs (the simple logging functions don't automatically add one like RLogger does)

