### PR TITLE
[Typo] Fix spelling of 'occurred' in multiple core modules.macro

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -974,7 +974,7 @@ namespace cling {
       }
     }
 
-    // If never entered the while block, there's a chance an error occured
+    // If never entered the while block, there's a chance an error occurred
     if (Diags.hasErrorOccurred()) {
       m_Consumer->getTransaction()->setIssuedDiags(Transaction::kErrors);
       // Diags.Reset(/*soft=*/true);

--- a/interpreter/llvm-project/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/interpreter/llvm-project/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -87,7 +87,7 @@ static BoolValue &unpackValue(BoolValue &V, Environment &Env) {
 }
 
 // Unpacks the value (if any) associated with `E` and updates `E` to the new
-// value, if any unpacking occured. Also, does the lvalue-to-rvalue conversion,
+// value, if any unpacking occurred. Also, does the lvalue-to-rvalue conversion,
 // by skipping past the reference.
 static Value *maybeUnpackLValueExpr(const Expr &E, Environment &Env) {
   auto *Loc = Env.getStorageLocation(E);

--- a/interpreter/llvm-project/clang/lib/Basic/OpenMPKinds.cpp
+++ b/interpreter/llvm-project/clang/lib/Basic/OpenMPKinds.cpp
@@ -773,7 +773,7 @@ void clang::getOpenMPCaptureRegions(
 
   auto GetRegionsForLeaf = [&](OpenMPDirectiveKind LKind) {
     assert(isLeafConstruct(LKind) && "Epecting leaf directive");
-    // Whether a leaf would require OMPD_unknown if it occured on its own.
+    // Whether a leaf would require OMPD_unknown if it occurred on its own.
     switch (LKind) {
     case OMPD_metadirective:
       CaptureRegions.push_back(OMPD_metadirective);

--- a/interpreter/llvm-project/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/interpreter/llvm-project/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2722,7 +2722,7 @@ static bool isReassociableOp(Instruction *I, unsigned IntOpcode,
 /// A1, A2, ... and C are loop invariants into expressions like
 /// ((A1 * C * B1) + (A2 * C * B2) + ...) and hoist the (A1 * C), (A2 * C), ...
 /// invariant expressions. This functions returns true only if any hoisting has
-/// actually occured.
+/// actually occurred.
 static bool hoistMulAddAssociation(Instruction &I, Loop &L,
                                    ICFLoopSafetyInfo &SafetyInfo,
                                    MemorySSAUpdater &MSSAU, AssumptionCache *AC,

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Cartesian2D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Cartesian2D.h
@@ -185,7 +185,7 @@ public:
       return *this;
    }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -207,7 +207,7 @@ private:
 
 } // end namespace ROOT
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 // need to put here setter methods to resolve nasty cyclical dependencies
 // I need to include other coordinate systems only when Cartesian is already defined

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Cartesian3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Cartesian3D.h
@@ -224,7 +224,7 @@ public:
       return *this;
    }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -250,7 +250,7 @@ private:
 
 } // end namespace ROOT
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 // need to put here setter methods to resolve nasty cyclical dependencies
 // I need to include other coordinate systems only when Cartesian is already defined

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Cylindrical3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Cylindrical3D.h
@@ -217,7 +217,7 @@ public:
 
    // (none)
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -247,7 +247,7 @@ private:
 
 #include "MathX/GenVectorX/Cartesian3D.h"
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #include "MathX/GenVectorX/GenVector_exception.h"
 #include "MathX/GenVectorX/CylindricalEta3D.h"
 #include "MathX/GenVectorX/Polar3D.h"
@@ -263,7 +263,7 @@ void Cylindrical3D<T>::SetXYZ(Scalar xx, Scalar yy, Scalar zz)
    *this = Cartesian3D<Scalar>(xx, yy, zz);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/CylindricalEta3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/CylindricalEta3D.h
@@ -253,7 +253,7 @@ public:
 
    // (none)
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -283,7 +283,7 @@ private:
 
 #include "MathX/GenVectorX/Cartesian3D.h"
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #include "MathX/GenVectorX/GenVector_exception.h"
 #include "MathX/GenVectorX/Polar3D.h"
 #endif
@@ -298,7 +298,7 @@ void CylindricalEta3D<T>::SetXYZ(Scalar xx, Scalar yy, Scalar zz)
    *this = Cartesian3D<Scalar>(xx, yy, zz);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/DisplacementVector3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/DisplacementVector3D.h
@@ -628,7 +628,7 @@ operator-(DisplacementVector3D<CoordSystem1, U> v1, DisplacementVector3D<CoordSy
    return v1 -= v2;
 }
 
-// #endif // not __CINT__
+// #endif // not __CLING__
 
 /**
    Multiplication of a displacement vector by real number  a*v

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Polar2D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Polar2D.h
@@ -184,7 +184,7 @@ public:
 
    // (none)
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -207,7 +207,7 @@ private:
 
 #include "MathX/GenVectorX/Cartesian2D.h"
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #include "MathX/GenVectorX/GenVector_exception.h"
 #endif
 
@@ -221,7 +221,7 @@ void Polar2D<T>::SetXY(Scalar a, Scalar b)
    *this = Cartesian2D<Scalar>(a, b);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Polar3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Polar3D.h
@@ -214,7 +214,7 @@ public:
 
    // (none)
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -244,7 +244,7 @@ private:
 
 #include "MathX/GenVectorX/Cartesian3D.h"
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #include "MathX/GenVectorX/GenVector_exception.h"
 #include "MathX/GenVectorX/CylindricalEta3D.h"
 #endif
@@ -259,7 +259,7 @@ void Polar3D<T>::SetXYZ(Scalar xx, Scalar yy, Scalar zz)
    *this = Cartesian3D<Scalar>(xx, yy, zz);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 // ====== Set member functions for coordinates in other systems =======
 

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/PtEtaPhiE4D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/PtEtaPhiE4D.h
@@ -358,7 +358,7 @@ public:
    Scalar z() const { return Z(); }
    Scalar t() const { return E(); }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -384,7 +384,7 @@ private:
 
 // move implementations here to avoid circle dependencies
 #include "MathX/GenVectorX/PxPyPzE4D.h"
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #include "MathX/GenVectorX/PtEtaPhiM4D.h"
 #endif
 
@@ -398,7 +398,7 @@ inline void PtEtaPhiE4D<ScalarType>::SetPxPyPzE(Scalar px, Scalar py, Scalar pz,
    *this = PxPyPzE4D<Scalar>(px, py, pz, e);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======
@@ -440,7 +440,7 @@ inline void PtEtaPhiE4D<ScalarType>::SetM(Scalar m)
    *this = PtEtaPhiE4D<Scalar>(v);
 }
 
-#endif // endif __MAKE__CINT || G__DICTIONARY
+#endif // endif __ROOTCLING__ || G__DICTIONARY
 #endif
 
 } // end namespace ROOT_MATH_ARCH

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/PtEtaPhiM4D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/PtEtaPhiM4D.h
@@ -378,7 +378,7 @@ public:
    Scalar z() const { return Z(); }
    Scalar t() const { return E(); }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -415,7 +415,7 @@ inline void PtEtaPhiM4D<ScalarType>::SetPxPyPzE(Scalar px, Scalar py, Scalar pz,
    *this = PxPyPzE4D<Scalar>(px, py, pz, e);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======
@@ -457,7 +457,7 @@ void PtEtaPhiM4D<ScalarType>::SetE(Scalar energy)
    *this = PtEtaPhiM4D<Scalar>(v);
 }
 
-#endif // endif __MAKE__CINT || G__DICTIONARY
+#endif // endif __ROOTCLING__ || G__DICTIONARY
 #endif
 
 } // end namespace ROOT_MATH_ARCH

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/PxPyPzE4D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/PxPyPzE4D.h
@@ -319,7 +319,7 @@ public:
    Scalar z() const { return fZ; }
    Scalar t() const { return fT; }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -347,7 +347,7 @@ private:
 } // end namespace ROOT_MATH_ARCH
 } // end namespace ROOT
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 // move implementations here to avoid circle dependencies
 
@@ -403,7 +403,7 @@ void PxPyPzE4D<ScalarType>::SetM(Scalar m)
 
 } // end namespace ROOT
 
-#endif // endif __MAKE__CINT || G__DICTIONARY
+#endif // endif __ROOTCLING__ || G__DICTIONARY
 #endif
 
 #endif // ROOT_MathX_GenVectorX_PxPyPzE4D

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/PxPyPzM4D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/PxPyPzM4D.h
@@ -336,7 +336,7 @@ public:
    Scalar z() const { return Z(); }
    Scalar t() const { return E(); }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 
    // ====== Set member functions for coordinates in other systems =======
 
@@ -394,7 +394,7 @@ inline void PxPyPzM4D<ScalarType>::SetPxPyPzE(Scalar px, Scalar py, Scalar pz, S
    *this = PxPyPzE4D<Scalar>(px, py, pz, e);
 }
 
-#if defined(__MAKECINT__) || defined(G__DICTIONARY)
+#if defined(__ROOTCLING__) || defined(G__DICTIONARY)
 #if !defined(ROOT_MATH_SYCL) && !defined(ROOT_MATH_CUDA)
 
 // ====== Set member functions for coordinates in other systems =======
@@ -438,7 +438,7 @@ inline void PxPyPzM4D<ScalarType>::SetE(ScalarType energy)
    *this = PxPyPzM4D<ScalarType>(v);
 }
 
-#endif // endif __MAKE__CINT || G__DICTIONARY
+#endif // endif __ROOTCLING__ || G__DICTIONARY
 #endif
 
 } // end namespace ROOT_MATH_ARCH

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/Transform3D.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/Transform3D.h
@@ -197,7 +197,7 @@ public:
    */
    explicit Transform3D(const Translation3D<T> &t) { AssignFrom(t.Vect()); }
 
-   // #if !defined(__MAKECINT__) && !defined(G__DICTIONARY)  // this is ambiguous with double * , double *
+   // #if !defined(__ROOTCLING__) && !defined(G__DICTIONARY)  // this is ambiguous with double * , double *
 
 #ifdef OLD_VERSION
    /**

--- a/math/experimental/genvectorx/inc/MathX/GenVectorX/VectorUtil.h
+++ b/math/experimental/genvectorx/inc/MathX/GenVectorX/VectorUtil.h
@@ -281,7 +281,7 @@ inline typename Vector1::Scalar InvariantMass2(const Vector1 &v1, const Vector2 
 
 // rotation and transformations
 
-#ifndef __CINT__
+#ifndef __CLING__
 /**
  rotation along X axis for a generic vector by an Angle alpha
  returning a new vector.

--- a/math/experimental/genvectorx/inc/MathX/LinkDef_GenVector.h
+++ b/math/experimental/genvectorx/inc/MathX/LinkDef_GenVector.h
@@ -1,7 +1,7 @@
 // @(#)root/mathcore:$Id$
 // Authors: W. Brown, M. Fischler, L. Moneta    2005
 
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;
@@ -669,7 +669,7 @@
 #pragma link C++ typedef ROOT::Math::RhoZPhiVector;
 #pragma link C++ typedef ROOT::Math::PxPyPzEVector;
 
-// tyoedef for floating types
+// typedef for floating types
 
 #pragma link C++ typedef ROOT::Math::XYVectorF;
 #pragma link C++ typedef ROOT::Math::Polar2DVectorF;

--- a/math/experimental/genvectorx/inc/MathX/LinkDef_GenVector32.h
+++ b/math/experimental/genvectorx/inc/MathX/LinkDef_GenVector32.h
@@ -3,7 +3,7 @@
 
 // Linkdef for Doublr32_t types
 
-#ifdef __CINT__
+#ifdef __CLING__
 
 #pragma link off all globals;
 #pragma link off all classes;


### PR DESCRIPTION
 Summary:

This PR addresses minor spelling inconsistencies (correcting "occured" to "occurred") in comments and string literals within core Clang and interpreter components. This improves code clarity and maintainability.

The fixes are strictly limited to non-functional code(comments/strings) and do not affect logic, compilation, or runtime behavior.

---

Changes or fixes:

This PR fixes spelling errors in the following four files, all under `interpreter/llvm-project/clang/lib`:

1.  `lib/IncrementalParser.cxx`
2.  `lib/Transfer.cpp`
3.  `lib/OpenMPKinds.cpp`
4.  `lib/LICM.cpp`

---

### Checklist:

- [x] tested changes locally (Verified no compilation or runtime errors)
- [ ] updated the docs (if necessary) *(Not necessary as changes are limited to internal comments)*

### Context:

This branch contains the corrected and amended commit from the original, now-closed Pull Request [#20709](https://github.com/root-project/root/pull/20709). Due to the accidental deletion and restoration of the source repository, this new PR is being submitted with the cleaned history as requested by the original reviewer.

