### PR TITLE
[cppyy] Improve test header

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/fragile.h
+++ b/bindings/pyroot/cppyy/cppyy/test/fragile.h
@@ -29,8 +29,8 @@ public:
     virtual int check(int, int) { return (int)'D'; }
     void overload() {}
     void overload(no_such_class*) {}
-    void overload(char, int i = 0) {}  // Reflex requires a named arg
-    void overload(int, no_such_class* p = 0) {}
+    void overload(char, [[maybe_unused]] int i = 0) {}  // Reflex requires a named arg
+    void overload(int, [[maybe_unused]] no_such_class* p = nullptr) {}
 };
 
 
@@ -122,6 +122,15 @@ public:
 class O {
 public:
    virtual int abstract() = 0;
+
+   // Abstract classes should declare a virtual destructor
+   virtual ~O() = default;
+
+   // Destructor was declared, apply rule of five
+   O(const O &) = default;
+   O &operator=(const O &) = default;
+   O(O &&) = default;
+   O &operator=(O &&) = default;
 };
 
 class OpaqueType;


### PR DESCRIPTION
Avoid warnings when compiling with aclic such as
```
18: In file included from /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/fragile_cxx_ACLiC_dict.cxx:41:
18: In file included from /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/./fragile.cxx:1:
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/./fragile.h:32:29: warning: unused parameter 'i' [-Wunused-parameter]
18:    32 |     void overload(char, int i = 0) {}  // Reflex requires a named arg
18:       |                             ^
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/./fragile.h:33:39: warning: unused parameter 'p' [-Wunused-parameter]
18:    33 |     void overload(int, no_such_class* p = 0) {}
18:       |                                       ^
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/fragile_cxx_ACLiC_dict.cxx:1571:7: warning: delete called on 'fragile::O' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
18:  1571 |       delete (static_cast<::fragile::O*>(p));
18:       |       ^
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/fragile_cxx_ACLiC_dict.cxx:1574:7: warning: delete called on 'fragile::O' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
18:  1574 |       delete [] (static_cast<::fragile::O*>(p));
18:       |       ^
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/fragile_cxx_ACLiC_dict.cxx:1578:7: warning: destructor called on 'fragile::O' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
18:  1578 |       (static_cast<current_t*>(p))->~current_t();
18:       |       ^
18: /Users/vpadulan/Programs/rootproject/rootbuild/cppyy_test_fragile/bindings/pyroot/cppyy/cppyy/test/fragile_cxx_ACLiC_dict.cxx:1578:37: note: qualify call to silence this warning
18:  1578 |       (static_cast<current_t*>(p))->~current_t();
18:       |                                     ^
18:       |                                     fragile::O::
```
