### PR TITLE
[ci] Simplify build configuration and pick up specific options

### DIFF
--- a/.github/workflows/root-ci-config/build_utils.py
+++ b/.github/workflows/root-ci-config/build_utils.py
@@ -189,8 +189,8 @@ def load_config(filename) -> dict:
                key = split_line[0]
                val = split_line[1]+'='+split_line[2]
 
-            if val.lower() in ["on", "off"]:
-                val = val.lower()
+            val_upper = val.upper()
+            val = val_upper if val_upper in ["ON", "OFF"] else val
 
             options[key] = val
 
@@ -204,6 +204,7 @@ def cmake_options_from_dict(config: Dict[str, str]) -> str:
        example: {"builtin_xrootd"="on", "alien"="on"}
                         ->
                  '"-Dalien=on" -Dbuiltin_xrootd=on"'
+       The key CMAKE_GENERATOR is used to set the CMake generator.
     """
 
     if not config:
@@ -211,12 +212,19 @@ def cmake_options_from_dict(config: Dict[str, str]) -> str:
 
     output = []
 
+    cmake_generator = None
     for key, value in config.items():
-        output.append(f'"-D{key}={value}"')
+        if key == "CMAKE_GENERATOR":
+            cmake_generator = value
+        else:
+            output.append(f'"-D{key}={value}"')
 
     output.sort()
+    if cmake_generator:
+        output.append(f'"-G{cmake_generator}"')
+    cmake_options = ' '.join(output)
 
-    return ' '.join(output)
+    return cmake_options
 
 def calc_options_hash(options: str) -> str:
     """Calculate the hash of the options string. If "march=native" is in the

--- a/.github/workflows/root-ci-config/buildconfig/alma10-benchmark.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-benchmark.txt
@@ -1,0 +1,8 @@
+CMAKE_CXX_STANDARD=20
+builtin_vdt=ON
+builtin_zlib=ON
+builtin_zstd=ON
+pythia8=ON
+r=OFF
+rootbench=ON
+tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/alma10-clang_ninja.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-clang_ninja.txt
@@ -1,0 +1,9 @@
+CMAKE_C_COMPILER=clang
+CMAKE_CXX_COMPILER=clang++
+CMAKE_GENERATOR=Ninja
+builtin_vdt=ON
+builtin_zlib=ON
+builtin_zstd=ON
+pythia8=ON
+r=OFF
+tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/alma10-minimal.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-minimal.txt
@@ -1,3 +1,8 @@
+ccache=ON
 builtin_vdt=ON
 builtin_zlib=ON
 builtin_zstd=ON
+fail-on-missing=ON
+minimal=ON
+roottest=ON
+testing=ON

--- a/.github/workflows/root-ci-config/buildconfig/alma9-march_native.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-march_native.txt
@@ -1,0 +1,12 @@
+CMAKE_CXX_FLAGS=-march=native
+CMAKE_C_FLAGS=-march=native
+CMAKE_CXX_STANDARD=20
+builtin_vc=ON
+builtin_vdt=ON
+builtin_veccore=ON
+builtin_zlib=ON
+builtin_zstd=ON
+pythia8=ON
+tmva-sofie=ON
+veccore=ON
+vc=ON

--- a/.github/workflows/root-ci-config/buildconfig/alma9-modules_off.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-modules_off.txt
@@ -1,0 +1,4 @@
+builtin_vdt=ON
+pythia8=ON
+runtime_cxxmodules=OFF
+tmva-sofie=ON

--- a/.github/workflows/root-ci-config/buildconfig/global-minimal.txt
+++ b/.github/workflows/root-ci-config/buildconfig/global-minimal.txt
@@ -1,5 +1,0 @@
-ccache=ON
-fail-on-missing=ON
-minimal=ON
-roottest=ON
-testing=ON

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -398,11 +398,13 @@ jobs:
           - image: alma9
             is_special: true
             property: modules_off
-            overrides: ["runtime_cxxmodules=Off", "CMAKE_CXX_STANDARD=20"]
+            platform_config: "alma9-modules_off"
+            overrides: ["CMAKE_CXX_STANDARD=20"]
           - image: alma9
             is_special: true
             property: march_native
-            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "builtin_zlib=ON", "builtin_zstd=ON", "CMAKE_CXX_STANDARD=20", "builtin_vc=ON", "builtin_veccore=ON", "vc=ON", "veccore=ON"]
+            platform_config: "alma9-march_native"
+            overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo"]
           - image: alma10
             is_special: true
             property: arm64
@@ -411,8 +413,8 @@ jobs:
           - image: alma10
             is_special: true
             property: "clang Ninja"
-            overrides: ["CMAKE_C_COMPILER=clang", "CMAKE_CXX_COMPILER=clang++", "CMAKE_CXX_STANDARD=20"]
-            cmake_generator: Ninja
+            platform_config: "alma10-clang_ninja"
+            overrides: ["CMAKE_CXX_STANDARD=20"]
           # Fedora Rawhide with Python debug build
           - image: rawhide
             is_special: true
@@ -421,14 +423,14 @@ jobs:
           # Minimal build
           - image: alma10
             is_special: true
-            minimal: true
+            platform_config: "alma10-minimal"
             property: "minimal build"
             overrides: ["CMAKE_CXX_STANDARD=20"]
           # Benchmark build
           - image: alma10
             is_special: true
+            platform_config: "alma10-benchmark"
             property: "benchmark build"
