### PR TITLE
[ci] Explicitly set Ruff version latest to avoid version warning

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Lint code
       run: |
-        files=$(cat changed_files.txt | grep '\.py$' || echo "")
+        files=$(grep '\.py$' changed_files.txt || echo "")
         if [ -n "$files" ]; then
           echo "$files" | xargs ruff check --diff || true
           echo "$files" | xargs ruff check
@@ -80,7 +80,7 @@ jobs:
     - name: Format code
       if: always()
       run: |
-        files=$(cat changed_files.txt | grep '\.py$' || echo "")
+        files=$(grep '\.py$' changed_files.txt || echo "")
         if [ -n "$files" ]; then
           diff_command=""
           apply_command=""


### PR DESCRIPTION
# This Pull request:

Explicitly sets the Ruff version in CI to avoid the warning:
`Warning: Could not parse version from …/pyproject.toml. Using latest version.`