### PR TITLE
[cppyy] Remove now irrelevant `load_cpp_backend()` call

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/python/cppyy/_cpython_cppyy.py
+++ b/bindings/pyroot/cppyy/cppyy/python/cppyy/_cpython_cppyy.py
@@ -19,23 +19,11 @@ __all__ = [
     '_end_capture_stderr'
     ]
 
-# First load the dependency libraries of the backend, then pull in the libcppyy
-# extension module. If the backed can't be loaded, it was probably linked
-# statically into the extension module, so we don't error out at this point.
-try:
-    from cppyy_backend import loader
-    c = loader.load_cpp_backend()
-except ImportError:
-    c = None
-
 if platform.system() == "Windows":
     # On Windows, the library has to be searched without prefix
     import libcppyy as _backend
 else:
     import cppyy.libcppyy as _backend
-
-if c is not None:
-    _backend._cpp_backend = c
 
 # explicitly expose APIs from libcppyy
 _w = ctypes.CDLL(_backend.__file__, ctypes.RTLD_GLOBAL)


### PR DESCRIPTION
As we don't have a separate `cppyy_backend` anymore (neither as a Python package, nor as a shared library), trying to load the backend library will always give an exception that will be caught as an `ImportError`.

It would be cleaner if this code branch is not even taken.