### PR TITLE
[CI] Remove the homebrew mac update job from pull requests.

### DIFF
--- a/.github/workflows/update-brew-macs.yml
+++ b/.github/workflows/update-brew-macs.yml
@@ -15,9 +15,6 @@ on:
     paths:
       - '.github/workflow/update-brew-macs.yml'
 
-  pull_request:
-    branches:
-      - 'master'
 env:
   VENV_DIR: ${{ github.workspace }}/ROOT_CI_VENV
 


### PR DESCRIPTION
Due to on outdated "on:" clause, the update job ran as part of every pull request on master.
