### PR TITLE
[RF] Don't fall back to default backend for codegen_no_grad if clad=OFF

### DIFF
--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -563,9 +563,9 @@ RooCmdArg EventRange(Int_t nStart, Int_t nStop)
 EvalBackend::EvalBackend(EvalBackend::Value value) : RooCmdArg{"EvalBackend", static_cast<int>(value)}
 {
 #ifndef ROOFIT_CLAD
-   if (value == Value::Codegen || value == Value::CodegenNoGrad) {
+   if (value == Value::Codegen) {
       oocoutE(nullptr, InputArguments)
-         << "RooFit was built without clad. Codegen backends are unavailable. Falling back to default.\n";
+         << "RooFit was built without clad. The \"codegen\" backend is unavailable. Falling back to default.\n";
       setInt(0, static_cast<int>(defaultValue()));
    }
 #endif


### PR DESCRIPTION
Even if Clad is not enabled, the `codegen_no_grad` backend can still be used to validate the RooFit code generation.

Follows up on 359637ff283.

Inspired by https://github.com/root-project/root/pull/20889#discussion_r2691207608