### PR TITLE
[Geom] Add missing includes of TMath.h

### DIFF
--- a/geom/geombuilder/src/TGeoParaEditor.cxx
+++ b/geom/geombuilder/src/TGeoParaEditor.cxx
@@ -27,6 +27,7 @@ Editor for a TGeoPara.
 #include "TVirtualGeoPainter.h"
 #include "TVirtualPad.h"
 #include "TView.h"
+#include "TMath.h"
 #include "TGButton.h"
 #include "TGTextEntry.h"
 #include "TGNumberEntry.h"

--- a/geom/geombuilder/src/TGeoPconEditor.cxx
+++ b/geom/geombuilder/src/TGeoPconEditor.cxx
@@ -27,6 +27,7 @@ Editor for a TGeoPcon.
 #include "TVirtualGeoPainter.h"
 #include "TVirtualPad.h"
 #include "TView.h"
+#include "TMath.h"
 #include "TGCanvas.h"
 #include "TGButton.h"
 #include "TGTextEntry.h"

--- a/geom/geombuilder/src/TGeoPgonEditor.cxx
+++ b/geom/geombuilder/src/TGeoPgonEditor.cxx
@@ -27,6 +27,7 @@ Editor for a TGeoPgon.
 #include "TVirtualGeoPainter.h"
 #include "TVirtualPad.h"
 #include "TView.h"
+#include "TMath.h"
 #include "TGTextEntry.h"
 #include "TGNumberEntry.h"
 #include "TGLabel.h"

--- a/geom/geombuilder/src/TGeoTrapEditor.cxx
+++ b/geom/geombuilder/src/TGeoTrapEditor.cxx
@@ -27,6 +27,7 @@ Editor for a TGeoTrap.
 #include "TVirtualGeoPainter.h"
 #include "TVirtualPad.h"
 #include "TView.h"
+#include "TMath.h"
 #include "TGButton.h"
 #include "TGTextEntry.h"
 #include "TGNumberEntry.h"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

```
.../root-6.38.00/geom/geombuilder/src/TGeoParaEditor.cxx: In member function ‘void TGeoParaEditor::DoAlpha()’:
.../root-6.38.00/geom/geombuilder/src/TGeoParaEditor.cxx:365:8: error: ‘TMath’ has not been declared
  365 |    if (TMath::Abs(alpha) >= 90) {
      |        ^~~~~
.../root-6.38.00/geom/geombuilder/src/TGeoParaEditor.cxx:366:22: error: ‘TMath’ has not been declared
  366 |       alpha = 89.9 * TMath::Sign(1., alpha);
      |                      ^~~~~
```
... and similar for the others.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
