### PR TITLE
[io] Add bounds checking to TMemFile

### DIFF
--- a/io/io/src/TMemFile.cxx
+++ b/io/io/src/TMemFile.cxx
@@ -454,6 +454,8 @@ Int_t TMemFile::SysReadImpl(Int_t, void *buf, Long64_t len)
          len = fSize - fSysOffset;
       }
 
+      R__ASSERT(len >= 0);
+
       if (fBlockOffset+len <= fBlockSeek->fSize) {
          // 'len' does not go past the end of the current block,
          // so let's make a simple copy.


### PR DESCRIPTION
Currently we just crash (if we're lucky) when we try to read past the TMemFile's size due to TMemFile issuing a memcpy with negative length.

Assert that len >= 0 to avoid reading out of bounds.