### PR TITLE
[hist] Allow to customize pads layout for THStack and TMultiGraph

### DIFF
--- a/hist/hist/inc/TMultiGraph.h
+++ b/hist/hist/inc/TMultiGraph.h
@@ -73,7 +73,7 @@ public:
    TAxis            *GetXaxis();
    TAxis            *GetYaxis();
    void              Paint(Option_t *chopt = "") override;
-   void              PaintPads(Option_t *chopt = "", Int_t fnx = 0);
+   void              PaintPads(Option_t *chopt = "", Int_t nColumn = 0);
    void              PaintPolyLine3D(Option_t *chopt = "");
    void              PaintReverse(Option_t *chopt = "");
    void              Print(Option_t *chopt="") const override;

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -781,7 +781,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stac
             nps++;
       }
       if (nps < npads) {
-         if (fnx == 0) {
+         if (fnx <= 0) {
             padsav->Clear();
             Int_t nx = (Int_t)TMath::Sqrt((Double_t)npads);
             if (nx * nx < npads)

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -46,9 +46,10 @@ extern void H1LeastSquareSeqnd(Int_t n, Double_t *a, Int_t idim, Int_t &ifail, I
     - [Setting drawing options](\ref MG01a)
     - [Titles setting](\ref MG01b)
     - [The option \"3D\"](\ref MG01c)
-    - [Legend drawing](\ref MG01d)
-    - [Automatic coloring](\ref MG01e)
-    - [Reverse axis](\ref MG01f)
+    - [Options \"PADS\" and \"PADSn\"](\ref MG01d)
+    - [Legend drawing](\ref MG01e)
+    - [Automatic coloring](\ref MG01f)
+    - [Reverse axis](\ref MG01g)
 - [MultiGraphs' fitting](\ref MG02)
     - [Fit box position](\ref MG02a)
 - [Axis' limits setting](\ref MG03)
@@ -155,6 +156,53 @@ Begin_Macro(source)
 End_Macro
 
 \anchor MG01d
+#### Options "PADS" and "PADSn"
+
+Like for THStack, options `PADS` and `PADSn` to split drawing into individual pads for each graph are also available.
+
+| Option     | Description                                                     |
+|------------|-----------------------------------------------------------------|
+| "PADS"     | The current pad/canvas is subdivided into a number of pads equal to the number of graphs in the multigraph and each graph is paint into a separate pad.|
+| "PADSn"    | Like PADS but the current pad/canvas is subdivided into `n` columns, automatically calculating the number of rows.|
+
+Begin_Macro(source)
+{
+auto c0 = new TCanvas("c1","multigraph L3",200,10,700,500);
+
+auto mg = new TMultiGraph();
+
+auto gr1 = new TGraph(); gr1->SetLineColor(kBlue);
+auto gr2 = new TGraph(); gr2->SetLineColor(kRed);
+auto gr3 = new TGraph(); gr3->SetLineColor(kGreen);
+auto gr4 = new TGraph(); gr4->SetLineColor(kOrange);
+
+Double_t dx = 6.28/1000;
+Double_t x  = -3.14;
+
+for (int i=0; i<=1000; i++) {
+    x = x+dx;
+    gr1->SetPoint(i,x,2.*TMath::Sin(x));
+    gr2->SetPoint(i,x,TMath::Cos(x));
+    gr3->SetPoint(i,x,TMath::Cos(x*x));
+    gr4->SetPoint(i,x,TMath::Cos(x*x*x));
+    }
+
+    mg->Add(gr4); gr4->SetTitle("Cos(x*x*x)"); gr4->SetLineWidth(3);
+    mg->Add(gr3); gr3->SetTitle("Cos(x*x)")  ; gr3->SetLineWidth(3);
+    mg->Add(gr2); gr2->SetTitle("Cos(x)")    ; gr2->SetLineWidth(3);
+    mg->Add(gr1); gr1->SetTitle("2*Sin(x)")  ; gr1->SetLineWidth(3);
+
+    mg->SetTitle("Multi-graph Title; X-axis Title; Y-axis Title");
+
+    mg->Draw("a fb l pads3");
+
+    mg->GetHistogram()->GetXaxis()->SetRangeUser(0.,2.5);
+    gPad->Modified();
+    gPad->Update();
+}
+End_Macro
+
+\anchor MG01e
 #### Legend drawing
 
 The method TPad::BuildLegend is able to extract the graphs inside a
@@ -216,7 +264,7 @@ Begin_Macro(source)
 }
 End_Macro
 
-\anchor MG01e
+\anchor MG01f
 #### Automatic coloring
 
 Automatic coloring according to the current palette is available as shown in the
@@ -226,7 +274,7 @@ Begin_Macro(source)
 ../../../tutorials/visualisation/graphs/gr105_multigraphpalettecolor.C
 End_Macro
 
-\anchor MG01f
+\anchor MG01g
 #### Reverse axis
 
 \since **ROOT version 6.19/02**
@@ -1379,9 +1427,9 @@ void TMultiGraph::Paint(Option_t *choptin)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Divides the active pad and draws all Graphs in the Multigraph separately.
-/// fnx parameter larger than 0 enforces number of columns for pad division
+/// nColumn parameter larger than 0 enforces number of columns for pad division
 
-void TMultiGraph::PaintPads(Option_t *option, Int_t fnx)
+void TMultiGraph::PaintPads(Option_t *option, Int_t nColumn)
 {
    if (!gPad) return;
 
@@ -1397,7 +1445,7 @@ void TMultiGraph::PaintPads(Option_t *option, Int_t fnx)
    }
    if (existingPads < neededPads) {
       curPad->Clear();
-      if (fnx == 0) {
+      if (nColumn <= 0) {
          Int_t nx = (Int_t)TMath::Sqrt((Double_t)neededPads);
          if (nx * nx < neededPads)
             nx++;
@@ -1406,10 +1454,10 @@ void TMultiGraph::PaintPads(Option_t *option, Int_t fnx)
             ny--;
          curPad->Divide(nx, ny);
       } else {
-         Int_t ny = (Int_t)((Double_t)neededPads / fnx);
-         if (fnx * ny < neededPads)
+         Int_t ny = (Int_t)((Double_t)neededPads / nColumn);
+         if (nColumn * ny < neededPads)
             ny++;
-         curPad->Divide(fnx, ny);
+         curPad->Divide(nColumn, ny);
       }
    }
    Int_t i = 0;

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -355,7 +355,7 @@ using `TH1::GetOption`:
 | "NOSTACK"  | Histograms in the stack are all paint in the same pad as if the option `SAME` had been specified.|
 | "NOSTACKB" | Histograms are  drawn next to each other as bar charts.|
 | "PADS"     | The current pad/canvas is subdivided into a number of pads equal to the number of histograms in the stack and each histogram is paint into a separate pad.|
-| "PADSn"    | Like PADS but the current pad/canvas is subdivided into a `n` columns x `m` rows of pads where `n` is given and `m` is calculated.|
+| "PADSn"    | Like PADS but the current pad/canvas is subdivided into a `n` columns, automatically calculating the number of rows.|
 | "PFC"      | Palette Fill Color: stack's fill color is taken in the current palette. |
 | "PLC"      | Palette Line Color: stack's line color is taken in the current palette. |
 | "PMC"      | Palette Marker Color: stack's marker color is taken in the current palette. |
@@ -2755,7 +2755,7 @@ compute X and Y scales common to all the histograms, like
 If the option `PADS` is specified, the current pad/canvas is subdivided into
 a number of pads equal to the number of histograms and each histogram is paint
 into a separate pad. With `PADSn`, the current pad/canvas is subdivided into
-`n` columns x `m` rows of pads where `n` is given and `m` is calculated.
+`n` columns, automatically calculating the number of rows.
 
 The following example shows various types of stacks (hist023_THStack_simple.C).
 


### PR DESCRIPTION
When using `PADS` drawing option, now one can add number specyfiing number of columns for new pads layout. Rows will be calculated autmatically.

Some examples:
```c++
auto make_hist(const char * name, const char * title, const char * f, int n_data) -> TH1I* {
    const int grad = 4;

    auto h = new TH1I(name, title, 20, -5, 5);

    for (int i = 0; i < n_data; ++i) {
        h->FillRandom(f, n_data);
    }
    h->SetLineColor(1);

    return h;
}

void demo() {
    gStyle->SetPalette(kRainBow);

    auto h1 = make_hist("Grupa 1", "Grupa 1;Punkty;Liczba", "gaus", 190);
    auto h3 = make_hist("Grupa 3", "Grupa 3;Punkty;Liczba", "gaus", 200);
    auto h4 = make_hist("Grupa 4", "Grupa 4;Punkty;Liczba", "gaus", 170);

    auto hs = new THStack();

    hs->Add(h1, "");
    hs->Add(h3, "");
    hs->Add(h4, "");

    auto can = new TCanvas("can", "can", 800, 400);
    can->Divide(2, 1);

    can->cd(1);
    hs->Draw("pfc");

    can->cd(2);
    hs->Draw("PADS3");
}
```
<img width="798" height="371" alt="hist_can_pads3" src="https://github.com/user-attachments/assets/2e00121a-d274-430f-abba-c4afbe7b8942" />

When changing the last but one line to:
```c++
hs->Draw("PADS1");
```
<img width="798" height="371" alt="hist_can_pads1" src="https://github.com/user-attachments/assets/9cfedc40-994f-45ae-be2d-36cd0e121fb1" />

and backward comaptibility:
```c++
hs->Draw("PADS");
// or
hs->Draw("PADS2");
```
<img width="798" height="371" alt="hist_can_pads" src="https://github.com/user-attachments/assets/81becc5b-9348-4136-b971-7eaec8abed2a" />

Same for graphs:
```c++
{
   auto mg  = new TMultiGraph();

   auto gr1 = new TGraph(); gr1->SetMarkerStyle(20);
   auto gr2 = new TGraph(); gr2->SetMarkerStyle(21);
   auto gr3 = new TGraph(); gr3->SetMarkerStyle(23);
   auto gr4 = new TGraph(); gr4->SetMarkerStyle(24);

   Double_t dx = 6.28/100;
   Double_t x  = -3.14;

   for (int i=0; i<=100; i++) {
      x = x+dx;
      gr1->SetPoint(i,x,2.*TMath::Sin(x));
      gr2->SetPoint(i,x,TMath::Cos(x));
      gr3->SetPoint(i,x,TMath::Cos(x*x));
      gr4->SetPoint(i,x,TMath::Cos(x*x*x));
   }

   mg->Add(gr4,"PL");
   mg->Add(gr3,"PL");
   mg->Add(gr2,"*L");
   mg->Add(gr1,"PL");

   mg->Draw("A pmc plc pads3");
}
```
<img width="698" height="471" alt="graph_can_pads3" src="https://github.com/user-attachments/assets/449ecfb0-f590-4e04-91c9-4b4520a8ae95" />

This does not work with `--web=on` (Web Canvas) but I am not good enough in JS to fix that. But `PADS` seems to not work nicely with the web interface anyway. Perhaps it could be fixed - `PADS` in general and `PADSn` for this PR. @linev could you help with that?

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

