### PR TITLE
Fix thisroot.sh: Added validation for SOURCE directory

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -262,7 +262,15 @@ if [ -z "${SOURCE}" ]; then
    fi
 else
    thisrootdir=$(dirname $(realpath "${SOURCE}"))
-   export ROOTSYS=${thisrootdir%/*}
+   thisroot=${thisrootdir%/*}
+   
+   if [ ! -f "${thisroot}/bin/thisroot.sh" ]; then
+      echo "ERROR: Could not determine correct ROOT installation directory" >&2
+      echo "       thisroot.sh not found at ${thisroot}/bin/thisroot.sh" >&2
+      return 1 2>/dev/null || exit 1
+   fi
+   
+   export ROOTSYS=${thisroot}
 fi
 
 if ! [ -f "${ROOTSYS}/bin/root-config" ] ; then


### PR DESCRIPTION
## Description
Fixes root-project/root#20786

This PR adds validation to config/thisroot.sh to check that the detected SOURCE directory actually contains thisroot.sh before using it to set ROOTSYS.

## Problem
When lsof fails to detect the correct source location (particularly with dash shell on Debian), SOURCE can resolve to invalid paths like /dev/pts/0, causing ROOTSYS to be incorrectly set to /dev.

## Solution
- Added thisroot variable to store the calculated ROOT directory
- Added validation check to verify ${thisroot}/bin/thisroot.sh exists before setting ROOTSYS
- Returns error with informative message if validation fails
- Only sets ROOTSYS if validation passes

## Changes
- Modified config/thisroot.sh around line 265
- Check happens before ROOTSYS is set (prevents invalid state)
- Proper error handling with return 1 2>/dev/null || exit 1

## Testing
- Tested failure case: cat config/thisroot.sh | dash shows error message
- Verified fix prevents ROOTSYS from being set to /dev
- Logic validated on source repository