### PR TITLE
[core] Move FileRaii to TestSupport.hxx

### DIFF
--- a/core/testsupport/inc/ROOT/TestSupport.hxx
+++ b/core/testsupport/inc/ROOT/TestSupport.hxx
@@ -152,6 +152,33 @@ private:
    static CheckDiagsRAII *sActiveInstance; /// Instance that will receive ROOT's callbacks.
 };
 
+///
+/// An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+/// goes out of scope.
+///
+class FileRaii final {
+private:
+   std::string fPath;
+   bool fPreserveFile = false;
+
+public:
+   explicit FileRaii(const std::string &path) : fPath(path) {}
+   FileRaii(FileRaii &&) = default;
+   FileRaii(const FileRaii &) = delete;
+   FileRaii &operator=(FileRaii &&) = default;
+   FileRaii &operator=(const FileRaii &) = delete;
+   ~FileRaii()
+   {
+      if (!fPreserveFile)
+         std::remove(fPath.c_str());
+   }
+   std::string GetPath() const { return fPath; }
+
+   // Useful if you want to keep a test file after the test has finished running
+   // for debugging purposes. Should only be used locally and never pushed.
+   void PreserveFile() { fPreserveFile = true; }
+};
+
 } // namespace TestSupport
 } // namespace ROOT
 

--- a/io/io/test/rfile.cxx
+++ b/io/io/test/rfile.cxx
@@ -13,37 +13,7 @@
 #include <ROOT/RLogger.hxx>
 
 using ROOT::Experimental::RFile;
-
-namespace {
-
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
- * goes out of scope.
- */
-class FileRaii {
-private:
-   std::string fPath;
-   bool fPreserveFile = false;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(FileRaii &&) = default;
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(FileRaii &&) = default;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!fPreserveFile)
-         std::remove(fPath.c_str());
-   }
-   const std::string &GetPath() const { return fPath; }
-
-   // Useful if you want to keep a test file after the test has finished running
-   // for debugging purposes. Should only be used locally and never pushed.
-   void PreserveFile() { fPreserveFile = true; }
-};
-
-} // anonymous namespace
+using ROOT::TestSupport::FileRaii;
 
 static std::string JoinKeyNames(const ROOT::Experimental::RFileKeyIterable &iterable)
 {

--- a/tree/ntuple/test/ntuple_test.hxx
+++ b/tree/ntuple/test/ntuple_test.hxx
@@ -115,33 +115,7 @@ template <typename T>
 using RNTupleView = ROOT::RNTupleView<T>;
 
 using ROOT::Internal::MakeUninitArray;
-
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
- * goes out of scope.
- */
-class FileRaii {
-private:
-   std::string fPath;
-   bool fPreserveFile = false;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(FileRaii &&) = default;
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(FileRaii &&) = default;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!fPreserveFile)
-         std::remove(fPath.c_str());
-   }
-   std::string GetPath() const { return fPath; }
-
-   // Useful if you want to keep a test file after the test has finished running
-   // for debugging purposes. Should only be used locally and never pushed.
-   void PreserveFile() { fPreserveFile = true; }
-};
+using ROOT::TestSupport::FileRaii;
 
 #ifdef R__USE_IMT
 struct IMTRAII {

--- a/tree/ntuplebrowse/test/ntuple_browse.cxx
+++ b/tree/ntuplebrowse/test/ntuple_browse.cxx
@@ -17,30 +17,9 @@
 #include <utility>
 #include <vector>
 
+using ROOT::TestSupport::FileRaii;
+
 namespace {
-
-class FileRaii {
-private:
-   std::string fPath;
-   bool fPreserveFile = false;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(FileRaii &&) = default;
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(FileRaii &&) = default;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!fPreserveFile)
-         std::remove(fPath.c_str());
-   }
-   std::string GetPath() const { return fPath; }
-
-   // Useful if you want to keep a test file after the test has finished running
-   // for debugging purposes. Should only be used locally and never pushed.
-   void PreserveFile() { fPreserveFile = true; }
-};
 
 class TBrowserTestImp : public TBrowserImp {
 public:

--- a/tree/ntupleutil/test/ntupleutil_test.hxx
+++ b/tree/ntupleutil/test/ntupleutil_test.hxx
@@ -9,30 +9,8 @@
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 #include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/TestSupport.hxx>
 
-/**
- * An RAII wrapper around an open temporary file on disk. It cleans up the
- * guarded file when the wrapper object goes out of scope.
- */
-class FileRaii {
-private:
-   std::string fPath;
-   bool fPreserveFile = false;
-
-public:
-   explicit FileRaii(const std::string &path) : fPath(path) {}
-   FileRaii(const FileRaii &) = delete;
-   FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii()
-   {
-      if (!fPreserveFile)
-         std::remove(fPath.c_str());
-   }
-   std::string GetPath() const { return fPath; }
-
-   // Useful if you want to keep a test file after the test has finished running
-   // for debugging purposes. Should only be used locally and never pushed.
-   void PreserveFile() { fPreserveFile = true; }
-};
+using ROOT::TestSupport::FileRaii;
 
 #endif // ROOT7_RNTupleUtil_Test


### PR DESCRIPTION
This is a general-purpose utility that can be used by many unit tests so it makes sense to deduplicate it and share it.

Note that for now this doesn't touch duplicated instances of `FileRaii` in roottest, to avoid introducing additional dependencies (e.g. to the dataframe roottest suite)

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


