### PR TITLE
[tmva][sofie] Guard old Keras parser against Keras-3

### DIFF
--- a/tmva/sofie_parsers/src/RModelParser_Keras.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_Keras.cxx
@@ -873,8 +873,16 @@ RModel Parse(std::string filename, int batch_size){
    // For each layer: type,name,activation,dtype,input tensor's name,
    // output tensor's name, kernel's name, bias's name
    // None object is returned for if property doesn't belong to layer
-   PyRunString("import tensorflow",fGlobalNS,fLocalNS);
-   PyRunString("import tensorflow.keras as keras",fGlobalNS,fLocalNS);
+   PyRunString("import tensorflow\n", fGlobalNS, fLocalNS);
+   PyRunString("import tensorflow.keras as keras\n"
+               "version = keras.__version__\n"
+               "major = int(version.split('.')[0])\n"
+               "if major >= 3:\n"
+               "    raise RuntimeError(\n"
+               "        'TMVA SOFIE Keras parser supports Keras 2 only.\\n'\n"
+               "        'Keras 3 detected. Please export the model to ONNX.\\n'\n"
+               "    )\n",
+               fGlobalNS, fLocalNS);
    PyRunString("from tensorflow.keras.models import load_model",fGlobalNS,fLocalNS);
    PyRunString("print('TF/Keras Version: '+ tensorflow.__version__)",fGlobalNS,fLocalNS);
    PyRunString(TString::Format("model=load_model('%s')",filename.c_str()),fGlobalNS,fLocalNS);


### PR DESCRIPTION
# This Pull request
Adds a defensive runtime guard to the TMVA SOFIE Keras parser to prevent segmentation faults when used with Keras 3 (enabled by default in TensorFlow ≥ 2.16).

The current parser is implemented against the Keras 2 API. When Keras 3 objects are encountered, undefined behavior may occur, leading to runtime crashes. This PR does not add Keras 3 support; it only detects the unsupported configuration early and fails cleanly with a clear error message.

This provides a temporary safety measure while proper Keras 3 support is being developed.

## Changes or fixes:
- Add an explicit runtime check for the Keras major version
- Disable the old SOFIE Keras parser when Keras ≥ 3 is detected
- Replace segmentation faults with a clear, user-facing error message
- Do not change behavior for Keras 2 users

## Checklist:
- [x] tested changes locally

This PR fixes #20591 

