### PR TITLE
Revert "[Python] Templated function invoked multiple times with incorrect template arguments"

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.h
@@ -5,7 +5,6 @@
 #include "PyCallable.h"
 
 // Standard
-#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>
@@ -14,8 +13,30 @@
 
 namespace CPyCppyy {
 
-// Signature hashing for memoization (implementation in CPPOverload.cxx)
-uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf);
+// signature hashes are also used by TemplateProxy
+inline uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf)
+{
+// Build a hash from the types of the given python function arguments.
+    uint64_t hash = 0;
+
+    Py_ssize_t nargs = CPyCppyy_PyArgs_GET_SIZE(args, nargsf);
+    for (Py_ssize_t i = 0; i < nargs; ++i) {
+    // TODO: hashing in the ref-count is for moves; resolve this together with the
+    // improved overloads for implicit conversions
+        PyObject* pyobj = CPyCppyy_PyArgs_GET_ITEM(args, i);
+        hash += (uint64_t)Py_TYPE(pyobj);
+#if PY_VERSION_HEX >= 0x030e0000
+        hash += (uint64_t)(PyUnstable_Object_IsUniqueReferencedTemporary(pyobj) ? 1 : 0);
+#else
+        hash += (uint64_t)(Py_REFCNT(pyobj) == 1 ? 1 : 0);
+#endif
+        hash += (hash << 10); hash ^= (hash >> 6);
+    }
+
+    hash += (hash << 3); hash ^= (hash >> 11); hash += (hash << 15);
+
+    return hash;
+}
 
 class CPPOverload {
 public:

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1159,28 +1159,6 @@ class TestTEMPLATES:
         assert ns.stringify["const char*"]("Aap")                    == "Aap "
         assert ns.stringify(ctypes.c_char_p(bytes("Noot", "ascii"))) == "Noot "
 
-    def test35_issue_20526_hash_collision(self):
-        """Fix #20526: Ensure distinct global functions have distinct hashes"""
-
-        import cppyy
-
-        cppyy.cppdef("""
-            namespace Issue20526 {
-                int funcA() { return 101; }
-                int funcB() { return 202; }
-                template<typename T> int call_it(T f) { return f(); }
-            }
-        """)
-
-        ns = cppyy.gbl.Issue20526
-
-        # If hashes collide, the cache returns the wrong instantiation
-        resA = ns.call_it(ns.funcA)
-        resB = ns.call_it(ns.funcB)
-
-        assert resA == 101
-        assert resB == 202
-
 
 class TestTEMPLATED_TYPEDEFS:
     def setup_class(cls):


### PR DESCRIPTION
This PR reverts #20742 and #20526.

See https://github.com/root-project/root/pull/20708#issuecomment-3664105392 for the reason.