### PR TITLE
[PyROOT] Remove a test that worked just by chance.

### DIFF
--- a/roottest/python/memory/PyROOT_memorytests.py
+++ b/roottest/python/memory/PyROOT_memorytests.py
@@ -60,21 +60,6 @@ class Memory1TestCase( MyTestCase ):
       del b, c
       self.assertEqual( MemTester.counter, 0 )
 
-   def test2ObjectDestructionCallback( self ):
-      """Test ROOT notification on object destruction"""
-
-    # create ROOT traced object
-      a = TH1F( 'memtest_th1f', 'title', 100, -1., 1. )
-
-    # locate it
-      self.assertTrue( a is gROOT.FindObject( 'memtest_th1f' ) )
-
-    # destroy it
-      del a
-
-    # should no longer be accessible
-      self.assertTrue( not gROOT.FindObject( 'memtest_th1f' ) )
-
    def test3ObjectCallHeuristics( self ):
       """Test memory mgmt heuristics for object calls"""
 
@@ -139,7 +124,7 @@ class Memory1TestCase( MyTestCase ):
       """Derived classes should call base dtor automatically"""
 
       MemTester = ROOT.MemTester
-      
+
       class D1( MemTester ):
          def __init__( self ):
             MemTester.__init__( self )


### PR DESCRIPTION
The test broke when implicit object ownership was switched off in ROOT. However, this test can also break in other circumstances, because
   del histogram
generally does not destroy the C++ object immediately. It used to work because only a single reference to the object was alive (which changed when trying to prepare the test for implicit object ownership off), but one cannot base a test on undocumented details of a Python implementation.

For this reason, it does not make sense to test if gDirectory (C++) contains an entry for the object that was just "del"-ed.