### PR TITLE
[core] Deprecate TROOT::GetSourceDir()

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -31,10 +31,14 @@ The following people have contributed to this new version:
  Devajith Valaparambil Sreeramaswamy, CERN/EP-SFT,\
  Vassil Vassilev, Princeton,\
 
-## Deprecation and Removal
+## Deprecations
+
+* The headers in `RooStats/HistFactory` for data classes related to the measurement definition were merged into the `RooStats/HistFactory/Measurement.h` header to simplify usage and development. For now, the whole set of header files is kept for backwards compatibility, but the empty headers will be removed in ROOT 7.
+* The `TROOT::GetSourceDir()` method is deprecated and will be removed in ROOT 6.42. It stopped making sense because the ROOT source is generally not shipped alongside ROOT in the `src/` subdirectory anymore.
+
+## Removals
 
 * The `TH1K` class was removed. `TMath::KNNDensity` can be used in its stead.
-* The headers in `RooStats/HistFactory` for data classes related to the measurement definition were merged into the `RooStats/HistFactory/Measurement.h` header to simplify usage and development. For now, the whole set of header files is kept for backwards compatibility, but the empty headers will be removed in ROOT 7.
 * The `TObject` equality operator pythonization (`TObject.__eq__`) that was deprecated in ROOT 6.38 and scheduled for removal in ROOT 6.40 is removed.
 * Comparing C++ `nullptr` objects with `None` in Python now raises a `TypeError`, as announced in the ROOT 6.38 release notes. Use truth-value checks like `if not x` or `x is None` instead.
 * The `TGLIncludes.h` and `TGLWSIncludes.h` that were deprecated in ROOT 6.38 and scheduled for removal are gone now. Please include your required headers like `<GL/gl.h>` or `<GL/glu.h>` directly.

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -366,7 +366,10 @@ public:
    static const TString& GetDocDir();
    static const TString& GetMacroDir();
    static const TString& GetTutorialDir();
-   static const TString& GetSourceDir();
+   static const TString &GetSourceDir()
+      R__DEPRECATED(6, 42,
+                    "This function is removed because it made only sense in the corner case where the ROOT source is "
+                    "copied inside the ROOT installation, which is never the case unless the user does it by hand.");
    static const TString& GetIconPath();
    static const TString& GetTTFFontDir();
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -686,7 +686,6 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc) : TDi
    GetDocDir();
    GetMacroDir();
    GetTutorialDir();
-   GetSourceDir();
    GetIconPath();
    GetTTFFontDir();
 

--- a/graf2d/gpad/src/TClassTree.cxx
+++ b/graf2d/gpad/src/TClassTree.cxx
@@ -47,7 +47,6 @@ const Int_t kIsBasic     = BIT(21);
 
 static Float_t gXsize, gYsize, gDx, gDy, gLabdx, gLabdy, gDxx, gCsize;
 
-
 /** \class TClassTree
 \ingroup gpad
 
@@ -140,8 +139,7 @@ in the list of data members.
  - References from code is shown by a full green line
 
 Use TClassTree::SetSourceDir to specify the search path for source files.
-By default the search path includes the `$ROOTSYS` directory, the current
-directory and the subdirectory `src`.
+By default the search path includes the current directory and the subdirectory `src`.
 
 The first time TClassTree::Draw is invoked, all the classes in the
 current application are processed, including the parsing of the code
@@ -180,7 +178,7 @@ TClassTree::TClassTree()
 {
    SetLabelDx();
    SetYoffset(0);
-   SetSourceDir(".:src:" + TROOT::GetSourceDir());
+   SetSourceDir(".:src");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -191,7 +189,7 @@ TClassTree::TClassTree(const char *name, const char *classes)
 {
    SetLabelDx();
    SetYoffset(0);
-   SetSourceDir(".:src:" + TROOT::GetSourceDir());
+   SetSourceDir(".:src");
 
    // draw list of classes (if specified)
    if (classes && strlen(classes)) {


### PR DESCRIPTION
The `TROOT::GetSourceDir()` method is deprecated and will be removed in ROOT 6.42. It stopped making sense because the ROOT source is generally not shipped alongside ROOT in the `src/` subdirectory anymore.

This is done with the overarching goal of avoiding the need for `ROOTSYS`, which is used to infer the source directory `$ROOTSYS/src` (which doesn't exist anyway).