### PR TITLE
[TMVA][Python] Fix feature name handling for `RBDT::LoadText`

### DIFF
--- a/tmva/tmva/test/CMakeLists.txt
+++ b/tmva/tmva/test/CMakeLists.txt
@@ -37,9 +37,12 @@ endif()
 
 if(dataframe)
   # Test uses the xgboost sklearn plugin, so we need to check for sklearn too.
+  # It also uses pandas to test the case where the training data is passed via
+  # a pandas DataFrame.
   ROOT_FIND_PYTHON_MODULE(xgboost)
+  ROOT_FIND_PYTHON_MODULE(pandas)
   ROOT_FIND_PYTHON_MODULE(sklearn)
-  if (ROOT_XGBOOST_FOUND AND ROOT_SKLEARN_FOUND)
+  if (ROOT_XGBOOST_FOUND AND ROOT_SKLEARN_FOUND AND ROOT_PANDAS_FOUND)
     ROOT_ADD_PYUNITTEST(rbdt_xgboost rbdt_xgboost.py)
   endif()
 endif()

--- a/tmva/tmva/test/rbdt_xgboost.py
+++ b/tmva/tmva/test/rbdt_xgboost.py
@@ -1,12 +1,9 @@
-# XGBoost has to be imported before ROOT to avoid crashes because of clashing
-# std::regexp symbols that are exported by cppyy.
-# See also: https://github.com/wlav/cppyy/issues/227
-import xgboost
-
 import unittest
-import ROOT
+
 import numpy as np
-import json
+import pandas
+import ROOT
+import xgboost
 
 np.random.seed(1234)
 
@@ -41,9 +38,18 @@ def _test_XGBRegression(label):
     """
     Compare response of XGB regressor and TMVA tree inference system.
     """
-    x, y = create_dataset(1000, 10, 1)
+    n_samples = 1000
+    n_features = 10
+    x, y = create_dataset(n_samples, n_features, 1)
+    # Other than in the XGBBinary test, we're passing the training features via
+    # a pandas DataFrame this time. In that case, XGBoost will define custom
+    # feature names according to the column names in the dataframe, and we can
+    # test the case where the feature names in the .txt dump are not the
+    # default "f0", "f1", "f2", etc.
+    df_x = pandas.DataFrame({f"myfeature_{i}": x[:, i] for i in range(n_features)})
+    assert len(x) == len(df_x)
     xgb = xgboost.XGBRegressor(n_estimators=1, max_depth=3)
-    xgb.fit(x, y)
+    xgb.fit(df_x, y)
     ROOT.TMVA.Experimental.SaveXGBoost(xgb, "myModel", "testXGBRegression{}.root".format(label), num_inputs=10)
     bdt = ROOT.TMVA.Experimental.RBDT("myModel", "testXGBRegression{}.root".format(label))
 


### PR DESCRIPTION
If the XGBoost model encodes feature names, they will also be used in the `.txt` dump of the model. We have to use these names in `RBDT::LoadTxt` as well, so that the `.txt` file can be read correctly without errors.

The RBDT unit test is also updated to cover this case of custom feature names, which happens when the training data comes from a pandas DataFrame.

Closes #20267. Credit goes to @jlidrych for the solution.