### PR TITLE
[v638]TGDMLWrite: fix segmentation fault when using non TGEORCExtension for user extensions

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -763,7 +763,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode *node)
 
    // export auxiliary user-data if present (TMap of TObjString->TObjString)
    {
-      TGeoRCExtension *rcext = (TGeoRCExtension *)volume->GetUserExtension();
+      TGeoRCExtension *rcext = dynamic_cast<TGeoRCExtension *>(volume->GetUserExtension());
       if (rcext) {
          TObject *userObj = rcext->GetUserObject();
          if (userObj && userObj->InheritsFrom("TMap")) {


### PR DESCRIPTION
(cherry picked from commit 277f87624736792bbc499454d39c49dd672b0b95)

Backport of https://github.com/root-project/root/pull/20627.