### PR TITLE
[tmva][sofie]  Fix testSofieModels for new torch version

### DIFF
--- a/tmva/sofie/test/Conv1dModelGenerator.py
+++ b/tmva/sofie/test/Conv1dModelGenerator.py
@@ -14,7 +14,7 @@ result = []
 
 
 class Net(nn.Module):
-    
+
     def __init__(self, nc = 1, ng = 1, nl = 4, use_bn = False, use_maxpool = False, use_avgpool = False):
         super(Net, self).__init__()
 
@@ -24,7 +24,7 @@ class Net(nn.Module):
         self.use_bn = use_bn
         self.use_maxpool = use_maxpool
         self.use_avgpool = use_avgpool
-        
+
         self.conv0 = nn.Conv1d(in_channels=self.nc, out_channels=4, kernel_size=2, groups=1, stride=1, padding=1)
         if (self.use_bn): self.bn1 = nn.BatchNorm2d(4)
         if (self.use_maxpool): self.pool1 = nn.MaxPool2d(2)
@@ -56,7 +56,7 @@ def main():
    parser = argparse.ArgumentParser(description='PyTorch model generator')
    parser.add_argument('params', type=int, nargs='+',
                     help='parameters for the Conv network : batchSize , inputChannels, inputImageSize, nGroups, nLayers ')
-   
+
    parser.add_argument('--bn', action='store_true', default=False,
                         help='For using batch norm layer')
    parser.add_argument('--maxpool', action='store_true', default=False,
@@ -70,13 +70,13 @@ def main():
 
 
    args = parser.parse_args()
-  
+
    #args.params = (4,2,4,1,4)
 
    np = len(args.params)
    if (np < 5) : exit()
    bsize = args.params[0]
-   nc = args.params[1] 
+   nc = args.params[1]
    d = args.params[2]
    ngroups = args.params[3]
    nlayers = args.params[4]
@@ -93,7 +93,7 @@ def main():
    input  = torch.zeros([])
    for ib in range(0,bsize):
       xa = torch.ones([1, 1, d]) * (ib+1)
-      if (nc > 1) : 
+      if (nc > 1) :
          xb = xa.neg()
          xc = torch.cat((xa,xb),1)  # concatenate tensors
          if (nc > 2) :
@@ -101,16 +101,16 @@ def main():
             xc = torch.cat((xa,xb,xd),1)
       else:
          xc = xa
-        
-      #concatenate tensors 
-      if (ib == 0) : 
+
+      #concatenate tensors
+      if (ib == 0) :
          xinput = xc
       else :
-         xinput = torch.cat((xinput,xc),0) 
+         xinput = torch.cat((xinput,xc),0)
 
    print("input data",xinput.shape)
    print(xinput)
-   
+
    name = "Conv1dModel"
    if (use_bn): name += "_BN"
    if (use_maxpool): name += "_MAXP"
@@ -121,24 +121,26 @@ def main():
    loadModel=False
    savePtModel = False
 
-    
+
    model = Net(nc,ngroups,nlayers, use_bn, use_maxpool, use_avgpool)
    print(model)
 
    model(xinput)
- 
+
    model.forward(xinput)
 
    if savePtModel :
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=True,
+         external_data=False
+      )
 
    if loadModel :
         print('Loading model from file....')
@@ -159,10 +161,10 @@ def main():
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-        f.write(str(float(yvec[i]))+" ")
-        
-        
-    
+        f.write(str(float(yvec[i].detach()))+" ")
+
+
+
 
 if __name__ == '__main__':
     main()

--- a/tmva/sofie/test/Conv2dModelGenerator.py
+++ b/tmva/sofie/test/Conv2dModelGenerator.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 result = []
 
 class Net(nn.Module):
-    
+
     def __init__(self, nc = 1, ng = 1, nl = 4, use_bn = False, use_maxpool = False, use_avgpool = False):
         super(Net, self).__init__()
 
@@ -23,7 +23,7 @@ class Net(nn.Module):
         self.use_bn = use_bn
         self.use_maxpool = use_maxpool
         self.use_avgpool = use_avgpool
