### PR TITLE
[CI] Limit concurrency of build cache update jobs.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -83,6 +83,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+
+    env:
+      group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.platform }}-${{ github.event_name == 'push' || github.run_id }}
+
+    steps:
+      - name: Print
+        run: echo "Concurrency group is ${group}"
+
   build-macos:
     # For any event that is not a PR, the CI will always run. In PRs, the CI
     # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
@@ -98,7 +108,7 @@ jobs:
       contents: read
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event_name == 'push' || github.run_id }}
+      group: ${{ github.workflow }}-${{ github.ref_name }}-${{ matrix.platform }}-${{ github.event_name == 'push' || github.run_id }}
 
     defaults:
       run:


### PR DESCRIPTION
If several merges are happening in close succession, the same number of build-cache update jobs will run (in parallel).
Here, the update jobs for macOS are assigned to a concurrency group. This ensures that only one job runs, and only one job is pending. The pending job always gets replaced with the latest version when a merge happens. For now, this is only in effect when the workflow is triggered by a push.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

