### PR TITLE
[tmva][sofie] Documentation of supported and missing ONNX operators

### DIFF
--- a/tmva/sofie/ONNX_OPERATOR_STATUS.md
+++ b/tmva/sofie/ONNX_OPERATOR_STATUS.md
@@ -1,0 +1,80 @@
+# ONNX Operators Status
+
+This file provides the status of the support of ONNX operators in TMVA/SOFIE.
+
+## Supported operators
+See the supported list in [`README.md`](README.md) (or obtain it programmatically via `GetRegisteredOperators()`).
+
+## Missing ONNX operators
+
+- And
+- ArgMax
+- ArgMin
+- Ceil
+- Clip
+- Compress
+- ConvInteger
+- CosH
+- CumSum
+- DequantizeLinear
+- DepthToSpace
+- Det
+- Dropout
+- Floor
+- GatherElements
+- GatherND
+- GlobalLpPool
+- GlobalMaxPool
+- GridSample
+- HardSigmoid
+- Hardmax
+- InstanceNormalization
+- IsInf
+- IsNaN
+- LRN
+- Loop
+- LpNormalization
+- LpPool
+- MatMulInteger
+- MaxRoiPool
+- MaxUnpool
+- MeanVarianceNormalization
+- Mod
+- Multinomial
+- NonMaxSuppression
+- NonZero
+- Not
+- OneHot
+- Optional
+- OptionalGetElement
+- OptionalHasElement
+- Or
+- PRelu
+- QLinearConv
+- QLinearMatMul
+- QuantizeLinear
+- ReduceL1
+- ReduceL2
+- ReduceLogSum
+- ReduceLogSumExp
+- ReduceMax
+- ReduceMin
+- Resize
+- ReverseSequence
+- RoiAlign
+- Round
+- Scan
+- ScatterND
+- Shrink
+- Sign
+- Sinh
+- Size
+- Softplus
+- Softsign
+- SpaceToDepth
+- StringNormalizer
+- Tan
+- ThresholdedRelu
+- Trilu
+- Unique
+- Xor

--- a/tmva/sofie/README.md
+++ b/tmva/sofie/README.md
@@ -169,6 +169,7 @@ SOFIE::RModelParser_ONNX parser;
 parser.CheckModel("example_model.ONNX");
 ```
 
+For a tracker of missing operator coverage, see [ONNX Operator Support Status](ONNX_OPERATOR_STATUS.md).
 
 
 ## Additional Links


### PR DESCRIPTION
# This Pull request

## Changes or fixes:
This PR adds documentation for ONNX operator support in TMVA SOFIE parsers. The list is derived directly from operators registered via `RegisterOperator(...)` in: `root/tmva/sofie_parsers/RModelParser_ONNX.cxx`. Only tensor-based operators are listed; sequence-based operators are explicitly out of scope.

## Checklist:
- [x] updated the documentation

This PR addresses #10360 by clarifying:
- which operators are currently supported.
- which operators are missing.

