### PR TITLE
[hist] prevent misalignment between contour levels and LIST of contours

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -6214,9 +6214,10 @@ void THistPainter::PaintContour(Option_t *option)
    fH->SetFillStyle(1001);
    for (k=0;k<ncontour;k++) {
       ipoly = polysort[k];
-      if (np[ipoly] == 0) continue;
       if (Hoption.List) list = (TList*)contours->At(contListNb);
       contListNb++;
+      if (np[ipoly] == 0)
+         continue;
       Double_t *xx = polys[ipoly]->GetX();
       Double_t *yy = polys[ipoly]->GetY();
       istart = 0;


### PR DESCRIPTION
Even if at that index there is no contour line.

Fixes https://github.com/root-project/root/issues/20860

Otherwise, in that issue we get
contour level 0 --> contour line corresponding to contour level 1
contour level 1 --> empty

whereas with this fix we will get:
contour level 0 --> empty
contour level 1 --> contour line corresponding to contour level 1

Instead of https://github.com/root-project/root/pull/20863

This was verified using [testContours.txt](https://github.com/user-attachments/files/24669313/testContours.txt)

```
Found 2 contour levels.
Contour with index 0 and level -0.966667 has no graph (no contour line since on the left we do not know if there is a transition to another level or if it continues at that level, on more negative x, so that would be misleading).
Contour with index 1 and level 0 (covering area until 0.966667) has 1 graphs with 30 points.
```

Related PR: https://github.com/root-project/root/pull/20911