### PR TITLE
[geom] prevent memleak when SetUserExtension

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -2242,7 +2242,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          if (!auxmap) {
             // printf("Auxiliary values for volume %s\n",vol->GetName());
             auxmap = new TMap();
-            vol->SetUserExtension(new TGeoRCExtension(auxmap));
+            auto ext = new TGeoRCExtension(auxmap);
+            vol->SetUserExtension(ext); // grabs a copy
+            ext->Release();
          }
          attr = gdml->GetFirstAttr(child);
          while (attr) {


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/20619

Follow the docu of SetUserExtension:
`The volume "grabs" a copy, so the original object can be released by the producer. Release the previously connected extension if any.`

Also in the TGeoRCExtension docu:
```
The following usage is not correct:
some_TGeoVolume->SetUserExtension(new TGeoRCExtension()) since the producer code does not release the extension. One cannot call directly "delete ext" nor allocate an extension on the stack, since the destructor is protected. Use Release instead.
```

Found out by @KoljaFrahm