### PR TITLE
Address some minor TODOs after CINT to Cling migration

### DIFF
--- a/graf2d/cocoa/inc/TGCocoa.h
+++ b/graf2d/cocoa/inc/TGCocoa.h
@@ -468,10 +468,10 @@ private:
 public:
    static Atom_t fgDeleteWindowAtom;
 
-private:
-   //TODO: use instead = delete syntax from C++0x11
-   TGCocoa(const TGCocoa &rhs);
-   TGCocoa &operator = (const TGCocoa &rhs);
+   TGCocoa(const TGCocoa &rhs) = delete;
+   TGCocoa &operator = (const TGCocoa &rhs) = delete;
+   TGCocoa(TGCocoa &&rhs) = delete;
+   TGCocoa &operator = (TGCocoa &&rhs) = delete;
 
    ClassDefOverride(TGCocoa, 0); //TVirtualX for MacOS X.
 };

--- a/graf2d/cocoa/inc/TGQuartz.h
+++ b/graf2d/cocoa/inc/TGQuartz.h
@@ -96,7 +96,6 @@ private:
    void AlignTTFString();
    Bool_t IsTTFStringVisible(Int_t x, Int_t y, UInt_t w, UInt_t h);
    void RenderTTFString(Int_t x, Int_t y, ETextMode mode);
-   //TODO: move internal headers like TGQuartz.h out of the public ROOT user interface. Then we can also use XQuartz types like QuartzPixmap* instead of void * in functions like these
    void DrawFTGlyphIntoPixmap(void *pixmap, FT_Bitmap *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by);
 
    void SetAA();

--- a/io/io/inc/TMapFile.h
+++ b/io/io/inc/TMapFile.h
@@ -73,16 +73,15 @@ protected:
 
    static void *MapToAddress();
 
-public:
-   enum { kDefaultMapSize = 0x80000 }; // default size of mapped heap is 500 KB
-
-   // TODO: Should both be protected
    ~TMapFile() override;
    void *operator new(size_t sz) { return TObject::operator new(sz); }
    void *operator new[](size_t sz) { return TObject::operator new[](sz); }
    void *operator new(size_t sz, void *vp) { return TObject::operator new(sz, vp); }
    void *operator new[](size_t sz, void *vp) { return TObject::operator new[](sz, vp); }
    void     operator delete(void *vp);
+
+public:
+   enum { kDefaultMapSize = 0x80000 }; // default size of mapped heap is 500 KB
 
    void          Browse(TBrowser *b) override;
    void          Close(Option_t *option = "") override;

--- a/tmva/tmva/inc/TMVA/MethodCuts.h
+++ b/tmva/tmva/inc/TMVA/MethodCuts.h
@@ -70,9 +70,6 @@ namespace TMVA {
       MethodCuts( DataSetInfo& theData,
                   const TString& theWeightFile);
 
-      // TODO: remove this is a workaround which was necessary when CINT was not capable of handling dynamic casts
-      static MethodCuts* DynamicCast( IMethod* method ) { return dynamic_cast<MethodCuts*>(method); }
-
       virtual ~MethodCuts( void );
 
       Bool_t HasAnalysisType( Types::EAnalysisType type, UInt_t numberClasses, UInt_t numberTargets ) override;


### PR DESCRIPTION
Follows up on the observations made in #20694.

I also understand now that the `TGQuartz.h` header is actually needed by the ROOT plugin system.