### PR TITLE
[Python] Update expected refcounts for Python 3.14 in Numba tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/numbadeclare.py
+++ b/bindings/pyroot/pythonizations/test/numbadeclare.py
@@ -21,10 +21,17 @@ class NumbaDeclareSimple(unittest.TestCase):
     def test_refcount_decorator(self):
         """
         Test refcount of decorator
+
+        In case of Python < 3.14, we expect a refcount of 2, because the call
+        to sys.getrefcount can create an additional reference itself. Starting
+        from Python 3.14, we expect a refcount of 1 because there were changes
+        to the interpreter to avoid some unnecessary ref counts. See also:
+        https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-refcount
         """
         x = ROOT.Numba.Declare(["float"], "float")
         gc.collect()
-        self.assertEqual(sys.getrefcount(x), 2)
+        extra_ref_count = int(sys.version_info < (3, 14))
+        self.assertEqual(sys.getrefcount(x), 1 + extra_ref_count)
 
     def test_refcount_pycallable(self):
         """

--- a/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_makenumpy.py
@@ -76,7 +76,7 @@ class DataFrameFromNumpy(unittest.TestCase):
         """
         Check refcounts of associated PyObjects
 
-        In case of Python <=3.14, we expect a refcount of 2 for the data dict,
+        In case of Python < 3.14, we expect a refcount of 2 for the data dict,
         because the call to sys.getrefcount creates a second reference by
         itself. Starting from Python 3.14, we expect a refcount of 1 because
         there were changes to the interpreter to avoid some unnecessary ref

--- a/bindings/pyroot/pythonizations/test/rvec_asrvec.py
+++ b/bindings/pyroot/pythonizations/test/rvec_asrvec.py
@@ -123,7 +123,7 @@ class AsRVec(unittest.TestCase):
         """
         Test reference count of returned RVec
 
-        In case of Python <=3.14, we expect a refcount of 2 for the RVec
+        In case of Python < 3.14, we expect a refcount of 2 for the RVec
         because the call to sys.getrefcount creates a second reference by
         itself. Starting from Python 3.14, we expect a refcount of 1 because
         there were changes to the interpreter to avoid some unnecessary ref


### PR DESCRIPTION
Similar to f26668d4 and 6c3a5743d66.

Also, fix a wrong version comparison in the Python comments.

Clear build, to make sure that the Fedora 43 build doesn't do the incremental build that was configured without Numba.