### PR TITLE
[hist] Assert on zero arguments to `Fill`

### DIFF
--- a/hist/histv7/inc/ROOT/RHist.hxx
+++ b/hist/histv7/inc/ROOT/RHist.hxx
@@ -294,8 +294,11 @@ public:
    template <typename... A>
    void Fill(const A &...args)
    {
-      fEngine.Fill(args...);
-      fStats.Fill(args...);
+      static_assert(sizeof...(A) >= 1, "need at least one argument to Fill");
+      if constexpr (sizeof...(A) >= 1) {
+         fEngine.Fill(args...);
+         fStats.Fill(args...);
+      }
    }
 
    /// Scale all histogram bin contents and statistics.

--- a/hist/histv7/inc/ROOT/RHistFillContext.hxx
+++ b/hist/histv7/inc/ROOT/RHistFillContext.hxx
@@ -101,8 +101,11 @@ public:
    template <typename... A>
    void Fill(const A &...args)
    {
-      fHist->fEngine.FillAtomic(args...);
-      fStats.Fill(args...);
+      static_assert(sizeof...(A) >= 1, "need at least one argument to Fill");
+      if constexpr (sizeof...(A) >= 1) {
+         fHist->fEngine.FillAtomic(args...);
+         fStats.Fill(args...);
+      }
    }
 
    /// Flush locally accumulated entries to the histogram.

--- a/hist/histv7/inc/ROOT/RHistStats.hxx
+++ b/hist/histv7/inc/ROOT/RHistStats.hxx
@@ -415,19 +415,22 @@ public:
    template <typename... A>
    void Fill(const A &...args)
    {
-      auto t = std::forward_as_tuple(args...);
-      if constexpr (std::is_same_v<typename Internal::LastType<A...>::type, RWeight>) {
-         static constexpr std::size_t N = sizeof...(A) - 1;
-         if (N != fDimensionStats.size()) {
-            throw std::invalid_argument("invalid number of arguments to Fill");
+      static_assert(sizeof...(A) >= 1, "need at least one argument to Fill");
+      if constexpr (sizeof...(A) >= 1) {
+         auto t = std::forward_as_tuple(args...);
+         if constexpr (std::is_same_v<typename Internal::LastType<A...>::type, RWeight>) {
+            static constexpr std::size_t N = sizeof...(A) - 1;
+            if (N != fDimensionStats.size()) {
+               throw std::invalid_argument("invalid number of arguments to Fill");
+            }
+            fNEntries++;
+            double w = std::get<N>(t).fValue;
+            fSumW += w;
+            fSumW2 += w * w;
+            FillImpl<0, N>(t, w);
+         } else {
+            Fill(t);
          }
-         fNEntries++;
-         double w = std::get<N>(t).fValue;
-         fSumW += w;
-         fSumW2 += w * w;
-         FillImpl<0, N>(t, w);
-      } else {
-         Fill(t);
       }
    }
 


### PR DESCRIPTION
... and avoid follow-up errors from called functions or `LastType` by wrapping the remaining body into `if constexpr`.