### PR TITLE
XMLParser: drop unused libm dependency

### DIFF
--- a/io/xmlparser/CMakeLists.txt
+++ b/io/xmlparser/CMakeLists.txt
@@ -24,7 +24,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(XMLParser
      src/TXMLDocument.cxx
      src/TXMLNode.cxx
      src/TXMLParser.cxx
-  DEPENDENCIES
+  LIBRARIES
     Core
 )
 


### PR DESCRIPTION
This PR removes an unused direct dependency on `libm` from `libXMLParser`.

The unused dependency was identified via `ldd -u` on the official ROOT 6.38.00 binary build for AlmaLinux 9.7.
## Checklist:

- [x] tested changes locally

This PR fixes #20731

