### PR TITLE
[cling] Unload implicit instantiations also from ASTFile

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclUnloader.h
+++ b/interpreter/cling/lib/Interpreter/DeclUnloader.h
@@ -59,11 +59,7 @@ namespace cling {
     ///\param[in] D - The declaration to unload
     ///\returns true on success.
     ///
-    bool UnloadDecl(clang::Decl* D) {
-      if (D->isFromASTFile())
-        return true;
-      return Visit(D);
-    }
+    bool UnloadDecl(clang::Decl* D);
 
     ///\brief If it falls back in the base class just remove the declaration
     /// only from the declaration context.

--- a/interpreter/cling/test/CodeUnloading/PCH/Inputs/TemplateAssert.h
+++ b/interpreter/cling/test/CodeUnloading/PCH/Inputs/TemplateAssert.h
@@ -1,0 +1,18 @@
+#ifndef TemplateAssert_h
+#define TemplateAssert_h
+
+template <typename T> struct Trait {
+  static constexpr bool Value = false;
+};
+
+template <> struct Trait<double> {
+  static constexpr bool Value = true;
+};
+
+template <typename T> struct RequiresTrait {
+  void Scale(double) { static_assert(Trait<T>::Value, "invalid type"); }
+};
+
+void inst() { RequiresTrait<int> r; }
+
+#endif

--- a/interpreter/cling/test/CodeUnloading/PCH/TemplateAssert.C
+++ b/interpreter/cling/test/CodeUnloading/PCH/TemplateAssert.C
@@ -1,0 +1,17 @@
+// RUN: %rm TemplateAssert.h.pch
+// RUN: %cling -x c++-header %S/Inputs/TemplateAssert.h -o TemplateAssert.h.pch
+// RUN: cat %s | %cling -I%p -Xclang -include-pch -Xclang TemplateAssert.h.pch 2>&1 | FileCheck %s
+
+#include "Inputs/TemplateAssert.h"
+
+RequiresTrait<int> r;
+
+// CHECK: static assertion failed
+// CHECK-SAME: invalid type
+r.Scale(1.0);
+
+// CHECK: static assertion failed
+// CHECK-SAME: invalid type
+r.Scale(1.0);
+
+.q


### PR DESCRIPTION
The assumption is that serialized declarations must be valid, however that doesn't hold anymore in the presence of static_assert in templated classes.

Fixes #20638