### PR TITLE
[cppyy] Review xfail'ed tests

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_aclassloader.py
@@ -1,6 +1,6 @@
 import pytest, os
 from pytest import raises, mark
-from support import setup_make, IS_MAC
+from support import setup_make, IS_WINDOWS
 
 test_dct = "libexample_cxx"
 
@@ -10,7 +10,7 @@ class TestACLASSLOADER:
     def setup_class(cls):
         import cppyy
 
-    @mark.xfail(reason="rootmap files are a legacy feature")
+    @mark.xfail(strict=True, condition=not IS_WINDOWS, reason="rootmap files are a legacy feature")
     def test01_class_autoloading(self):
         """Test whether a class can be found through .rootmap."""
         import cppyy

--- a/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_advancedcpp.py
@@ -11,7 +11,6 @@ class TestADVANCEDCPP:
         import cppyy
         cls.advanced = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail
     def test01_default_arguments(self):
         """Test usage of default arguments"""
 
@@ -386,7 +385,6 @@ class TestADVANCEDCPP:
         assert gbl.get_d(d) == 44
         d.__destruct__()
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_void_pointer_passing(self):
         """Test passing of variants of void pointer arguments"""
 
@@ -597,7 +595,6 @@ class TestADVANCEDCPP:
         gc.collect()
         assert cppyy.gbl.new_overloader.s_instances == 0
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test15_template_instantiation_with_vector_of_float(self):
         """Test template instantiation with a std::vector<float>"""
 
@@ -623,7 +620,6 @@ class TestADVANCEDCPP:
         assert f(3.) == 3.
         assert type(f(4.)) == type(4.)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test17_assign_to_return_byref(self):
         """Test assignment to an instance returned by reference"""
 
@@ -684,7 +680,7 @@ class TestADVANCEDCPP:
         assert cppyy.gbl.overload_one_way().gime() == 1
         assert cppyy.gbl.overload_the_other_way().gime() == "aap"
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test21_access_to_global_variables(self):
         """Access global_variables_and_pointers"""
 
@@ -773,7 +769,7 @@ class TestADVANCEDCPP:
         assert d2.vcheck()  == 'A'
         assert d2.vcheck(1) == 'B'
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test24_typedef_to_private_class(self):
         """Typedefs to private classes should not resolve"""
 
@@ -781,7 +777,7 @@ class TestADVANCEDCPP:
 
         assert cppyy.gbl.TypedefToPrivateClass().f().m_val == 42
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test25_ostream_printing(self):
         """Mapping of __str__ through operator<<(ostream&)"""
 
@@ -879,7 +875,7 @@ class TestADVANCEDCPP:
         #assert type(ns.A.Val(1)) == int
         #assert type(ns.B.Val(1)) == float
 
-    @mark.skip()
+    @mark.xfail(strict=True)
     def test28_extern_C_in_namespace(self):
         """Access to extern "C" declared functions in namespaces"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_boost.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_boost.py
@@ -141,7 +141,7 @@ class TestBOOSTERASURE:
         cppyy.include("boost/type_erasure/member.hpp")
         cppyy.include("boost/mpl/vector.hpp")
 
-    @mark.skip
+    @mark.skipif(noboost, reason="boost not found")
     def test01_erasure_usage(self):
         """boost::type_erasure usage"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_concurrent.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_concurrent.py
@@ -22,7 +22,7 @@ class TestCONCURRENT:
 
         cppyy.gbl.Workers.calc.__release_gil__ = True
 
-    @mark.skip
+    @mark.xfail(run=False, reason="Crashes because TClingCallFunc generates wrong code")
     def test01_simple_threads(self):
         """Run basic Python threads"""
 
@@ -41,7 +41,7 @@ class TestCONCURRENT:
         for t in threads:
             t.join()
 
-    @mark.skip
+    @mark.xfail(run=False, reason="Crashes because the interpreter emits too many warnings")
     def test02_futures(self):
         """Run with Python futures"""
 
@@ -91,7 +91,7 @@ class TestCONCURRENT:
         if t.is_alive():        # was timed-out
             cppyy.gbl.test12_timeout.stopit[0] = True
 
-    @mark.xfail(condition=IS_WINDOWS, reason="Fails on Windows")
+    @mark.xfail(strict=True, condition=IS_WINDOWS, reason="Fails on Windows")
     def test04_cpp_threading_with_exceptions(self):
         """Threads and Python exceptions"""
 
@@ -262,7 +262,7 @@ class TestCONCURRENT:
         for t in threads:
             t.join()
 
-    @mark.skip()
+    @mark.xfail(run=False, reason="segmentation violation")
     def test07_overload_reuse_in_threads_wo_gil(self):
         """Threads reuse overload objects; check for clashes if no GIL"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_conversions.py
@@ -1,6 +1,6 @@
 import pytest, os
 from pytest import raises, mark
-from support import setup_make, IS_WINDOWS, WINDOWS_BITS
+from support import setup_make, IS_WINDOWS
 
 test_dct = "conversions_cxx"
 
@@ -11,7 +11,6 @@ class TestCONVERSIONS:
         import cppyy
         cls.conversion = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_implicit_vector_conversions(self):
         """Test implicit conversions of std::vector"""
 
@@ -36,7 +35,6 @@ class TestCONVERSIONS:
         assert CNS.sumit(range(N), v2)          == total
         assert CNS.sumit(range(N), range(M, N)) == total
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_memory_handling_of_temporaries(self):
         """Verify that memory of temporaries is properly cleaned up"""
 
@@ -58,7 +56,6 @@ class TestCONVERSIONS:
         gc.collect()
         assert CC.s_count == 0
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_error_handling(self):
         """Verify error handling"""
 
@@ -86,7 +83,7 @@ class TestCONVERSIONS:
         gc.collect()
         assert CC.s_count == 0
 
-    @mark.xfail(condition=IS_WINDOWS, reason="Fails on Windows")
+    @mark.xfail(strict=True, condition=IS_WINDOWS, reason="Fails on Windows")
     def test04_implicit_conversion_from_tuple(self):
         """Allow implicit conversions from tuples as arguments {}-like"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_cpp11features.py
@@ -263,7 +263,6 @@ class TestCPP11FEATURES:
         assert cppyy.gbl.TestMoving1.s_instance_counter == 0
         assert cppyy.gbl.TestMoving2.s_instance_counter == 0
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_initializer_list(self):
         """Initializer list construction"""
 
@@ -301,7 +300,7 @@ class TestCPP11FEATURES:
         for l in (['x'], ['x', 'y', 'z']):
             assert ns.foo(l) == std.vector['std::string'](l)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test09_lambda_calls(self):
         """Call (global) lambdas"""
 
@@ -347,7 +346,7 @@ class TestCPP11FEATURES:
         c = cppyy.gbl.std.nullopt
         assert cppyy.gbl.callopt(c)
 
-    @mark.xfail(run = False, reason = "Crashes")
+    @mark.xfail(run=False, reason = "Crashes")
     def test11_chrono(self):
         """Use of chrono and overloaded operator+"""
 
@@ -358,7 +357,7 @@ class TestCPP11FEATURES:
         # following used to fail with compilation error
         t = std.chrono.system_clock.now() + std.chrono.seconds(1)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test12_stdfunction(self):
         """Use of std::function with arguments in a namespace"""
 
