### PR TITLE
[hist] Disable thread-safe TH3D on 32-bit platforms.

### DIFF
--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -28,6 +28,11 @@
 class TH2D;
 class TProfile2D;
 
+#if defined R__B64 && defined __cpp_lib_atomic_ref
+// ROOT-20834 Atomic_ref on 32 bit can fail because of alignment problems
+#define TH3D_FILL_THREADSAFE
+#endif
+
 namespace ROOT::Internal {
 /// Entrypoint for thread-safe filling from RDataFrame.
 template <typename T, typename... Args>
@@ -455,7 +460,7 @@ protected:
            Double_t RetrieveBinContent(Int_t bin) const override { return fArray[bin]; }
            void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = content; }
 private:
-#ifdef __cpp_lib_atomic_ref
+#ifdef TH3D_FILL_THREADSAFE
            void FillThreadSafe(Double_t x, Double_t y, Double_t z, Double_t w = 1.);
            template <typename T, typename... Args>
            friend auto ROOT::Internal::FillThreadSafe(T &histo, Args... args)

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -438,7 +438,7 @@ Int_t TH3::Fill(Double_t x, Double_t y, Double_t z, Double_t w)
    return bin;
 }
 
-#ifdef __cpp_lib_atomic_ref
+#ifdef TH3D_FILL_THREADSAFE
 ////////////////////////////////////////////////////////////////////////////////
 /// Atomically increment cell defined by x,y,z by a weight w.
 ///

--- a/hist/hist/test/test_TH3.cxx
+++ b/hist/hist/test/test_TH3.cxx
@@ -14,7 +14,7 @@ TEST(TH3L, SetBinContent)
    EXPECT_EQ(h.GetBinContent(1, 1, 1), Large);
 }
 
-#ifdef __cpp_lib_atomic_ref
+#ifdef TH3D_FILL_THREADSAFE
 
 TEST(TH3D, FillThreadSafe)
 {


### PR DESCRIPTION
On 32 bits, the alignment of double is less strict than for atomic_ref<double>, so TH3D::FillThreadSafe cannot be used.

Tested the `#if defined` in a 32 bit container, and it indeed disables the Fill function. I couldn't reproduce the alignment failure, though, since it ran on a 64 bit machine that kept the alignment at 64.

Fixes #20834.

