### PR TITLE
[CMake] Schedule `rpath` build option for removal

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -35,6 +35,7 @@ The following people have contributed to this new version:
 
 * The headers in `RooStats/HistFactory` for data classes related to the measurement definition were merged into the `RooStats/HistFactory/Measurement.h` header to simplify usage and development. For now, the whole set of header files is kept for backwards compatibility, but the empty headers will be removed in ROOT 7.
 * The `TROOT::GetSourceDir()` method is deprecated and will be removed in ROOT 6.42. It stopped making sense because the ROOT source is generally not shipped alongside ROOT in the `src/` subdirectory anymore.
+* Using the `rpath` build option - deprecated and without effect since ROOT 6.38 - is now scheduled to give configuration errors starting from ROOT 6.42.
 
 ## Removals
 

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -404,6 +404,7 @@ if(DEFINED rpath)
   message(DEPRECATION ">>> Option 'rpath' is deprecated and without effect."
       " Relative RPATHs to the main ROOT libraries are unconditionally appended to all ROOT"
       " executables and libraries."
+      " Using this option will result in configuration errors in ROOT 6.42."
       "") # empty line at the end to make the deprecation message more visible
 endif()
 


### PR DESCRIPTION
I realized that in commit 26d24de5db6078427697, I didn't properly set a target release for removing the `rpath` option.