### PR TITLE
[tmva][sofie] arguments check to avoid mismatches with dynamic parameters

### DIFF
--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1016,18 +1016,13 @@ void RModel::GenerateOutput()
                }
                dynamic_parameters_check += d.param + " > f" + cap + " || ";
                input_params_checked.insert(pName);
+               fGC += SP + "if (" + d.param + " > f" + cap + ") {\n";
+               fGC += SP + SP + "throw std::runtime_error(\"TMVA-SOFIE: dynamic input tensor shape parameter " +
+                      d.param + " exceeds the initialized maximum allowed shape.\");\n";
+               fGC += SP + "}\n";
             }
          }
       }
-   }
-   // remove last && from fGC
-   if (input_params_checked.size() > 0) {
-      dynamic_parameters_check = dynamic_parameters_check.substr(0, dynamic_parameters_check.size() - 4);
-      fGC += "\n" + SP + "if (" + dynamic_parameters_check + ") {\n";
-      fGC += SP + SP +
-             "throw std::runtime_error(\"TMVA-SOFIE: dynamic input tensor shape parameters exceed the initialized "
-             "maximum allowed shape.\");\n";
-      fGC += SP + "}\n";
    }
 
    fGC += SP + "doInfer(" + doInferArgs + ");\n";


### PR DESCRIPTION
This PR implements checks on the arguments of the infer method to avoid any mismatches with the dynamic parameters.

When SOFIE is used to infer models with dynamic parameters, it is essential to check if they are in the allowed range. Otherwise this may cause an overflow and subsequently a segmentation fault. This check verifies is the passed
parameters is lesser or equal to their limits set during instantion of the Session object, otherwise throws a runtime error.