### PR TITLE
[CMake] Fix problems in handling Python code in cppyy and ROOT

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/cppyy/CMakeLists.txt
@@ -19,19 +19,60 @@ set(py_sources
   cppyy/types.py
 )
 
-set(cppyyPySrcDir python/cppyy)
-file(COPY ${cppyyPySrcDir} DESTINATION ${localruntimedir})
+# Ensure output directory exists
+file(MAKE_DIRECTORY ${localruntimedir}/cppyy)
+
+set(cppyy_copy_commands)
+set(cppyy_py_sources_in_source_dir)
+set(cppyy_py_sources_in_localruntimedir)
+
+foreach(py_source ${py_sources})
+  list(APPEND cppyy_copy_commands
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different
+               ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source}
+               ${localruntimedir}/${py_source})
+
+  list(APPEND cppyy_py_sources_in_source_dir
+       ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source})
+
+  list(APPEND cppyy_py_sources_in_localruntimedir
+       ${localruntimedir}/${py_source})
+endforeach()
+
+add_custom_command(
+  OUTPUT ${cppyy_py_sources_in_localruntimedir}
+  ${cppyy_copy_commands}
+  DEPENDS ${cppyy_py_sources_in_source_dir}
+  COMMENT "Copying cppyy Python sources"
+)
+
+add_custom_target(cppyyPySources ALL DEPENDS ${cppyy_py_sources_in_localruntimedir})
 
 # Compile .py files
-foreach(py_source ${py_sources})
-  install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -m py_compile ${localruntimedir}/${py_source})")
-  install(CODE "execute_process(COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${localruntimedir}/${py_source})")
-endforeach()
+
+# Stamp file so CMake knows it doesn't need to re-compile. We can't set the
+# actual bytecode files as the OUTPUT of the custom command, because their
+# names are CPython implementation dependent and therefore not reliable.
+set(cppyy_bytecode_stamp ${localruntimedir}/cppyy/bytecode.stamp)
+
+# It's 10x faster to compile all in one go than in single invocations
+add_custom_command(
+  OUTPUT ${cppyy_bytecode_stamp}
+  COMMAND ${Python3_EXECUTABLE} -m py_compile ${cppyy_py_sources_in_localruntimedir}
+  COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${cppyy_py_sources_in_localruntimedir}
+  COMMAND ${CMAKE_COMMAND} -E touch ${cppyy_bytecode_stamp}
+  DEPENDS ${cppyy_py_sources_in_localruntimedir}
+  COMMENT "Compiling cppyy Python sources"
+)
+
+add_custom_target(cppyyPyBytecode ALL DEPENDS ${cppyy_bytecode_stamp})
+add_dependencies(cppyyPyBytecode cppyyPySources)
 
 # Install Python sources and bytecode
 install(DIRECTORY ${localruntimedir}/cppyy
         DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
         COMPONENT libraries
+        PATTERN *.stamp EXCLUDE
         PATTERN *.so EXCLUDE)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -149,16 +149,32 @@ set(cpp_sources
 set(ROOTPySrcDir python/ROOT)
 set(ROOT_headers_dir inc)
 
-# Add custom rules to copy the Python sources into the build directory
+# Ensure output directory exists
+file(MAKE_DIRECTORY ${localruntimedir}/ROOT)
+
+set(root_copy_commands)
+set(py_sources_in_source_dir)
+set(py_sources_in_localruntimedir)
+
 foreach(py_source ${py_sources})
-  add_custom_command(
-      OUTPUT ${localruntimedir}/${py_source}
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source}
-                                       ${localruntimedir}/${py_source}
-      DEPENDS python/${py_source}
-      COMMENT "Copying ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source}")
-  list(APPEND py_sources_in_localruntimedir ${localruntimedir}/${py_source})
+  list(APPEND root_copy_commands
+       COMMAND ${CMAKE_COMMAND} -E copy_if_different
+               ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source}
+               ${localruntimedir}/${py_source})
+
+  list(APPEND py_sources_in_source_dir
+       ${CMAKE_CURRENT_SOURCE_DIR}/python/${py_source})
+
+  list(APPEND py_sources_in_localruntimedir
+       ${localruntimedir}/${py_source})
 endforeach()
+
+add_custom_command(
+  OUTPUT ${py_sources_in_localruntimedir}
+  ${root_copy_commands}
+  DEPENDS ${py_sources_in_source_dir}
+  COMMENT "Copying ROOT Pythonization Python sources"
+)
 
 # A custom target that depends on the Python sources being present in the build
 # directory. This will be used as a dependency of the pythonization libraries,
