### PR TITLE
[build] Comply with PEP625

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["cmake", "setuptools<72", "wheel", "numpy"]
 
 [project]
 name = "ROOT"
-version = "0.1a8"
-requires-python = ">=3.8"
+version = "0.1a9"
+requires-python = ">=3.9"
 maintainers = [
   {name = "Vincenzo Eduardo Padulano", email = "vincenzo.eduardo.padulano@cern.ch"}
 ]

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,16 @@ This distribution of ROOT is in alpha stage. Feedback is welcome and appreciated
 
 
 class ROOTBuild(_build):
+    def finalize_options(self):
+        # Normalize the distribution name before building
+        if self.distribution.metadata.name == "ROOT":
+            # Store original name for metadata
+            self.distribution.metadata._original_name = "ROOT"
+            # Use normalized name to comply with PEP625 and avoid errors
+            # caused by https://github.com/pypi/warehouse/pull/18924
+            self.distribution.metadata.name = "root"
+        super().finalize_options()
+
     def run(self):
         _build.run(self)
 
@@ -94,6 +104,16 @@ class ROOTBuild(_build):
 
 
 class ROOTInstall(_install):
+    def finalize_options(self):
+        # Normalize the distribution name before installing
+        if self.distribution.metadata.name == "ROOT":
+            # Store original name for metadata
+            self.distribution.metadata._original_name = "ROOT"
+            # Use normalized name to comply with PEP625 and avoid errors
+            # caused by https://github.com/pypi/warehouse/pull/18924
+            self.distribution.metadata.name = "root"
+        super().finalize_options()
+
     def _get_install_path(self):
         if hasattr(self, "bdist_dir") and self.bdist_dir:
             install_path = self.bdist_dir


### PR DESCRIPTION
PEP625 mandates that distribution names be normalised https://peps.python.org/pep-0625/. The full specification is available at https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format. For the ROOT package, this means that the wheel name must have the lowercase spelling of the project name.
