### PR TITLE
[CI] Add openstacksdk to packages installed with homebrew.

### DIFF
--- a/.github/workflows/update-brew-macs.yml
+++ b/.github/workflows/update-brew-macs.yml
@@ -86,6 +86,7 @@ jobs:
           $(brew --prefix "${PYTHON_PACKAGE_BREW}")/bin/${PYTHON_EXECUTABLE} -m venv "${VENV_DIR}"
           source "${VENV_DIR}"/bin/activate
           pip3 install --upgrade pip
+          pip3 install openstacksdk
           while read -r PACKAGE; do
             PACKAGE="${PACKAGE%%#*}" # Skip comments
             if [ -n "${PACKAGE}" ]; then


### PR DESCRIPTION
The homebrew VM successfully built ROOT in the last nightlies, but because of the missing openstack sdk, it didn't establish a connection to upload the tar archive:
https://github.com/root-project/root/actions/runs/19997135200/job/57346442580#step:7:9926