### PR TITLE
TGDMLWrite: fix segmentation fault when using non-TGeoRCExtension for user extensions

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -763,7 +763,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode *node)
 
    // export auxiliary user-data if present (TMap of TObjString->TObjString)
    {
-      TGeoRCExtension *rcext = (TGeoRCExtension *)volume->GetUserExtension();
+      TGeoRCExtension *rcext = dynamic_cast<TGeoRCExtension *>(volume->GetUserExtension());
       if (rcext) {
          TObject *userObj = rcext->GetUserObject();
          if (userObj && userObj->InheritsFrom("TMap")) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR fixes test errors seen in DD4hep tests with ROOT master

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffcc24c23e in TGDMLWrite::ExtractVolumes (this=0x7fffffff8c60, node=0x265ffe0) at /build/jenkins/workspace/lcg_nightly_pipeline/build/projects/ROOT-HEAD/src/ROOT/HEAD/geom/gdml/src/TGDMLWrite.cxx:769
```

DD4hep uses DD4hep::VolumeExtension, which inherits from TGeoExtension. Without the c-style cast the difference in types is not taken into account. dynamic_cast is needed to check the actual type of the user extension.

The debugger shows this for the userObj because our DD4hep extension is sufficiently different.
```
(gdb) print userObj
$2 = (TObject *) 0x1
```

## Checklist:

- [x] tested changes locally

This PR is a fix on top of #20356

