### PR TITLE
[io] TDirectoryFile: propagate returnExistingDirectory to sub-calls and properly apply title

### DIFF
--- a/io/io/src/TDirectoryFile.cxx
+++ b/io/io/src/TDirectoryFile.cxx
@@ -1258,7 +1258,9 @@ TFile *TDirectoryFile::OpenFile(const char *name, Option_t *option,const char *f
 /// Create a sub-directory "a" or a hierarchy of sub-directories "a/b/c/...".
 ///
 /// @param name the name or hierarchy of the subdirectory ("a" or "a/b/c")
-/// @param title the title
+/// @param title the title of the directory. For hierarchies, this is only applied
+/// to the innermost directory (so if `name == "a/b/c"` and `title == "my dir"`,
+/// only `c` will have the title `"my dir"`).
 /// @param returnExistingDirectory if key-name is already existing, the returned
 /// value points to preexisting sub-directory if true and to `nullptr` if false.
 /// @return a pointer to the created sub-directory, not to the top sub-directory
@@ -1284,10 +1286,11 @@ TDirectory *TDirectoryFile::mkdir(const char *name, const char *title, Bool_t re
       TDirectoryFile *tmpdir = nullptr;
       GetObject(workname.Data(), tmpdir);
       if (!tmpdir) {
-         tmpdir = (TDirectoryFile*)mkdir(workname.Data(),title);
+         // We give all intermediate directories a default title, as `title` is only given to the innermost dir.
+         tmpdir = (TDirectoryFile *)mkdir(workname.Data(), "");
          if (!tmpdir) return nullptr;
       }
-      return tmpdir->mkdir(slash + 1, "", returnExistingDirectory);
+      return tmpdir->mkdir(slash + 1, title, returnExistingDirectory);
    }
 
    TDirectory::TContext ctxt(this);

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -285,7 +285,7 @@ TEST(TDirectoryFile, SeekParent)
 TEST(TDirectoryFile, RecursiveMkdir)
 {
    TMemFile f("mkdirtest.root", "RECREATE");
-   auto dir1 = f.mkdir("a/b/c");
+   auto dir1 = f.mkdir("a/b/c", "my dir");
    EXPECT_NE(dir1, nullptr);
    {
       ROOT::TestSupport::CheckDiagsRAII diags;
@@ -293,8 +293,15 @@ TEST(TDirectoryFile, RecursiveMkdir)
       auto dir2 = f.mkdir("a/b/c", "", /* returnExisting = */ false);
       EXPECT_EQ(dir2, nullptr);
    }
-   auto dir3 = f.mkdir("a/b/c", "", /* returnExisting = */ true);
+   auto dir3 = f.mkdir("a/b/c", "foobar", /* returnExisting = */ true);
    EXPECT_EQ(dir3, dir1);
+   EXPECT_STREQ(dir3->GetTitle(), "my dir");
+   auto dirB = dir3->GetMotherDir();
+   ASSERT_NE(dirB, nullptr);
+   EXPECT_STREQ(dirB->GetTitle(), "b");
+   auto dirA = dirB->GetMotherDir();
+   ASSERT_NE(dirA, nullptr);
+   EXPECT_STREQ(dirA->GetTitle(), "a");
 }
 
 // https://its.cern.ch/jira/browse/ROOT-10581


### PR DESCRIPTION
Currently this doesn't work as expected:
```c++
auto dir1 = file->mkdir("a/b");
auto dir2 = file->mkdir("a/b", "", /* returnExisting = */ true); // should return the already-existing dir
EXPECT_EQ(dir1, dir2); // FAILS: dir2 is nullptr
```

because TDirectoryFile::mkdir doesn't propagate the value of `returnExistingDirectory` to recursive mkdir calls. This PR fixes it.

In addition, `title` was currently only applied to the *topmost* directory in case of hierarchies, which is counterintuitive as the returned TDirectory is actually the innermost. This PR changes the (previously undocumented) title logic to the opposite: every non-leaf directory gets created with a default title and only the innermost gets the user-defined one. In our codebase we have 0 cases of `mkdir` being called with a hierarchy and an explicit title, so this change shouldn't impact anything.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


