### PR TITLE
[test] Add test of signalling unused read rules

### DIFF
--- a/roottest/root/meta/genreflex/CMakeLists.txt
+++ b/roottest/root/meta/genreflex/CMakeLists.txt
@@ -238,3 +238,11 @@ ROOTTEST_ADD_TEST(attributesCheck
                   MACRO execAttributesCheck.C
                   OUTREF execAttributesCheck.ref
                   FIXTURES_REQUIRED root-meta-genreflex-attributesCheck-fixture)
+
+# ROOT-3746
+if(NOT MSVC OR win_broken_tests) # "Error: At line 4. Bad tag: />" there is no error and no such substring at line 4...
+ROOTTEST_ADD_TEST(unusedReadRule
+                  COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/classes_root_3746.h
+                          --select=${CMAKE_CURRENT_SOURCE_DIR}/sel_root_3746.xml
+                  ERRREF root_3746.eref)
+endif()

--- a/roottest/root/meta/genreflex/classes_root_3746.h
+++ b/roottest/root/meta/genreflex/classes_root_3746.h
@@ -1,0 +1,3 @@
+#ifndef CLASSES_H
+class ClassAIns2{};
+#endif

--- a/roottest/root/meta/genreflex/root_3746.eref
+++ b/roottest/root/meta/genreflex/root_3746.eref
@@ -1,0 +1,1 @@
+Warning: 1 rule for target class ClassAIns2FOO was not used!

--- a/roottest/root/meta/genreflex/sel_root_3746.xml
+++ b/roottest/root/meta/genreflex/sel_root_3746.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="ClassAIns2" ClassVersion="2" />
+  <read sourceClass="ClassAIns" version="[2]" targetClass="ClassAIns2FOO" />
+</lcgdict>


### PR DESCRIPTION
therewith demonstrating that [ROOT-3746](https://its.cern.ch/jira/browse/ROOT-3746) has been fixed, probably a long time ago.


