### PR TITLE
[Geom] Fix compiler warnings in TGDMLWrite

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -765,13 +765,12 @@ void TGDMLWrite::ExtractVolumes(TGeoNode *node)
    {
       TGeoRCExtension *rcext = (TGeoRCExtension *)volume->GetUserExtension();
       if (rcext) {
-         TMap *auxmap = nullptr;
          TObject *userObj = rcext->GetUserObject();
          if (userObj && userObj->InheritsFrom("TMap")) {
             TMap *auxmap = (TMap *)userObj;
             TIterator *it = auxmap->MakeIterator();
             TObject *k = nullptr;
-            while (k = it->Next()) {
+            while ((k = it->Next())) {
                TObject *valobj = auxmap->GetValue(k);
                if (!valobj || !k->InheritsFrom("TObjString") || !valobj->InheritsFrom("TObjString"))
                   continue;


### PR DESCRIPTION
This follows up on 74e607e6c08, which introduced some compiler warnings that cause the Debian CI to fail.

Same situation as in https://github.com/root-project/root/pull/20351, where the failures didn't appear in the CI run for the PR that made the changes yet...