### PR TITLE
[cling] Treat `-Wreturn-type` as an error

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1422,6 +1422,11 @@ namespace {
       argvCompile.push_back("-fno-omit-frame-pointer");
     }
 
+    // Promote -Wreturn-type to an error. A missing return in a non-void
+    // function is a warning by default, and cling cannot safely continue and
+    // crashes later.
+    argvCompile.push_back("-Werror=return-type");
+
 #ifdef CLING_WITH_ADAPTIVECPP
     argvCompile.push_back("-D__ACPP_ENABLE_LLVM_SSCP_TARGET__");
     argvCompile.push_back("-Xclang");


### PR DESCRIPTION
Cling currently crashes when a non-void function is missing a return, upgrade this warning to an error.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/15537

