### PR TITLE
[roottest][io] Bring back `__CLING__` guard in Hard2Stream members

### DIFF
--- a/roottest/root/io/customStreamer/header.h
+++ b/roottest/root/io/customStreamer/header.h
@@ -2,7 +2,9 @@
 #include "TClass.h"
 class Hard2Stream {
 private:
+#ifndef __CLING__
    double val;
+#endif
 public:
    Hard2Stream() : val(-1) {};
    Hard2Stream(double v) : val(v) {};


### PR DESCRIPTION
Follows up on 5727e1d6a65, bringing back a `__CINT__` preprocessor guard that should have stayed and rename it to `__CLING__`.

Address https://github.com/root-project/root/pull/20613/files#r2590556753