### PR TITLE
[io] rootPcmObjs depends on Core and RIO

### DIFF
--- a/io/rootpcm/CMakeLists.txt
+++ b/io/rootpcm/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT io/rootpcm package
 ############################################################################
 
-ROOT_OBJECT_LIBRARY(RootPcmObjs src/rootclingIO.cxx)
+ROOT_OBJECT_LIBRARY(RootPcmObjs src/rootclingIO.cxx BUILTINS Core RIO)
 
 target_include_directories(RootPcmObjs PRIVATE
    ${CMAKE_SOURCE_DIR}/io/io/inc


### PR DESCRIPTION
exploring here if this might be a reason why sometimes one gets 'out of date' modules?

rootclingIO.cxx uses RIO and Core classes.

I am not sure if BUILTINS is working well: with add_dependencies explicitly, I got a cyclic dependency error.

see occurrence: https://github.com/root-project/root/actions/runs/20365372252/job/58519132341?pr=20758
and https://github.com/root-project/root/issues/7704

I also attach here the dependency graph by
```
 cmake --graphviz=dep.dot /opt/root_src
 dot -Tsvg dep.dot -o dep.svg
```

![dep](https://github.com/user-attachments/assets/3850acd3-68b5-400e-9cf7-c332c8f1cad0)

using `CMakeGraphVizOptions.cmake` in the source or binary dir:

```
# https://embeddeduse.com/2022/03/01/visualising-module-dependencies-with-cmake-and-graphviz/
set(GRAPHVIZ_EXTERNAL_LIBS FALSE)
set(GRAPHVIZ_IGNORE_TARGETS "LLVM*" ".*clang*" ".*resource-headers" "G__*")
set(GRAPHVIZ_EXECUTABLES FALSE)
```

Btw this SVG graph might be useful to add in the Doxygen docu @couet

I do it as follows in my projects:

Somewhere in the index.md file I write

```
A graph of CMake target dependencies can be found here:
\dotfile dependencies.dot
```
and in the CMake:
```
    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CMakeGraphVizOptions.cmake ${CMAKE_BINARY_DIR}/CMakeGraphVizOptions.cmake COPYONLY)
    add_custom_target(graphviz
        COMMAND ${CMAKE_COMMAND} "--graphviz=SOME_OUTPUT_DIRECTORY/dependencies.dot" ${CMAKE_SOURCE_DIR}
        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
    )
```
In the Doxyfile:
`DOTFILE_DIRS = SOME_OUTPUT_DIR`