### PR TITLE
[cling] Recognize Mach-O bundles as shared libraries on macOS

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -481,6 +481,7 @@ namespace cling {
       (Magic == file_magic::macho_fixed_virtual_memory_shared_lib
        || Magic == file_magic::macho_dynamically_linked_shared_lib
        || Magic == file_magic::macho_dynamically_linked_shared_lib_stub
+       || Magic == file_magic::macho_bundle
        || Magic == file_magic::macho_universal_binary)
 #elif defined(LLVM_ON_UNIX)
 #ifdef __CYGWIN__


### PR DESCRIPTION
## Problem

On macOS, external dictionary libraries built as Mach-O bundles (MH_BUNDLE) fail to load, while the same libraries built as dylibs (MH_DYLIB) work correctly.

When calling `gSystem->Load("libGaudiKernelDict")` for a dictionary built as a bundle:

```
Error in <TInterpreter::TCling::AutoLoad>: failure loading library libGaudiKernelDict.so for DataObject
TClass::Init: RuntimeWarning: no dictionary for class DataObject is available
```

`gSystem->Load()` returns -1 even though the library file exists and is valid.

## Root Cause

Cling's `isSharedLibrary()` function in `DynamicLibraryManager.cpp` checks the Mach-O file type but doesn't recognize bundles:

```cpp
bool result =
#ifdef __APPLE__
  (Magic == file_magic::macho_fixed_virtual_memory_shared_lib
   || Magic == file_magic::macho_dynamically_linked_shared_lib
   || Magic == file_magic::macho_dynamically_linked_shared_lib_stub
   || Magic == file_magic::macho_universal_binary)  // macho_bundle is missing!
```

This causes `lookupLibrary()` to fail for bundle files, as they're not recognized as valid shared libraries.

## Evidence

```bash
$ file $CONDA_PREFIX/lib/libHist.so
libHist.so: Mach-O 64-bit dynamically linked shared library arm64

$ file $CONDA_PREFIX/lib/libGaudiKernelDict.so
libGaudiKernelDict.so: Mach-O 64-bit bundle arm64

$ root -l -b -q -e 'std::cout << gSystem->Load("libHist") << std::endl;'
0   # Success (dylib)

$ root -l -b -q -e 'std::cout << gSystem->Load("libGaudiKernelDict") << std::endl;'
-1  # Failure (bundle)
```

## Solution

Add `file_magic::macho_bundle` to the list of recognized shared library types:

```cpp
|| Magic == file_magic::macho_bundle
```

This is correct because Mach-O bundles are loadable code that can be `dlopen()`'d, which is exactly how ROOT loads dictionary libraries. Gaudi uses CMake's `MODULE` library type which produces bundles.