### PR TITLE
Const polynomial roots

### DIFF
--- a/math/mathmore/inc/Math/Polynomial.h
+++ b/math/mathmore/inc/Math/Polynomial.h
@@ -116,20 +116,20 @@ public:
       equation is very small. In that case it might be more robust to use the numerical method, by calling directly FindNumRoots()
 
    */
-   const std::vector<std::complex <double> > & FindRoots();
+   std::vector<std::complex<double>> FindRoots() const;
 
    /**
       Find the only the real polynomial roots.
       For n <= 4, the roots are found analytically while for larger order an iterative numerical method is used
       The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
-   std::vector<double > FindRealRoots();
+   std::vector<double> FindRealRoots() const;
 
    /**
       Find the polynomial roots using always an iterative numerical methods
       The numerical method used is from GSL (see <A HREF="https://www.gnu.org/software/gsl/doc/html/poly.html">documentation</A> )
    */
-   const std::vector<std::complex <double> > & FindNumRoots();
+   std::vector<std::complex<double>> FindNumRoots() const;
 
    /**
       Order of Polynomial
@@ -164,11 +164,6 @@ private:
 
    // cache Parameters for Gradient
    mutable std::vector<double> fDerived_params;
-
-   // roots
-
-   std::vector< std::complex < double > > fRoots;
-
 };
 
 } // namespace Math


### PR DESCRIPTION
# This Pull request:

Hi @hageboeck @vepadulano ; This is a followup on my previous PR https://github.com/root-project/root/pull/20524 https://github.com/root-project/root/pull/20539

## Changes or fixes:

    - Remove unused `fRoots` data member (it was cleared before each root computation and provided no persistent state).
    - Return polynomial roots by value instead of via internal storage.
    - Mark the affected query/utility methods as `const` to make the class usable in const contexts.
    - Apply clang-format to the modified sections.
    - Applied @vepadulano suggestions 
    - Squashed all commits into one.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

## Tests:

I ran the ROOT battery of tests with couple of issues.
```
cmake -DCMAKE_BUILD_TYPE=Debug -Dtesting=ON -Droottest=ON -Dmathmore=ON ../polynomial-patch
make -j8
ctest -j8
```

Regarding the Polynomial class modifications, my use case output remains unchanged. (I use polynomials to compute digital filtering, biquad, etc..) I also paid attention in particular to those related to polynomials: `gtest-hist-hist-testTProfile2Poly`, etc.. 
