### PR TITLE
[cppyy] Avoid `cppdef` in templates test test33_using_template_argument

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/templates.h
+++ b/bindings/pyroot/cppyy/cppyy/test/templates.h
@@ -522,4 +522,17 @@ extern template class B<int>;
 
 }
 
+namespace UsingPtr {
+
+struct Test {};
+using testptr = Test *;
+
+template <typename T>
+bool testfun(T const &x)
+{
+   return !(bool)x;
+}
+
+}
+
 #endif // !CPPYY_TEST_TEMPLATES_H

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1129,15 +1129,6 @@ class TestTEMPLATES:
 
         import cppyy
 
-        cppyy.cppdef("""
-        namespace UsingPtr {
-        struct Test {};
-        using testptr = Test*;
-
-        template<typename T>
-        bool testfun(T const& x) { return !(bool)x; }
-        }""")
-
         ns = cppyy.gbl.UsingPtr
 
         assert ns.testfun["testptr"](cppyy.bind_object(cppyy.nullptr, ns.Test))


### PR DESCRIPTION
The test hangs up occasionally in the CI like in the last nightlies on **macOS 26**:
```txt
../../../../../../src/bindings/pyroot/cppyy/cppyy/test/test_templates.py::TestTEMPLATES::test33_using_template_argument CMake Error at /Users/sftnight/ROOT-CI/src/cmake/modules/RootTestDriver.cmake:232 (message):
  error code: 129
```
Unfortunately I'm blind to what happens there.

My best-effort solution for now would be to silmplify the test by
avoiding declaring some code inside the test with `cppyy.cppdef` (aka.
`gInterpreter.Declare`). Like this, many steps like C++ parsing or
dictionary generation are not happening during the test, lowering the
surface of where the hangup might happen. If we're lucky this fixes it,
and if not we have at least narrowed down a bit where the crash might
happen.