### PR TITLE
[cppyy] Disallow conversion from C++ instance to function pointers

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -408,13 +408,16 @@ public:
 protected:
     std::string fRetType;
     std::string fSignature;
+    bool fAllowCppInstance = false;
 };
 
 // std::function
 class StdFunctionConverter : public FunctionPointerConverter {
 public:
     StdFunctionConverter(Converter* cnv, const std::string& ret, const std::string& sig) :
-        FunctionPointerConverter(ret, sig), fConverter(cnv) {}
+        FunctionPointerConverter(ret, sig), fConverter(cnv) {
+        fAllowCppInstance = true;
+    }
     StdFunctionConverter(const StdFunctionConverter&) = delete;
     StdFunctionConverter& operator=(const StdFunctionConverter&) = delete;
     virtual ~StdFunctionConverter() { delete fConverter; }


### PR DESCRIPTION
Implicit conversion from C++ instances to function pointers is not allowed in C++, and it can result in confusing overload resolutions if we allow it in cppyy.

See:
https://github.com/root-project/root/issues/20687#issuecomment-3641579159