### PR TITLE
[ci] Remove Debian 12 build

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -390,8 +390,6 @@ jobs:
           - image: ubuntu2404
             overrides: ["CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2510
-          - image: debian125
-            overrides: ["CMAKE_CXX_STANDARD=20", "dev=ON", "CMAKE_CXX_FLAGS=-Wsuggest-override"]
           - image: debian13
             overrides: ["dev=ON", "CMAKE_CXX_FLAGS=-Wsuggest-override"]
           # Special builds


### PR DESCRIPTION
We have Ubuntu 22,24,25 as well as Debian 13. Without loosing real coverage, build capacity can be recovered for other builds, e.g. special ones dedicated to benchmarking or other kind of in-depth testing (for example asan or valgrind).