-        
+
         self.conv0 = nn.Conv2d(in_channels=self.nc, out_channels=4, kernel_size=2, groups=1, stride=1, padding=1)
         if (self.use_bn): self.bn1 = nn.BatchNorm2d(4)
         if (self.use_maxpool): self.pool1 = nn.MaxPool2d(2)
@@ -33,7 +33,7 @@ class Net(nn.Module):
            self.conv1  = nn.Conv2d(in_channels=4,   out_channels=8, groups = self.ng,   kernel_size=3, stride=1, padding=1)
            #output is same 4x4
            self.conv2  = nn.Conv2d(in_channels=8,   out_channels=4, kernel_size=3, stride=1, padding=1)
-           #use stride last layer 
+           #use stride last layer
            self.conv3 =  nn.Conv2d(in_channels=4,   out_channels=1,   kernel_size=2, stride=2, padding=0)
 
 
@@ -61,7 +61,7 @@ def main():
    parser = argparse.ArgumentParser(description='PyTorch model generator')
    parser.add_argument('params', type=int, nargs='+',
                     help='parameters for the Conv network : batchSize , inputChannels, inputImageSize, nGroups, nLayers ')
-   
+
    parser.add_argument('--bn', action='store_true', default=False,
                         help='For using batch norm layer')
    parser.add_argument('--maxpool', action='store_true', default=False,
@@ -73,13 +73,13 @@ def main():
 
 
    args = parser.parse_args()
-  
+
    #args.params = (4,2,4,1,4)
 
    np = len(args.params)
    if (np < 5) : exit()
    bsize = args.params[0]
-   nc = args.params[1] 
+   nc = args.params[1]
    d = args.params[2]
    ngroups = args.params[3]
    nlayers = args.params[4]
@@ -95,7 +95,7 @@ def main():
    input  = torch.zeros([])
    for ib in range(0,bsize):
       xa = torch.ones([1, 1, d, d]) * (ib+1)
-      if (nc > 1) : 
+      if (nc > 1) :
          xb = xa.neg()
          xc = torch.cat((xa,xb),1)  # concatenate tensors
          if (nc > 2) :
@@ -103,16 +103,16 @@ def main():
             xc = torch.cat((xa,xb,xd),1)
       else:
          xc = xa
-        
-      #concatenate tensors 
-      if (ib == 0) : 
+
+      #concatenate tensors
+      if (ib == 0) :
          xinput = xc
       else :
-         xinput = torch.cat((xinput,xc),0) 
+         xinput = torch.cat((xinput,xc),0)
 
    print("input data",xinput.shape)
    print(xinput)
-   
+
    name = "Conv2dModel"
    if (use_bn): name += "_BN"
    if (use_maxpool): name += "_MAXP"
@@ -123,24 +123,33 @@ def main():
    loadModel=False
    savePtModel = False
 
-    
+
    model = Net(nc,ngroups,nlayers, use_bn, use_maxpool, use_avgpool)
    print(model)
 
    model(xinput)
- 
+
    model.forward(xinput)
 
    if savePtModel :
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
+
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+
+      #new ONNX exporter does not work for batchmorm
+      dynamo_export=True
+      if (use_bn): dynamo_export=False
+
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=dynamo_export,
+         external_data=False
+      )
+
 
    if loadModel :
         print('Loading model from file....')
@@ -161,10 +170,10 @@ def main():
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-        f.write(str(float(yvec[i]))+" ")
-        
-        
-    
+        f.write(str(float(yvec[i].detach()))+" ")
+
+
+
 
 if __name__ == '__main__':
     main()

--- a/tmva/sofie/test/Conv3dModelGenerator.py
+++ b/tmva/sofie/test/Conv3dModelGenerator.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 result = []
 
 class Net(nn.Module):
-    
+
     def __init__(self, nc = 1, ng = 1, nl = 4, use_bn = False, use_maxpool = False, use_avgpool = False):
         super(Net, self).__init__()
 
@@ -23,7 +23,7 @@ class Net(nn.Module):
         self.use_bn = use_bn
         self.use_maxpool = use_maxpool
         self.use_avgpool = use_avgpool
