### PR TITLE
[CMake] Make `hsimple.root` generation less verbose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,12 +584,16 @@ ROOT_ADD_TEST_SUBDIRECTORY(tutorials)
 add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
 add_dependencies(hsimple onepcm)
 add_custom_command(OUTPUT tutorials/hsimple.root
+                   VERBATIM
                    COMMAND
                      ${CMAKE_COMMAND} -E env
                      ROOT_INCLUDE_PATH=${DEFAULT_ROOT_INCLUDE_PATH}
                      ROOTIGNOREPREFIX=1
                      ROOT_HIST=0
-                     $<TARGET_FILE:root.exe> -l -q -b -n -x ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C -e return
+                     $<TARGET_FILE:root.exe> -l -q -b -n
+                       -e ".L ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C"
+                       -e "hsimple();"
+                       -e return
                    WORKING_DIRECTORY tutorials
                    DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts)
 install(FILES ${CMAKE_BINARY_DIR}/tutorials/hsimple.root DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)


### PR DESCRIPTION
Generating `hsimple.root` is a bit verbose for my taste, because it is
the only target that actually has some output beyond `make`/`ninja`
printouts. We don't need a "Processing ..." printout for something that
takes 0.04 seconds, and also not the random address of the TFile.

Before:
```txt
[3/4] Generating tutorials/hsimple.root

Processing /home/rembserj/code/root/root_src/tutorials/hsimple.C...
hsimple   : Real Time =   0.05 seconds Cpu Time =   0.04 seconds
(TFile *) 0x5653caeaf2e0
```

After:
```
[4/5] Generating tutorials/hsimple.root

hsimple   : Real Time =   0.05 seconds Cpu Time =   0.04 seconds
```

There is still this benchmark output and a line break, which we can
maybe get rid of in the future another way.