### PR TITLE
[6.34][FP][core] Remove potential leftover paths from future ROOT versions

### DIFF
--- a/config/thisroot.csh
+++ b/config/thisroot.csh
@@ -161,6 +161,14 @@ if ($?old_rootsys) then
                                  -e "s;^$old_rootsys/etc/notebook:;;g"   \
                                  -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
    endif
+   # Potential leftovers from future ROOT > v6.34
+   if ($?JUPYTER_CONFIG_PATH) then
+      setenv JUPYTER_CONFIG_PATH `set DOLLAR='$'; echo $JUPYTER_CONFIG_PATH | \
+                             sed -e "s;:$old_rootsys/etc/notebook:;:;g" \
+                                 -e "s;:$old_rootsys/etc/notebook${DOLLAR};;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook:;;g"   \
+                                 -e "s;^$old_rootsys/etc/notebook${DOLLAR};;g"`
+   endif
 
 endif
 

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -78,6 +78,11 @@ clean_environment()
          drop_from_path "$JUPYTER_CONFIG_DIR" "${old_rootsys}/etc/notebook"
          JUPYTER_CONFIG_DIR=$newpath
       fi
+      # Potential leftovers from future ROOT > v6.34
+      if [ -n "${JUPYTER_CONFIG_PATH-}" ]; then
+         drop_from_path "$JUPYTER_CONFIG_PATH" "${old_rootsys}/etc/notebook"
+         JUPYTER_CONFIG_PATH=$newpath
+      fi
    fi
    if [ -z "${MANPATH-}" ]; then
       # Grab the default man path before setting the path to avoid duplicates


### PR DESCRIPTION
FP of https://github.com/root-project/root/pull/20654

6.34 is EOL but it seems some exps are using it since it's the last supporting odbc
https://root-forum.cern.ch/t/the-thisroot-sh-misbahes-in-root-6-34/64513/11?u=ferhue

The other fix in thisroot drop_from_path was also pushed last week to this branch, so for consistency adding it here, too.

Side note: should the CI for 6.34 be disabled?