### PR TITLE
Starting with gcc 16, libstdc++ links to libatomic. Add to whitelist.

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -77,6 +77,7 @@ class ImportLoadLibs(unittest.TestCase):
         "ld.*",
         "libffi",
         "libgcc_s",
+        "libatomic",
         # AddressSanitizer runtime and ROOT configuration
         "libclang_rt.asan-.*",
         "libROOTSanitizerConfig",


### PR DESCRIPTION
# This Pull request:
```
  87/1559 Test   #36: pyunittests-bindings-pyroot-pythonizations-pyroot-import-load-libs ............................***Failed    0.75 sec
test_import (import_load_libs.ImportLoadLibs.test_import)
Test libraries loaded after importing ROOT ... ERROR
======================================================================
ERROR: test_import (import_load_libs.ImportLoadLibs.test_import)
Test libraries loaded after importing ROOT
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/root-6.38.00-build/root-6.38.00/bindings/pyroot/pythonizations/test/import_load_libs.py", line 135, in test_import
    raise Exception(
    ...<4 lines>...
    )
Exception: Found not whitelisted libraries after importing ROOT:
 - libatomic
If the test fails with a library that is loaded on purpose, please add it to the whitelist.
----------------------------------------------------------------------
Ran 1 test in 0.654s
FAILED (errors=1)
CMake Error at /builddir/build/BUILD/root-6.38.00-build/root-6.38.00/cmake/modules/RootTestDriver.cmake:232 (message):
  error code: 1
```
Starting with gcc 16, libstdc++ links to libatomic.
```
$ ldd /lib64/libstdc++.so.6
	linux-vdso.so.1 (0x00007f3cb4c13000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f3cb4afc000)
	libatomic.so.1 => /lib64/libatomic.so.1 (0x00007f3cb4af1000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f3cb460d000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f3cb4ac5000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f3cb4c15000)
```

## Changes or fixes:

Add to whitelist.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

