### PR TITLE
[win] Fix ACLiC compilation warnings on Windows

### DIFF
--- a/roottest/root/io/customCollection/execWriteCustomCollection.cxx
+++ b/roottest/root/io/customCollection/execWriteCustomCollection.cxx
@@ -31,8 +31,7 @@ public:
 
    void Print() {
       for(size_t i = 0; i < fValues.size(); ++i) {
-         printf("values: %zu / %zu : %s\n",
-                i, fValues.size(), fValues[i].GetName());
+         printf("values: %zu / %zu : %s\n", i, fValues.size(), fValues[i].GetName());
       }
    }
 };
@@ -52,8 +51,7 @@ public:
 
    void Print() {
       for(size_t i = 0; i < fValues.size(); ++i) {
-         printf("values: %zu / %zu : %s\n",
-                i, fValues.size(), fValues[i].GetName());
+         printf("values: %zu / %zu : %s\n", i, fValues.size(), fValues[i].GetName());
       }
    }
 };


### PR DESCRIPTION
Fix several compilation warnings like the following:
```
execWriteCustomCollection.cxx(55): warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'size_t'
execWriteCustomCollection.cxx(55): note: consider using '%zu' in the format string
```
