### PR TITLE
[v632][ci] Add Ubuntu 26.04

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/ubuntu2604.txt
+++ b/.github/workflows/root-ci-config/buildconfig/ubuntu2604.txt
@@ -1,0 +1,5 @@
+mysql=OFF
+pyroot=OFF
+pythia8=OFF
+tmva-cpu=OFF
+unuran=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -248,6 +248,7 @@ jobs:
             overrides: ["imt=Off", "LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
           - image: ubuntu2404
             overrides: ["LLVM_ENABLE_ASSERTIONS=On", "CMAKE_BUILD_TYPE=Debug"]
+          - image: ubuntu2604
     runs-on:
       - self-hosted
       - linux


### PR DESCRIPTION
To validate the older ROOT releases on the upcoming Ubuntu LTS.