### PR TITLE
[tut] Run ntpl014 with ACLiC to generate the dictionaries

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -705,6 +705,9 @@ set(analysis-dataframe-df015_LazyDataSource-depends tutorial-analysis-dataframe-
 # Download the input root file only once from a python tutorial, the C++ one depends on it
 set(hist-hist039_TH2Poly_usa-depends tutorial-hist-hist039_TH2Poly_usa-py)
 
+# Specify which tutorials should be run with ACLiC, e.g. because they contain classes instances of which are written
+set(io-ntuple-ntpl014_framework-aclic "+")
+
 #---Loop over all tutorials and define the corresponding test---------
 foreach(t ${tutorials})
   list(FIND returncode_1 ${t} index)

--- a/tutorials/io/ntuple/ntpl014_framework.C
+++ b/tutorials/io/ntuple/ntpl014_framework.C
@@ -36,6 +36,8 @@
 #include <ROOT/RNTupleWriter.hxx>
 #include <ROOT/RNTupleWriteOptions.hxx>
 
+#include <TFile.h>
+
 #include <cassert>
 #include <cstddef>    // for std::size_t
 #include <cstdint>    // for std::uint32_t
@@ -148,6 +150,8 @@ public:
          }
       }
    }
+   // Version 0 signals to ROOT's typesystem that this instances of this class will never be written
+   ClassDef(ParallelOutputter,0)
 };
 
 // A SerializingOutputter uses a sequential RNTupleWriter to append an RNTuple to a TFile and a std::mutex to
@@ -215,6 +219,8 @@ public:
          }
       }
    }
+   // Version 0 signals to ROOT's typesystem that this instances of this class will never be written
+   ClassDef(SerializingOutputter,0) 
 };
 
 // === END OF TUTORIAL FRAMEWORK CODE ===


### PR DESCRIPTION
of the classes which are written in the example, therewith removing a warning prompted.
This is in principle the correct thing to do. Hopefully, this will also fix a spurious exception of Windows builds.