### PR TITLE
[win] Fix XMLReader on Windows

### DIFF
--- a/core/dictgen/src/XMLReader.cxx
+++ b/core/dictgen/src/XMLReader.cxx
@@ -454,7 +454,7 @@ bool XMLReader::GetAttributes(const std::string& tag, std::vector<Attributes>& o
 bool XMLReader::Parse(const std::string &fileName, SelectionRules& out)
 {
 
-   std::ifstream file(fileName);
+   std::ifstream file(fileName, std::ios::binary);
 
    PopulateMap();
 

--- a/roottest/root/io/datamodelevolution/01/CMakeLists.txt
+++ b/roottest/root/io/datamodelevolution/01/CMakeLists.txt
@@ -68,21 +68,18 @@ ROOTTEST_ADD_TEST(test3
                                     root-io-datamodelevolution-01-test1-fixture
                                     root-io-datamodelevolution-01-test3-compile-fixture)
 
-# problem with XML file parsing on windows
-if(NOT MSVC OR win_broken_tests)
-  ROOTTEST_GENERATE_REFLEX_DICTIONARY(libDatModelV2_dictrflx
-                    DataModelV2.h
-                    SELECTION DataModelV2_selection.xml
-                    LIBNAME libDatModelV2_dictrflx
-                    NO_ROOTMAP
-                    FIXTURES_SETUP root-io-datamodelevolution-01-libDatModelV2_dictrflx-fixture)
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(libDatModelV2_dictrflx
+                  DataModelV2.h
+                  SELECTION DataModelV2_selection.xml
+                  LIBNAME libDatModelV2_dictrflx
+                  NO_ROOTMAP
+                  FIXTURES_SETUP root-io-datamodelevolution-01-libDatModelV2_dictrflx-fixture)
 
-  ROOTTEST_ADD_TEST(rtest3
-                    MACRO test3.cxx+
-                    MACROARG "\"r\""
-                    OUTREF rtest3.ref
-                    LABELS longtest
-                    FIXTURES_REQUIRED root-io-datamodelevolution-01-libDatModelV2_dictrflx-fixture
-                                      root-io-datamodelevolution-01-rtest1-fixture
-                                      root-io-datamodelevolution-01-test3-compile-fixture)
-endif()
+ROOTTEST_ADD_TEST(rtest3
+                  MACRO test3.cxx+
+                  MACROARG "\"r\""
+                  OUTREF rtest3.ref
+                  LABELS longtest
+                  FIXTURES_REQUIRED root-io-datamodelevolution-01-libDatModelV2_dictrflx-fixture
+                                    root-io-datamodelevolution-01-rtest1-fixture
+                                    root-io-datamodelevolution-01-test3-compile-fixture)

--- a/roottest/root/io/evolution/equivalent/CMakeLists.txt
+++ b/roottest/root/io/evolution/equivalent/CMakeLists.txt
@@ -1,14 +1,11 @@
-# there is problem parsing XML file on Windows, therefore reflex dictionary generation fails
-if (NOT MSVC OR win_broken_tests)
-  ROOTTEST_GENERATE_REFLEX_DICTIONARY(ioReadRuleEquivalentCode
-                                      ioReadRuleEquivalentCode.h
-                                      SELECTION ioReadRuleEquivalentCode_selection.xml
-                                      FIXTURES_SETUP root-io-evolution-equivalent-ioReadRuleEquivalentCode-fixture)
+ROOTTEST_GENERATE_REFLEX_DICTIONARY(ioReadRuleEquivalentCode
+                                    ioReadRuleEquivalentCode.h
+                                    SELECTION ioReadRuleEquivalentCode_selection.xml
+                                    FIXTURES_SETUP root-io-evolution-equivalent-ioReadRuleEquivalentCode-fixture)
 
-  ROOTTEST_ADD_TEST(ioReadRuleEquivalentCode
-                    MACRO execioReadRuleEquivalentCode.C
-                    OUTREF execioReadRuleEquivalentCode.ref
-                    COPY_TO_BUILDDIR ioReadRuleEquivalentCode.root
-                    LABELS longtest io
-                    FIXTURES_REQUIRED root-io-evolution-equivalent-ioReadRuleEquivalentCode-fixture)
-endif()
+ROOTTEST_ADD_TEST(ioReadRuleEquivalentCode
+                  MACRO execioReadRuleEquivalentCode.C
+                  OUTREF execioReadRuleEquivalentCode.ref
+                  COPY_TO_BUILDDIR ioReadRuleEquivalentCode.root
+                  LABELS longtest io
+                  FIXTURES_REQUIRED root-io-evolution-equivalent-ioReadRuleEquivalentCode-fixture)

--- a/roottest/root/meta/genreflex/CMakeLists.txt
+++ b/roottest/root/meta/genreflex/CMakeLists.txt
@@ -240,9 +240,7 @@ ROOTTEST_ADD_TEST(attributesCheck
                   FIXTURES_REQUIRED root-meta-genreflex-attributesCheck-fixture)
 
 # ROOT-3746
-if(NOT MSVC OR win_broken_tests) # "Error: At line 4. Bad tag: />" there is no error and no such substring at line 4...
 ROOTTEST_ADD_TEST(unusedReadRule
                   COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/classes_root_3746.h
                           --select=${CMAKE_CURRENT_SOURCE_DIR}/sel_root_3746.xml
                   ERRREF root_3746.eref)
-endif()

--- a/roottest/root/meta/genreflex/ROOT-5594/CMakeLists.txt
+++ b/roottest/root/meta/genreflex/ROOT-5594/CMakeLists.txt
@@ -5,9 +5,7 @@
 #                  OUTREF execdummy.ref
 #                  DEPENDS ${GENERATE_REFLEX_TEST})
 
-if(NOT MSVC OR win_broken_tests)
-  ROOTTEST_ADD_TEST(5594
-                    COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid.h
-                                 -o  AliAODPid.cxx
-                                 --select=${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid_selection.xml)
-endif()
+ROOTTEST_ADD_TEST(5594
+                  COMMAND ${ROOT_genreflex_CMD} ${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid.h
+                               -o  AliAODPid.cxx
+                               --select=${CMAKE_CURRENT_SOURCE_DIR}/AliAODPid_selection.xml)


### PR DESCRIPTION
- Use `std::ios::binary` flag to fix `LF` vs `CRLF` issue on Windows
- Enable related failing tests
