### PR TITLE
[Python] Raise minimum required Python version from 3.9 to 3.10

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [cp39-manylinux_x86_64, cp310-manylinux_x86_64, cp311-manylinux_x86_64, cp312-manylinux_x86_64, cp313-manylinux_x86_64]
+        target: [cp310-manylinux_x86_64, cp311-manylinux_x86_64, cp312-manylinux_x86_64, cp313-manylinux_x86_64]
     name: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: test-wheel-cp${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4

--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -106,6 +106,8 @@ As part of this migration, the following build options are deprecated. From ROOT
 
 ## Python Interface
 
+ROOT dropped support for Python 3.9, meaning ROOT now requires at least Python 3.10.
+
 ## Command-line utilities
 
 ## JavaScript ROOT

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -206,11 +206,6 @@ extern "C" PyObject *PyInit_libROOTPythonizations()
    // keep gRootModule, but do not increase its reference count even as it is borrowed,
    // or a self-referencing cycle would be created
 
-   // Initialize and acquire the GIL to allow for threading in ROOT
-#if PY_VERSION_HEX < 0x03090000
-   PyEval_InitThreads();
-#endif
-
    // Make sure the interpreter is initialized once gROOT has been initialized
    TInterpreter::Instance();
 

--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -160,9 +160,6 @@ Bool_t TPython::Initialize()
       }
       PyConfig_Clear(&config);
 #endif
-#if PY_VERSION_HEX < 0x03090000
-      PyEval_InitThreads();
-#endif
 
       // try again to see if the interpreter is initialized
       if (!Py_IsInitialized()) {

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -708,7 +708,7 @@ endif()
 if(tmva-pymva OR tmva-sofie)
   list(APPEND python_components NumPy)
 endif()
-find_package(Python3 3.9 COMPONENTS ${python_components})
+find_package(Python3 3.10 COMPONENTS ${python_components})
 
 #---Check for OpenGL installation-------------------------------------------------------
 # OpenGL is required by various graf3d features that are enabled with opengl=ON,

--- a/test/PostInstall/CMakeLists.txt
+++ b/test/PostInstall/CMakeLists.txt
@@ -19,7 +19,7 @@ if(BUILD_TESTING)
   set_tests_properties(run-hsimple   PROPERTIES FIXTURES_SETUP    HSIMPLE)
   set_tests_properties(read-hsimple  PROPERTIES FIXTURES_REQUIRED HSIMPLE)
   if(ROOT_pyroot_FOUND)
-    find_package(Python3 3.9 REQUIRED)
+    find_package(Python3 3.10 REQUIRED)
     # Need to duplicate the import ROOT test because the PASS_REGULAR_EXPRESSION
     # property will disable checking the exit code of the test so import ROOT
     # might fail but ctest would not report it


### PR DESCRIPTION
Python 3.8 has been end-of-life since the release of Python 3.14 in October 2025.

The macOS runners are now using Python 3.11 and also our `alma9` images were upgraded to Python 3.12:
https://github.com/root-project/root-ci-images/pull/90

That means we can now follow the official Python end-of-life cycle and support only Python 3.10+ in the upcoming ROOT 6.40.

Note that for ROOT 6.40, we already raised the minimum supported version from 3.8 to 3.9 in 599cbfd279ff.

The next minimum Python version raise will be done in April 2027 when Ubuntu 22.04 is end-of-life, because that Ubuntu version uses Python 3.10.


See also:
  * https://devguide.python.org/versions/