### PR TITLE
[io] Add ROOT::Internal::DumpBin(TMemFile&) for debugging purposes

### DIFF
--- a/io/io/inc/TMemFile.h
+++ b/io/io/inc/TMemFile.h
@@ -16,7 +16,17 @@
 #include <vector>
 #include <memory>
 
+class TMemFile;
+
+namespace ROOT::Internal {
+
+void DumpBin(const TMemFile &file, FILE *out);
+
+}
+
 class TMemFile : public TFile {
+   friend void ROOT::Internal::DumpBin(const TMemFile &file, FILE *out);
+   
 public:
    using ExternalDataPtr_t = std::shared_ptr<const std::vector<char>>;
    /// A read-only memory range which we do not control.

--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -313,6 +313,26 @@ void TMemFile::Print(Option_t *option /* = "" */) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Writes the contents of the TMemFile to the given file. This is meant to be
+/// used mostly for debugging, as it dumps the current file's content as-is with
+/// no massaging (meaning the content might not be a valid ROOT file): for regular use cases, use Cp().
+/// Example usage:
+/// ~~~ {.cpp}
+/// FILE *out = fopen("memfile_dump.root", "wb");
+/// ROOT::Internal::DumpBin(memFile, out);
+/// fclose(out);
+/// ~~~
+void ROOT::Internal::DumpBin(const TMemFile &file, FILE *out)
+{
+   const auto *cur = &file.fBlockList;
+   while (cur && cur->fSize) {
+      fwrite(cur->fBuffer, cur->fSize, 1, out);
+      cur = cur->fNext;
+   }
+   fflush(out);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Wipe all the data from the permanent buffer but keep, the in-memory object
 /// alive.
 


### PR DESCRIPTION
# This Pull request:
adds a method to `TMemFile` that allows to dump the current contents of the memory blocks to file. Differently from `Cp`, it does not modify the contents in any way, so it's useful/meant to be used for debugging.

The doc comment clarifies that `Cp` should still be preferred for regular use cases.

