### PR TITLE
[v638] Fix a numpy test for 32 bit archs

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdataframe_misc.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_misc.py
@@ -132,7 +132,7 @@ class RDataFrameMisc(unittest.TestCase):
             return
         out_path = "dataframe_misc_regression_gh20291.root"
         try:
-            x, y = numpy.array([1, 2, 3]), numpy.array([4, 5, 6])
+            x, y = numpy.array([1, 2, 3], dtype='int64'), numpy.array([4, 5, 6], dtype='int64')
             df = ROOT.RDF.FromNumpy({"x": x, "y": y})
 
             df.Snapshot("tree", out_path)


### PR DESCRIPTION
The default dtype used in numpy array is "int". This type has different sizes on 32 and 64 bit architectures. The test tries to use the numpy array as a Long64_t dataframe. On 32 bit architectures this results in an error.

This commit explicitly changes the numpy array's dtype to "int64" to match the Long64_t dataframe type on all architectyres.

(cherry picked from commit 2ab39c13897252118867c9b8019ed21f0c20bb98)