@@ -385,7 +384,6 @@ class TestCPP11FEATURES:
         f = FunctionNS.FNCreateTestStructFunc()
         assert f(t) == 27
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test13_stdhash(self):
         """Use of std::hash"""
 
@@ -414,7 +412,7 @@ class TestCPP11FEATURES:
             assert hash(sw)  == 17
             assert hash(sw)  == 17
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test14_shared_ptr_passing(self):
         """Ability to pass normal pointers through shared_ptr by value"""
 
@@ -440,7 +438,7 @@ class TestCPP11FEATURES:
             gc.collect()
             assert TestSmartPtr.s_counter == 0
 
-    @mark.xfail(condition=IS_WINDOWS | IS_MAC_ARM, reason='ValueError: Could not find "make_unique<int>"')
+    @mark.xfail(strict=True, condition=IS_WINDOWS | IS_MAC_ARM, reason='ValueError: Could not find "make_unique<int>"')
     def test15_unique_ptr_template_deduction(self):
         """Argument type deduction with std::unique_ptr"""
 
@@ -460,7 +458,7 @@ class TestCPP11FEATURES:
         with raises(ValueError):  # not an RValue
             cppyy.gbl.UniqueTempl.returnptr[int](uptr_in)
 
-    @mark.xfail(condition=IS_WINDOWS | IS_MAC_ARM, reason='TypeError: Could not find "make_unique<int>"')
+    @mark.xfail(strict=True, condition=IS_WINDOWS | IS_MAC_ARM, reason='TypeError: Could not find "make_unique<int>"')
     def test16_unique_ptr_moves(self):
         """std::unique_ptr requires moves"""
 
