### PR TITLE
[cling] Recognize Mach-O bundles as shared libraries on macOS [v6.36]

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -481,6 +481,7 @@ namespace cling {
       (Magic == file_magic::macho_fixed_virtual_memory_shared_lib
        || Magic == file_magic::macho_dynamically_linked_shared_lib
        || Magic == file_magic::macho_dynamically_linked_shared_lib_stub
+       || Magic == file_magic::macho_bundle
        || Magic == file_magic::macho_universal_binary)
 #elif defined(LLVM_ON_UNIX)
 #ifdef __CYGWIN__


### PR DESCRIPTION
Add `file_magic::macho_bundle` to the list of recognized shared library types in `isSharedLibrary()`. This allows Cling to correctly identify and load Mach-O bundle files, which are produced by CMake's `MODULE` library type.

Without this fix, external dictionary libraries built as bundles (`MH_BUNDLE`) fail to load on macOS, while the same libraries built as dylibs (`MH_DYLIB`) work correctly. This is because `lookupLibrary()` uses `isSharedLibrary()` to validate library files, and bundles were incorrectly rejected.

(cherry picked from commit 2ef9dbb5b2279a712e6582b45ced8d3ab21c1aa3)

Backport of PR https://github.com/root-project/root/pull/20861, FYI @chrisburr 