### PR TITLE
[core] Use shared library dir as anchor in `GetIncludeDir()`

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -233,15 +233,19 @@ set(full_core_filename $<TARGET_FILE_NAME:Core>)
 # Absolue CMAKE_INSTALL_<dir> paths are discouraged in CMake, but some
 # packagers use them anyway. So we support it.
 if(IS_ABSOLUTE ${CMAKE_INSTALL_INCLUDEDIR})
-   set(install_includedir_is_absolute 1)
+  set(install_lib_to_include "${CMAKE_INSTALL_INCLUDEDIR}")
 else()
-   set(install_includedir_is_absolute 0)
+  if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+    set(libdir "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    set(libdir "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  endif()
+  file(RELATIVE_PATH install_lib_to_include "${libdir}" "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
+  unset(libdir)
 endif()
-file(TO_NATIVE_PATH "${CMAKE_INSTALL_INCLUDEDIR}" install_includedir_native)
 
 target_compile_options(Core PRIVATE -DLIB_CORE_NAME=${full_core_filename}
-                                    -DINSTALL_INCLUDEDIR=${install_includedir_native}
-                                    -DINSTALL_INCLUDEDIR_IS_ABSOLUTE=${install_includedir_is_absolute}
+                                    -DINSTALL_LIB_TO_INCLUDE="${install_lib_to_include}"
 )
 add_dependencies(Core ensure_build_tree_marker)
 

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -20,6 +20,7 @@ if(ROOT_NEED_STDCXXFS)
     target_link_libraries(CoreBaseTests PRIVATE stdc++fs)
 endif()
 target_compile_options(CoreBaseTests PRIVATE -DEXPECTED_SHARED_LIBRARY_DIR="${localruntimedir}")
+target_compile_options(CoreBaseTests PRIVATE -DEXPECTED_INCLUDE_DIR="${CMAKE_BINARY_DIR}/include")
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)
 

--- a/core/base/test/TROOTTests.cxx
+++ b/core/base/test/TROOTTests.cxx
@@ -41,3 +41,13 @@ TEST(TROOT, GetSharedLibDir)
 
    EXPECT_EQ(libDir, libDirRef);
 }
+
+TEST(TROOT, GetIncludeDir)
+{
+   namespace fs = std::filesystem;
+
+   fs::path includeDir = gROOT->GetIncludeDir().Data();
+   fs::path includeDirRef = EXPECTED_INCLUDE_DIR;
+
+   EXPECT_EQ(includeDir, includeDirRef);
+}


### PR DESCRIPTION
Using the shared library directory as the anchor to resolve the resource directories like `GetIncludeDir()` is more direct and robust than using `GetRootSys()`, which loses its meaning in some installations (e.g. what should it be when ROOT is installed by the package manager? Just `/`?).

Most importantly, this change lifts some more constraint from how the install tree can be reorganized after the fact. One can for example move the include and library directory around as wanted, as long as their relative paths don't change. This fixes the Python wheels, which were broken by commit a5b1ed9080aca63347d3156540864f774ac49d4d.

As of commit a5b1ed9080aca63347d3156540864f774ac49d4d, ROOT became smarter about finding the include path in the install tree, inferring the correct relative path from $ROOTSYS and the CMAKE_INSTALL_INCLUDEDIR variable at build time. Before, that only happened for gnuinstall=ON, but now it always happens.

However, for the Python wheel, we are breaking the assumptions that ROOT makes by moving around directories in the install tree. This commit fixes that situation.


I tested this with three build configurations:
  * no `CMAKE_INSTALL_INCLUDEDIR` set
  * `CMAKE_INSTALL_INCLUDEDIR` relative path
  * `CMAKE_INSTALL_INCLUDEDIR` absolute path

In all cases, `gROOT->GetIncludeDir()` returns the correct path, both via the `root` executable in the build and install tree.