@@ -547,7 +545,7 @@ class TestCPP11FEATURES:
         p2 = c.pget()
         assert p1 is p2
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test19_smartptr_from_callback(self):
         """Return a smart pointer from a callback"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
@@ -11,7 +11,7 @@ class TestCROSSINHERITANCE:
         import cppyy
         cls.example01 = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test01_override_function(self):
         """Test ability to override a simple function"""
 
@@ -225,7 +225,7 @@ class TestCROSSINHERITANCE:
         p1 = TPyDerived1()
         assert p1.get_value() == 13
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM | IS_WINDOWS, reason = "Crashes on OS X ARM with" \
+    @mark.xfail(strict=True, condition=IS_MAC_ARM | IS_WINDOWS, reason = "Crashes on OS X ARM with" \
     "libc++abi: terminating due to uncaught exception")
     def test08_error_handling(self):
         """Python errors should propagate through wrapper"""
@@ -269,8 +269,6 @@ class TestCROSSINHERITANCE:
         assert 'ValueError' in res
         assert os.path.basename(__file__) in res
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception")
     def test09_interface_checking(self):
         """Conversion errors should be Python exceptions"""
 
@@ -288,7 +286,6 @@ class TestCROSSINHERITANCE:
 
         assert raises(TypeError, Base1.call_get_value, d)
 
-    @mark.xfail(condition=IS_WINDOWS, reason="TypeError: 'NoneType' object cannot be interpreted as an integer")
     def test10_python_in_templates(self):
         """Usage of Python derived objects in std::vector"""
 
@@ -372,7 +369,6 @@ class TestCROSSINHERITANCE:
         assert call_shared(v) == 13
         assert v.some_imp() == 13
 
-    @mark.xfail(condition=IS_WINDOWS, reason="assert 0 == (0 + 1)")
     def test12a_counter_test(self):
         """Test countable base counting"""
 
@@ -474,7 +470,7 @@ class TestCROSSINHERITANCE:
         class MyPyDerived4(VD.MyClass4[int]):
             pass
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test14_protected_access(self):
         """Derived classes should have access to protected members"""
 
@@ -735,7 +731,6 @@ class TestCROSSINHERITANCE:
             def abstract1(self):
                 return ns.Result(1)
 
-    @mark.skip
     def test20_basic_multiple_inheritance(self):
         """Basic multiple inheritance"""
 
@@ -814,7 +809,6 @@ class TestCROSSINHERITANCE:
         assert a.m_2 == 42
         assert a.m_3 == 67
 
-    @mark.skip()
     def test21_multiple_inheritance_with_constructors(self):
         """Multiple inheritance with constructors"""
 
@@ -902,7 +896,6 @@ class TestCROSSINHERITANCE:
         assert a.m_2 ==  88
         assert a.m_3 == -11
 
-    @mark.skip()
     def test22_multiple_inheritance_with_defaults(self):
         """Multiple inheritance with defaults"""
 
@@ -993,7 +986,6 @@ class TestCROSSINHERITANCE:
         a = MyPyDerived(27, 55, nArgs=2)
         verify(a, 27, 55, 67)
 
-    @mark.xfail(run=False, condition=IS_WINDOWS, reason="TypeError: <class cppyy.gbl.std.string at 0x0000018A025B6C60> has no attribute 'npos'.")
     def test23_const_byvalue_return(self):
         """Const by-value return in overridden method"""
 
@@ -1023,7 +1015,7 @@ class TestCROSSINHERITANCE:
         assert a.return_const().m_value == "abcdef"
         assert ns.callit(a).m_value     == "abcdef"
 
-    @mark.skip()
+    @mark.xfail(strict=True)
     def test24_non_copyable(self):
         """Inheriting from a non-copyable base class"""
 
@@ -1104,7 +1096,6 @@ class TestCROSSINHERITANCE:
 
         assert DerivedNoCopyNoMove().callme() == "Hello, World!"
 
-    @mark.skip()
     def test25_default_ctor_and_multiple_inheritance(self):
         """Regression test: default ctor did not get added"""
 
@@ -1145,7 +1136,6 @@ class TestCROSSINHERITANCE:
         d = DerivedMulti()
         assert d
 
-    @mark.skip()
     def test26_no_default_ctor(self):
         """Make sure no default ctor is created if not viable"""
 
@@ -1275,7 +1265,6 @@ class TestCROSSINHERITANCE:
             assert inst.fun1() == val1
             assert inst.fun2() == inst.fun1()
 
-    @mark.skip()
     def test29_cross_deep_multi(self):
         """Deep multi-inheritance hierarchy"""
 
@@ -1392,7 +1381,7 @@ class TestCROSSINHERITANCE:
         class PyDerived(ns.Base):
             pass
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test31_object_rebind(self):
         """Usage of bind_object to cast with Python derived objects"""
 
@@ -1550,7 +1539,7 @@ class TestCROSSINHERITANCE:
 
         assert p.func(d) == 42 + 2 * d.value
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test33_direct_base_methods(self):
         """Call base class methods directly"""
 
@@ -1782,7 +1771,7 @@ class TestCROSSINHERITANCE:
         assert pysub.f3() == "Python: PySub::f3()"
         assert ns.call_fs(pysub) == pysub.f1() + pysub.f2() + pysub.f3()
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test38_protected_data(self):
         """Multiple cross inheritance with protected data"""
 
@@ -1841,4 +1830,4 @@ class TestCROSSINHERITANCE:
                 return 1
 
 if __name__ == "__main__":
-    exit(pytest.main(args=['-ra', __file__]))
+    exit(pytest.main(args=['-sv', '-ra', __file__]))

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -1,6 +1,6 @@
 import sys, pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, pyunicode, IS_MAC, IS_MAC_ARM, IS_WINDOWS, WINDOWS_BITS
+from support import setup_make, pylong, pyunicode, IS_MAC, IS_MAC_ARM, IS_WINDOWS
 
 test_dct = "datatypes_cxx"
 
@@ -13,7 +13,7 @@ class TestDATATYPES:
         cls.datatypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = cppyy.gbl.N
 
-    @mark.skip()
+    @mark.xfail(strict=True)
     def test01_instance_data_read_access(self):
         """Read access to instance public data and verify values"""
 
@@ -184,7 +184,7 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test02_instance_data_write_access(self):
         """Test write access to instance public data and verify values"""
 
@@ -366,7 +366,6 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
     def test04_class_read_access(self):
         """Test read access to class public data and verify values"""
 
@@ -529,7 +528,6 @@ class TestDATATYPES:
 
         c.__destruct__()
 
-    @mark.xfail()
     def test07_type_conversions(self):
         """Test conversions between builtin types"""
 
@@ -723,7 +721,7 @@ class TestDATATYPES:
         assert gbl.EnumSpace.AA == 1
         assert gbl.EnumSpace.BB == 2
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test11_typed_enums(self):
         """Determine correct types of enums"""
 
@@ -766,7 +764,7 @@ class TestDATATYPES:
         assert type(sc.vraioufaux.faux) == bool  # no bool as base class
         assert isinstance(sc.vraioufaux.faux, bool)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test12_enum_scopes(self):
         """Enum accessibility and scopes"""
 
@@ -1092,7 +1090,7 @@ class TestDATATYPES:
 
         assert not d2
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test22_buffer_shapes(self):
         """Correctness of declared buffer shapes"""
 
@@ -1222,7 +1220,7 @@ class TestDATATYPES:
                 for k in range(7):
                     assert int(ns.vvv[i,j,k]) == i+j+k
 
-    @mark.skip()
+    @mark.xfail(run=False, reason="segmentation violation")
     def test25_byte_arrays(self):
         """Usage of unsigned char* as byte array and std::byte*"""
 
@@ -1256,7 +1254,7 @@ class TestDATATYPES:
         run(self, cppyy.gbl.sum_uc_data, buf, total)
         run(self, cppyy.gbl.sum_byte_data, buf, total)
 
-    @mark.xfail(run=not IS_MAC, reason = "Fails on all platforms; crashes on macOS with " \
+    @mark.xfail(strict=True, run=not IS_MAC, reason="Fails on all platforms; crashes on macOS with " \
     "libc++abi: terminating due to uncaught exception")
     def test26_function_pointers(self):
         """Function pointer passing"""
@@ -1320,8 +1318,6 @@ class TestDATATYPES:
         ns = cppyy.gbl.FuncPtrReturn
         assert ns.foo()() == "Hello, World!"
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception")
     def test27_callable_passing(self):
         """Passing callables through function pointers"""
 
@@ -1394,8 +1390,6 @@ class TestDATATYPES:
         gc.collect()
         raises(TypeError, c, 3, 3) # lambda gone out of scope
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM or (WINDOWS_BITS == 64), reason = "Crashes on Windows 64 bit or OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception")
     def test28_callable_through_function_passing(self):
         """Passing callables through std::function"""
 
@@ -1468,7 +1462,6 @@ class TestDATATYPES:
         gc.collect()
         raises(TypeError, c, 3, 3) # lambda gone out of scope
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test29_std_function_life_lines(self):
         """Life lines to std::function data members"""
 
@@ -1540,7 +1533,7 @@ class TestDATATYPES:
                 p = (ctype * len(buf)).from_buffer(buf)
                 assert [p[j] for j in range(width*height)] == [2*j for j in range(width*height)]
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test31_anonymous_union(self):
         """Anonymous unions place there fields in the parent scope"""
 
@@ -1634,7 +1627,7 @@ class TestDATATYPES:
         assert type(p.data_c[0]) == float
         assert p.intensity == 5.
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test32_anonymous_struct(self):
         """Anonymous struct creates an unnamed type"""
 
@@ -1683,7 +1676,7 @@ class TestDATATYPES:
 
         assert 'foo' in dir(ns.libuntitled1_ExportedSymbols().kotlin.root.com.justamouse.kmmdemo)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test33_pointer_to_array(self):
         """Usability of pointer to array"""
 
@@ -1863,7 +1856,6 @@ class TestDATATYPES:
         m = ns.create_matrix(N, M)
         assert ns.destroy_matrix(ns.g_matrix, N, M)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test38_plain_old_data(self):
         """Initializer construction of PODs"""
 
@@ -1950,7 +1942,7 @@ class TestDATATYPES:
             assert len(f1.fPtrArr) == 3
             assert list(f1.fPtrArr) == [1., 2., 3]
 
-    @mark.xfail(condition=IS_WINDOWS, reason="Test doesn't work on Windows")
+    @mark.xfail(strict=True, condition=IS_WINDOWS, reason="Test doesn't work on Windows")
     def test39_aggregates(self):
         """Initializer construction of aggregates"""
 
@@ -2003,8 +1995,8 @@ class TestDATATYPES:
         assert b.name     == "aap"
         assert b.buf_type == ns.SHAPE
 
-    @mark.skip()
-    def test40_more_aggregates(self):
+    @mark.xfail(run=False, reason="error code: Subprocess aborted")
+    def test40_more_aggregates(self, capfd):
         """More aggregate testings (used to fail/report errors)"""
 
         import cppyy
@@ -2040,8 +2032,13 @@ class TestDATATYPES:
         r2 = ns.make_R2()
         assert r2.s.x == 1
 
-    @mark.xfail()
-    def test41_complex_numpy_arrays(self):
+        # Fail if there was an interpreter error
+        captured = capfd.readouterr()
+        output = (captured.out + captured.err).lower()
+        assert "error:" not in output
+
+    @mark.xfail(strict=True)
+    def test41_complex_numpy_arrays(self, capfd):
         """Usage of complex numpy arrays"""
 
         import cppyy
@@ -2088,7 +2085,13 @@ class TestDATATYPES:
             Ccl = func(Acl, Bcl, 2)
             assert complex(Ccl) == pyCcl
 
-    @mark.xfail()
+        # Fail if there was an interpreter error about calling an
+        # implicitly-deleted copy constructor
+        captured = capfd.readouterr()
+        output = (captured.out + captured.err).lower()
+        assert "call to implicitly-deleted copy constructor" not in output
+
+    @mark.xfail(strict=True, condition=IS_MAC or IS_WINDOWS, reason="Argument conversion error on macOS and Windows")
     def test42_mixed_complex_arithmetic(self):
         """Mixin of Python and C++ std::complex in arithmetic"""
 
@@ -2102,7 +2105,6 @@ class TestDATATYPES:
         assert c*(c*c) == p*(p*p)
         assert (c*c)*c == (p*p)*p
 
-    @mark.xfail()
     def test43_ccharp_memory_handling(self):
         """cppyy side handled memory of C strings"""
 
@@ -2219,7 +2221,7 @@ class TestDATATYPES:
         b = ns.B()
         assert b.body1.name == b.body2.name
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test46_small_int_enums(self):
         """Proper typing of small int enums"""
 
@@ -2274,7 +2276,7 @@ class TestDATATYPES:
         assert ns.func_int8()  == -1
         assert ns.func_uint8() == 255
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test47_hidden_name_enum(self):
         """Usage of hidden name enum"""
 
@@ -2337,7 +2339,7 @@ class TestDATATYPES:
         assert str(bt(1)) == 'True'
         assert str(bt(0)) == 'False'
 
-    @mark.xfail(run = not IS_MAC_ARM, reason="Crashes on mac-beta ARM64, fails on alma9 runtime_cxxmodules=off")
+    @mark.xfail(strict=True, condition=IS_MAC_ARM or IS_WINDOWS, reason="Crashes on mac-beta ARM64 and fails on Windows")
     def test49_addressof_method(self):
         """Use of addressof for (const) methods"""
 
@@ -2391,7 +2393,6 @@ class TestDATATYPES:
             else:
                 assert type(v) == gbl.PolymorphicMaps.Derived
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test52_virtual_inheritance(self):
         import cppyy
         from cppyy import gbl
@@ -2429,4 +2430,4 @@ class TestDATATYPES:
             assert i.name == "NAME"
 
 if __name__ == "__main__":
-    exit(pytest.main(args=['-sv', '-ra', __file__]))
+    exit(pytest.main(args=['-v', '-ra', __file__]))

--- a/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_doc_features.py
@@ -380,7 +380,6 @@ namespace Namespace {
 
         pass
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test_x_inheritance(self):
         import cppyy
         from cppyy.gbl import Abstract, Concrete, call_abstract_method
@@ -428,7 +427,6 @@ namespace Namespace {
         pc = PyConcrete4()
         assert call_abstract_method(pc) == "Hello, Python World! (4)"
 
-    @mark.skip
     def test_multi_x_inheritance(self):
         """Multiple cross-inheritance"""
 
@@ -446,8 +444,7 @@ namespace Namespace {
         assert cppyy.gbl.call_abstract_method1(pc) == "first message"
         assert cppyy.gbl.call_abstract_method2(pc) == "second message"
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM | (WINDOWS_BITS == 64), reason = "Crashes on Windows 64 bit and macOS ARM with" \
-    "libc++abi: terminating due to uncaught exception")
+    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason = "Crashes on Windows 64 bit")
     def test_exceptions(self):
         """Exception throwing and catching"""
 
@@ -568,7 +565,6 @@ namespace Zoo {
         assert not isinstance(i, int)
         assert isinstance(i, Integer1)
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_STL_containers(self):
         """Instantiate STL contaienrs with new class"""
 
@@ -785,7 +781,7 @@ class TestADVERTISED:
         Advert02.Picam_OpenFirstCamera(cam)
         assert Advert02.Picam_CloseCamera(cam)
 
-    @mark.xfail(condition=IS_WINDOWS, reason="Fails on Windows")
+    @mark.xfail(strict=True, condition=IS_WINDOWS, reason="Fails on Windows")
     def test03_use_of_ctypes_and_enum(self):
         """Use of (opaque) enum through ctypes.c_void_p"""
 
@@ -837,7 +833,6 @@ class TestADVERTISED:
         assert list(arr) == [1, 42, 1, 42]
         cppyy.gbl.free(vp)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test04_ptr_ptr_python_owns(self):
         """Example of ptr-ptr use where python owns"""
 
@@ -923,7 +918,6 @@ class TestADVERTISED:
         val = createit(ptr)
         assert destroyit(ptr) == val
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test07_array_of_arrays(self):
         """Example of array of array usage"""
 
@@ -1077,7 +1071,6 @@ class TestTALKEXAMPLES:
 
         cppyy.gbl.talk_examples
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test_template_instantiation(self):
         """Run-time template instantiation example"""
 
@@ -1130,7 +1123,7 @@ class TestTALKEXAMPLES:
 
         assert v.back().add(17) == 4+42+2*17
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test_fallbacks(self):
         """Template instantation switches based on value sizes"""
 
@@ -1149,7 +1142,6 @@ class TestTALKEXAMPLES:
         assert CC.passT(2**64-1) == 2**64-1
         assert 'unsigned long long' in CC.passT.__doc__
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test_callbacks(self):
         """Function callback example"""
 
@@ -1176,7 +1168,7 @@ class TestTALKEXAMPLES:
         assert CC.callPtr(lambda i: 5*i, 4) == 20
         assert CC.callFun(lambda i: 6*i, 4) == 24
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test_templated_callback(self):
         """Templated callback example"""
 
@@ -1229,8 +1221,7 @@ class TestTALKEXAMPLES:
         assert type(b) == CC.Derived
         assert d is b
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM | IS_WINDOWS, reason = "Crashes on OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception, and also on Windows")
+    @mark.xfail(strict=True, condition=IS_WINDOWS, reason = "Crashes on Windows")
     def test_exceptions(self):
         """Exceptions example"""
 
@@ -1255,7 +1246,7 @@ class TestTALKEXAMPLES:
         with raises(CC.MyException):
             CC.throw_error()
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test_unicode(self):
         """Unicode non-UTF-8 example"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_eigen.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_eigen.py
