### PR TITLE
[RF] Prepare RooFit and HistFactory for ROOT without implicit ownership

### DIFF
--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -170,6 +170,7 @@ TEST(RooDataSet, ReducingData)
    for (int i = 0; i < 3; ++i) {
       // Check with root:
       TH1F test_hist(("h" + std::to_string(i)).c_str(), "histo", 10, massmin, massmax);
+      test_hist.SetDirectory(gDirectory); // TTree::Draw needs to find the histogram
       chi2cutval += 0.5;
 
       std::stringstream cutString;
@@ -439,6 +440,7 @@ TEST(RooDataSet, SplitDataSetWithWeightErrors)
 TEST(RooDataSet, ReadDataSetWithErrors626)
 {
    std::unique_ptr<TFile> file{TFile::Open("dataSet_with_errors_6_26_10.root", "READ")};
+   ASSERT_NE(file, nullptr);
 
    auto data = file->Get<RooDataSet>("data");
 


### PR DESCRIPTION
This takes a few RooFit-related commits out of #18083.
- ~~The backend-related commit fixes the tests in case root has been configured with `-Dclad=off`.~~ Went to #20890 
- The other two move over to explicitly registering/writing histograms instead of relying on implicit ownership. This way, the tests are independent of whether implicit registration is used or not.

Note:
- [x] This contains the commit from #20888, so let's merge that one first.