### PR TITLE
[hist] Remove CINT compatibility constructors from TF1, THF2, and TF3

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -39,6 +39,7 @@ The following people have contributed to this new version:
 * Comparing C++ `nullptr` objects with `None` in Python now raises a `TypeError`, as announced in the ROOT 6.38 release notes. Use truth-value checks like `if not x` or `x is None` instead.
 * The `TGLIncludes.h` and `TGLWSIncludes.h` that were deprecated in ROOT 6.38 and scheduled for removal are gone now. Please include your required headers like `<GL/gl.h>` or `<GL/glu.h>` directly.
 * The GLEW headers (`GL/eglew.h`, `GL/glew.h`, `GL/glxew.h`, and `GL/wglew.h`) that were installed when building ROOT with `builtin_glew=ON` are no longer installed. This is done because ROOT is moving away from GLEW for loading OpenGL extensions.
+* The `TF1`, `TF2`, and `TF3` constructors for CINT compatibility were removed. This concerns the templated constructors that additionally took the name of the used functor class and member function. With ROOT 6, these names can be omitted.
 
 ## Build System
 

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -352,15 +352,6 @@ public:
       ROOT::Internal::TF1Builder<Func>::Build(this, f);
    }
 
-   /// backward compatible interface
-   template <typename Func>
-   TF1(const char *name, Func f, Double_t xmin, Double_t xmax, Int_t npar, const char *, EAddToList addToGlobList = EAddToList::kDefault) :
-      TF1(EFType::kTemplScalar, name, xmin, xmax, npar, 1, addToGlobList, new TF1Parameters(npar))
-   {
-      ROOT::Internal::TF1Builder<Func>::Build(this, f);
-   }
-
-
    /// Template constructors from a pointer to any C++ class of type PtrObj with a specific member function of type
    /// MemFn.
    /// The member function must have the signature of  (double * , double *) and returning a double.
@@ -372,12 +363,6 @@ public:
    template <class PtrObj, typename MemFn>
    TF1(const char *name, const  PtrObj &p, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar, Int_t ndim = 1, EAddToList addToGlobList = EAddToList::kDefault) :
       TF1(EFType::kTemplScalar, name, xmin, xmax, npar, ndim, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(p, memFn)))
-   {}
-
-   /// backward compatible interface
-   template <class PtrObj, typename MemFn>
-   TF1(const char *name, const  PtrObj &p, MemFn memFn, Double_t xmin, Double_t xmax, Int_t npar, const char *, const char *, EAddToList addToGlobList = EAddToList::kDefault) :
-      TF1(EFType::kTemplScalar, name, xmin, xmax, npar, 1, addToGlobList, new TF1Parameters(npar), new TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctor(p, memFn)))
    {}
 
    TF1(const TF1 &f1);

--- a/hist/hist/inc/TF2.h
+++ b/hist/hist/inc/TF2.h
@@ -53,15 +53,6 @@ public:
       fNpx = 30;
    }
 
-   /// Backward compatible ctor
-   template <class PtrObj, typename MemFn>
-   TF2(const char *name, const  PtrObj& p, MemFn memFn, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar, const char * , const char *) :
-      TF1(name,p,memFn,xmin,xmax,npar,2),
-   fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
-   {
-      fNpx = 30;
-   }
-
    /// Template constructors from any  C++ callable object,  defining  the operator() (double * , double *) and returning a double.
    template <typename Func>
    TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,Int_t ndim = 2, EAddToList addToGlobList = EAddToList::kDefault) :
@@ -70,16 +61,6 @@ public:
    {
       fNpx = 30;
    }
-
-   /// Backward compatible ctor
-   template <typename Func>
-   TF2(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Int_t npar,const char *) :
-      TF1(name,f,xmin,xmax,npar,2),
-   fYmin(ymin), fYmax(ymax), fNpy(30), fContour(0)
-   {
-      fNpx = 30;
-   }
-
 
    TF2(const TF2 &f2);
    TF2 &operator=(const TF2& rhs);

--- a/hist/hist/inc/TF3.h
+++ b/hist/hist/inc/TF3.h
@@ -53,27 +53,11 @@ public:
       fZmin(zmin), fZmax(zmax), fNpz(30)
    {   }
 
-   /// Backward compatible ctor
-   template <class PtrObj, typename MemFn>
-   TF3(const char *name, const  PtrObj& p, MemFn memFn, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Int_t npar,
-       const char * , const char *  ) :
-      TF2(name,p,memFn,xmin,xmax,ymin,ymax,npar,3),
-      fZmin(zmin), fZmax(zmax), fNpz(30)
-   {   }
-
    /// Template constructors from any  C++ callable object,  defining  the operator() (double * , double *) and returning a double.
    template <typename Func>
    TF3(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Int_t npar,
        Int_t ndim = 3, EAddToList addToGlobList = EAddToList::kDefault) :
       TF2(name,f,xmin,xmax,ymin,ymax,npar,ndim,addToGlobList),
-      fZmin(zmin), fZmax(zmax), fNpz(30)
-   { }
-
-   /// Backward compatible ctor
-   template <typename Func>
-   TF3(const char *name, Func f, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax, Int_t npar,
-       const char *  ) :
-      TF2(name,f,xmin,xmax,ymin,ymax,npar,3),
       fZmin(zmin), fZmax(zmax), fNpz(30)
    { }
 

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -471,7 +471,7 @@ class  MyFunction {
 {
     ....
    MyFunction *fptr = new MyFunction(....);  // create the user function class
-   auto f = new TF1("f",fptr,&MyFunction::Evaluate,0,1,npar,"MyFunction","Evaluate");   // create TF1 class.
+   auto f = new TF1("f",fptr,&MyFunction::Evaluate,0,1,npar);   // create TF1 class.
 
    .....
 }


### PR DESCRIPTION
The `TF1`, `TF2`, and `TF3` constructors for CINT compatibility can be removed. This concerns the templated constructors that additionally took the name of the used functor class and member function. With ROOT 6, these names can be omitted.

See also commit 4e4cdfb from 2015, where these constructors were introduced.

The idea is to clear a bit more the jungle of `TH1` constructors, of which there are too many. That makes it confusing for our uses and for cppyy overload resolution.