### PR TITLE
[core] Generalize TROOT::GetIncludeDir() using build tree marker

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -548,6 +548,19 @@ endif()
 string(REGEX MATCH "__cplusplus[=| ]([0-9]+)" __cplusplus "${__cplusplus_PPout}")
 set(__cplusplus ${CMAKE_MATCH_1}L)
 
+# To mark the build tree. Important for automatic resolution of relative paths,
+# for example to the include directory. Use custom target to ensure re-creation
+# when someone deletes the marker.
+set(build_tree_marker "${localruntimedir}/root-build-tree-marker")
+add_custom_command(
+  OUTPUT "${build_tree_marker}"
+  COMMAND ${CMAKE_COMMAND} -E touch "${build_tree_marker}"
+  COMMENT "Ensuring that \"${build_tree_marker}\" exists"
+)
+add_custom_target(ensure_build_tree_marker ALL
+  DEPENDS "${build_tree_marker}"
+)
+
 configure_file(${PROJECT_SOURCE_DIR}/config/RConfigure.in ginclude/RConfigure.h NEWLINE_STYLE UNIX)
 install(FILES ${CMAKE_BINARY_DIR}/ginclude/RConfigure.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -9,7 +9,6 @@
 #define ROOTPREFIX    "@prefix@"
 #define ROOTBINDIR    "@bindir@"
 #define ROOTLIBDIR    "@libdir@"
-#define ROOTINCDIR    "@incdir@"
 #define ROOTETCDIR    "@etcdir@"
 #define ROOTDATADIR   "@datadir@"
 #define ROOTDOCDIR    "@docdir@"

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -236,9 +236,21 @@ if(core_soversion)
 else()
     set(full_core_filename "${core_prefix}Core${core_suffix}")
 endif()
+
+# Absolue CMAKE_INSTALL_<dir> paths are discouraged in CMake, but some
+# packagers use them anyway. So we support it.
+if(IS_ABSOLUTE ${CMAKE_INSTALL_INCLUDEDIR})
+   set(install_includedir_is_absolute 1)
+else()
+   set(install_includedir_is_absolute 0)
+endif()
+file(TO_NATIVE_PATH "${CMAKE_INSTALL_INCLUDEDIR}" install_includedir_native)
+
 target_compile_options(Core PRIVATE -DLIB_CORE_NAME=${full_core_filename}
-                                    -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+                                    -DINSTALL_INCLUDEDIR=${install_includedir_native}
+                                    -DINSTALL_INCLUDEDIR_IS_ABSOLUTE=${install_includedir_is_absolute}
 )
+add_dependencies(Core ensure_build_tree_marker)
 
 if(PCRE2_FOUND)
   target_link_libraries(Core PRIVATE PCRE2::PCRE2)

--- a/core/foundation/res/ROOT/FoundationUtils.hxx
+++ b/core/foundation/res/ROOT/FoundationUtils.hxx
@@ -67,10 +67,6 @@ namespace FoundationUtils {
    ///
    const std::string& GetRootSys();
 
-   ///\ returns the include directory in the installation.
-   ///
-   const std::string& GetIncludeDir();
-
    ///\returns the sysconfig directory in the installation.
    const std::string& GetEtcDir();
 

--- a/core/foundation/src/FoundationUtils.cxx
+++ b/core/foundation/src/FoundationUtils.cxx
@@ -167,30 +167,16 @@ const std::string& GetRootSys() {
    if (rootsys.empty()) {
       if (const char* envValue = std::getenv("ROOTSYS")) {
          rootsys = envValue;
+#ifndef WIN32
          // We cannot use gSystem->UnixPathName.
          ConvertToUnixPath(rootsys);
+#endif
       }
    }
    // FIXME: Should this also call UnixPathName for consistency?
    if (rootsys.empty())
       rootsys = GetFallbackRootSys();
    return rootsys;
-}
-
-
-const std::string& GetIncludeDir() {
-#ifdef ROOTINCDIR
-   if (!IgnorePrefix()) {
-      const static std::string rootincdir = ROOTINCDIR;
-      return rootincdir;
-   }
-#endif
-   static std::string rootincdir;
-   if (rootincdir.empty()) {
-      const std::string& sep = GetPathSeparator();
-      rootincdir = GetRootSys() + sep + "include" + sep;
-   }
-   return rootincdir;
 }
 
 const std::string& GetEtcDir() {


### PR DESCRIPTION
Introducing a new marker file generalizes `TROOT::GetIncludeDir()` to
work in all cases for both relocated install and build trees, even if
the `CMAKE_INSTALL_INCLUDEDIR` is different from `include`.

This follows up on https://github.com/root-project/root/commit/43ec084a466458e09ed2cb7ad018418a739a8082, which was incomplete and left ROOT
configuration in a broken state, because `ROOTINCDIR` was not defined
anymore but still used.

The `RConfigure.h` header still defines a few other internal macros with
hardcoded paths, and if the suggested mechanism proves to be stable for
the include directory, we can also migrate the other macros. They are
fragile anyway. For example, they contain relative paths for
`gnuinstall=OFF` and absolute paths for `gnuinstall=ON`, which is
nowhere documented and breaks relocatable builds. Also, they use
`ROOTSYS` in the case of `gnuinstall=OFF`, which we want to migrate away
from.

The `ROOT::FoundationUtils::GetIncludeDir()` function was also removed
and completely absorbed into `TROOT::GetIncludeDir()`, as it was not
used in any other place.

Also, allow absolute `CMAKE_INSTALL_INCLUDEDIR` paths.

Follows up on:
  * https://github.com/root-project/root/pull/20823#issuecomment-3728343702