@@ -100,7 +100,7 @@ class TestEIGEN:
         for i in range(5):
             assert v(i) == i+1
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test03_matrices_and_vectors(self):
         """Matrices and vectors"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_leakcheck.py
@@ -99,7 +99,7 @@ class TestLEAKCHECK:
         self.check_func(ns, 'free_f_ret1')
         self.check_func(ns, 'free_f_ret1')
 
-    @mark.xfail()
+    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
     def test02_test_static_methods(self):
         """Leak test of static methods"""
 
@@ -227,6 +227,7 @@ class TestLEAKCHECK:
         self.check_func(ns, 'SomeBuf')
         self.check_func(ns, 'SomeBuf', val=10, name="aap", buf_type=ns.SHAPE)
 
+    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
     def test06_dir(self):
         """Global function uploads used to cause more function generation"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
@@ -44,7 +44,6 @@ class TestLOWLEVEL:
         assert len(ll.reinterpret_cast['int*'](0)) == 0
         raises(ReferenceError, ll.reinterpret_cast['int*'](0).__getitem__, 0)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_memory(self):
         """Memory allocation and free-ing"""
 
@@ -82,7 +81,6 @@ class TestLOWLEVEL:
         mem.__python_owns__ = True
         assert     mem.__python_owns__
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test04_python_casts(self):
         """Casts to common Python pointer encapsulations"""
 
@@ -105,7 +103,6 @@ class TestLOWLEVEL:
         ptrptr = cppyy.ll.as_ctypes(s, byref=True)
         assert pycasts.get_deref(ptrptr) == actual
 
-    @mark.xfail()
     def test05_array_as_ref(self):
         """Use arrays for pass-by-ref"""
 
@@ -135,7 +132,7 @@ class TestLOWLEVEL:
         f = array('f', [0]);     ctd.set_float_r(f);  assert f[0] ==  5.
         f = array('d', [0]);     ctd.set_double_r(f); assert f[0] == -5.
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test06_ctypes_as_ref_and_ptr(self):
         """Use ctypes for pass-by-ref/ptr"""
 
