### PR TITLE
[roottest] Fix invalid `setattr` call in test

### DIFF
--- a/roottest/python/basic/PyROOT_datatypetest.py
+++ b/roottest/python/basic/PyROOT_datatypetest.py
@@ -558,7 +558,7 @@ class TestClassDATATYPES:
             setattr(gbl, 'g_'+name, adat)
             assert getattr(gbl, 'g_'+name)   == adat
             assert getattr(gbl, 'g_c_'+name) == cdat
-            raises(TypeError, setattr, 'g_c_'+name, acdat)
+            raises(TypeError, setattr, gbl, 'g_c_'+name, acdat)
             testcount += 1
         assert testcount == len(testdata)
 


### PR DESCRIPTION
The `setattr` function requires three arguments, not two.

Forgetting the `gbl` variable for which the attribute should be set resulted in pretty nonsensical code, which tried to set attributes of string literals. Maybe this was the result of the nighly failure on Fedora 42, where no ROOT/cppyy was in the stack trace at all.

The `_PyErr_SetString` clearly told us that the crash happens in the formatting of the error message of some of the expected exceptions. So the call to `setattr` that is invalid for two reasons (wrong number of args, trying to set attribute of immutable string literal) is my best guess.

```txt
 381/3712 Test #1851: roottest-python-basic-datatype ....................................................................***Failed    7.54 sec
Info in <TUnixSystem::ACLiC>: creating shared library /github/home/ROOT-CI/build/roottest/python/basic/./DataTypes_C.so

-- TEST COMMAND --
cd /github/home/ROOT-CI/build/roottest/python/basic
/usr/sbin/timeout -s USR2 270s /py-venv/ROOT-CI/bin/python3.13 /github/home/ROOT-CI/src/roottest/python/basic/PyROOT_datatypetest.py --fixcling
-- BEGIN TEST OUTPUT --
============================= test session starts ==============================
platform linux -- Python 3.13.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /github/home/ROOT-CI/src
configfile: pyproject.toml
plugins: anyio-4.12.0
collected 24 items

../../../../src/roottest/python/basic/PyROOT_datatypetest.py ........... [ 45%]
....... *** Break *** segmentation violation
 Generating stack trace...
 0x00007f1e372498b7 in _PyErr_SetString + 0x47 from /lib64/libpython3.13.so.1.0
 0x00007f1e370c06da in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371d37ff in _PyEval_EvalFrameDefault + 0x441f from /lib64/libpython3.13.so.1.0
 0x00007f1e372bf359 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e37320c37 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371d41b5 in _PyEval_EvalFrameDefault + 0x4dd5 from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372aa82f in PyEval_EvalCode + 0x9f from /lib64/libpython3.13.so.1.0
 0x00007f1e372e9dec in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e6f05 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e3587 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e31ff in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e3021 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e13e7 in Py_RunMain + 0x3f7 from /lib64/libpython3.13.so.1.0
 0x00007f1e3729820b in Py_BytesMain + 0x3b from /lib64/libpython3.13.so.1.0
 0x00007f1e36e90575 in <unknown> from /lib64/libc.so.6
 0x00007f1e36e90628 in __libc_start_main at :? from /lib64/libc.so.6
 0x0000564c4b8a23d5 in _start + 0x25 from /py-venv/ROOT-CI/bin/python3.13
 *** Break *** segmentation violation
 Generating stack trace...
 0x00007f1e372498b7 in _PyErr_SetString + 0x47 from /lib64/libpython3.13.so.1.0
 0x00007f1e370c06da in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371d37ff in _PyEval_EvalFrameDefault + 0x441f from /lib64/libpython3.13.so.1.0
 0x00007f1e372bf359 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e37320c37 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371d41b5 in _PyEval_EvalFrameDefault + 0x4dd5 from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372a88c4 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372f9b49 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e371bdcbc in _PyObject_MakeTpCall + 0x2ac from /lib64/libpython3.13.so.1.0
 0x00007f1e371d955a in _PyEval_EvalFrameDefault + 0xa17a from /lib64/libpython3.13.so.1.0
 0x00007f1e372aa82f in PyEval_EvalCode + 0x9f from /lib64/libpython3.13.so.1.0
 0x00007f1e372e9dec in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e6f05 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e3587 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e31ff in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e3021 in <unknown> from /lib64/libpython3.13.so.1.0
 0x00007f1e372e13e7 in Py_RunMain + 0x3f7 from /lib64/libpython3.13.so.1.0
 0x00007f1e3729820b in Py_BytesMain + 0x3b from /lib64/libpython3.13.so.1.0
 0x00007f1e36e90575 in <unknown> from /lib64/libc.so.6
 0x00007f1e36e90628 in __libc_start_main at :? from /lib64/libc.so.6
 0x0000564c4b8a23d5 in _start + 0x25 from /py-venv/ROOT-CI/bin/python3.13

-- END TEST OUTPUT --
CMake Error at /github/home/ROOT-CI/build/RootTestDriver.cmake:186 (message):
  got exit code 129 but expected 0

```