### PR TITLE
[cppyy] Skip one more memory leak check that might sporadically fail

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
@@ -237,7 +237,7 @@ class TestLEAKCHECK:
 
         self.check_func(cppyy.gbl, '__dir__', cppyy.gbl)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
+    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
     def test07_string_handling(self):
         """Leak check of returning an std::string by value"""
 


### PR DESCRIPTION
In 8ad3cb1cb1652, I only disabled the "leakcheck" tests that I saw actually failing in a CI run rather than skipping the whole `test_leakcheck`, to be more conservative. That means that some tests were left enabled.

However, now I saw one one the re-enabled tests failing in a [recent `mac14` CI run](https://github.com/root-project/root/actions/runs/21023549989/job/60442891035?pr=20892), so it needs to be disabled again.