### PR TITLE
[ntuple] add support for leaf count arrays in classes

### DIFF
--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -36,8 +36,10 @@
 #include <vector>
 
 class TClass;
+class TDataMember;
 class TEnum;
 class TObject;
+class TRealData;
 class TVirtualStreamerInfo;
 
 namespace ROOT {
@@ -197,6 +199,9 @@ private:
    /// Fields may not have an on-disk representation (e.g., when inserted by schema evolution), in which case the passed
    /// field descriptor is nullptr.
    std::vector<const TSchemaRule *> FindRules(const ROOT::RFieldDescriptor *fieldDesc);
+   /// Checks if the data member dm in fClass is a leaf count array. If so, returns a pointer to the data member
+   /// corresponding to the count leaf (which may be in a base class).
+   TRealData *IsLeafCountArray(const TDataMember &dm) const;
 
 protected:
    std::unique_ptr<RFieldBase> CloneImpl(std::string_view newName) const final;

--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -91,6 +91,7 @@ public:
    virtual void VisitVectorField(const ROOT::RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const ROOT::RRVecField &field) { VisitField(field); }
+   virtual void VisitLeafCountArrayField(const RLeafCountArrayField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail
@@ -245,6 +246,7 @@ public:
    void VisitVectorField(const ROOT::RVectorField &field) final;
    void VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field) final;
    void VisitRVecField(const ROOT::RRVecField &field) final;
+   void VisitLeafCountArrayField(const RLeafCountArrayField &field) final;
    void VisitBitsetField(const ROOT::RBitsetField &field) final;
    void VisitNullableField(const ROOT::RNullableField &field) final;
    void VisitEnumField(const ROOT::REnumField &field) final;

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -412,6 +412,11 @@ void ROOT::Internal::RPrintValueVisitor::VisitRVecField(const ROOT::RRVecField &
    PrintCollection(field);
 }
 
+void ROOT::Internal::RPrintValueVisitor::VisitLeafCountArrayField(const ROOT::RLeafCountArrayField &field)
+{
+   PrintCollection(field);
+}
+
 //---------------------------- RNTupleFormatter --------------------------------
 
 std::string ROOT::Internal::RNTupleFormatter::FitString(const std::string &str, int availableSpace)

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -460,4 +460,28 @@ struct ExampleMC {
 };
 } // namespace v2
 
+struct LeafCountInClassBase {
+   Int_t fSize = 0;
+};
+
+struct LeafCountInClass : public LeafCountInClassBase {
+   unsigned char *fPayload1 = nullptr; //[fSize];
+   unsigned char *fPayload2 = nullptr; //[fSize];
+};
+
+struct LeafCountInClassFail1 {
+   int fSize = 0;
+   unsigned char *fPayload = nullptr; //[fTypo];
+};
+
+struct LeafCountInClassFail2 {
+   char fSize = 0;                    // wrong count leaf type
+   unsigned char *fPayload = nullptr; //[fSize];
+};
+
+struct LeafCountInClassFail3 {
+   unsigned char *fPayload = nullptr; //[fSize];
+   int fSize = 0;                     // declared after the array
+};
+
 #endif

--- a/tree/ntuple/test/CustomStructLinkDef.h
+++ b/tree/ntuple/test/CustomStructLinkDef.h
@@ -175,4 +175,10 @@
 #pragma read sourceClass = "v1::ExampleMC" source = "v1::Vector3D fSpin" version="[1-]" targetClass = \
    "v2::ExampleMC" target = "fHelicity" code = "{ fHelicity = onfile.fSpin.fZ; }"
 
+#pragma link C++ class LeafCountInClassBase+;
+#pragma link C++ class LeafCountInClass+;
+#pragma link C++ class LeafCountInClassFail1+;
+#pragma link C++ class LeafCountInClassFail2+;
+#pragma link C++ class LeafCountInClassFail3+;
+
 #endif

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -466,3 +466,36 @@ TEST(RNTuple, StreamerInfoRecords)
       }
    }
 }
+
+TEST(RNTuple, LeafCountInClass)
+{
+   auto model = ROOT::RNTupleModel::Create();
+
+   try {
+      model->MakeField<LeafCountInClassFail1>("f");
+      FAIL() << "typo in count leaf name should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid count leaf name"));
+   }
+
+   try {
+      model->MakeField<LeafCountInClassFail2>("f");
+      FAIL() << "invalid count leaf type should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid count leaf type"));
+   }
+
+   try {
+      model->MakeField<LeafCountInClassFail3>("f");
+      FAIL() << "wrong order of count leaf member should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("count leaf member defined after array"));
+   }
+
+   try {
+      model->MakeField<LeafCountInClass>("f");
+      FAIL() << "class with leaf count array should throw";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("leaf count arrays are currently unsupported"));
+   }
+}


### PR DESCRIPTION
Transparently translates a leaf count array in a custom class in an RVec (read & write). Classes with leaf count arrays are used, e.g., in the ALICE RAW EDM but most likely there are other relevant cases, too.

EDIT: also needed for LHCb DST files.

Since this approach diverges the in-memory representation from the on-disk representation, we should discuss if we actually want this.

In any case, we probably want the first commit that detects leaf count arrays in classes and fails gracefully in such a case.

