### PR TITLE
[v636][CPyCppyy] Work around non-instantiable `std::span` iterators in GCC 15

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -2121,3 +2121,31 @@ class TestSTLEXCEPTION:
 
         gc.collect()
         assert cppyy.gbl.GetMyErrorCount() == 0
+
+
+def has_cpp_20():
+    import cppyy
+
+    return cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") >= 202002
+
+
+@mark.skipif(not has_cpp_20(), reason="std::span requires C++20")
+class TestSTLSPAN:
+    import cppyy
+
+    def test01_span_iterators(self):
+        """
+        Test that std::span::begin() and std::span::end() can be used.
+
+        Covers https://github.com/root-project/root/issues/18837
+        """
+        import cppyy
+
+        l1 = [1, 2, 3]
+        v = cppyy.gbl.vector(int)(l1)
+        s = cppyy.gbl.span(int)(v)
+        s.begin()
+        s.end()
+        # Check that the iteration also works, which uses begin() and end()
+        # internally.
+        assert [b for b in s] == l1


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/20891 as requested by @sponce