### PR TITLE
[tmva][sofie] Only one statement per line in `PyRunString`

### DIFF
--- a/tmva/sofie_parsers/src/RModelParser_Keras.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_Keras.cxx
@@ -873,11 +873,10 @@ RModel Parse(std::string filename, int batch_size){
    // For each layer: type,name,activation,dtype,input tensor's name,
    // output tensor's name, kernel's name, bias's name
    // None object is returned for if property doesn't belong to layer
+   PyRunString("import tensorflow",fGlobalNS,fLocalNS);
+   PyRunString("import tensorflow.keras as keras",fGlobalNS,fLocalNS);
    PyRunString("import tensorflow\n", fGlobalNS, fLocalNS);
-   PyRunString("import tensorflow.keras as keras\n"
-               "version = keras.__version__\n"
-               "major = int(version.split('.')[0])\n"
-               "if major >= 3:\n"
+   PyRunString("if int(keras.__version__.split('.')[0]) >= 3:\n"
                "    raise RuntimeError(\n"
                "        'TMVA SOFIE Keras parser supports Keras 2 only.\\n'\n"
                "        'Keras 3 detected. Please export the model to ONNX.\\n'\n"


### PR DESCRIPTION
This follows up on 29b8e84b3d0ff1d0f, fixing a syntax error:
```txt
Python error message:
  File "<string>", line 1
    import tensorflow.keras as keras
                                    ^
SyntaxError: multiple statements found while compiling a single statement
```