@@ -346,7 +343,6 @@ class TestLOWLEVEL:
         x = np.array([True], dtype=bool)
         assert cppyy.gbl.convert_bool(x)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test10_array_of_const_char_star(self):
         """Test passting of const char*[]"""
 
@@ -493,7 +489,7 @@ class TestLOWLEVEL:
         assert cppyy.gbl.std.vector[cppyy.gbl.std.vector[int]].value_type == 'std::vector<int>'
         assert cppyy.gbl.std.vector['int[1]'].value_type == 'int[1]'
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test15_templated_arrays_gmpxx(self):
         """Use of gmpxx array types in templates"""
 
@@ -547,7 +543,6 @@ class TestMULTIDIMARRAYS:
     def _data_m(self, lbl):
         return [('m_'+tp.replace(' ', '_')+lbl, tp) for tp in self.numeric_builtin_types]
 
-    @mark.xfail()
     def test01_2D_arrays(self):
         """Access and use of 2D data members"""
 
@@ -590,7 +585,6 @@ class TestMULTIDIMARRAYS:
                     assert arr[i][j] == val
                     assert arr[i, j] == val
 
-    @mark.xfail()
     def test02_assign_2D_arrays(self):
         """Direct assignment of 2D arrays"""
 
@@ -643,7 +637,6 @@ class TestMULTIDIMARRAYS:
             arr[2][3] = 10
             assert arr[2][3] == 10
 
-    @mark.xfail()
     def test03_3D_arrays(self):
         """Access and use of 3D data members"""
 
@@ -690,7 +683,6 @@ class TestMULTIDIMARRAYS:
                         assert arr[i][j][k] == val
                         assert arr[i, j, k] == val
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test04_malloc(self):
         """Use of malloc to create multi-dim arrays"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_operators.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_operators.py
@@ -6,6 +6,12 @@ from support import setup_make, pylong, maxvalue, IS_WINDOWS, IS_MAC, no_root_er
 test_dct = "operators_cxx"
 
 
+def compiled_with_gcc16():
+    import cppyy
+
+    return "gcc16" in cppyy.gbl.gSystem.GetBuildCompilerVersion()
+
+
 class TestOPERATORS:
     def setup_class(cls):
         cls.test_dct = test_dct
@@ -221,7 +227,7 @@ class TestOPERATORS:
             assert m[1]    == 74
             assert m(1,2)  == 74
 
-    @mark.xfail(reason="Compilation of unused call wrappers emits errors")
+    @mark.xfail(strict=True, reason="Compilation of unused call wrappers emits errors")
     def test09_templated_operator(self):
         """Templated operator<()"""
 
@@ -337,7 +343,7 @@ class TestOPERATORS:
         b = ns.Bar()
         assert b[42] == 42
 
-    @mark.xfail(reason='Fails on macOS and on Linux with gcc 16 because cppyy picks the wrong "operator-" overload.')
+    @mark.xfail(strict=True, condition=IS_MAC or compiled_with_gcc16(), reason="Fails on macOS or gcc 16")
     def test15_class_and_global_mix(self):
         """Iterator methods have both class and global overloads"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
@@ -1,6 +1,6 @@
 import pytest, os
 from pytest import raises, skip, mark
-from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM, WINDOWS_BITS
+from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
 
 
 test_dct = "overloads_cxx"
@@ -139,7 +139,6 @@ class TestOVERLOADS:
             a = array.array(l, numbers)
             assert round(cmean(len(a), a) - mean, 8) == 0
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_const_non_const_overloads(self):
         """Check selectability of const/non-const overloads"""
 
@@ -199,8 +198,6 @@ class TestOVERLOADS:
         with raises(ValueError):
             cpp.BoolInt4.fff(2)
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM, reason = "Crashes on OS X ARM with" \
-    "libc++abi: terminating due to uncaught exception")
     def test10_overload_and_exceptions(self):
         """Prioritize reporting C++ exceptions from callee"""
 
@@ -406,7 +403,6 @@ class TestOVERLOADS:
         assert result_instance == result_direct
 
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test14_disallow_functor_to_function_pointer(self):
         """Make sure we're no allowing to convert C++ functors to function
         pointers, extending the C++ language in an unnatural way that can lead

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonify.py
@@ -1,6 +1,6 @@
 import pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, ispypy, WINDOWS_BITS
+from support import setup_make, pylong, ispypy
 
 
 test_dct = "example01_cxx"
@@ -197,6 +197,7 @@ class TestPYTHONIFY:
         assert cppyy.gbl.ns_example01.globalAddOneToInt(4) == 5
         assert cppyy.gbl.ns_example01.globalAddOneToInt(4) == 5
 
+    @mark.skip(reason="Garbage collection tests are fragile")
     def test09_memory(self):
         """Test proper C++ destruction by the garbage collector"""
 
@@ -241,7 +242,6 @@ class TestPYTHONIFY:
 
         # TODO: need ReferenceError on touching pl_a
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test10_default_arguments(self):
         """Test propagation of default function arguments"""
 
@@ -376,7 +376,6 @@ class TestPYTHONIFY:
 
         assert example01.getCount() == 0
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test17_chaining(self):
         """Respective return values of temporaries should not go away"""
 
@@ -394,7 +393,6 @@ class TestPYTHONIFY:
 
         assert cppyy.gbl.Lifeline.gime(42).get()[0].get()[0].get()[0].get()[0].x == 42
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test18_keywords(self):
         """Use of keyword arguments"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
@@ -11,7 +11,7 @@ class TestClassPYTHONIZATION:
         import cppyy
         cls.pyzables = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test00_api(self):
         """Test basic semantics of the pythonization API"""
 
