### PR TITLE
[h2root] Adapt to GCC 8 passing convention for string length

### DIFF
--- a/main/src/h2root.cxx
+++ b/main/src/h2root.cxx
@@ -131,6 +131,15 @@ void MAIN__() {}
 # define type_of_call
 # define DEFCHAR  const char*
 # define PASSCHAR(string) string
+
+// As recommended in
+// https://gcc.gnu.org/onlinedocs/gfortran/Argument-passing-conventions.html
+#if __GNUC__ > 7
+typedef size_t fortran_charlen_t;
+#else
+typedef int fortran_charlen_t;
+#endif
+
 #else
 # define hlimit  HLIMIT
 # define hropen  HROPEN
@@ -169,7 +178,7 @@ void MAIN__() {}
 extern "C" void  type_of_call hlimit(const int&);
 #ifndef WIN32
 extern "C" void  type_of_call hropen(const int&,DEFCHAR,DEFCHAR,DEFCHAR,
-                        const int&,const int&,const int,const int,const int);
+                        const int&,const int&,fortran_charlen_t,fortran_charlen_t,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hropen(const int&,DEFCHAR,DEFCHAR,DEFCHAR,
                         const int&,const int&);
@@ -179,7 +188,7 @@ extern "C" void  type_of_call hrin(const int&,const int&,const int&);
 extern "C" void  type_of_call hnoent(const int&,const int&);
 #ifndef WIN32
 extern "C" void  type_of_call hgive(const int&,DEFCHAR,const int&,const float&,const float&,
-   const int&,const float&,const float&,const int&,const int&,const int);
+   const int&,const float&,const float&,const int&,const int&,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hgive(const int&,DEFCHAR,const int&,const float&,const float&,
    const int&,const float&,const float&,const int&,const int&);
@@ -187,20 +196,20 @@ extern "C" void  type_of_call hgive(const int&,DEFCHAR,const int&,const float&,c
 
 #ifndef WIN32
 extern "C" void  type_of_call hgiven(const int&,DEFCHAR,const int&,DEFCHAR,
-   const float&,const float&,const int,const int);
+   const float&,const float&,fortran_charlen_t,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hgiven(const int&,DEFCHAR,const int&,DEFCHAR,
    const float&,const float&);
 #endif
 
 #ifndef WIN32
-extern "C" void  type_of_call hntvar2(const int&,const int&,DEFCHAR,DEFCHAR,DEFCHAR,int&,int&,int&,int&,int&,const int,const int, const int);
+extern "C" void  type_of_call hntvar2(const int&,const int&,DEFCHAR,DEFCHAR,DEFCHAR,int&,int&,int&,int&,int&,fortran_charlen_t,fortran_charlen_t,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hntvar2(const int&,const int&,DEFCHAR,DEFCHAR,DEFCHAR,int&,int&,int&,int&,int&);
 #endif
 
 #ifndef WIN32
-extern "C" void  type_of_call hbnam(const int&,DEFCHAR,const int&,DEFCHAR,const int&,const int, const int);
+extern "C" void  type_of_call hbnam(const int&,DEFCHAR,const int&,DEFCHAR,const int&,fortran_charlen_t,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hbnam(const int&,DEFCHAR,const int&,DEFCHAR,const int&);
 #endif
@@ -232,14 +241,14 @@ extern "C" double type_of_call hije(const int&,const int&,const int&);
 #endif
 
 #ifndef WIN32
-extern "C" void  type_of_call hcdir(DEFCHAR,DEFCHAR ,const int,const int);
+extern "C" void  type_of_call hcdir(DEFCHAR,DEFCHAR ,fortran_charlen_t,fortran_charlen_t);
 #else
 extern "C" void  type_of_call hcdir(DEFCHAR,DEFCHAR);
 #endif
 
 extern "C" void  type_of_call zitoh(const int&,const int&,const int&);
 #ifndef WIN32
-extern "C" void  type_of_call uhtoc(const int&,const int&,DEFCHAR,int&,const int);
+extern "C" void  type_of_call uhtoc(const int&,const int&,DEFCHAR,int&,fortran_charlen_t);
 #else
 extern "C" void  type_of_call uhtoc(const int&,const int&,DEFCHAR,int&);
 #endif


### PR DESCRIPTION
According to the `gfortran` argument passing conventions, for any Fortran procedure, the compiler will automatically define a C prototype. This is what we use in `h2root`.

Note that for procedures like `HROPEN` that takes string arguments, the signature of the C prototype will have extra arguments for the string lengths, which we also have to include in our forward declaration and usage. However, the type of these was changed with GCC 8 to size_t, so we have to also account for that as recommended in [1]. Otherwise, we get undefined behavor, which causes the `h2root` test to fail on ARM64 with GCC 14.

[1] https://gcc.gnu.org/onlinedocs/gfortran/Argument-passing-conventions.html

See also this PR that tests this commit on Alma 10 ARM, with GCC 14:
  * https://github.com/root-project/root/pull/20501