### PR TITLE
[RF] Remove `ExpectedRelative` normalization flag from rf202 tutorial

### DIFF
--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -900,18 +900,16 @@ public:
       // Fit model to data, extended ML term automatically included
       model.fitTo(*data);
 
-      // Plot data and PDF overlaid, use expected number of events for p.d.f projection normalization
-      // rather than observed number of events (==data->numEntries())
+      // Plot data and PDF overlaid
       RooPlot *xframe = x.frame(Title("extended ML fit example"));
       data->plotOn(xframe);
-      model.plotOn(xframe, Normalization(1.0, RooAbsReal::RelativeExpected));
+      model.plotOn(xframe);
 
       // Overlay the background component of model with a dashed line
-      model.plotOn(xframe, Components(bkg), LineStyle(kDashed), Normalization(1.0, RooAbsReal::RelativeExpected));
+      model.plotOn(xframe, Components(bkg), LineStyle(kDashed));
 
       // Overlay the background+sig2 components of model with a dotted line
-      model.plotOn(xframe, Components(RooArgSet(bkg, sig2)), LineStyle(kDotted),
-                   Normalization(1.0, RooAbsReal::RelativeExpected));
+      model.plotOn(xframe, Components(RooArgSet(bkg, sig2)), LineStyle(kDotted));
 
       /////////////////////
       // M E T H O D   2 //

--- a/tutorials/roofit/roofit/rf202_extendedmlfit.C
+++ b/tutorials/roofit/roofit/rf202_extendedmlfit.C
@@ -69,18 +69,16 @@ void rf202_extendedmlfit()
    // Fit model to data, extended ML term automatically included
    model.fitTo(*data, PrintLevel(-1));
 
-   // Plot data and PDF overlaid, use expected number of events for pdf projection normalization
-   // rather than observed number of events (==data->numEntries())
+   // Plot data and PDF overlaid
    RooPlot *xframe = x.frame(Title("extended ML fit example"));
    data->plotOn(xframe);
-   model.plotOn(xframe, Normalization(1.0, RooAbsReal::RelativeExpected));
+   model.plotOn(xframe);
 
    // Overlay the background component of model with a dashed line
-   model.plotOn(xframe, Components(bkg), LineStyle(kDashed), Normalization(1.0, RooAbsReal::RelativeExpected));
+   model.plotOn(xframe, Components(bkg), LineStyle(kDashed));
 
    // Overlay the background+sig2 components of model with a dotted line
-   model.plotOn(xframe, Components(RooArgSet(bkg, sig2)), LineStyle(kDotted),
-                Normalization(1.0, RooAbsReal::RelativeExpected));
+   model.plotOn(xframe, Components(RooArgSet(bkg, sig2)), LineStyle(kDotted));
 
    // Print structure of composite pdf
    model.Print("t");

--- a/tutorials/roofit/roofit/rf202_extendedmlfit.py
+++ b/tutorials/roofit/roofit/rf202_extendedmlfit.py
@@ -55,28 +55,17 @@ data = model.generate({x})
 # Fit model to data, ML term automatically included
 model.fitTo(data, PrintLevel=-1)
 
-# Plot data and PDF overlaid, expected number of events for pdf projection normalization
-# rather than observed number of events (==data.numEntries())
+# Plot data and PDF overlaid
 xframe = x.frame(Title="extended ML fit example")
 data.plotOn(xframe)
-model.plotOn(xframe, Normalization=dict(scaleFactor=1.0, scaleType=ROOT.RooAbsReal.RelativeExpected))
+model.plotOn(xframe)
 
 # Overlay the background component of model with a dashed line
-model.plotOn(
-    xframe,
-    Components={bkg},
-    LineStyle=":",
-    Normalization=dict(scaleFactor=1.0, scaleType=ROOT.RooAbsReal.RelativeExpected),
-)
+model.plotOn(xframe, Components={bkg}, LineStyle=":")
 
 # Overlay the background+sig2 components of model with a dotted line
 ras_bkg_sig2 = {bkg, sig2}
-model.plotOn(
-    xframe,
-    Components=ras_bkg_sig2,
-    LineStyle=":",
-    Normalization=dict(scaleFactor=1.0, scaleType=ROOT.RooAbsReal.RelativeExpected),
-)
+model.plotOn(xframe, Components=ras_bkg_sig2, LineStyle=":")
 
 # Print structure of composite pdf
 model.Print("t")


### PR DESCRIPTION
Since #19656, scaling the pdf to the expected number of events in the plot is the default behavior, because this is what makes sense when comparing predictions to data. Therefore, the explicit `ExpectedRelative` normalization flag can be removed.