### PR TITLE
[CI] Add a github action linter.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,19 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels: [mac14, mac15, mac26, mac-beta, cpu]
+
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null
+
+# Configuration for file paths. The keys are glob patterns to match to file
+# paths relative to the repository root. The values are the configurations for
+# the file paths. Note that the path separator is always '/'.
+# The following configurations are available.
+#
+# "ignore" is an array of regular expression patterns. Matched error messages
+# are ignored. This is similar to the "-ignore" command line option.
+paths:
+#  .github/workflows/**/*.yml:
+#    ignore: []

--- a/.github/workflows/lint-action-files.yml
+++ b/.github/workflows/lint-action-files.yml
@@ -1,0 +1,22 @@
+name: 'Lint Github Action Files'
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/workflows/*.yml'
+
+jobs:
+  lint-action-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+        with:
+          files: '.github/workflows/*.yml'
+          fail-on-error: false
+          flags: '-ignore SC2046 -ignore SC2086' # Variable quoting error in shellcheck


### PR DESCRIPTION
The linter checks all action configs in the .github/workflows folder.

Given that we have some work to do, it's for now set to `fail-on-error: false`. The step will pass, but generate warnings.