### PR TITLE
[CI] Stabilise computing the list of changed files for ruff.

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -54,12 +54,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
 
     - name: Get the list of changed files
       id: diff
       run: |
-        git fetch --depth=1 origin $GITHUB_BASE_REF 
-        git diff --diff-filter=AMR --name-only origin/$GITHUB_BASE_REF > changed_files.txt
+        git diff --diff-filter=AMR --name-only HEAD~1 | tee changed_files.txt
 
     - name: Install ruff
       uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
When a user branched from master a while ago, the diff step in the ruff action will compute the list of changed files wrongly. Here, we use the fact that the checkout action uses a merge commit on top of the target branch, so computing the diff between the last two commits encompasses all the files touched in the PR.

An example of the failure case can be seen in this PR: https://github.com/root-project/root/pull/20992
It doesn't touch any Python files, but the ruff check failed.