-        
+
         self.conv0 = nn.Conv3d(in_channels=self.nc, out_channels=4, kernel_size=(2,3,3), groups=1, stride=1, padding=(0,1,1))
         if (self.use_bn): self.bn1 = nn.BatchNorm2d(4)
         if (self.use_maxpool): self.pool1 = nn.MaxPool2d(2)
@@ -33,7 +33,7 @@ class Net(nn.Module):
            self.conv1  = nn.Conv3d(in_channels=4,   out_channels=8, groups = self.ng,   kernel_size=3, stride=1, padding=1)
            #output is same 4x4
            self.conv2  = nn.Conv3d(in_channels=8,   out_channels=4, kernel_size=3, stride=1, padding=1)
-           #use stride last layer 
+           #use stride last layer
            self.conv3 =  nn.Conv3d(in_channels=4,   out_channels=1,   kernel_size=2, stride=2, padding=0)
 
 
@@ -61,7 +61,7 @@ def main():
    parser = argparse.ArgumentParser(description='PyTorch model generator')
    parser.add_argument('params', type=int, nargs='+',
                     help='parameters for the Conv network : batchSize , inputChannels, inputImageSize, nGroups, nLayers ')
-   
+
    parser.add_argument('--bn', action='store_true', default=False,
                         help='For using batch norm layer')
    parser.add_argument('--maxpool', action='store_true', default=False,
@@ -73,13 +73,13 @@ def main():
 
 
    args = parser.parse_args()
-  
+
    #args.params = (4,2,4,1,4)
 
    np = len(args.params)
    if (np < 5) : exit()
    bsize = args.params[0]
-   nc = args.params[1] 
+   nc = args.params[1]
    d = args.params[2]
    depth = args.params[3]
 #   ngroups = args.params[3]
@@ -97,14 +97,14 @@ def main():
    input  = torch.zeros([])
    xa = torch.zeros([])
    for ib in range(0,bsize):
-      for id in range(0,depth): 
+      for id in range(0,depth):
           xd = torch.ones([1, 1, 1, d, d]) * ( ib + 1 )
           if (id == 0) :
             xa = xd
           else :
             xa = torch.cat((xa,xd),2)
-    
-      if (nc > 1) : 
+
+      if (nc > 1) :
          xb = xa.neg()
          xc = torch.cat((xa,xb),1)  # concatenate tensors
          if (nc > 2) :
@@ -112,16 +112,16 @@ def main():
             xc = torch.cat((xa,xb,xd),1)
       else:
          xc = xa
-        
-      #concatenate tensors 
-      if (ib == 0) : 
+
+      #concatenate tensors
+      if (ib == 0) :
          xinput = xc
       else :
-         xinput = torch.cat((xinput,xc),0) 
+         xinput = torch.cat((xinput,xc),0)
 
    print("input data",xinput.shape)
    print(xinput)
-   
+
    name = "Conv3dModel"
    if (use_bn): name += "_BN"
    if (use_maxpool): name += "_MAXP"
@@ -132,24 +132,26 @@ def main():
    loadModel=False
    savePtModel = False
 
-    
+
    model = Net(nc,ngroups,nlayers, use_bn, use_maxpool, use_avgpool)
    print(model)
 
    model(xinput)
- 
+
    model.forward(xinput)
 
    if savePtModel :
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=True,
+         external_data=False
+      )
 
    if loadModel :
         print('Loading model from file....')
@@ -170,10 +172,10 @@ def main():
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-        f.write(str(float(yvec[i]))+" ")
-        
-        
-    
+        f.write(str(float(yvec[i].detach()))+" ")
+
+
+
 
 if __name__ == '__main__':
     main()

--- a/tmva/sofie/test/ConvTrans2dModelGenerator.py
+++ b/tmva/sofie/test/ConvTrans2dModelGenerator.py
@@ -138,12 +138,14 @@ def main():
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=True,
+         external_data=False
+      )
 
    if loadModel :
         print('Loading model from file....')
