### PR TITLE
[roottest] Skip `rootcling` instead of `rootcint` from output

### DIFF
--- a/roottest/scripts/custom_diff.py
+++ b/roottest/scripts/custom_diff.py
@@ -26,7 +26,7 @@ def filter(lines, ignoreWhiteSpace = False):
         continue
       if ' -nologo -TP -c -nologo -I' in line:
         continue
-      if 'rootcint -v1 -f ' in line:
+      if 'rootcling -v1 -f ' in line:
         continue
       if 'No precompiled header available' in line:
         continue


### PR DESCRIPTION
Now that we use `rootcling` instead of `rootcint` in Make project, this
needs to be updated.

Follows up on https://github.com/guitargeek/root/commit/e421de683b2f31b6bdf11378c4c0097322d8dbab.