### PR TITLE
[CPyCppyy] Correctly propagate template argument name errors

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -173,6 +173,13 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
 
         Py_DECREF(pyargs);
         Py_DECREF(tpArgs);
+
+    // Propagate the error that occurs if we can't construct the C++ name
+    // from the provided template argument
+        if (PyErr_Occurred()) {
+            return nullptr;
+        }
+
         if (name_v1.size())
             proto = name_v1.substr(1, name_v1.size()-2);
     }
@@ -720,6 +727,11 @@ static PyObject* tpp_subscript(TemplateProxy* pytmpl, PyObject* args)
     Py_XDECREF(typeBoundMethod->fTemplateArgs);
     typeBoundMethod->fTemplateArgs = CPyCppyy_PyText_FromString(
         Utility::ConstructTemplateArgs(nullptr, args).c_str());
+// Propagate the error that occurs if we can't construct the C++ name
+// from the provided template argument
+    if (PyErr_Occurred()) {
+        return nullptr;
+    }
     return (PyObject*)typeBoundMethod;
 }
 
@@ -815,6 +827,11 @@ static PyObject* tpp_overload(TemplateProxy* pytmpl, PyObject* args)
         if (ol) return ol;
 
         proto = Utility::ConstructTemplateArgs(nullptr, args);
+    // Propagate the error that occurs if we can't construct the C++ name
+    // from the provided template argument
+        if (PyErr_Occurred()) {
+            return nullptr;
+        }
 
         scope = ((CPPClass*)pytmpl->fTI->fPyClass)->fCppType;
         cppmeth = Cppyy::GetMethodTemplate(

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1177,6 +1177,22 @@ class TestTEMPLATES:
         assert ns.stringify["const char*"]("Aap")                    == "Aap "
         assert ns.stringify(ctypes.c_char_p(bytes("Noot", "ascii"))) == "Noot "
 
+    def test35_no_possible_cpp_name(self):
+        """Verify that we get a meaningful error if the C++ name can't be
+        constructed, e.g. because one attempts to use a Python object that
+        doens't map to a C++ type.
+        """
+
+        import cppyy
+
+        cppyy.cppdef(r"""
+        template<class T, class Y=void>
+        void test35_func () { }
+        """)
+
+        with pytest.raises(TypeError, match=r"could not construct C\+\+ name"):
+            cppyy.gbl.test35_func[set(), list()]()
+
 
 class TestTEMPLATED_TYPEDEFS:
     def setup_class(cls):


### PR DESCRIPTION
In case the `Utility::ConstructTemplateArgs()` method fails to create the C++ template names, it sets a useful Python exception that is unfortunately not propagated, because the calling code in `TemplateProxy.cxx` is ignoring it. This is fixed in this commit.

The place where the error is set is also moved from `Utility::ConstructTemplateArgs()` to the actual implementation: `AddTypeName()`. This means the error is set by the function that actually has the context of the error, which is conceptually cleaner and will allow us also to set more detailed errors for different failure modes of `AddTypeName()`.

Demo code:
```python
import cppyy

cppyy.cppdef("""

template<class T>
class Foo {};

template<class T, class Y=void>
auto make_foo () { return Foo<T>{}; }

template<class T, class Y=void>
auto make_foo (T x) { return Foo<T>{}; }

""")

cppyy.gbl.make_foo[set(), list()]()

```

Before:
```
    cppyy.gbl.make_foo[set(), list()]()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
TypeError: Could not find "make_foo" (set cppyy.set_debug() for C++ errors):
  Template method resolution failed:
  Failed to instantiate "make_foo()"
  Failed to instantiate "make_foo()"
```

After:
```
    cppyy.gbl.make_foo[set(), list()]()
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: could not construct C++ name from template argument set()
```

Note: this work is orthogonal to the rebase of `cppyy` on CppInterOp.