### PR TITLE
[ntuple] Explicitly delete some move constructors

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
@@ -109,6 +109,8 @@ private:
    RNTupleFillContext(std::unique_ptr<ROOT::RNTupleModel> model, std::unique_ptr<ROOT::Internal::RPageSink> sink);
    RNTupleFillContext(const RNTupleFillContext &) = delete;
    RNTupleFillContext &operator=(const RNTupleFillContext &) = delete;
+   RNTupleFillContext(RNTupleFillContext &&) = delete;
+   RNTupleFillContext &operator=(RNTupleFillContext &&) = delete;
 
 public:
    ~RNTupleFillContext();

--- a/tree/ntuple/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleModel.hxx
@@ -200,6 +200,8 @@ private:
 public:
    RNTupleModel(const RNTupleModel &) = delete;
    RNTupleModel &operator=(const RNTupleModel &) = delete;
+   RNTupleModel(RNTupleModel &&) = delete;
+   RNTupleModel &operator=(RNTupleModel &&) = delete;
    ~RNTupleModel() = default;
 
    std::unique_ptr<RNTupleModel> Clone() const;

--- a/tree/ntuple/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleParallelWriter.hxx
@@ -75,6 +75,8 @@ private:
    RNTupleParallelWriter(std::unique_ptr<ROOT::RNTupleModel> model, std::unique_ptr<ROOT::Internal::RPageSink> sink);
    RNTupleParallelWriter(const RNTupleParallelWriter &) = delete;
    RNTupleParallelWriter &operator=(const RNTupleParallelWriter &) = delete;
+   RNTupleParallelWriter(RNTupleParallelWriter &&) = delete;
+   RNTupleParallelWriter &operator=(RNTupleParallelWriter &&) = delete;
 
 public:
    /// Recreate a new file and return a writer to write an RNTuple.

--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -225,6 +225,11 @@ public:
       options.SetEnableMetrics(fMetrics.IsEnabled());
       return std::unique_ptr<RNTupleReader>(new RNTupleReader(fSource->Clone(), options));
    }
+
+   RNTupleReader(const ROOT::RNTupleReader &) = delete;
+   RNTupleReader &operator=(const ROOT::RNTupleReader &) = delete;
+   RNTupleReader(ROOT::RNTupleReader &&) = delete;
+   RNTupleReader &operator=(ROOT::RNTupleReader &&) = delete;
    ~RNTupleReader();
 
    /// Returns the number of entries in this RNTuple.

--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -154,6 +154,8 @@ public:
                                                 const ROOT::RNTupleWriteOptions &options = ROOT::RNTupleWriteOptions());
    RNTupleWriter(const RNTupleWriter &) = delete;
    RNTupleWriter &operator=(const RNTupleWriter &) = delete;
+   RNTupleWriter(RNTupleWriter &&) = delete;
+   RNTupleWriter &operator=(RNTupleWriter &&) = delete;
    ~RNTupleWriter();
 
    /// The simplest user interface if the default entry that comes with the ntuple model is used.


### PR DESCRIPTION
For the following classes:
- RNTupleModel
- RNTupleWriter
- RNTupleReader
- RNTupleFillContext
- RNTupleParallelWriter

