### PR TITLE
[ntuple] Fix exporting columns with variable bit sizes

### DIFF
--- a/tree/ntupleutil/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/src/RNTupleExporter.cxx
@@ -154,6 +154,8 @@ RNTupleExporter::ExportPages(ROOT::Internal::RPageSource &source, const RPagesOp
          const auto &pages = clusterDesc.GetPageRange(columnId);
          const auto &colRange = clusterDesc.GetColumnRange(columnId);
          auto colElement = ROOT::Internal::RColumnElementBase::Generate<void>(colInfo.fColDesc->GetType());
+         colElement->SetBitsOnStorage(colInfo.fColDesc->GetBitsOnStorage());
+
          std::uint64_t pageIdx = 0;
 
          R__LOG_DEBUG(0, RNTupleExporterLog())


### PR DESCRIPTION
Particularly important when the `kDecompress` option is set, which without this change will throw an `R__unzip_header: error in header` exception.
