### PR TITLE
[skip-ci] clarify how contour lines will be created

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -8536,7 +8536,11 @@ void TH1::SetBuffer(Int_t bufsize, Option_t * /*option*/)
 /// By default the number of contour levels is set to 20. The contours values
 /// in the array "levels" should be specified in increasing order.
 ///
-/// if argument levels = 0 or missing, equidistant contours are computed
+/// if argument levels = 0 or missing, `nlevels` equidistant contours are computed
+/// between `zmin` and `zmax - dz`, both included, with step
+/// `dz = (zmax - zmin)/nlevels`. Note that contour lines are not centered, but
+/// contour surfaces (when drawing with `COLZ`) will be, since contour color `i` covers
+/// the region of values between contour line `i` and `i+1`.
 
 void TH1::SetContour(Int_t  nlevels, const Double_t *levels)
 {


### PR DESCRIPTION
contour line is at low-edge of contour color region.

verified that the red line is the contour line of the yellow region.

<img width="700" height="500" alt="c" src="https://github.com/user-attachments/assets/f3093355-3aa2-4739-8c5a-7207f634649d" />

using the reproducer of https://github.com/root-project/root/pull/20910#issue-3821197454