### PR TITLE
Fix TestRWLock compilation with external TBB

### DIFF
--- a/core/thread/test/CMakeLists.txt
+++ b/core/thread/test/CMakeLists.txt
@@ -5,6 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 ROOT_ADD_GTEST(testRWLock testRWLock.cxx LIBRARIES Core Thread Hist ${TBB_LIBRARIES} INCLUDE_DIRS ${TBB_INCLUDE_DIRS})
+set_target_properties(testRWLock PROPERTIES COMPILE_FLAGS "${TBB_CXXFLAGS}")
 
 ROOT_ADD_GTEST(testTThreadedObject testTThreadedObject.cxx LIBRARIES Hist)
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR fixes the compilation of testRWLock with external TBB

```
In file included from /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/core/thread/test/../src/TRWMutexImp.h:16,
                 from /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/core/thread/test/testRWLock.cxx:7:
/build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/core/thread/test/../src/TReentrantRWLock.hxx:26:10: fatal error: tbb/enumerable_thread_specific.h: No such file or directory
   26 | #include "tbb/enumerable_thread_specific.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```
With external TBB the testRWLock fails to compile because it cannot find the tbb header file.

See https://lcgapp-services.cern.ch/cdash/build/130957/files


The compilation unit needs to be told about the `${TBB_INCLUDE_DIRS}` or TBB_LIBRARIES has to switch to targets

https://github.com/root-project/root/blob/8a4a8cbc31ce72e8254f08949c6af9ff7ceee7a8/core/thread/test/CMakeLists.txt#L7


## Checklist:

- [x] tested changes locally

This PR fixes #20564 #19798






