### PR TITLE
[ci] Remove Ubuntu 25.04

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -392,8 +392,6 @@ jobs:
             overrides: ["imt=Off", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2404
             overrides: ["CMAKE_BUILD_TYPE=Debug"]
-          - image: ubuntu2504
-            overrides: ["CMAKE_CXX_STANDARD=23"]
           - image: ubuntu2510
           - image: debian125
             overrides: ["CMAKE_CXX_STANDARD=20", "dev=ON", "CMAKE_CXX_FLAGS=-Wsuggest-override"]


### PR DESCRIPTION
Ubuntu 25.04 will be end-of-life in January 2026, so the current 6.40 development cycle will never see a release on that platform. We can remove it from the CI to free up some resources. It will be kept in the 6.38 patch release branch, so patch release binaries are built for it before its end-of-life.