### PR TITLE
[tutorials] Remove `main()` function with no return statement

### DIFF
--- a/tutorials/machine_learning/TMVA_SOFIE_GNN_Application.C
+++ b/tutorials/machine_learning/TMVA_SOFIE_GNN_Application.C
@@ -234,10 +234,3 @@ void TMVA_SOFIE_GNN_Application (bool verbose = false)
    c2->cd(3); o3->Draw();
 
 }
-
-int main () {
-
-   TMVA_SOFIE_GNN_Application();
-}
-
-


### PR DESCRIPTION
This is to avoid an error when running the tutorials:
```txt
Processing /github/home/ROOT-CI/src/tutorials/machine_learning/TMVA_SOFIE_GNN_Application.C...
 ##[error]/github/home/ROOT-CI/src/tutorials/machine_learning/TMVA_SOFIE_GNN_Application.C:138:1: error: non-void function does not return a value [-Werror,-Wreturn-type]
}
^
```