### PR TITLE
Add parameter domain checks to analytical integrals

### DIFF
--- a/hist/hist/src/AnalyticalIntegrals.cxx
+++ b/hist/hist/src/AnalyticalIntegrals.cxx
@@ -59,6 +59,8 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double amp   = p[0];
       double mean  = p[1];
       double sigma = p[2];
+      if (sigma <= 0)
+   return TMath::QuietNaN();
       if (formula->TestBit(TFormula::kNormalized))
          result = amp * (ROOT::Math::gaussian_cdf(xmax, sigma, mean) - ROOT::Math::gaussian_cdf(xmin, sigma, mean));
       else
@@ -71,6 +73,8 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double amp   = p[0];
       double mean  = p[1];
       double sigma = p[2];
+      if (sigma <= 0)
+      return TMath::QuietNaN();
       //printf("computing integral for landau in [%f,%f] for m=%f s = %f \n",xmin,xmax,mean,sigma);
       if (formula->TestBit(TFormula::kNormalized) )
          result = amp*(ROOT::Math::landau_cdf(xmax,sigma,mean) - ROOT::Math::landau_cdf(xmin,sigma,mean));
@@ -84,7 +88,8 @@ Double_t AnalyticalIntegral(TF1 *f, Double_t a, Double_t b)
       double sigma = p[2];
       double alpha = p[3];
       double n     = p[4];
-
+      if (sigma <= 0 || n <= 0)
+   return TMath::QuietNaN();
       //printf("computing integral for CB in [%f,%f] for m=%f s = %f alpha = %f n = %f\n",xmin,xmax,mean,sigma,alpha,n);
       if (alpha > 0)
          result = amp*( ROOT::Math::crystalball_integral(xmin,alpha,n,sigma,mean) -  ROOT::Math::crystalball_integral(xmax,alpha,n,sigma,mean) );


### PR DESCRIPTION
Depends on #20992

Motivation:
Several analytical integrals assume valid parameter domains (e.g. sigma > 0)
without enforcing them, which may lead to undefined numerical behavior.

Changes:
- Add explicit parameter-domain checks for Gaussian, Landau, and Crystal Ball integrals
- Return QuietNaN for invalid parameter configurations

Impact:
- Improves robustness and predictability of analytical integrations
- No API changes
