### PR TITLE
[ci] Use C++20 also in the nightly build with `cmake_cxxmodules=OFF`

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9-modules_off.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-modules_off.txt
@@ -1,3 +1,4 @@
+CMAKE_CXX_STANDARD=20
 builtin_vdt=ON
 pythia8=ON
 runtime_cxxmodules=OFF

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -403,7 +403,6 @@ jobs:
             platform_config: alma9-modules_off
             is_special: true
             property: modules_off
-            overrides: ["CMAKE_CXX_STANDARD=20"]
           - image: alma9
             platform_config: alma9-march_native
             is_special: true


### PR DESCRIPTION
This avoids surprises where fragile test failures with C++17 and modules=OFF cannot be anticipated from the PR builds.

The test in question is in `test_datatypes.py` in the cppyy test suite:
```txt
=================================== FAILURES ===================================
____________________ TestDATATYPES.test49_addressof_method _____________________

self = <test.test_datatypes.TestDATATYPES object at 0x7fb5a77f3200>

    @mark.xfail(strict=True, condition=IS_MAC_ARM or IS_WINDOWS, reason="Crashes on mac-beta ARM64 and fails on Windows")
    def test49_addressof_method(self):
        """Use of addressof for (const) methods"""

        import cppyy

>       assert cppyy.addressof(cppyy.gbl.std.vector[int].at.__overload__(':any:', False))
E       AssertionError: assert 0
E        +  where 0 = <built-in function addressof>(<cppyy.CPPOverload object at 0x7fb5a7a62000>)
E        +    where <built-in function addressof> = <module 'cppyy' from '/github/home/ROOT-CI/build/lib/cppyy/__init__.py'>.addressof
E        +    and   <cppyy.CPPOverload object at 0x7fb5a7a62000> = <built-in method __overload__ of cppyy.CPPOverload object at 0x7fb5a7aaaa00>(':any:', False)
E        +      where <built-in method __overload__ of cppyy.CPPOverload object at 0x7fb5a7aaaa00> = <cppyy.CPPOverload object at 0x7fb5a7aaaa00>.__overload__
E        +        where <cppyy.CPPOverload object at 0x7fb5a7aaaa00> = <class cppyy.gbl.std.vector<int> at 0x5628463dfb40>.at

../../../../../../src/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py:2348: AssertionError
----------------------------- Captured stderr call -----------------------------
input_line_412:2:106: error: 'RActivePhysicalColumns' is a protected member of 'ROOT::Internal::RPageSource'
 (vector<int>::reference (std::vector<int, std::allocator<int> >::*)(vector<ROOT::Internal::RPageSource::RActivePhysicalColumns::RColumnInfo>::size_type))&std::vector<int, std::allocator<int> >::at
                                                                                                         ^
/github/home/ROOT-CI/build/include/ROOT/RPageStorage.hxx:653:10: note: declared protected here
   class RActivePhysicalColumns {
         ^
=========================== short test summary info ============================
```