### PR TITLE
[RF] Fix RooLognormal analytical integral for xMin < zero

### DIFF
--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -27,7 +27,6 @@ The parameterization here is physics driven and differs from the ROOT::Math::log
 
 #include "RooLognormal.h"
 #include "RooRandom.h"
-#include "RooMath.h"
 #include "RooHelpers.h"
 #include "RooBatchCompute.h"
 
@@ -104,9 +103,11 @@ double RooLognormal::analyticalIntegral(Int_t /*code*/, const char *rangeName) c
    static const double root2 = std::sqrt(2.);
 
    double ln_k = std::abs(_useStandardParametrization ? k : std::log(k));
-   double scaledMin = _useStandardParametrization ? std::log(x.min(rangeName)) - m0 : std::log(x.min(rangeName) / m0);
-   double scaledMax = _useStandardParametrization ? std::log(x.max(rangeName)) - m0 : std::log(x.max(rangeName) / m0);
-   return 0.5 * (RooMath::erf(scaledMax / (root2 * ln_k)) - RooMath::erf(scaledMin / (root2 * ln_k)));
+   const double xMin = std::max(x.min(rangeName), 0.);
+   const double xMax = x.max(rangeName);
+   double scaledMax = _useStandardParametrization ? std::log(xMax) - m0 : std::log(xMax / m0);
+   double scaledMin = _useStandardParametrization ? std::log(xMin) - m0 : std::log(xMin / m0);
+   return 0.5 * (std::erf(scaledMax / (root2 * ln_k)) - std::erf(scaledMin / (root2 * ln_k)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Just like for other pdfs that are strictly zero for negative observable values, the integral for xMin < zero should still evaluate correctly (compare for example with the RooLandau).

Addresses this forum report:
https://root-forum.cern.ch/t/roofit-pdfs-with-different-domain-in-the-same-model-e-g-gauss-lognormal/64505/3

Little demo that it works now:
```c++
RooRealVar x("x", "x", 0.0, 10.0);
RooRealVar mu("mu", "mu", 1.0);
RooRealVar sigma("sigma", "sigma", 0.5);
RooLognormal logn("logn", "lognormal pdf", x, mu, sigma);

double a = -1.0;
double b = 5.0;

x.setRange("intRange", -1.0, 5.0);

RooAbsReal* integral = logn.createIntegral(x, RooFit::NormSet(x),
                                           RooFit::Range("intRange"));

double result = integral->getVal();

std::cout << "Integral of Lognormal from " << a << " to " << b
          << " = " << result << std::endl;
```