### PR TITLE
[v626][cmake] Build clad with one core only

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -74,8 +74,12 @@ ExternalProject_Add(
              -DLLVM_DIR=${LLVM_BINARY_DIR}
              -DCLANG_INCLUDE_DIRS=${CLANG_INCLUDE_DIRS}
              ${_clad_extra_cmake_args}
-  BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type}
-  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type} --target install
+  # FIXME
+  # Building with 1 core is a temporary workaround for #16654 and has to be 
+  # there until the behaviour of the clad build on ubuntu 24.10 is understood.
+  # The performance penalty in the build is negligible.
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type} -j 1
+  INSTALL_COMMAND ${CMAKE_COMMAND} --build . --config ${_clad_build_type} -j 1 --target install
   BUILD_BYPRODUCTS ${CLAD_BYPRODUCTS}
   ${_clad_cmake_logging_settings}
   # We need the target clangBasic to be built before building clad. However, we


### PR DESCRIPTION
Backport to fix the Ubuntu 22.04 nightlies