### PR TITLE
[CPyCppyy] Fix `std::wstring` Pythonization

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -2083,7 +2083,14 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
         Utility::AddToClass(pyclass, "__str__",   (PyCFunction)STLViewStringStr,        METH_NOARGS);
     }
 
-    else if (name == "basic_string<wchar_t,char_traits<wchar_t>,allocator<wchar_t> >" || name == "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >") {
+// The first condition was already present in upstream CPyCppyy. The other two
+// are special to ROOT, because its reflection layer gives us the types without
+// the "std::" namespace. On some platforms, that applies only to the template
+// arguments, and on others also to the "basic_string".
+    else if (name == "std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t> >"
+          || name == "basic_string<wchar_t,char_traits<wchar_t>,allocator<wchar_t> >"
+          || name == "std::basic_string<wchar_t,char_traits<wchar_t>,allocator<wchar_t> >"
+    ) {
         Utility::AddToClass(pyclass, "__repr__",  (PyCFunction)STLWStringRepr,       METH_NOARGS);
         Utility::AddToClass(pyclass, "__str__",   (PyCFunction)STLWStringStr,        METH_NOARGS);
         Utility::AddToClass(pyclass, "__bytes__", (PyCFunction)STLWStringBytes,      METH_NOARGS);

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -899,7 +899,6 @@ class TestSTLSTRING:
 
             raises(TypeError, c.get_string2, "temp string")
 
-    @mark.xfail()
     def test02_string_data_access(self):
         """Test access to std::string object data members"""
 


### PR DESCRIPTION
Follows up on 760b6cc5c7c5, where not all possible type names were used to match `std::wstring`. Somtimes, the initial `basic_string` part is still prefixed with `std::`.

This enables the `test02_string_data_access` unit test in `test_stltypes` from the cppyy test suite on all platforms.