### PR TITLE
[Minuit2] Use signed integer as index variable in OpenMP 'for' statement

### DIFF
--- a/math/minuit2/src/Numerical2PGradientCalculator.cxx
+++ b/math/minuit2/src/Numerical2PGradientCalculator.cxx
@@ -99,7 +99,9 @@ operator()(const MinimumParameters &par, const FunctionGradient &Gradient) const
 #pragma omp parallel for if (fDoParallelOMP)
    //#pragma omp for schedule (static, N_PARALLEL_PAR)
 
-   for (unsigned int i = 0; i < n; i++) {
+   // Note: the MSVC compiler enforces that the index variable in OpenMP 'for'
+   // statements must have signed int type!
+   for (int i = 0; i < int(n); i++) {
 
 #endif
 


### PR DESCRIPTION
Compiling Minuit2 with `minuit2_omp=ON` when using MVSC raises `error C3016: 'i': index variable in OpenMP 'for' statement must have signed integral type`

Source of the error is line 102 in
`math/minuit2/src/Numerical2PGradientCalculator.cxx` where (in commit 95035e2) the for-loop variable type was changed from integer to unsigned integer. While this is no problem for GCC, MVSC apparently strictly forbids this.

Closes #20586.