### PR TITLE
[CMake] Don't set `PATH` for running tutorials and explicitly get ROOT executable from target

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-set(ROOT_root_CMD root.exe)
+set(ROOT_root_CMD $<TARGET_FILE:root.exe>)
 
 set(pythonpaths ${localruntimedir} $ENV{PYTHONPATH})
 cmake_path(CONVERT "${pythonpaths}" TO_NATIVE_PATH_LIST pythonpaths_native)


### PR DESCRIPTION
Follows up on https://github.com/root-project/root/pull/20996, implementing suggestions by @hageboeck.