-            overrides: ["CMAKE_CXX_STANDARD=20", "rootbench=ON"]
           # Disable GPU builds until the DNS problem is solved
           # - image: ubuntu2404-cuda
           #   is_special: true
@@ -501,19 +503,6 @@ jobs:
         run:  'printf "%s@%s\\n" "$(whoami)" "$(hostname)";
                ls -la
               '
-      - name: Apply option minimal request from matrix for this job
-        if: ${{ matrix.minimal == true }}
-        env:
-          GLOBAL_CONFIG_DIR: '.github/workflows/root-ci-config/buildconfig'
-          CONFIGFILE_STEM: '.github/workflows/root-ci-config/buildconfig/${{ matrix.image }}'
-        run: |
-          echo "Applying minimal request options"
-          # Add commands to apply minimal request options here
-          set -x
-          cp "$GLOBAL_CONFIG_DIR/global-minimal.txt" "$GLOBAL_CONFIG_DIR/global.txt"
-          if [ -f "${CONFIGFILE_STEM}-minimal.txt" ]; then
-            cp "${CONFIGFILE_STEM}-minimal.txt" "${CONFIGFILE_STEM}.txt"
-          fi
 
       - uses: root-project/gcc-problem-matcher-improved@main
         with:
@@ -524,11 +513,11 @@ jobs:
         env:
           INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') }}
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
-          CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
           OVERRIDES: ${{ join( matrix.overrides, ' ') }}
         run: ".github/workflows/root-ci-config/build_root.py
                     --buildtype       RelWithDebInfo
                     --platform        ${{ matrix.image }}
+                    --platform_config ${{ matrix.platform_config }}
                     --dockeropts      \"$CONTAINER_OPTIONS\"
                     --incremental     $INCREMENTAL
                     --base_ref        ${{ github.base_ref }}
@@ -543,24 +532,26 @@ jobs:
       - name: Workflow dispatch
         if:   ${{ github.event_name == 'workflow_dispatch' && !matrix.is_special }}
         run: ".github/workflows/root-ci-config/build_root.py
-                    --buildtype      ${{ inputs.buildtype }}
-                    --platform       ${{ matrix.image }}
-                    --incremental    ${{ inputs.incremental }}
-                    --base_ref       ${{ inputs.base_ref }}
-                    --head_ref       ${{ inputs.head_ref }}
-                    --binaries       ${{ inputs.binaries }}
-                    --repository     ${{ github.server_url }}/${{ github.repository }}
+                    --buildtype       ${{ inputs.buildtype }}
+                    --platform        ${{ matrix.image }}
+                    --platform_config ${{ matrix.platform_config }}
+                    --incremental     ${{ inputs.incremental }}
+                    --base_ref        ${{ inputs.base_ref }}
+                    --head_ref        ${{ inputs.head_ref }}
+                    --binaries        ${{ inputs.binaries }}
+                    --repository      ${{ github.server_url }}/${{ github.repository }}
               "
 
       - name: Nightly build
         if:   github.event_name == 'schedule'
         run: ".github/workflows/root-ci-config/build_root.py
-                    --buildtype      Release
-                    --platform       ${{ matrix.image }}
-                    --incremental    false
-                    --binaries       true
-                    --base_ref       ${{ inputs.ref_name }}
-                    --repository     ${{ github.server_url }}/${{ github.repository }}
+                    --buildtype       Release
+                    --platform        ${{ matrix.image }}
+                    --platform_config ${{ matrix.platform_config }}
+                    --incremental     false
+                    --binaries        true
+                    --base_ref        ${{ inputs.ref_name }}
+                    --repository      ${{ github.server_url }}/${{ github.repository }}
               "
 
       - name: Update build cache after push to release branch
@@ -568,12 +559,13 @@ jobs:
         env:
           OVERRIDES: ${{ join( matrix.overrides, ' ') }}
         run: ".github/workflows/root-ci-config/build_root.py
-                    --buildtype      RelWithDebInfo
-                    --platform       ${{ matrix.image }}
-                    --incremental    false
-                    --base_ref       ${{ github.ref_name }}
-                    --binaries       ${{ startsWith(github.ref, 'refs/tags/') }}
-                    --repository     ${{ github.server_url }}/${{ github.repository }}
+                    --buildtype       RelWithDebInfo
+                    --platform        ${{ matrix.image }}
+                    --platform_config ${{ matrix.platform_config }}
+                    --incremental     false
+                    --base_ref        ${{ github.ref_name }}
+                    --binaries        ${{ startsWith(github.ref, 'refs/tags/') }}
+                    --repository      ${{ github.server_url }}/${{ github.repository }}
                     --overrides       ${GLOBAL_OVERRIDES} ${OVERRIDES}
               "
 


### PR DESCRIPTION
This PR decouples the concept of plarform and platform configuration. If no platform configuration is specified, the default platform configuration is picked. Otherwise, a special one, `<platform>-<config label>.txt` is picked. 
This has multiple benefits, at least:
- Simpler yml files for steering builds
- Same PR, scheduled and workflow dispatch builds (modulo inlined overrides in the yml, as usual) *.
- Possibility to use the same platform (container) for many different configuration without specifying more parameters in the yml, e.g.: minimal builds, benchmark builds, march native, clang and in the future asan, tsan, ubsan, valgrind, helgrind...


* So far, for scheduled builds and workflow dispatch builds, the override parameters specified in the yml were simply ignored.