### PR TITLE
[cppyy] Check early for conversion to initializer list

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_regression.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_regression.py
@@ -1387,6 +1387,29 @@ class TestREGRESSION:
         with raises(cppyy.gbl.std.logic_error):
             foo.bar()
 
+    def test47_initializer_list_fail(self, capfd):
+        """Conversion to intializer_list requires default constructor"""
+
+        import cppyy
+
+        cppyy.cppdef("""\
+        namespace regression_test47 {
+        std::size_t size = 0;
+        struct IntWrapper { IntWrapper(int i) : fInt(i) {} int fInt; };
+        void f(std::initializer_list<IntWrapper> l) {}
+        void f(std::vector<IntWrapper> l) { size = l.size(); }
+        }""")
+
+        r47 = cppyy.gbl.regression_test47
+
+        assert r47.size == 0
+
+        r47.f([1])
+        assert r47.size == 1
+        (out, err) = capfd.readouterr()
+        assert out == ""
+        assert err == ""
+
 
 if __name__ == "__main__":
     exit(pytest.main(args=['-v', '-ra', __file__]))


### PR DESCRIPTION
It requires to construct default objects. Before it would blindly call `Cppyy::Construct` and check the return value. This leads to a confusing error message from `TClass::New` even though conversion to `std::vector` subsequently succeeds (which doesn't need to construct default objects).