@@ -164,7 +166,7 @@ def main():
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-        f.write(str(float(yvec[i]))+" ")
+        f.write(str(float(yvec[i].detach()))+" ")
 
 
 

--- a/tmva/sofie/test/LinearModelGenerator.py
+++ b/tmva/sofie/test/LinearModelGenerator.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 result = []
 
 class Net(nn.Module):
-    
+
     def __init__(self, nd = 1, nc = 1, nl = 4, use_bn = False):
         super(Net, self).__init__()
 
@@ -22,7 +22,7 @@ class Net(nn.Module):
         self.use_bn = use_bn
 
         nout = 50
-        if (nl == 1) : nout = nc 
+        if (nl == 1) : nout = nc
         self.out0 = nn.Linear(in_features=nd, out_features=50)
         if (self.use_bn): self.bn1 = nn.BatchNorm1d(50)
         self.out1 = nn.Linear(in_features=50, out_features=100)
@@ -55,10 +55,10 @@ def main():
    parser.add_argument('--v', action='store_true', default=False,
                         help='For verbose mode')
 
-   
+
    args = parser.parse_args()
-  
-  
+
+
    bsize = 1
    d = 10
    nlayers = 4
@@ -67,9 +67,9 @@ def main():
    np = len(args.params)
    if (np < 2) : exit()
    bsize = args.params[0]
-   d = args.params[1] 
+   d = args.params[1]
    if (np > 2) : nlayers = args.params[2]
-  
+
 
    print ("using batch-size =",bsize,"input dim =",d,"nlayers =",nlayers)
 
@@ -89,7 +89,7 @@ def main():
 
    xinput_test = xinput
    #in case of batch normalization generate different data for training
-   if (use_bn): 
+   if (use_bn):
        for id in range(0,d):
            xa = torch.randn([bsize,1]) * (id+1) + id * torch.ones([bsize,1])
            #concatenate tensors
@@ -120,33 +120,41 @@ def main():
    if savePtModel :
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
+
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+      #new ONNX exporter does not work for batchmorm
+      dynamo_export=True
+      if (use_bn): dynamo_export=False
+
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=dynamo_export,
+         external_data=False
+      )
+
 
    if loadModel :
         print('Loading model from file....')
         checkpoint = torch.load(name + ".pt")
         model.load_state_dict(checkpoint['model_state_dict'])
 
-   #set model in evaluation format 
-   model.eval() 
+   #set model in evaluation format
+   model.eval()
    y = model.forward(xinput_test)
-   
+
    print("output data : shape, ",y.shape)
    print(y)
 
    outSize = y.nelement()
    yvec = y.reshape([outSize])
-   
+
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-        f.write(str(float(yvec[i]))+" ")
+        f.write(str(float(yvec[i].detach()))+" ")
 
 
 

--- a/tmva/sofie/test/RecurrentModelGenerator.py
+++ b/tmva/sofie/test/RecurrentModelGenerator.py
@@ -14,10 +14,10 @@ result = []
 verbose=False
 
 class Net(nn.Module):
-    
+
    def __init__(self, type, input_size, hidden_size, num_layers=1, output_size=2):
       super(Net, self).__init__()
-        
+
 
       if (type == "LSTM") :
             self.rc = nn.LSTM(input_size, hidden_size, num_layers,  batch_first=True)
@@ -25,7 +25,7 @@ class Net(nn.Module):
             self.rc = nn.GRU(input_size, hidden_size, num_layers, batch_first=True)
       if (type == "RNN"):
             self.rc = nn.RNN(input_size, hidden_size, num_layers, batch_first=True)
-        # FC layer 
+        # FC layer
       self.fc = nn.Linear(hidden_size, output_size)
 
       self.hidden_dim = hidden_size
@@ -34,13 +34,13 @@ class Net(nn.Module):
    def forward(self, x):
 
       batch_size = x.size(0)
-        
+
       #Initializing hidden state for first input using method defined below
       #hidden = self.init_hidden(batch_size)
 
       # Passing in the input and hidden state into the model and obtaining outputs
       rc_out,self.hidden_cell  = self.rc(x)
