### PR TITLE
[cppyy] Allow implicit conversion on templated constructor call

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -663,8 +663,8 @@ static PyObject* tpp_call(TemplateProxy* pytmpl, PyObject* args, PyObject* kwds)
         int pcnt = 0;
         pymeth = pytmpl->Instantiate(pytmpl->fTI->fCppName, args, nargsf, pref, &pcnt);
         if (pymeth) {
-        // attempt actual call; argument based, so do not allow implicit conversions
-            result = CallMethodImp(pytmpl, pymeth, args, nargsf, kwds, false, sighash);
+        // attempt actual call; even if argument based, allow implicit conversions, for example for non-template arguments
+            result = CallMethodImp(pytmpl, pymeth, args, nargsf, kwds, true, sighash);
             if (result) TPPCALL_RETURN;
         }
         Utility::FetchError(errors);

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1184,6 +1184,29 @@ class TestTEMPLATES:
         with pytest.raises(TypeError, match=r"could not construct C\+\+ name"):
             cppyy.gbl.test35_func[set(), list()]()
 
+    def test36_constructor_implicit_conversion(self):
+        """Implicit conversion to call a templated constructor"""
+
+        import cppyy
+
+        cppyy.cppdef("""\
+        namespace ConstructorImplicitConversion {
+        struct IntWrapper {
+            IntWrapper(int i) : m_i(i) {}
+            int m_i;
+        };
+        struct S {
+            template <typename T>
+            S(IntWrapper a, T b) : m_a(a.m_i) {}
+
+            int m_a = 0;
+        }; }""")
+
+        ns = cppyy.gbl.ConstructorImplicitConversion
+
+        a = ns.S(1, 2)
+        assert a.m_a == 1
+
 
 class TestTEMPLATED_TYPEDEFS:
     def setup_class(cls):


### PR DESCRIPTION
If some arguments have a non-template type, implicit conversion may be required as demonstrated by the test case. This will be used by the new histogram package (with variadic templates as an additional complication).