### PR TITLE
[main] rootbrowse: instance a TRint instead of TApplication

### DIFF
--- a/main/src/rootbrowse.cxx
+++ b/main/src/rootbrowse.cxx
@@ -9,7 +9,7 @@
 #include "logging.hxx"
 #include "optparse.hxx"
 
-#include <TApplication.h>
+#include <TRint.h>
 #include <TBrowser.h>
 #include <TError.h>
 #include <TFile.h>
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
    // NOTE: we need to instantiate TApplication ourselves, otherwise TBrowser
    // will create a batch application that cannot show graphics.
-   TApplication app("rootbrowse", nullptr, nullptr);
+   TRint app("rootbrowse", nullptr, nullptr);
 
    if (!args.fWeb.empty())
       gROOT->SetWebDisplay(std::string(args.fWeb).c_str());
@@ -130,11 +130,11 @@ int main(int argc, char **argv)
    // For classic graphics: ensure rootbrowse quits when the window is closed
    if (auto imp = browser->GetBrowserImp()) {
       if (auto mainframe = imp->GetMainFrame()) {        
-         mainframe->Connect("CloseWindow()", "TApplication", &app, "Terminate()");
+         mainframe->Connect("CloseWindow()", "TRint", &app, "Terminate()");
       }
    }
 
-   std::cout << "Press ctrl+c to exit.\n";
+   std::cout << ".q to exit.\n";
    while (!gROOT->IsInterrupted() && !gSystem->ProcessEvents()) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
    }


### PR DESCRIPTION
This gives 2 advantages: it executes .rootlogon.C on startup (like the old rootbrowse did) and it provides an interactive prompt to the user while using rootbrowse.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #20674

