### PR TITLE
[VecOps] Remove outdated `IsSmall` helper function in tests

### DIFF
--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1493,13 +1493,6 @@ TEST(VecOps, Construct)
    EXPECT_TRUE(fourVects[2] == ref2);
 }
 
-bool IsSmall(const RVec<int> &v)
-{
-   // the first array element is right after the 3 data members of SmallVectorBase
-   return reinterpret_cast<std::uintptr_t>(v.begin()) - reinterpret_cast<std::uintptr_t>(&v) ==
-          sizeof(void *) + 2 * sizeof(int);
-}
-
 // this is a regression test for https://github.com/root-project/root/issues/6796
 TEST(VecOps, MemoryAdoptionAndClear)
 {


### PR DESCRIPTION
The commit https://github.com/guitargeek/root/commit/2605710bea7b169dde75bb2f89172a31df3ad157 changed from using the `ROOT::Detail::VecOps::` namespace explicitly for `IsSmall` to a `using` statement. However, there was also a remnant `IsSmall` function with an outdated implementation in the test file itself, which we can now remove.