### PR TITLE
[PyROOT] Don't install the python modules twice

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 add_library(cppyy SHARED src/CPyCppyyPyModule.cxx)
 
 # Set the suffix to '.so' and the prefix to 'lib'
-set_target_properties(cppyy PROPERTIES  ${ROOT_LIBRARY_PROPERTIES}
+set_target_properties(cppyy PROPERTIES  ${ROOT_LIBRARY_PROPERTIES_NO_VERSION}
   LIBRARY_OUTPUT_DIRECTORY ${localruntimedir}/cppyy)
 if(MSVC)
   target_link_libraries(cppyy PRIVATE CPyCppyy)

--- a/bindings/pyroot/cppyy/cppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/CMakeLists.txt
@@ -31,7 +31,8 @@ endforeach()
 # Install Python sources and bytecode
 install(DIRECTORY ${localruntimedir}/cppyy
         DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
-        COMPONENT libraries)
+        COMPONENT libraries
+        PATTERN *.so EXCLUDE)
 
 if(NOT MSVC)
   ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -239,7 +239,8 @@ install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
 # Install Python sources and bytecode
 install(DIRECTORY ${localruntimedir}/ROOT
         DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
-        COMPONENT libraries)
+        COMPONENT libraries
+        PATTERN *.so EXCLUDE)
 
 # Install headers required by pythonizations
 install(FILES ${PYROOT_EXTRA_HEADERS}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The binary python modules were moved one directory level down into the ROOT and cppyy directories, so that they reside alongside the python files in the same directories. The install rule for the python files must therefore be extended to exclude the binary modules (`PATTERN *.so EXCLUDE`) so that these are not installed a second time overwriting the files installed by the install rule for the binary modules with another copy with the wrong file permissions.

Also use the no-version option for the cppyy binary module as is already done for the pythonization binary module, since it is now installed in the python directory. Before it was installed in the library directory with an unversioned symlink in the python directory.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
