### PR TITLE
[CI] Use inputs.ref_name in initial checkout.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.ref_name }}
           path: "src/"
 
       - uses: root-project/gcc-problem-matcher-improved@main
@@ -276,6 +277,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref_name }}
 
       - name: Pull Request Build
         if: github.event_name == 'pull_request'
@@ -468,6 +471,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref_name }}
 
       - name: Dump GitHub context
         env:


### PR DESCRIPTION
Workflows for released branches are triggered from master. To ensure that the build_root.py used in each workflow is that from the released branches, the checkout action is instructed to switch to the branch given in ref_name.