### PR TITLE
[cppyy] Remove xfail condition for test_fragile:test01_abortive_signals

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -753,7 +753,11 @@ class TestSIGNALS:
         import cppyy
         cls.fragile = cppyy.load_reflection_info(cls.test_dct)
 
-    @mark.xfail(run=False, condition=is_modules_off(), reason="Crashes on build with modules off: Fatal Python error: Segmentation fault")
+    # This test has unclear failure conditions. On the ROOT CI PR builds if
+    # passes, but it fails in the nightlies with:
+    # "Failed: DID NOT RAISE <class 'cppyy.ll.AbortSignal'>"
+    # We can therefore not use strict=True and a meaningful failure condition.
+    @mark.xfail()
     def test01_abortive_signals(self):
         """Conversion from abortive signals to Python exceptions"""
 


### PR DESCRIPTION
This reverts a change made in commit 50ae29d4343, where an xfail condition was added to a tests that was not correct.

This test has unclear failure conditions. On the ROOT CI PR builds if passes, but it fails in the nightlies with:
"Failed: DID NOT RAISE <class 'cppyy.ll.AbortSignal'>"

I thought the difference might be the presence of `asserts=ON` in the CI builds, but also locally the tests pass for me with `asserts=OFF`. So I can't identify what is different in the nightlies that makes this test fail.

We can therefore not use strict=True and a meaningful failure condition.