### PR TITLE
[ci] Don't override C++ standard for modules=off PR builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -403,7 +403,6 @@ jobs:
             platform_config: alma9-modules_off
             is_special: true
             property: modules_off
-            overrides: ["CMAKE_CXX_STANDARD=20"]
           - image: alma9
             platform_config: alma9-march_native
             is_special: true


### PR DESCRIPTION
Trial commit to see if we can reproduce the failures in the nightlies also in the CI.