### PR TITLE
[tmva][sofie] Require `onnx!=1.19.0` and `keras<3.5` for tests

### DIFF
--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -109,7 +109,21 @@ endif()
 ROOT_FIND_PYTHON_MODULE(torch)
 ROOT_FIND_PYTHON_MODULE(keras)
 
-if (ROOT_TORCH_FOUND)
+
+
+# onnx 1.19.0 has a bug that makes this version unusable:
+# https://github.com/onnx/onnx/issues/7249
+# In that case, we have to disable the "TestSofieModels" and
+# "TestRModelParserPyTorch" tests, which import onnx indirectly via torch.onnx
+ROOT_FIND_PYTHON_MODULE(onnx)
+if (ROOT_ONNX_FOUND AND DEFINED ROOT_ONNX_VERSION)
+  if(ROOT_ONNX_VERSION VERSION_EQUAL "1.19.0")
+    message(WARNING "Found broken onnx version ${ROOT_ONNX_VERSION} (see https://github.com/onnx/onnx/issues/7249). Some TMVA SOFIE tests will be disabled.")
+    set(broken_onnx TRUE)
+  endif()
+endif()
+
+if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND NOT broken_onnx)
   configure_file(Conv1dModelGenerator.py  Conv1dModelGenerator.py COPYONLY)
   configure_file(Conv2dModelGenerator.py  Conv2dModelGenerator.py COPYONLY)
   configure_file(Conv3dModelGenerator.py  Conv3dModelGenerator.py COPYONLY)
@@ -129,8 +143,8 @@ if (ROOT_TORCH_FOUND)
   endif()
 endif()
 
-# Any reatures that link against libpython are disabled if built with tpython=OFF
-if (tpython AND ROOT_TORCH_FOUND AND BLAS_FOUND)
+# Any features that link against libpython are disabled if built with tpython=OFF
+if (tpython AND ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND BLAS_FOUND AND NOT broken_onnx)
   configure_file(generatePyTorchModelClassification.py generatePyTorchModelClassification.py COPYONLY)
   configure_file(generatePyTorchModelMulticlass.py generatePyTorchModelMulticlass.py COPYONLY)
   configure_file(generatePyTorchModelRegression.py generatePyTorchModelRegression.py COPYONLY)
@@ -151,7 +165,7 @@ if (tpython AND ROOT_TORCH_FOUND AND BLAS_FOUND)
 endif()
 
 
-# Any reatures that link against libpython are disabled if built with tpython=OFF
+# Any features that link against libpython are disabled if built with tpython=OFF
 if (tpython AND ROOT_KERAS_FOUND AND BLAS_FOUND)
 
   set(unsupported_keras_version "3.5.0")


### PR DESCRIPTION
The Python package onnx 1.19.0 has a bug that makes this version unusable: https://github.com/onnx/onnx/issues/7249. In that case, we have to disable the "TestSofieModels" and "TestRModelParserPyTorch" tests, which import onnx indirectly via `torch.onnx`.

We should also consider to require `onnx!=1.19.1` in our `requirements.txt` in the future, so our users don't face similar trouble from exporting PyTorch models to onnx. But this should only be done once we are sure that it can also be installed on macOS without breaking something else.

Closes https://github.com/root-project/root/issues/20571.

There is also a followup to https://github.com/guitargeek/root/commit/10f28b62f64eaabb317433c297f599b08a85ebb5, where I used a random keras version in a check in order to make the CI configuration at the time pass. In fact, `keras=>3.5` also didn't work, as we see now after updating the macOS runners from Keras 2 to Keras 3.

It could actually turn out that `keras>=3` is not supported at all, so we should be prepared to lower the maximum supported Keras version even further. But for now we don't know, as no platform has `keras>=3.0&&keras<3.5` installed.