### PR TITLE
[vecops] Alignment-related fix for getting first element of small vector

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -213,7 +213,9 @@ class R__CLING_PTRCHECK(off) SmallVectorTemplateCommon : public SmallVectorBase 
    /// SmallVectorStorage is properly-aligned even for small-size of 0.
    void *getFirstEl() const
    {
-      return const_cast<void *>(reinterpret_cast<const void *>(reinterpret_cast<const char *>(this) +
+      // get the SmallVectorBase subobject inside RVec
+      auto *base = static_cast<const SmallVectorBase *>(this);
+      return const_cast<void *>(reinterpret_cast<const void *>(reinterpret_cast<const char *>(base) +
                                                                offsetof(SmallVectorAlignmentAndSize<T>, FirstEl)));
    }
    // Space after 'FirstEl' is clobbered, do not add any instance vars after it.


### PR DESCRIPTION
In the RVec code, we assumed that the location of the SmallVectorBase subobject inside the RVec is identical to the RVec itself.

This assumption is not always correct. For example, on AArch64 GCC 14, some extra padding seems to be inserted before the base class.

This commit generalized the implementation of getting the first element by first casting to the SmallVectorBase class, which is what is required to calculate the correct offset to the SmallVectorBase data members.

We can see in this PRs CI run if it actually works:
  * https://github.com/root-project/root/pull/20501