-        
+
       # Reshaping the outputs such that it can be fit into the fully connected layer
       #out = lstm_out.view(self.hidden_dim,-1)
 
@@ -50,21 +50,21 @@ class Net(nn.Module):
 
       out = rc_out[:,-1,:]
       out = self.fc(out)
-        
+
       return out
 
    def init_hidden(self, batch_size):
         # This method generates the first hidden state of zeros which we'll use in the forward pass
       hidden = (torch.zeros(self.n_layers, batch_size, self.hidden_dim), torch.zeros(1, 1, self.hidden_dim))
       return hidden
-        
+
 def main():
 
    #print(arguments)
    parser = argparse.ArgumentParser(description='PyTorch model generator')
    parser.add_argument('params', type=int, nargs='+',
                     help='parameters for the Recurrent network : batchSize , inputSize, seqSize, hiddenSize, nLayers ')
-   
+
    parser.add_argument('--lstm', action='store_true', default=False,
                          help='For using LSTM  layer')
    parser.add_argument('--gru', action='store_true', default=False,
@@ -76,14 +76,14 @@ def main():
 
 
    args = parser.parse_args()
-  
+
    ##args.params = (1,3,10,4,1)
 
    np = len(args.params)
    if (np < 5) : exit()
    bsize = args.params[0]
    nd = args.params[1]
-   nt = args.params[2] 
+   nt = args.params[2]
    nh = args.params[3]
    nl = args.params[4]
 
@@ -101,19 +101,19 @@ def main():
    for ib in range(0, bsize):
       for it in range(0,nt) :
          xa = torch.ones([1, 1, nd]) * (it + 1) * pow(-1, ib + 2)
-      #concatenate tensors 
+      #concatenate tensors
          if (it == 0):
             xb = xa
          else:
-            xb = torch.cat((xb,xa),1) 
-      if (ib == 0) : 
+            xb = torch.cat((xb,xa),1)
+      if (ib == 0) :
          xinput = xb
       else :
-         xinput = torch.cat((xinput,xb),0) 
+         xinput = torch.cat((xinput,xb),0)
 
    print("input data",xinput.shape)
    print(xinput)
-  
+
    name = type + "Model"
    name += "_B" + str(bsize)
 
@@ -121,24 +121,26 @@ def main():
    loadModel=False
    savePtModel = False
 
-    
+
    model = Net(type, nd, nh, nl)
    print(model)
 
    model(xinput)
- 
+
    model.forward(xinput)
 
    if savePtModel :
       torch.save({'model_state_dict':model.state_dict()}, name + ".pt")
 
    if saveOnnx:
-        torch.onnx.export(
-                model,
-                xinput,
-                name + ".onnx",
-                export_params=True
-        )
+      torch.onnx.export(
+         model,
+         xinput,
+         name + ".onnx",
+         export_params=True,
+         dynamo=False,  #for recurrent model new export does not work
+         external_data=False
+      )
 
    if loadModel :
         print('Loading model from file....')
@@ -157,10 +159,10 @@ def main():
 
    f = open(name + ".out", "w")
    for i in range(0,outSize):
-      f.write(str(float(yvec[i]))+" ")
-        
-        
-    
+      f.write(str(float(yvec[i].detach()))+" ")
+
+
+
 
 if __name__ == '__main__':
     main()

--- a/tmva/sofie/test/TestSofieModels.cxx
+++ b/tmva/sofie/test/TestSofieModels.cxx
@@ -13,7 +13,7 @@
 #include  "gtest/gtest.h"
 #define USE_ONNXSIM
 
-bool verbose = true;
+bool verbose = false;
 int sessionId = 0;
 
 void ExecuteSofieParser(std::string modelName) {


### PR DESCRIPTION
Copy the commit from the master, but keep usage of ONNXSIM wich is probbaly needed for 6.32 where support for many operators is not yet there

New torch versions comes with a new export mode to ONNX. One needs to specify forst to have a single onnx file with the weights (external_data=False) and then in some case (new export mode, which is with dynamo=True) does not fork for batchNorm and recurrent network. Disable it for these cases.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

