### PR TITLE
[CMake] Remove unused `GLIBCXX_USE_CXX11_ABI` compiler check

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -267,15 +267,3 @@ endif()
 if(gnuinstall)
   set(R__HAVE_CONFIG 1)
 endif()
-
-#---Check if we use the new libstdc++ CXX11 ABI-----------------------------------------------------
-# Necessary to compile check_cxx_source_compiles this early
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(
-"
-#include <string>
-#if _GLIBCXX_USE_CXX11_ABI == 0
-  #error NOCXX11
-#endif
-int main() {}
-" GLIBCXX_USE_CXX11_ABI)


### PR DESCRIPTION
Remove a compiler check introduced in commit 07d6afd7e013a that was only used for the removed `sql/oracle` feature.