@@ -222,7 +222,6 @@ class TestClassPYTHONIZATION:
         # associative  container, with 'index' a key, not a counter
         #raises(IndexError, d.__getitem__, 1)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test09_cpp_side_pythonization(self):
         """Use of C++ side pythonizations"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -189,7 +189,6 @@ def getslice_cpython_test(type2test):
     assert a[3::maxvalue]      == type2test([3])
 
 
-@mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
 class TestSTLVECTOR:
     def setup_class(cls):
         cls.test_dct = test_dct
@@ -197,7 +196,6 @@ class TestSTLVECTOR:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = global_n
 
-    @mark.xfail(run=False, condition=IS_WINDOWS, reason="Fails on Windows")
     def test01_builtin_type_vector_types(self):
         """Test access to std::vector<int>/std::vector<double>"""
 
@@ -253,7 +251,6 @@ class TestSTLVECTOR:
             assert v.size() == self.N
             assert len(v) == self.N
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_user_type_vector_type(self):
         """Test access to an std::vector<just_a_class>"""
 
@@ -286,7 +283,6 @@ class TestSTLVECTOR:
         assert len(v) == self.N
         v.__destruct__()
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_empty_vector_type(self):
         """Test behavior of empty std::vector<>"""
 
@@ -301,7 +297,6 @@ class TestSTLVECTOR:
         for x in cppyy.gbl.std.vector["std::string*"]():
             pass
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test04_vector_iteration(self):
         """Test iteration over an std::vector<int>"""
 
@@ -327,7 +322,6 @@ class TestSTLVECTOR:
 
         v.__destruct__()
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test05_push_back_iterables_with_iadd(self):
         """Test usage of += of iterable on push_back-able container"""
 
@@ -366,7 +360,6 @@ class TestSTLVECTOR:
         v += []
         assert len(v) == sz
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test06_vector_indexing(self):
         """Test python-style indexing to an std::vector<int>"""
 
@@ -394,7 +387,6 @@ class TestSTLVECTOR:
         assert v2[-1] == v[-2]
         assert v2[self.N-4] == v[-2]
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test07_vector_bool(self):
         """Usability of std::vector<bool> which can be a specialization"""
 
@@ -413,7 +405,6 @@ class TestSTLVECTOR:
         assert len(vb[4:8]) == 4
         assert list(vb[4:8]) == [False]*3+[True]
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_vector_enum(self):
         """Usability of std::vector<> of some enums"""
 
@@ -447,7 +438,6 @@ class TestSTLVECTOR:
 
         raises(TypeError, cppyy.gbl.std.vector["std::string"], "abc")
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test10_vector_std_distance(self):
         """Use of std::distance with vector"""
 
@@ -459,7 +449,6 @@ class TestSTLVECTOR:
         assert std.distance(v.begin(), v.end()) == v.size()
         assert std.distance[type(v).iterator](v.begin(), v.end()) == v.size()
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test11_vector_of_pair(self):
         """Use of std::vector<std::pair>"""
 
@@ -503,7 +492,7 @@ class TestSTLVECTOR:
         ll4[1] = 'a'
         raises(TypeError, a.vector_pair, ll4)
 
-    @mark.skip()
+    @mark.xfail(run=False, reason="Fatal Python error: Segmentation fault")
     def test12_vector_lifeline(self):
         """Check lifeline setting on vectors of objects"""
 
@@ -536,7 +525,6 @@ class TestSTLVECTOR:
         for val in l:
             assert hasattr(val, '__lifeline')
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test13_vector_smartptr_iteration(self):
         """Iteration over smart pointers"""
 
@@ -570,7 +558,6 @@ class TestSTLVECTOR:
             i += 1
         assert i == len(result)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test14_vector_of_vector_of_(self):
         """Nested vectors"""
 
@@ -586,7 +573,6 @@ class TestSTLVECTOR:
         assert vv[1][0] == 3
         assert vv[1][1] == 4
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test15_vector_slicing(self):
         """Advanced test of vector slicing"""
 
@@ -613,7 +599,6 @@ class TestSTLVECTOR:
       # additional test from CPython's test suite
         getslice_cpython_test(vector[int])
 
-    @mark.xfail(run=False, condition=IS_WINDOWS, reason="Fails on Windows")
     def test16_vector_construction(self):
         """Vector construction following CPython's sequence"""
 
@@ -630,7 +615,7 @@ class TestSTLVECTOR:
         v = cppyy.gbl.std.vector(l)
         assert list(l) == l
 
-    @mark.xfail(run=False)
+    @mark.xfail(strict=True)
     def test18_array_interface(self):
         """Test usage of __array__ from numpy"""
 
@@ -865,7 +850,6 @@ class TestSTLSTRING:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_string_argument_passing(self):
         """Test mapping of python strings and std::[w]string"""
 
@@ -966,7 +950,6 @@ class TestSTLSTRING:
                 for k in range(2):
                     assert str_array_4[i][j][k] == vals[i*4+j*2+k]
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test05_stlstring_and_unicode(self):
         """Mixing unicode and std::string"""
 
@@ -1031,7 +1014,7 @@ class TestSTLSTRING:
         assert d[x] == 0
         assert d['x'] == 0
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test08_string_operators(self):
         """Mixing of C++ and Python types in global operators"""
 
@@ -1059,7 +1042,7 @@ class TestSTLSTRING:
         assert s1+s2 == "Hello, World!"
         assert s2+s1 == ", World!Hello"
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
+    @mark.xfail(strict=True, condition=WINDOWS_BITS == 64, reason="AttributeError: <class cppyy.gbl.std.string at 0x0000021275350610> has no attribute 'size_type'")
     def test09_string_as_str_bytes(self):
         """Python-style methods of str/bytes on std::string"""
 
@@ -1122,7 +1105,7 @@ class TestSTLSTRING:
         assert s.rfind('c')  < 0
         assert s.rfind('c') == s.npos
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test10_string_in_repr_and_str_bytes(self):
         """Special cases for __str__/__repr__"""
 
@@ -1166,7 +1149,6 @@ class TestSTLLIST:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = 13
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_builtin_list_type(self):
         """Test access to a list<int>"""
 
@@ -1283,7 +1265,6 @@ class TestSTLMAP:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = 13
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_builtin_map_type(self):
         """Test access to a map<int,int>"""
 
@@ -1322,7 +1303,6 @@ class TestSTLMAP:
                 assert key   == self.N-1
                 assert value == (self.N-1)*(self.N-1)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_keyed_maptype(self):
         """Test access to a map<std::string,int>"""
 
@@ -1415,7 +1395,6 @@ class TestSTLMAP:
             assert m['1'] == 2
             assert m['2'] == 1
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_map_derived_objects(self):
         """Enter derived objects through an initializer list"""
 
@@ -1463,7 +1442,6 @@ class TestSTLITERATOR:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_builtin_vector_iterators(self):
         """Test iterator comparison with operator== reflected"""
 
@@ -1491,7 +1469,6 @@ class TestSTLITERATOR:
         assert b1 != b2
         assert b1 == e2
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_STL_like_class_iterators(self):
         """Test the iterator protocol mapping for an STL like class"""
 
@@ -1627,7 +1604,6 @@ class TestSTLARRAY:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_array_of_basic_types(self):
         """Usage of std::array of basic types"""
 
@@ -1640,7 +1616,6 @@ class TestSTLARRAY:
             a[i] = i
             assert a[i] == i
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_array_of_pods(self):
         """Usage of std::array of PODs"""
 
@@ -1664,7 +1639,6 @@ class TestSTLARRAY:
         assert a[2].px == 6
         assert a[2].py == 7
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_array_of_pointer_to_pods(self):
         """Usage of std::array of pointer to PODs"""
 
@@ -1695,7 +1669,6 @@ class TestSTLARRAY:
             assert gbl.ArrayTest.get_pa_px(a.data(), i) == 13*i
             assert gbl.ArrayTest.get_pa_py(a.data(), i) == 42*i
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test04_array_from_aggregate(self):
         """Initialize an array from an aggregate contructor"""
 
@@ -1718,7 +1691,6 @@ class TestSTLSTRING_VIEW:
         import cppyy
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_string_through_string_view(self):
         """Usage of std::string_view as formal argument"""
 
@@ -1782,7 +1754,6 @@ class TestSTLDEQUE:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = global_n
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_deque_byvalue_regression(self):
         """Return by value of a deque used to crash"""
 
@@ -1810,7 +1781,6 @@ class TestSTLSET:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = global_n
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_set_iteration(self):
         """Iterate over a set"""
 
@@ -1828,7 +1798,6 @@ class TestSTLSET:
             assert i in s
             assert i in r
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_set_iterators(self):
         """Access to set iterators and their comparisons"""
 
