### PR TITLE
[cppyy] Fix invalid `static_cast` in last commit

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -53,12 +53,12 @@ uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf)
       if (CPPOverload_Check(pyobj)) {
          // Hash the method name and overload count for uniqueness
          // All O(1) access - no RTTI, no string construction
-         auto *ol = static_cast<CPPOverload *>(pyobj);
+         auto *ol = reinterpret_cast<CPPOverload *>(pyobj);
          hash_combine(hash, str_hash(ol->fMethodInfo->fName));
          hash_combine(hash, static_cast<uint64_t>(ol->fMethodInfo->fMethods.size()));
       } else if (TemplateProxy_Check(pyobj)) {
          // Hash the stable template name (fCppName includes scope for templates)
-         auto *tp = static_cast<TemplateProxy *>(pyobj);
+         auto *tp = reinterpret_cast<TemplateProxy *>(pyobj);
          hash_combine(hash, str_hash(tp->fTI->fCppName));
       } else {
          // Standard type-based hashing for other objects


### PR DESCRIPTION
Fixup the invalid `static_cast` in the last commit 87380b591 that was casting to a class unrelated by inheritance.

Casting between technically unrelated classes is standard in CPython extension code, but one has to use C-style casts of `reinterpret_cast` for that.

This follows up on https://github.com/root-project/root/pull/20708, where this invalid cast was introduced but the **CI still passed** even though the correct commit from the PR branch seems to have been checked out! See:
  * https://github.com/root-project/root/actions/runs/20262315595/job/58184834679#step:2:73
    `  HEAD is now at 48ecf8f27 Merge 94d9c9d7c9c6215bfe72fab4c14db10ecb07bbe0 into 2f1d165234bc718600f6f3a590573fc6bb727ac8`
  * https://github.com/root-project/root/pull/20708/commits
    Last commit is indeed `94d9c9d7c9c6215bfe72fab4c14db10ecb07bbe0`

The problem is that the PR branch was called `master`, which fails to get rebased correctly in the CI. From the Fedora43 logs for example:
```txt
git fetch origin 94d9c9d7c9c6215bfe72fab4c14db10ecb07bbe0:master
git checkout master
git rebase 2f1d165234bc718600f6f3a590573fc6bb727ac8
[0m
[90mfatal: refusing to fetch into branch 'refs/heads/master' checked out at '/github/home/ROOT-CI/src'
Already on 'master'
Your branch is up to date with 'origin/master'.
Current branch master is up to date.
[0m
** Elapsed time for group "Rebase" 0:00:00.4
```

By the way, it's the third time now within a few months that I need an emergency PR like this, the other two times being because the warnings that caused the Debian builds to fail were not visible in the CI run of the PR:
  * https://github.com/root-project/root/pull/20351
  * https://github.com/root-project/root/pull/20569