@@ -198,13 +214,25 @@ endif()
 
 
 # Compile .py files
-foreach(py_source ${py_sources})
-  add_custom_command(TARGET ${libname}
-                      POST_BUILD
-                      COMMAND ${Python3_EXECUTABLE} -m py_compile ${localruntimedir}/${py_source}
-                      COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${localruntimedir}/${py_source}
-                      COMMENT "Compiling PyROOT source ${py_source} for Python ${Python3_VERSION}")
-endforeach()
+
+# Stamp file so CMake knows it doesn't need to re-compile. We can't set the
+# actual bytecode files as the OUTPUT of the custom command, because their
+# names are CPython implementation dependent and therefore not reliable.
+set(root_bytecode_stamp ${localruntimedir}/ROOT/bytecode.stamp)
+
+# It's 10x faster to compile all in one go than in single invocations
+add_custom_command(
+  OUTPUT ${root_bytecode_stamp}
+  COMMAND ${Python3_EXECUTABLE} -m py_compile ${py_sources_in_localruntimedir}
+  COMMAND ${Python3_EXECUTABLE} -O -m py_compile ${py_sources_in_localruntimedir}
+  COMMAND ${CMAKE_COMMAND} -E touch ${root_bytecode_stamp}
+  DEPENDS ${py_sources_in_localruntimedir}
+  COMMENT "Compiling ROOT Pythonization Python sources"
+)
+
+add_custom_target(ROOTPythonizationsPyBytecode ALL DEPENDS ${root_bytecode_stamp})
+add_dependencies(ROOTPythonizationsPyBytecode ROOTPythonizationsPySources)
+
 
 # Create meta-target PyROOT3 (INTERFACE library)
 # Export of targets are not supported for custom targets(add_custom_targets())
@@ -244,6 +272,7 @@ install(TARGETS ${libname} EXPORT ${CMAKE_PROJECT_NAME}Exports
 install(DIRECTORY ${localruntimedir}/ROOT
         DESTINATION ${CMAKE_INSTALL_PYTHONDIR}
         COMPONENT libraries
+        PATTERN *.stamp EXCLUDE
         PATTERN *.so EXCLUDE)
 
 # Install headers required by pythonizations


### PR DESCRIPTION
The CMake code for managing the ROOT Pythonization Python sources had many flaws:

  1. Overly verbose, because every Python source file had its own copy target

  2. Lots of time wasted in starting up the Python interpreter for compiling Python sources to byte code. It is several seconds faster to call `python -m py_compile` once, with all the sources passed as arguments. Fixing this makes the build step when changing only Python sources feel instant again.

  3. Wrong dependency graph (introduced with commit b824594), because the Python sources were compiled to byte code as a POST_BUILD step for the CPython extension library, which is not strictly related. As a result, the Python code was not re-compiled when *only* Python sources were updated, and unnecessarily re-compiled when the CPython extension was changed.

The `cppyy` package also has the first two problems, but instead of the third problem with the wrong dependency graph, it didn't have targets for copying and compiling the Python sources at all. It used `copy(FILE ..)` and `install(CODE ..)` to do the copying and configuration time and the compiling at install time, which makes incremental builds mute and developing the `cppyy` Python package without manual copying impossible.

This commit re-implements the handling of the Python code in CMake for these two Python packages to solve all of these problems.

As a result, things are now clean, correct, and fast. To illustrate, here is the Ninja output for building `bindings/pyroot/cppyy` and `bindings/pyroot/pythonizations`:

```txt
[3/9] Copying cppyy Python sources
[4/9] Linking CXX shared library lib/cppyy/libcppyy.so
[5/9] Compiling cppyy Python sources
[6/9] Copying ROOT Pythonization Python sources
[7/9] Compiling ROOT Pythonization Python sources
[8/9] Linking CXX shared library lib/ROOT/libROOTPythonizations.so
```

The C++ translation units are missing, because they were c-cached in that case.

As a followup, one might consider writing CMake functions in `RootMacros.cmake` to avoid code repetition and then also use it for JupyROOT and DistRDF, which have similar problems. But I thought that was a too big of a change to do and review at once. My suggestion would be to first establish the new pattern in cppyy and ROOTPythonizations, and then abstract and expand from there.