### PR TITLE
Fix linker errors when building cling with MSVC

### DIFF
--- a/interpreter/cling/tools/libcling/CMakeLists.txt
+++ b/interpreter/cling/tools/libcling/CMakeLists.txt
@@ -37,6 +37,7 @@ set( LLVM_LINK_COMPONENTS
   object
   option
   orcjit
+  orcdebugging
   runtimedyld
   scalaropts
   support


### PR DESCRIPTION
I'm encountering the following linker errors when building the latest Cling (https://github.com/root-project/cling/commit/4b670214d57433f11144e96ba5da7914becb3ec1) against LLVM 20 (https://github.com/root-project/llvm-project/commit/7c49650f1446898cb437657b36b867764ef93660) with MSVC 2022. Adding `orcdebugging` to the list of link components for libcling seemed to resolve the issues.

```
Creating library lib\libcling.lib and object lib\libcling.exp
IncrementalJIT.cpp.obj : error LNK2019: unresolved external symbol "class llvm::Error __cdecl llvm::orc::preserveDebugSections(class llvm::jitlink::LinkGraph &)" (?preserveDebugSections@orc@llvm@@YA?AVError@2@AEAVLinkGraph@jitlink@2@@Z) referenced in function "public: virtual void __cdecl llvm::orc::DebugInfoPreservationPlugin::modifyPassConfig(class llvm::orc::MaterializationResponsibility &,class llvm::jitlink::LinkGraph &,struct llvm::jitlink::PassConfiguration &)" (?modifyPassConfig@DebugInfoPreservationPlugin@orc@llvm@@UEAAXAEAVMaterializationResponsibility@23@AEAVLinkGraph@jitlink@3@AEAUPassConfiguration@63@@Z)
IncrementalJIT.cpp.obj : error LNK2019: unresolved external symbol "class llvm::Error __cdecl llvm::orc::enableDebuggerSupport(class llvm::orc::LLJIT &)" (?enableDebuggerSupport@orc@llvm@@YA?AVError@2@AEAVLLJIT@12@@Z) referenced in function "protected: static class llvm::Error __cdecl llvm::detail::UniqueFunctionBase<class llvm::Error,class llvm::orc::LLJIT &>::CallImpl<class `public: __cdecl cling::IncrementalJIT::IncrementalJIT(class cling::IncrementalExecutor &,class clang::CompilerInstance const &,class std::unique_ptr<class llvm::orc::ExecutorProcessControl,struct std::default_delete<class llvm::orc::ExecutorProcessControl> >,class llvm::Error &,void *,bool)'::`5'::<lambda_1> >(void *,class llvm::orc::LLJIT &)" (??$CallImpl@V<lambda_1>@?4???0IncrementalJIT@cling@@QEAA@AEAVIncrementalExecutor@3@AEBVCompilerInstance@clang@@V?$unique_ptr@VExecutorProcessControl@orc@llvm@@U?$default_delete@VExecutorProcessControl@orc@llvm@@@std@@@std@@AEAVError@llvm@@PEAX_N@Z@@?$UniqueFunctionBase@VError@llvm@@AEAVLLJIT@orc@2@@detail@llvm@@KA?AVError@2@PEAXAEAVLLJIT@orc@2@@Z)
IncrementalJIT.cpp.obj : error LNK2019: unresolved external symbol "public: static class llvm::Expected<class std::unique_ptr<class llvm::orc::PerfSupportPlugin,struct std::default_delete<class llvm::orc::PerfSupportPlugin> > > __cdecl llvm::orc::PerfSupportPlugin::Create(class llvm::orc::ExecutorProcessControl &,class llvm::orc::JITDylib &,bool,bool)" (?Create@PerfSupportPlugin@orc@llvm@@SA?AV?$Expected@V?$unique_ptr@VPerfSupportPlugin@orc@llvm@@U?$default_delete@VPerfSupportPlugin@orc@llvm@@@std@@@std@@@3@AEAVExecutorProcessControl@23@AEAVJITDylib@23@_N2@Z) referenced in function "class llvm::Error __cdecl `anonymous namespace'::enablePerfSupport(class llvm::orc::LLJIT &)" (?enablePerfSupport@?A0xe11be1f4@@YA?AVError@llvm@@AEAVLLJIT@orc@3@@Z)
bin\libcling.dll : fatal error LNK1120: 3 unresolved externals
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)