### PR TITLE
[net] Add TParallelMergingFile::OpenConnection()

### DIFF
--- a/net/net/inc/TParallelMergingFile.h
+++ b/net/net/inc/TParallelMergingFile.h
@@ -51,6 +51,7 @@ public:
    ~TParallelMergingFile();
 
    void   Close(Option_t *option="") override;
+   Bool_t OpenConnection();
    Bool_t UploadAndReset();
    Int_t  Write(const char *name=nullptr, Int_t opt=0, Int_t bufsize=0) override;
    Int_t  Write(const char *name=nullptr, Int_t opt=0, Int_t bufsize=0) const override;


### PR DESCRIPTION
# This Pull request:
Adds a method to `TParallelMergingFile` that allows opening the connection to the server explicitly without having to call `Write()`. Can be useful in specific situations such as writing RNTuples.