### PR TITLE
[cppyy] Skip crashing test using `boost::type_erasure`

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_boost.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_boost.py
@@ -141,7 +141,7 @@ class TestBOOSTERASURE:
         cppyy.include("boost/type_erasure/member.hpp")
         cppyy.include("boost/mpl/vector.hpp")
 
-    @mark.xfail(strict=True, reason="TClassInfo for 'Lengths' is missing")
+    @mark.xfail(run=False, reason="TClassInfo for 'Lengths' is missing & triggering Cling assertions during unloading")
     def test01_erasure_usage(self):
         """boost::type_erasure usage"""
 


### PR DESCRIPTION
It was enabled in commit 50ae29d434 and marked as `xfail(strict=True)` in commit a7131ffd3d, but is still crashing with assertions enabled on AlmaLinux 8: "Must not nest within unloading transaction"