### PR TITLE
[core] Add TGenericClassInfo::AdoptMemberStreamer()

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -584,10 +584,6 @@ public:
 
    void               AdoptReferenceProxy(TVirtualRefProxy* proxy);
    void               AdoptStreamer(TClassStreamer *strm);
-   // Returns false if the member streamer could not be adopted (which happens if this class had its StreamerInfo
-   // compiled already).
-   // This function transfers ownership of the `strm` pointer to the TClass, so it should not be used anymore on the
-   // caller side. In particular, if `AdoptMemberStreamer` returns false `strm` has been deleted and becomes invalid.
    bool               AdoptMemberStreamer(const char *name, TMemberStreamer *strm);
    void               SetMemberStreamer(const char *name, MemberStreamerFunc_t strm);
    void               SetStreamerFunc(ClassStreamerFunc_t strm);

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -120,8 +120,6 @@ namespace ROOT {
       TClass                           *IsA(const void *obj);
 
       void                              AdoptAlternate(ROOT::TClassAlt *alt);
-      // Returns false if the member streamer could not be adopted (this happens if the underlying TClass had its
-      // StreamerInfo compiled already).
       bool                              AdoptMemberStreamer(const char *name, TMemberStreamer *strm);
       Short_t                           AdoptStreamer(TClassStreamer*);
       Short_t                           AdoptCollectionProxy(TVirtualCollectionProxy*);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6747,7 +6747,10 @@ void TClass::AdoptReferenceProxy(TVirtualRefProxy* proxy)
 ////////////////////////////////////////////////////////////////////////////////
 /// Adopt the TMemberStreamer pointer to by p and use it to Stream non basic
 /// member name.
-
+/// Returns false if the member streamer could not be adopted (which happens if this class had its StreamerInfo
+/// compiled already).
+/// This function transfers ownership of the `strm` pointer to the TClass, so it should not be used anymore on the
+/// caller side. In particular, if `AdoptMemberStreamer` returns false `strm` has been deleted and becomes invalid.
 bool TClass::AdoptMemberStreamer(const char *name, TMemberStreamer *p)
 {
    // Too late to add member streamers!

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -438,6 +438,8 @@ namespace Internal {
       fAlternate.push_back(alt);
    }
 
+   /// Returns false if the member streamer could not be adopted (this happens if the underlying TClass had its
+   /// StreamerInfo compiled already).
    bool TGenericClassInfo::AdoptMemberStreamer(const char *name, TMemberStreamer *strm)
    {
       if (fClass) {

--- a/roottest/root/io/customStreamer/CMakeLists.txt
+++ b/roottest/root/io/customStreamer/CMakeLists.txt
@@ -12,3 +12,18 @@ ROOTTEST_ADD_TEST(StreamerThrow
                   MACRO StreamerThrow.C+
                   OUTREF StreamerThrow.ref
                   FIXTURES_REQUIRED root-io-customStreamer-StreamerThrowClass-fixture)
+
+ROOTTEST_GENERATE_DICTIONARY(MemberStreamerLib
+                             MemberStreamerLib.h
+                             LINKDEF MemberStreamerLib_LinkDef.h
+                             FIXTURES_SETUP root-io-customStreamer-MemberStreamerLib-fixture)
+
+ROOTTEST_ADD_TEST(MemberStreamer
+                  MACRO testMemberStreamer.C
+                  PASSRC 0
+                  FIXTURES_REQUIRED root-io-customStreamer-MemberStreamerLib-fixture)
+
+ROOTTEST_ADD_TEST(MemberStreamer2
+                  MACRO testMemberStreamer2.C
+                  PASSRC 0
+                  FIXTURES_REQUIRED root-io-customStreamer-MemberStreamerLib-fixture)

--- a/roottest/root/io/customStreamer/MemberStreamerLib.h
+++ b/roottest/root/io/customStreamer/MemberStreamerLib.h
@@ -1,0 +1,16 @@
+#ifndef TEST_MEMBER_STREAMER_LIB
+#define TEST_MEMBER_STREAMER_LIB
+
+#include <memory>
+
+struct MemberStreamer {
+   int fData = 0;
+};
+
+struct MemberStreamerContainer {
+   std::unique_ptr<MemberStreamer> fMember;
+
+   MemberStreamerContainer() : fMember(new MemberStreamer()) {}
+};
+
+#endif

--- a/roottest/root/io/customStreamer/MemberStreamerLib_LinkDef.h
+++ b/roottest/root/io/customStreamer/MemberStreamerLib_LinkDef.h
@@ -1,0 +1,2 @@
+#pragma link C++ struct MemberStreamer+;
+#pragma link C++ struct MemberStreamerContainer+;

--- a/roottest/root/io/customStreamer/testMemberStreamer.C
+++ b/roottest/root/io/customStreamer/testMemberStreamer.C
@@ -1,0 +1,107 @@
+#include <TGenericClassInfo.h>
+#include <TMemberStreamer.h>
+#include <TBuffer.h>
+#include <TClass.h>
+#include <TFile.h>
+#include <TError.h>
+#include "MemberStreamerLib.h"
+
+static int gTimesWritten, gTimesRead;
+
+template <int DataValue>
+void customMemberStreamer(TBuffer &R__b, void *objp, Int_t /*size*/)
+{
+   TClass *R__cl = TClass::GetClass("MemberStreamer");
+
+   auto *obj = static_cast<MemberStreamerContainer *>(objp);
+   UInt_t R__s, R__c;
+
+   if (R__b.IsReading()) {
+      /* Version_t v =  */ R__b.ReadVersion(&R__s, &R__c);
+
+      R__b >> obj->fMember->fData;
+
+      R__b.CheckByteCount(R__s, R__c, R__cl);
+
+      ++gTimesRead;
+
+   } else {
+      R__c = R__b.WriteVersion(R__cl, kTRUE);
+
+      obj->fMember->fData = DataValue;
+      R__b << obj->fMember->fData;
+
+      R__b.SetByteCount(R__c, kTRUE);
+
+      ++gTimesWritten;
+   }
+}
+
+namespace ROOT {
+TGenericClassInfo *GenerateInitInstance(const MemberStreamerContainer *);
+}
+
+template <int DataValue>
+bool setupMemberStreamer()
+{
+   ROOT::TGenericClassInfo *classInfo = ROOT::GenerateInitInstance((const MemberStreamerContainer *)nullptr);
+   R__ASSERT(classInfo);
+   return classInfo->AdoptMemberStreamer("fMember", new TMemberStreamer(customMemberStreamer<DataValue>));
+}
+
+static bool __attribute__((used)) memberStreamerStaticInitter = ([] { return setupMemberStreamer<42>(); })();
+
+static bool VerifyTimesWrittenAndRead(int expectedTimesWritten, int expectedTimesRead)
+{
+   if (gTimesWritten != expectedTimesWritten) {
+      Error("checkMemberStreamer", "should have written %d times but actually written %d times!",
+            expectedTimesWritten, gTimesWritten);
+      return false;
+   }
+   if (gTimesRead != expectedTimesRead) {
+      Error("checkMemberStreamer", "should have read %d times but actually read %d times!",
+            expectedTimesRead, gTimesRead);
+      return false;
+   }
+   return true;
+}
+
+bool checkMemberStreamer(int expectedDataValue)
+{
+   static int timesFunctionWasRun = 0;
+   
+   {
+      MemberStreamerContainer container{};
+      TFile file("testMemberStreamer.root", "RECREATE");
+      file.WriteObject(&container, "container");
+      // custom streamer should have modified the data
+      if (container.fMember->fData != expectedDataValue) {
+         Error("checkMemberStreamer", "value was supposed to be %d but it's %d", expectedDataValue,
+               container.fMember->fData);
+         return false;
+      }
+      file.Close();
+
+      if (!VerifyTimesWrittenAndRead(timesFunctionWasRun + 1, timesFunctionWasRun))
+         return false;
+   }
+
+   TFile file("testMemberStreamer.root", "READ");
+   auto *container = file.Get<MemberStreamerContainer>("container");
+   if (!VerifyTimesWrittenAndRead(timesFunctionWasRun + 1, timesFunctionWasRun + 1))
+      return false;
+
+   ++timesFunctionWasRun;
+   return container && container->fMember->fData == expectedDataValue;
+}
+
+int testMemberStreamer()
+{
+   // initially the expected data value is 42 due to memberStreamerStaticInitter.
+   if (!checkMemberStreamer(42))
+      return 1; // failure
+
+   // this should fail, since the class StreamerInfo was already compiled and cannot adopt member streamers anymore.
+   // (note that `return 1` means we failed)
+   return setupMemberStreamer<99>();
+}

--- a/roottest/root/io/customStreamer/testMemberStreamer2.C
+++ b/roottest/root/io/customStreamer/testMemberStreamer2.C
@@ -1,0 +1,105 @@
+// This test is exactly the same as testMemberStreamer.C, except it doesn't have a statically-initialized
+// custom streamer.
+// Returns 0 on success, 1 on failure.
+#include <TGenericClassInfo.h>
+#include <TMemberStreamer.h>
+#include <TBuffer.h>
+#include <TClass.h>
+#include <TFile.h>
+#include <TError.h>
+#include "MemberStreamerLib.h"
+
+static int gTimesWritten, gTimesRead;
+
+template <int DataValue>
+void customMemberStreamer(TBuffer &R__b, void *objp, Int_t /*size*/)
+{
+   TClass *R__cl = TClass::GetClass("MemberStreamer");
+
+   auto *obj = static_cast<MemberStreamerContainer *>(objp);
+   UInt_t R__s, R__c;
+
+   if (R__b.IsReading()) {
+      /* Version_t v =  */ R__b.ReadVersion(&R__s, &R__c);
+
+      R__b >> obj->fMember->fData;
+
+      R__b.CheckByteCount(R__s, R__c, R__cl);
+
+      ++gTimesRead;
+
+   } else {
+      R__c = R__b.WriteVersion(R__cl, kTRUE);
+
+      obj->fMember->fData = DataValue;
+      R__b << obj->fMember->fData;
+
+      R__b.SetByteCount(R__c, kTRUE);
+
+      ++gTimesWritten;
+   }
+}
+
+namespace ROOT {
+TGenericClassInfo *GenerateInitInstance(const MemberStreamerContainer *);
+}
+
+template <int DataValue>
+bool setupMemberStreamer()
+{
+   ROOT::TGenericClassInfo *classInfo = ROOT::GenerateInitInstance((const MemberStreamerContainer *)nullptr);
+   R__ASSERT(classInfo);
+   return classInfo->AdoptMemberStreamer("fMember", new TMemberStreamer(customMemberStreamer<DataValue>));
+}
+
+static bool VerifyTimesWrittenAndRead(int expectedTimesWritten, int expectedTimesRead)
+{
+   if (gTimesWritten != expectedTimesWritten) {
+      Error("checkMemberStreamer", "should have written %d times but actually written %d times!",
+            expectedTimesWritten, gTimesWritten);
+      return false;
+   }
+   if (gTimesRead != expectedTimesRead) {
+      Error("checkMemberStreamer", "should have read %d times but actually read %d times!",
+            expectedTimesRead, gTimesRead);
+      return false;
+   }
+   return true;
+}
+
+bool checkMemberStreamer(int expectedDataValue)
+{
+   static int timesFunctionWasRun = 0;
+   
+   {
+      MemberStreamerContainer container{};
+      TFile file("testMemberStreamer.root", "RECREATE");
+      file.WriteObject(&container, "container");
+      // custom streamer should have modified the data
+      if (container.fMember->fData != expectedDataValue) {
+         Error("checkMemberStreamer", "value was supposed to be %d but it's %d", expectedDataValue,
+               container.fMember->fData);
+         return false;
+      }
+      file.Close();
+
+      if (!VerifyTimesWrittenAndRead(timesFunctionWasRun + 1, timesFunctionWasRun))
+         return false;
+   }
+
+   TFile file("testMemberStreamer.root", "READ");
+   auto *container = file.Get<MemberStreamerContainer>("container");
+   if (!VerifyTimesWrittenAndRead(timesFunctionWasRun + 1, timesFunctionWasRun + 1))
+      return false;
+
+   ++timesFunctionWasRun;
+   return container && container->fMember->fData == expectedDataValue;
+}
+
+int testMemberStreamer()
+{  
+   if (!setupMemberStreamer<99>())
+      return 1; // failure
+
+   return !checkMemberStreamer(99);
+}


### PR DESCRIPTION
# This Pull request:
adds a new function to `TGenericClassInfo` to allow deferring the registration of a MemberStreamer during static initialization. Performs a similar function to `TGenericClassInfo::AdoptStreamer` et al. but for `TMemberStreamer`s.

## Reason
Currently it's impossible to register a MemberStreamer of a class during static initialization without invoking `TClass::GetClass`, which should never be done at library loading time, as it causes [issues](https://github.com/root-project/root/issues/20673#issuecomment-3640963838).

Specifically, ALICE was hit by this after [adding a GetClass in a static initializer](https://github.com/AliceO2Group/AliceO2/commit/2439bbec037ff4b4c40361cbeaec97fafbaae132#diff-553ae85251c34492bd9adbecd77a43e390e740d98be2e13a4f2b2939a02d256eR68) and as a result observed huge performance regressions due to Cling being initialized earlier than intended (which in turn causes modules to be registered too early).

cc @ktf 



