### PR TITLE
[CI] Limit concurrency of build cache update jobs (MacOS only for now)

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -97,6 +97,13 @@ jobs:
     permissions:
       contents: read
 
+    concurrency:
+      # We need only one build cache update to run after merges to master
+      # The group name expands to something like
+      # "ROOT CI-20964/merge-mac26-21173435944", unless it's a build cache update, where it will be
+      # "ROOT CI-master     -mac26-update_build_cache", so only one of these jobs will run
+      group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.platform }}-${{ github.event_name == 'push' && 'update_build_cache' || github.run_id }}
+
     defaults:
       run:
         shell: bash -leo pipefail {0} # Use login shell, so profile scripts get sourced


### PR DESCRIPTION
If several merges are happening in close succession, the same number of build-cache update jobs will run (in parallel).
Here, the update jobs for macOS are assigned to a concurrency group. This ensures that only one job runs, and only one job is pending. The pending job always gets replaced with the latest version when a merge happens. For now, this is only in effect when the workflow is triggered by a push.

Explanation:
Jobs that are triggered on "push" will get assigned a concurrency group called something like
`ROOT CI-master-mac26-update_build_cache` because event_name is "push". For other jobs, it'
`ROOT CI-20964/merge-mac26-21173435944` or similar, so they don't interfere with each other.

This means that the number of jobs after pushes will be limited to one running and one pending. A similar thing could be done for workflows triggered manually or other platforms if desired.