@@ -1912,7 +1881,6 @@ class TestSTLTUPLE:
         cls.stltypes = cppyy.load_reflection_info(cls.test_dct)
         cls.N = global_n
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test01_tuple_creation_and_access(self):
         """Create tuples and access their elements"""
 
@@ -1947,7 +1915,6 @@ class TestSTLTUPLE:
 
         # TODO: should be easy enough to add iterators over std::tuple?
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test02_tuple_size(self):
         """Usage of tuple_size helper class"""
 
@@ -1957,7 +1924,7 @@ class TestSTLTUPLE:
         t = std.make_tuple("aap", 42, 5.)
         assert std.tuple_size(type(t)).value == 3
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test03_tuple_iter(self):
         """Pack/unpack tuples"""
 
@@ -1972,7 +1939,7 @@ class TestSTLTUPLE:
         assert b == '2'
         assert c == 5.
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test04_tuple_lifeline(self):
         """Tuple memory management"""
 
@@ -2145,7 +2112,7 @@ class TestSTLEXCEPTION:
         gc.collect()
         assert cppyy.gbl.GetMyErrorCount() == 0
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
+    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Crashes on Windows 64 bit")
     def test04_from_cpp(self):
         """Catch C++ exceptiosn from C++"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_streams.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_streams.py
@@ -45,7 +45,7 @@ class TestSTDStreams:
         cppyy.gbl.stringstream_base.pass_through_base(s)
         assert s.str() == "TEST STRING"
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test04_naming_of_ostringstream(self):
         """Naming consistency of ostringstream"""
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1,6 +1,6 @@
 import pytest, os
 from pytest import mark, raises
-from support import setup_make, pylong, IS_WINDOWS, WINDOWS_BITS
+from support import setup_make, pylong, IS_WINDOWS
 
 
 test_dct = "templates_cxx"
@@ -68,7 +68,6 @@ class TestTEMPLATES:
         assert cppyy.gbl.nt_templ_args[1]()   == 1
         assert cppyy.gbl.nt_templ_args[256]() == 256
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test03_templated_function(self):
         """Templated global and static functions lookup and calls"""
 
@@ -149,9 +148,8 @@ class TestTEMPLATES:
         assert cppyy.gbl.isSomeInt()           == False
         assert cppyy.gbl.isSomeInt(1, 2, 3)    == False
 
-    @mark.xfail(run = False, reason = "This test causes the interpreter to raises errors and" \
-    "should not be run until further investigated")
-    def test06_variadic_sfinae(self):
+    @mark.xfail(strict=True, reason="This test causes the interpreter to raises errors")
+    def test06_variadic_sfinae(self, capfd):
         """Attribute testing through SFINAE"""
 
         import cppyy
@@ -166,6 +164,11 @@ class TestTEMPLATES:
 
         assert call_has_var1(move(Obj1())) == True
         assert call_has_var1(move(Obj2())) == False
+
+        # Fail if there were interpreter errors:
+        captured = capfd.readouterr()
+        output = (captured.out + captured.err).lower()
+        assert "error:" not in output
 
     def test07_type_deduction(self):
         """Traits/type deduction"""
@@ -185,7 +188,6 @@ class TestTEMPLATES:
         assert issubclass(select_template_arg[0, int, float].argument, int)
         assert issubclass(select_template_arg[1, int, float].argument, float)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test08_using_of_static_data(self):
         """Derived class using static data of base"""
 
@@ -275,7 +277,7 @@ class TestTEMPLATES:
         assert round(RTTest2[int](1, 3.1).m_double - 4.1, 8) == 0.
         assert round(RTTest2[int]().m_double + 1., 8) == 0.
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test12_template_aliases(self):
         """Access to templates made available with 'using'"""
 
@@ -325,7 +327,7 @@ class TestTEMPLATES:
         assert nsup.Foo
         assert nsup.Bar.Foo        # used to fail
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test13_using_templated_method(self):
         """Access to base class templated methods through 'using'"""
 
@@ -349,7 +351,7 @@ class TestTEMPLATES:
         assert type(d.get3()) == int
         assert d.get3() == 5
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test14_templated_return_type(self):
         """Use of a templated return type"""
 
@@ -396,7 +398,6 @@ class TestTEMPLATES:
         assert is_valid(1.)
         assert not is_valid(0.)
 
-    @mark.xfail()
     def test16_variadic(self):
         """Range of variadic templates"""
 
@@ -450,7 +451,6 @@ class TestTEMPLATES:
         b.b_T['int'](1, 1., 'a')
         assert get_tn(ns).find("int(some_variadic::B::*)(int&&,double&&,std::") == 0
 
-    @mark.xfail()
     def test17_empty_body(self):
         """Use of templated function with empty body"""
 
@@ -462,7 +462,6 @@ class TestTEMPLATES:
         assert f_T[int]() is None
         assert cppyy.gbl.T_WithEmptyBody.side_effect == "side effect"
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test18_greedy_overloads(self):
         """void*/void** should not pre-empt template instantiations"""
 
@@ -530,7 +529,6 @@ class TestTEMPLATES:
 
         assert cppyy.gbl.TemplatedCtor.C(0)
 
-    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test21_type_deduction_with_conversion(self):
         """Template instantiation with [] -> std::vector conversion"""
 
@@ -569,7 +567,6 @@ class TestTEMPLATES:
         assert l2v.test3[int]([d1])     == 1
         assert l2v.test3[int]([d1, d1]) == 2
 
-    @mark.xfail(condition=IS_WINDOWS, reason="Fails on Windows: TypeError: Template method resolution failed: Python int too large to convert to C long")
     def test22_type_deduction_of_proper_integer_size(self):
         """Template type from integer arg should be big enough"""
 
@@ -585,7 +582,6 @@ class TestTEMPLATES:
         for val in [2**64, -2**63-1]:
             raises(OverflowError, PassSomeInt, val)
 
-    @mark.xfail(condition=WINDOWS_BITS == 64, reason="Fails on Windows 64 bit")
     def test23_overloaded_setitem(self):
         """Template with overloaded non-templated and templated setitem"""
 
@@ -596,7 +592,7 @@ class TestTEMPLATES:
         v = MyVec["float"](2)
         v[0] = 1        # used to throw TypeError
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test24_stdfunction_templated_arguments(self):
         """Use of std::function with templated arguments"""
 
@@ -623,7 +619,7 @@ class TestTEMPLATES:
 
         assert cppyy.gbl.std.function['double(std::vector<double>)']
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test25_stdfunction_ref_and_ptr_args(self):
         """Use of std::function with reference or pointer args"""
 
@@ -690,7 +686,6 @@ class TestTEMPLATES:
         foo.fnc = ns.bar
         foo.fnc       # <- this access used to fail
 
-    @mark.xfail()
     def test26_partial_templates(self):
         """Deduction of types with partial templates"""
 
@@ -809,7 +804,7 @@ class TestTEMPLATES:
         assert ns.FS('i', ns.ST.I32,    ns.FS.EQ,   10)
         assert ns.FS('i', ns.ST.TI.I32, ns.FS.R.EQ, 10)
 
-    @mark.skip()
+    @mark.xfail(run=False, reason="error code: Subprocess aborted")
     def test29_function_ptr_as_template_arg(self):
         """Function pointers as template arguments"""
 
@@ -921,7 +916,7 @@ class TestTEMPLATES:
 
         ns.Templated()       # used to crash
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test31_ltlt_in_template_name(self):
         """Verify lookup of template names with << in the name"""
 
@@ -987,7 +982,7 @@ class TestTEMPLATES:
         assert len(cppyy.gbl.gLutData6) == (1<<3)+1
         assert len(cppyy.gbl.gLutData8) == 14<<2
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test32_template_of_function_with_templated_args(self):
         """Lookup of templates of function with templated args used to fail"""
 
@@ -1129,7 +1124,6 @@ class TestTEMPLATES:
                         run_n = getattr(cppyy.gbl, 'TNaRun_%d' % n)
                         getattr(run_n, t)
 
-    @mark.xfail(run = False, reason = "This test crashes sporadically")
     def test33_using_template_argument(self):
         """`using` type as template argument"""
 
@@ -1159,7 +1153,7 @@ class TestTEMPLATES:
         assert ns.testptr
         assert cppyy.gbl.std.vector[ns.testptr]
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test34_cstring_template_argument(self):
         """`const char*` use over std::string"""
 
@@ -1256,7 +1250,7 @@ class TestTEMPLATED_TYPEDEFS:
         assert tct['long double', dum, 4] is tct[in_type, dum, 4]
         assert tct['double', dum, 4] is not tct[in_type, dum, 4]
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test04_type_deduction(self):
         """Usage of type reducer"""
 
@@ -1272,7 +1266,7 @@ class TestTEMPLATED_TYPEDEFS:
         three = w.whatis(3)
         assert three == 3
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test05_type_deduction_and_extern(self):
         """Usage of type reducer with extern template"""
 
@@ -1335,7 +1329,7 @@ class TestTEMPLATE_TYPE_REDUCTION:
         import cppyy
         cls.templates = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail()
+    @mark.xfail(strict=True)
     def test01_reduce_binary(self):
         """Squash template expressions for binary operations (like in gmpxx)"""
 
@@ -1386,4 +1380,4 @@ class TestTEMPLATED_CALLBACK:
 
 
 if __name__ == "__main__":
-    exit(pytest.main(args=['-sv', '-ra', __file__]))
+    exit(pytest.main(args=['-v', '-ra', __file__]))


### PR DESCRIPTION
All xfail'ed cppyy tests have been reviewed, and the ones that are
actually failing are now marked as `xfail(strict=True)`, so the test
fails if it unexpectedly passes.

This gives us a very useful baseline for what works now in ROOT and what
doesn't, and we'll learn when our developments like the cppyy upgrade on
the CppInterOp-based version will fix some tests.

There are some tests remaining that can't be run because they crash, and
therefore the `strict` mode doesn't make sense there. But the number of
these tests is not high, and now we always give a reason for why they
crash:

```txt
git grep xfail | grep -v "strict"
```
```txt
test_concurrent.py:    @mark.xfail(run=False, reason="Crashes because TClingCallFunc generates wrong code")
test_concurrent.py:    @mark.xfail(run=False, reason="Crashes because the interpreter emits too many warnings")
test_concurrent.py:    @mark.xfail(run=False, reason="segmentation violation")
test_cpp11features.py:    @mark.xfail(run=False, reason = "Crashes")
test_datatypes.py:    @mark.xfail(run=False, reason="segmentation violation")
test_datatypes.py:    @mark.xfail(run=False, reason="error code: Subprocess aborted")
test_doc_features.py:    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason = "Crashes on Windows 64 bit")
test_fragile.py:    @mark.xfail(run=False, condition=has_asserts(),
test_fragile.py:    @mark.xfail(run=False, reason="Fatal Python error: Aborted")
test_fragile.py:    @mark.xfail(run=False, reason="Fatal Python error: Aborted")
test_fragile.py:    @mark.xfail(run=False, condition=is_modules_off(), reason="Crashes on build with modules off: Fatal Python error: Segmentation fault")
test_lowlevel.py:    @mark.xfail(run=False, condition=IS_WINDOWS, reason="Windows fatal exception: access violation")
test_regression.py:    @mark.xfail(run=WINDOWS_BITS != 64, condition=IS_MAC_ARM | WINDOWS_BITS == 64, reason = "Crashes on Windows 64 bit and fails macOS ARM with" \
test_stltypes.py:    @mark.xfail(run=False, reason="Fatal Python error: Segmentation fault")
test_stltypes.py:    @mark.xfail(run=False, condition=WINDOWS_BITS == 64, reason="Crashes on Windows 64 bit")
test_templates.py:    @mark.xfail(run=False, reason="error code: Subprocess aborted")
```

A future development could be to ensure in Cling or cppyy that these
tests at least don't crash but fail gracefully, but that's better to be
done after the cppyy upgrade because some tests might be fixed anyway.

Some tests remain skipped for good reasons:
```txt
git grep "mark\.skip"
```
```txt
test_boost.py:@mark.skipif(noboost == True, reason="boost not found")
test_boost.py:@mark.skipif(noboost == True, reason="boost not found")
test_boost.py:@mark.skipif(noboost == True, reason="boost not found")
test_boost.py:@mark.skipif(noboost == True, reason="boost not found")
test_boost.py:    @mark.skipif(noboost, reason="boost not found")
test_eigen.py:@mark.skipif(eigen_path is None, reason="Eigen not found")
test_eigen.py:@mark.skipif(eigen_path is None, reason="Eigen not found")
test_fragile.py:    @mark.skip(reason="This test is very verbose since it sets gDebug to True")
test_fragile.py:    @mark.skip(reason="Not actually a cppyy test")
test_fragile.py:    @mark.skipif(not has_cpp_20(), reason="std::span requires C++20")
test_leakcheck.py:@mark.skipif(nopsutil == True, reason="module psutil not installed")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_leakcheck.py:    @mark.skip(reason="disabled due to its sporadic nature, especially fragile on VMs")
test_numba.py:@mark.skipif(has_numba == False, reason="numba not found")
test_numba.py:    @mark.skip(reason="Numba tests comparing execution times are sensitive and fail sporadically")
test_numba.py:    @mark.skip(reason="Numba tests comparing execution times are sensitive and fail sporadically.")
test_numba.py:    @mark.skip(reason="Numba tests comparing execution times are sensitive and fail sporadically.")
test_numba.py:    @mark.skip(reason="Numba tests comparing execution times are sensitive and fail sporadically.")
test_numba.py:@mark.skipif(has_numba == False, reason="numba not found")
test_eigen.py:    @mark.skipif(eigen_path is None, reason="Eigen not found")
test_pythonify.py:    @mark.skip(reason="Garbage collection tests are fragile")
test_regression.py:    @mark.skip(reason="For ROOT, we don't enable AVX by default ('-mavx' is not passed to Cling)")
test_stltypes.py:@mark.skipif(not has_cpp_20(), reason="std::span requires C++20")
```

Sorry that these `git grep` commands don't show the names of the tests!
They are to illustrate how many tests are still marked as `skip`/`xfail`
without `strict=True`.

Closes https://github.com/root-project/root/issues/20085.