### PR TITLE
[ci] Move arm build to alma10

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -394,7 +394,7 @@ jobs:
             is_special: true
             property: march_native
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_CXX_FLAGS=-march=native", "CMAKE_C_FLAGS=-march=native", "builtin_zlib=ON", "builtin_zstd=ON"]
-          - image: alma9
+          - image: alma10
             is_special: true
             property: arm64
             overrides: ["CMAKE_BUILD_TYPE=RelWithDebInfo", "builtin_zlib=ON", "builtin_zstd=ON"]


### PR DESCRIPTION
This also removes some pressure from the nodes and the infrastructure in general, e.g. for caching images.