### PR TITLE
[tmva][sofie] Add README for SOFIE parsers

### DIFF
--- a/tmva/sofie_parsers/README.md
+++ b/tmva/sofie_parsers/README.md
@@ -35,7 +35,7 @@ Each supported format is translated into a common internal representation (`RMod
 
 ## Model Format Compatibility
 
-Compatibility of external models with SOFIE is determined by operator support rather than by strict guarantees on model format or version.
+Compatibility of external models with SOFIE is determined primarily by operator support rather than by strict guarantees on model format or version.
 
 For ONNX models:
 - Compatibility depends on whether all operators used in the model are implemented and registered in the SOFIE ONNX parser.
@@ -57,7 +57,7 @@ SOFIE::RModelParser_ONNX parser;
 SOFIE::RModel model = parser.Parse("model.onnx");
 ```
 
-## ONNX Operator support
+## ONNX Operator Support
 
 ONNX operator support in TMVA SOFIE is determined by operators registered via `RegisterOperator(...)` in `root/tmva/sofie_parsers/RModelParser_ONNX.cxx` in the current ROOT source tree.
 


### PR DESCRIPTION
## This Pull request:

Adds a README to the `root/tmva/sofie_parsers` directory describing the purpose, scope, basic usage, and internal structure of the SOFIE parser infrastructure.  The documentation is intended to be descriptive and does not introduce any functional changes.

The documentation is intended to complement the existing SOFIE README with parser-specific information for both users and contributors, and can be extended in the further if needed.

## Changes or fixes:

- Add a comprehensive README for the SOFIE parsers
- Document supported model formats and parser responsibilities
- Describe ONNX operator support and validation workflow
- Add developer-oriented notes on parser architecture and extension

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)