### PR TITLE
[geom] [mini] Replaced use of legacy TVector3

### DIFF
--- a/geom/geom/CMakeLists.txt
+++ b/geom/geom/CMakeLists.txt
@@ -124,7 +124,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Geom
     RIO
     MathCore
     Hist
-    Physics
+    GenVector
     Imt
 )
 

--- a/geom/geom/inc/TGeoBBox.h
+++ b/geom/geom/inc/TGeoBBox.h
@@ -13,7 +13,7 @@
 #define ROOT_TGeoBBox
 
 #include "TGeoShape.h"
-#include "TVector3.h"
+#include "Math/Vector3D.h"
 
 class TGeoBBox : public TGeoShape {
 protected:
@@ -66,7 +66,7 @@ public:
    void GetBoundingCylinder(Double_t *param) const override;
    const TBuffer3D &GetBuffer3D(Int_t reqSections, Bool_t localFrame) const override;
    Int_t GetByteCount() const override { return 36; }
-   inline TVector3 GetDimensions() const { return TVector3(fDX, fDY, fDZ); }
+   inline ROOT::Math::XYZVector GetDimensions() const { return ROOT::Math::XYZVector(fDX, fDY, fDZ); }
    virtual Double_t GetFacetArea(Int_t index = 0) const;
    virtual Bool_t GetPointsOnFacet(Int_t index, Int_t npoints, Double_t *array) const;
    Bool_t GetPointsOnSegments(Int_t npoints, Double_t *array) const override;
@@ -79,15 +79,17 @@ public:
    virtual Double_t GetDY() const { return fDY; }
    virtual Double_t GetDZ() const { return fDZ; }
    virtual const Double_t *GetOrigin() const { return fOrigin; }
-   TVector3 GetWorldCenter(const TGeoMatrix *m) const;
+   ROOT::Math::XYZVector GetWorldCenter(const TGeoMatrix *m) const;
    void InspectShape() const override;
    Bool_t IsConvex() const override { return kTRUE; }
    Bool_t IsCylType() const override { return kFALSE; }
    Bool_t IsValidBox() const override { return ((fDX < 0) || (fDY < 0) || (fDZ < 0)) ? kFALSE : kTRUE; }
    virtual Bool_t IsNullBox() const { return ((fDX < 1.E-16) && (fDY < 1.E-16) && (fDZ < 1.E-16)) ? kTRUE : kFALSE; }
-   static Bool_t IsSeparatingAxis(const TVector3 &L, const TVector3 &D, const TVector3 &Ax, const TVector3 &Ay,
-                                  const TVector3 &Az, const TVector3 &Bx, const TVector3 &By, const TVector3 &Bz,
-                                  const TVector3 &dA, const TVector3 &dB, Double_t tol);
+   static Bool_t IsSeparatingAxis(const ROOT::Math::XYZVector &L, const ROOT::Math::XYZVector &D,
+                                  const ROOT::Math::XYZVector &Ax, const ROOT::Math::XYZVector &Ay,
+                                  const ROOT::Math::XYZVector &Az, const ROOT::Math::XYZVector &Bx,
+                                  const ROOT::Math::XYZVector &By, const ROOT::Math::XYZVector &Bz,
+                                  const ROOT::Math::XYZVector &dA, const ROOT::Math::XYZVector &dB, Double_t tol);
    TBuffer3D *MakeBuffer3D() const override;
    static bool MayIntersect(const TGeoBBox *boxA, const TGeoMatrix *mA, const TGeoBBox *boxB, const TGeoMatrix *mB);
    Double_t Safety(const Double_t *point, Bool_t in = kTRUE) const override;

--- a/geom/geom/inc/TGeoMatrix.h
+++ b/geom/geom/inc/TGeoMatrix.h
@@ -19,7 +19,7 @@
  *************************************************************************/
 
 #include "TNamed.h"
-#include "TVector3.h"
+#include "Math/Vector3D.h"
 
 //--- globals
 const Double_t kNullVector[3] = {0.0, 0.0, 0.0};
@@ -74,7 +74,7 @@ public:
    Bool_t IsRotAboutZ() const;
    void GetHomogenousMatrix(Double_t *hmat) const;
    const char *GetPointerName() const;
-   void GetWorldAxes(TVector3 &ax, TVector3 &ay, TVector3 &az) const;
+   void GetWorldAxes(ROOT::Math::XYZVector &ax, ROOT::Math::XYZVector &ay, ROOT::Math::XYZVector &az) const;
    virtual Int_t GetByteCount() const;
    virtual const Double_t *GetTranslation() const = 0;
    virtual const Double_t *GetRotationMatrix() const = 0;

--- a/geom/geom/src/TGeoBBox.cxx
+++ b/geom/geom/src/TGeoBBox.cxx
@@ -832,11 +832,11 @@ void TGeoBBox::GetMeshNumbers(Int_t &nvert, Int_t &nsegs, Int_t &npols) const
 /// @param[in] m   Pointer to the placement TGeoMatrix.
 /// @return        World-space center of the box.
 
-TVector3 TGeoBBox::GetWorldCenter(const TGeoMatrix *m) const
+ROOT::Math::XYZVector TGeoBBox::GetWorldCenter(const TGeoMatrix *m) const
 {
    Double_t w[3];
    m->LocalToMaster(fOrigin, w);
-   return TVector3(w[0], w[1], w[2]);
+   return ROOT::Math::XYZVector(w[0], w[1], w[2]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -883,9 +883,11 @@ void TGeoBBox::InspectShape() const
 /// @return true  If L is a separating axis (boxes do NOT intersect).
 /// @return false If L does not separate the boxes or is degenerate.
 
-Bool_t TGeoBBox::IsSeparatingAxis(const TVector3 &L, const TVector3 &D, const TVector3 &Ax, const TVector3 &Ay,
-                                  const TVector3 &Az, const TVector3 &Bx, const TVector3 &By, const TVector3 &Bz,
-                                  const TVector3 &dA, const TVector3 &dB, Double_t tol)
+Bool_t TGeoBBox::IsSeparatingAxis(const ROOT::Math::XYZVector &L, const ROOT::Math::XYZVector &D,
+                                  const ROOT::Math::XYZVector &Ax, const ROOT::Math::XYZVector &Ay,
+                                  const ROOT::Math::XYZVector &Az, const ROOT::Math::XYZVector &Bx,
+                                  const ROOT::Math::XYZVector &By, const ROOT::Math::XYZVector &Bz,
+                                  const ROOT::Math::XYZVector &dA, const ROOT::Math::XYZVector &dB, Double_t tol)
 {
    // Degenerate axes can arise from cross products of nearly parallel axes.
    const Double_t eps = 1e-18;
@@ -893,8 +895,8 @@ Bool_t TGeoBBox::IsSeparatingAxis(const TVector3 &L, const TVector3 &D, const TV
       return false;
 
    const Double_t dist = std::fabs(D.Dot(L));
-   const Double_t rA = TMath::Abs(dA[0] * Ax.Dot(L)) + TMath::Abs(dA[1] * Ay.Dot(L)) + TMath::Abs(dA[2] * Az.Dot(L));
-   const Double_t rB = TMath::Abs(dB[0] * Bx.Dot(L)) + TMath::Abs(dB[1] * By.Dot(L)) + TMath::Abs(dB[2] * Bz.Dot(L));
+   const Double_t rA = TMath::Abs(dA.x() * Ax.Dot(L)) + TMath::Abs(dA.y() * Ay.Dot(L)) + TMath::Abs(dA.z() * Az.Dot(L));
+   const Double_t rB = TMath::Abs(dB.x() * Bx.Dot(L)) + TMath::Abs(dB.y() * By.Dot(L)) + TMath::Abs(dB.z() * Bz.Dot(L));
 
    // Touching within tolerance is treated as non-intersecting
    return dist >= (rA + rB - tol);
@@ -952,17 +954,17 @@ bool TGeoBBox::MayIntersect(const TGeoBBox *boxA, const TGeoMatrix *mA, const TG
    const Double_t tol = TGeoShape::Tolerance();
 
    // Half-lengths vectors
-   const TVector3 dA = boxA->GetDimensions();
-   const TVector3 dB = boxB->GetDimensions();
+   const ROOT::Math::XYZVector dA = boxA->GetDimensions();
+   const ROOT::Math::XYZVector dB = boxB->GetDimensions();
 
    // Correct world-space centers (including TGeoBBox origin)
-   const TVector3 oA = boxA->GetWorldCenter(mA);
-   const TVector3 oB = boxB->GetWorldCenter(mB);
-   const TVector3 D = oB - oA;
+   const ROOT::Math::XYZVector oA = boxA->GetWorldCenter(mA);
+   const ROOT::Math::XYZVector oB = boxB->GetWorldCenter(mB);
+   const ROOT::Math::XYZVector D = oB - oA;
 
    // Very cheap early rejection using bounding spheres
-   const Double_t rA = dA.Mag();
-   const Double_t rB = dB.Mag();
+   const Double_t rA = TMath::Sqrt(dA.Mag2());
+   const Double_t rB = TMath::Sqrt(dB.Mag2());
    const Double_t dmax = rA + rB - tol;
 
    // Touching within tolerance is treated as non-intersecting
@@ -970,8 +972,8 @@ bool TGeoBBox::MayIntersect(const TGeoBBox *boxA, const TGeoMatrix *mA, const TG
       return kFALSE;
 
    // World-space box axes
-   TVector3 Ax, Ay, Az;
-   TVector3 Bx, By, Bz;
+   ROOT::Math::XYZVector Ax, Ay, Az;
+   ROOT::Math::XYZVector Bx, By, Bz;
    mA->GetWorldAxes(Ax, Ay, Az);
    mB->GetWorldAxes(Bx, By, Bz);
 
@@ -991,12 +993,12 @@ bool TGeoBBox::MayIntersect(const TGeoBBox *boxA, const TGeoMatrix *mA, const TG
       return kFALSE;
 
    // SAT: cross-product axes (9 tests)
-   const TVector3 Aaxes[3] = {Ax, Ay, Az};
-   const TVector3 Baxes[3] = {Bx, By, Bz};
+   const ROOT::Math::XYZVector Aaxes[3] = {Ax, Ay, Az};
+   const ROOT::Math::XYZVector Baxes[3] = {Bx, By, Bz};
 
    for (int i = 0; i < 3; ++i) {
       for (int j = 0; j < 3; ++j) {
-         const TVector3 L = Aaxes[i].Cross(Baxes[j]);
+         const ROOT::Math::XYZVector L = Aaxes[i].Cross(Baxes[j]);
          if (IsSeparatingAxis(L, D, Ax, Ay, Az, Bx, By, Bz, dA, dB, tol))
             return kFALSE;
       }

--- a/geom/geom/src/TGeoMatrix.cxx
+++ b/geom/geom/src/TGeoMatrix.cxx
@@ -352,7 +352,7 @@ void TGeoMatrix::GetHomogenousMatrix(Double_t *hmat) const
 /// @param[out] ay World-space direction of the local Y axis.
 /// @param[out] az World-space direction of the local Z axis.
 
-void TGeoMatrix::GetWorldAxes(TVector3 &ax, TVector3 &ay, TVector3 &az) const
+void TGeoMatrix::GetWorldAxes(ROOT::Math::XYZVector &ax, ROOT::Math::XYZVector &ay, ROOT::Math::XYZVector &az) const
 {
    const Double_t *r = GetRotationMatrix();
    ax.SetXYZ(r[0], r[3], r[6]);


### PR DESCRIPTION
`TVector3` was very recently introduced in some interfaces and implementations in geom, which should be replaced  with `XYZVector` before potential adoption of these interfaces.

# This Pull request:

## Changes or fixes:
Replaced the use of `TVector3` with `ROOT::Math::XYZVector`

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

