### PR TITLE
[tmva][sofie] Fix Keras BinaryOp test model shapes and improve reproducibility

### DIFF
--- a/tmva/sofie/test/generateKerasModels.py
+++ b/tmva/sofie/test/generateKerasModels.py
@@ -5,6 +5,7 @@ os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 import numpy as np
 import tensorflow as tf
+tf.keras.utils.set_random_seed(0)
 from tensorflow.keras.models import Model,Sequential
 from tensorflow.keras.layers import Input,Dense,Activation,ReLU,LeakyReLU,BatchNormalization,Conv2D,Reshape,Concatenate,Add,Subtract,Multiply
 from tensorflow.keras.optimizers import SGD
@@ -118,9 +119,9 @@ def generateBinaryOpModel():
     model    = Model(inputs=[input1, input2], outputs=multiply)
 
     randomGenerator=np.random.RandomState(0)
-    x1_train = randomGenerator.rand(2,1)
-    x2_train = randomGenerator.rand(2,1)
-    y_train  = randomGenerator.rand(2,1)
+    x1_train = randomGenerator.rand(2,2)
+    x2_train = randomGenerator.rand(2,2)
+    y_train  = randomGenerator.rand(2,2)
 
     model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
     model.fit([x1_train,x2_train], y_train, epochs=10, verbose=0, batch_size=2)


### PR DESCRIPTION
# This Pull request
Fixes a shape mismatch in the Keras test model generator used for SOFIE tests and improves reproducibility of generated models.

## Changes or fixes:
- Fixed incorrect training input/target tensor shapes in `generateBinaryOpModel()` from `(2,1)` to `(2,2)` to match the model input signature `Input(shape=(2,))`
- Added `tf.keras.utils.set_random_seed(0)` so model initialization and generated outputs are reproducible across runs, improving stability of SOFIE Keras parser tests.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)