### PR TITLE
[roottest] Move hist ownership test from diffs to programmatic test.

### DIFF
--- a/roottest/root/hist/misc/CMakeLists.txt
+++ b/roottest/root/hist/misc/CMakeLists.txt
@@ -1,6 +1,4 @@
-ROOTTEST_ADD_TEST(runownership
-                  MACRO runownership.C+
-                  OUTREF ownership.ref)
+ROOTTEST_ADD_TEST(runownership MACRO runownership.C+)
 
 ROOTTEST_ADD_TEST(testSparse
                   MACRO testSparse.cxx

--- a/roottest/root/hist/misc/ownership.ref
+++ b/roottest/root/hist/misc/ownership.ref
@@ -1,5 +1,0 @@
-
-Processing runownership.C+...
-So far: 0
-So far: 0
-(int)0

--- a/roottest/root/hist/misc/runownership.C
+++ b/roottest/root/hist/misc/runownership.C
@@ -54,9 +54,15 @@ bool read(const char *filename = "histo.root")
 
 int runownership(const char *filename = "histo.root")
 {
+   bool failure = false;
    write(filename);
-   cout << "So far: " << TH1F_inst::fgCount << '\n';
+   failure |= TH1F_inst::fgCount;
+   if (failure)
+      std::cerr << "After write, instance count was " << TH1F_inst::fgCount << "\n";
    read(filename);
-   cout << "So far: " << TH1F_inst::fgCount << '\n';
-   return 0;
+   failure |= TH1F_inst::fgCount;
+   if (failure)
+      std::cerr << "After read, instance count was " << TH1F_inst::fgCount << "\n";
+
+   return failure;
 }


### PR DESCRIPTION
Diffs of the outputs are fragile, so the ownership of histograms is now tested programmatically.