### PR TITLE
[cppyy] Fix memory leak in TemplateProxy::Instantiate()

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -296,6 +296,7 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
         }
 
     // cleanup
+        Py_XDECREF(exact);
         Py_DECREF(pyresname);
         Py_DECREF(pycachename);
 


### PR DESCRIPTION
The `PyObject * exact` is set to be the return value of `PyObject_GetItem()`, which returns a new reference that needs to be dereferenced when not used anymore. Otherwise, memory will leak.

This could be a problem in code that uses lots of template instantiations.