### PR TITLE
[CMake] Don't set ROOTSYS in rootcling_stage1

### DIFF
--- a/core/dictgen/res/rootcling_impl.h
+++ b/core/dictgen/res/rootcling_impl.h
@@ -30,10 +30,6 @@ namespace RootCling {
       void (*fAddEnumToROOTFile)(const char *tdname) = nullptr;
       bool (*fCloseStreamerInfoROOTFile)(bool writeEmptyRootPCM) = nullptr;
    };
-
-   struct TROOTSYSSetter {
-     TROOTSYSSetter();
-   };
 } // namespace RootCling
 } // namespace Internal
 } // namespace ROOT

--- a/core/rootcling_stage1/CMakeLists.txt
+++ b/core/rootcling_stage1/CMakeLists.txt
@@ -35,6 +35,7 @@ ROOT_EXECUTABLE(rootcling_stage1 src/rootcling_stage1.cxx
                               $<TARGET_OBJECTS:Foundation_Stage1>
                               LIBRARIES ${CLING_LIBRARIES} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${ROOT_ATOMIC_LIBS}
                               NOINSTALL)
+target_compile_options(rootcling_stage1 PRIVATE -DCMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}")
 
 target_include_directories(rootcling_stage1 PRIVATE
    ${CMAKE_SOURCE_DIR}/core/foundation/inc    # for RConfig.hxx

--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -21,21 +21,13 @@ extern "C" {
 // force compiler to emit symbol for function above
 static void (*dlsymaddr)() = &usedToIdentifyRootClingByDlSym;
 
-ROOT::Internal::RootCling::TROOTSYSSetter gROOTSYSSetter;
-
 static const char *GetIncludeDir() {
-   auto renv = std::getenv("ROOTSYS");
-   if (!renv)
-      return nullptr;
-   static std::string incdir = std::string(renv) + "/include";
+   static std::string incdir = CMAKE_BINARY_DIR "/include";
    return incdir.c_str();
 }
 
 static const char *GetEtcDir() {
-   auto renv = std::getenv("ROOTSYS");
-   if (!renv)
-      return nullptr;
-   static std::string etcdir = std::string(renv) + "/etc";
+   static std::string etcdir = CMAKE_BINARY_DIR "/etc";
    return etcdir.c_str();
 }
 


### PR DESCRIPTION
During build time, the build directory path has to be fixed anyway, so we might as well hardcode it in the `rootcling_stage1` executable.

This implements a suggestion by @pcanal in this comment: https://github.com/root-project/root/pull/20828#discussion_r2682980144

It's one more step towards completely avoiding the need for the `ROOTSYS` environment variable.