### PR TITLE
[hist] Count bins as `std::uint64_t`

### DIFF
--- a/hist/histv7/inc/ROOT/RAxes.hxx
+++ b/hist/histv7/inc/ROOT/RAxes.hxx
@@ -14,6 +14,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
@@ -64,9 +65,9 @@ public:
    /// It is the product of each dimension's total number of bins.
    ///
    /// \return the total number of bins
-   std::size_t ComputeTotalNBins() const
+   std::uint64_t ComputeTotalNBins() const
    {
-      std::size_t totalNBins = 1;
+      std::uint64_t totalNBins = 1;
       for (auto &&axis : fAxes) {
          if (auto *regular = std::get_if<RRegularAxis>(&axis)) {
             totalNBins *= regular->GetTotalNBins();
@@ -155,7 +156,7 @@ public:
       if (N != fAxes.size()) {
          throw std::invalid_argument("invalid number of indices passed to ComputeGlobalIndex");
       }
-      std::size_t globalIndex = 0;
+      std::uint64_t globalIndex = 0;
       for (std::size_t i = 0; i < N; i++) {
          const auto &index = indices[i];
          const auto &axis = fAxes[i];

--- a/hist/histv7/inc/ROOT/RBinIndexRange.hxx
+++ b/hist/histv7/inc/ROOT/RBinIndexRange.hxx
@@ -8,7 +8,7 @@
 #include "RBinIndex.hxx"
 
 #include <cassert>
-#include <cstddef>
+#include <cstdint>
 #include <iterator>
 
 namespace ROOT {
@@ -17,7 +17,7 @@ namespace Experimental {
 // forward declarations for friend declaration
 class RBinIndexRange;
 namespace Internal {
-static RBinIndexRange CreateBinIndexRange(RBinIndex begin, RBinIndex end, std::size_t nNormalBins);
+static RBinIndexRange CreateBinIndexRange(RBinIndex begin, RBinIndex end, std::uint64_t nNormalBins);
 } // namespace Internal
 
 /**
@@ -40,14 +40,14 @@ for (auto index : axis.GetFullRange()) {
 Feedback is welcome!
 */
 class RBinIndexRange final {
-   friend RBinIndexRange Internal::CreateBinIndexRange(RBinIndex, RBinIndex, std::size_t);
+   friend RBinIndexRange Internal::CreateBinIndexRange(RBinIndex, RBinIndex, std::uint64_t);
 
    /// The begin of the range (inclusive)
    RBinIndex fBegin;
    /// The end of the range (exclusive)
    RBinIndex fEnd;
    /// The number of normal bins, after which iteration advances to RBinIndex::Overflow()
-   std::size_t fNNormalBins = 0;
+   std::uint64_t fNNormalBins = 0;
 
 public:
    /// Construct an invalid bin index range.
@@ -69,7 +69,7 @@ public:
       /// The current bin index
       RBinIndex fIndex;
       /// The number of normal bins, after which iteration advances to RBinIndex::Overflow()
-      std::size_t fNNormalBins = 0;
+      std::uint64_t fNNormalBins = 0;
 
    public:
       using difference_type = std::ptrdiff_t;
@@ -79,7 +79,7 @@ public:
       using iterator_category = std::input_iterator_tag;
 
       RIterator() = default;
-      RIterator(RBinIndex index, std::size_t nNormalBins) : fIndex(index), fNNormalBins(nNormalBins) {}
+      RIterator(RBinIndex index, std::uint64_t nNormalBins) : fIndex(index), fNNormalBins(nNormalBins) {}
 
       RIterator &operator++()
       {
@@ -130,7 +130,7 @@ namespace Internal {
 /// \param[in] begin the begin of the bin index range (inclusive)
 /// \param[in] end the end of the bin index range (exclusive)
 /// \param[in] nNormalBins the number of normal bins, after which iteration advances to RBinIndex::Overflow()
-static RBinIndexRange CreateBinIndexRange(RBinIndex begin, RBinIndex end, std::size_t nNormalBins)
+static RBinIndexRange CreateBinIndexRange(RBinIndex begin, RBinIndex end, std::uint64_t nNormalBins)
 {
    RBinIndexRange range;
    range.fBegin = begin;

--- a/hist/histv7/inc/ROOT/RCategoricalAxis.hxx
+++ b/hist/histv7/inc/ROOT/RCategoricalAxis.hxx
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -69,8 +70,8 @@ public:
       }
    }
 
-   std::size_t GetNNormalBins() const { return fCategories.size(); }
-   std::size_t GetTotalNBins() const { return fEnableOverflowBin ? fCategories.size() + 1 : fCategories.size(); }
+   std::uint64_t GetNNormalBins() const { return fCategories.size(); }
+   std::uint64_t GetTotalNBins() const { return fEnableOverflowBin ? fCategories.size() + 1 : fCategories.size(); }
    const std::vector<std::string> &GetCategories() const { return fCategories; }
    bool HasOverflowBin() const { return fEnableOverflowBin; }
 
@@ -118,7 +119,7 @@ public:
          return {0, false};
       }
       assert(index.IsNormal());
-      std::size_t bin = index.GetIndex();
+      std::uint64_t bin = index.GetIndex();
       return {bin, bin < fCategories.size()};
    }
 

--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -12,6 +12,8 @@
 
 #include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
@@ -72,10 +74,11 @@ public:
    /// \param[in] nNormalBins the number of normal bins, must be > 0
    /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \par See also
-   /// the
-   /// \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins)
-   /// "constructor of RRegularAxis"
-   RHist(std::size_t nNormalBins, std::pair<double, double> interval) : RHist({RRegularAxis(nNormalBins, interval)}) {}
+   /// the \ref RRegularAxis::RRegularAxis(std::uint64_t nNormalBins, std::pair<double, double> interval, bool
+   /// enableFlowBins) "constructor of RRegularAxis"
+   RHist(std::uint64_t nNormalBins, std::pair<double, double> interval) : RHist({RRegularAxis(nNormalBins, interval)})
+   {
+   }
 
    /// The copy constructor is deleted.
    ///
@@ -104,7 +107,7 @@ public:
 
    const std::vector<RAxisVariant> &GetAxes() const { return fEngine.GetAxes(); }
    std::size_t GetNDimensions() const { return fEngine.GetNDimensions(); }
-   std::size_t GetTotalNBins() const { return fEngine.GetTotalNBins(); }
+   std::uint64_t GetTotalNBins() const { return fEngine.GetTotalNBins(); }
 
    std::uint64_t GetNEntries() const { return fStats.GetNEntries(); }
    /// \copydoc RHistStats::ComputeNEffectiveEntries()

--- a/hist/histv7/inc/ROOT/RHistAutoAxisFiller.hxx
+++ b/hist/histv7/inc/ROOT/RHistAutoAxisFiller.hxx
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -53,7 +54,7 @@ private:
    std::optional<RHist<BinContentType>> fHist;
 
    /// The number of normal bins
-   std::size_t fNNormalBins;
+   std::uint64_t fNNormalBins;
    /// The maximum buffer size until Flush() is automatically called
    std::size_t fMaxBufferSize;
    /// The fraction of the axis interval to use as margin
@@ -74,7 +75,8 @@ public:
    /// \param[in] nNormalBins the number of normal bins, must be > 0
    /// \param[in] maxBufferSize the maximum buffer size, must be > 0
    /// \param[in] marginFraction the fraction of the axis interval to use as margin, must be > 0
-   explicit RHistAutoAxisFiller(std::size_t nNormalBins, std::size_t maxBufferSize = 1024, double marginFraction = 0.05)
+   explicit RHistAutoAxisFiller(std::uint64_t nNormalBins, std::size_t maxBufferSize = 1024,
+                                double marginFraction = 0.05)
       : fNNormalBins(nNormalBins), fMaxBufferSize(maxBufferSize), fMarginFraction(marginFraction)
    {
       if (nNormalBins == 0) {
@@ -88,7 +90,7 @@ public:
       }
    }
 
-   std::size_t GetNNormalBins() const { return fNNormalBins; }
+   std::uint64_t GetNNormalBins() const { return fNNormalBins; }
    std::size_t GetMaxBufferSize() const { return fMaxBufferSize; }
    double GetMarginFraction() const { return fMarginFraction; }
 

--- a/hist/histv7/inc/ROOT/RHistEngine.hxx
+++ b/hist/histv7/inc/ROOT/RHistEngine.hxx
@@ -14,6 +14,8 @@
 
 #include <array>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
@@ -87,10 +89,9 @@ public:
    /// \param[in] nNormalBins the number of normal bins, must be > 0
    /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \par See also
-   /// the
-   /// \ref RRegularAxis::RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins)
-   /// "constructor of RRegularAxis"
-   RHistEngine(std::size_t nNormalBins, std::pair<double, double> interval)
+   /// the \ref RRegularAxis::RRegularAxis(std::uint64_t nNormalBins, std::pair<double, double> interval, bool
+   /// enableFlowBins) "constructor of RRegularAxis"
+   RHistEngine(std::uint64_t nNormalBins, std::pair<double, double> interval)
       : RHistEngine({RRegularAxis(nNormalBins, interval)})
    {
    }
@@ -119,7 +120,7 @@ public:
 
    const std::vector<RAxisVariant> &GetAxes() const { return fAxes.Get(); }
    std::size_t GetNDimensions() const { return fAxes.GetNDimensions(); }
-   std::size_t GetTotalNBins() const { return fBinContents.size(); }
+   std::uint64_t GetTotalNBins() const { return fBinContents.size(); }
 
    /// Get the content of a single bin.
    ///

--- a/hist/histv7/inc/ROOT/RHistStats.hxx
+++ b/hist/histv7/inc/ROOT/RHistStats.hxx
@@ -10,6 +10,7 @@
 #include "RWeight.hxx"
 
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <tuple>

--- a/hist/histv7/inc/ROOT/RLinearizedIndex.hxx
+++ b/hist/histv7/inc/ROOT/RLinearizedIndex.hxx
@@ -6,6 +6,7 @@
 #define ROOT_RLinearizedIndex
 
 #include <cstddef>
+#include <cstdint>
 
 namespace ROOT {
 namespace Experimental {
@@ -19,7 +20,11 @@ For example, when an argument is outside the axis and underflow / overflow bins 
 Feedback is welcome!
 */
 struct RLinearizedIndex final {
-   std::size_t fIndex = 0;
+   // We use std::uint64_t instead of std::size_t for the index because for sparse histograms, not all bins have to be
+   // allocated in memory. However, we require that the index has at least that size.
+   static_assert(sizeof(std::uint64_t) >= sizeof(std::size_t), "index type not large enough to address all bins");
+
+   std::uint64_t fIndex = 0;
    bool fValid = false;
 };
 

--- a/hist/histv7/inc/ROOT/RRegularAxis.hxx
+++ b/hist/histv7/inc/ROOT/RRegularAxis.hxx
@@ -10,7 +10,7 @@
 #include "RLinearizedIndex.hxx"
 
 #include <cassert>
-#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -40,7 +40,7 @@ public:
 
 private:
    /// The number of normal bins
-   std::size_t fNNormalBins;
+   std::uint64_t fNNormalBins;
    /// The lower end of the axis interval
    double fLow;
    /// The upper end of the axis interval
@@ -56,7 +56,7 @@ public:
    /// \param[in] nNormalBins the number of normal bins, must be > 0
    /// \param[in] interval the axis interval (lower end inclusive, upper end exclusive)
    /// \param[in] enableFlowBins whether to enable underflow and overflow bins
-   RRegularAxis(std::size_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins = true)
+   RRegularAxis(std::uint64_t nNormalBins, std::pair<double, double> interval, bool enableFlowBins = true)
       : fNNormalBins(nNormalBins), fLow(interval.first), fHigh(interval.second), fEnableFlowBins(enableFlowBins)
    {
       if (nNormalBins == 0) {
@@ -69,8 +69,8 @@ public:
       fInvBinWidth = nNormalBins / (fHigh - fLow);
    }
 
-   std::size_t GetNNormalBins() const { return fNNormalBins; }
-   std::size_t GetTotalNBins() const { return fEnableFlowBins ? fNNormalBins + 2 : fNNormalBins; }
+   std::uint64_t GetNNormalBins() const { return fNNormalBins; }
+   std::uint64_t GetTotalNBins() const { return fEnableFlowBins ? fNNormalBins + 2 : fNNormalBins; }
    double GetLow() const { return fLow; }
    double GetHigh() const { return fHigh; }
    bool HasFlowBins() const { return fEnableFlowBins; }
@@ -100,7 +100,7 @@ public:
          return {fNNormalBins + 1, fEnableFlowBins};
       }
 
-      std::size_t bin = (x - fLow) * fInvBinWidth;
+      std::uint64_t bin = (x - fLow) * fInvBinWidth;
       if (bin >= fNNormalBins) {
          bin = fNNormalBins - 1;
       }
@@ -124,7 +124,7 @@ public:
          return {0, false};
       }
       assert(index.IsNormal());
-      std::size_t bin = index.GetIndex();
+      std::uint64_t bin = index.GetIndex();
       return {bin, bin < fNNormalBins};
    }
 

--- a/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
+++ b/hist/histv7/inc/ROOT/RVariableBinAxis.hxx
@@ -66,8 +66,8 @@ public:
       }
    }
 
-   std::size_t GetNNormalBins() const { return fBinEdges.size() - 1; }
-   std::size_t GetTotalNBins() const { return fEnableFlowBins ? fBinEdges.size() + 1 : fBinEdges.size() - 1; }
+   std::uint64_t GetNNormalBins() const { return fBinEdges.size() - 1; }
+   std::uint64_t GetTotalNBins() const { return fEnableFlowBins ? fBinEdges.size() + 1 : fBinEdges.size() - 1; }
    const std::vector<double> &GetBinEdges() const { return fBinEdges; }
    bool HasFlowBins() const { return fEnableFlowBins; }
 
@@ -122,7 +122,7 @@ public:
          return {0, false};
       }
       assert(index.IsNormal());
-      std::size_t bin = index.GetIndex();
+      std::uint64_t bin = index.GetIndex();
       return {bin, bin < fBinEdges.size() - 1};
    }
 

--- a/hist/histv7/test/hist_index.cxx
+++ b/hist/histv7/test/hist_index.cxx
@@ -1,5 +1,6 @@
 #include "hist_test.hxx"
 
+#include <cstdint>
 #include <iterator>
 #include <vector>
 
@@ -56,7 +57,7 @@ TEST(RBinIndex, Plus)
    }
 
    // Matches RBinIndex::UnderflowIndex
-   static constexpr std::size_t UnderflowIndex = -3;
+   static constexpr std::uint64_t UnderflowIndex = -3;
    EXPECT_TRUE((RBinIndex(0) + UnderflowIndex).IsInvalid());
    EXPECT_TRUE((RBinIndex(3) + UnderflowIndex).IsInvalid());
 }


### PR DESCRIPTION
This is semantically more correct because for sparse histograms, not all bins have to be allocated in memory. For `RRegularAxis`, it also makes the member definition portable across platforms with different widths of `std::size_t`.