### PR TITLE
[v638][RF] Don't use `removeServer` to clean RooAbsAnaConvPdf compute graph

### DIFF
--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -697,11 +697,6 @@ RooAbsAnaConvPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Co
    }
    std::unique_ptr<RooAbsAnaConvPdf> pdfClone(static_cast<RooAbsAnaConvPdf *>(this->Clone()));
 
-   // The actual resolution model is not serving the RooAbsAnaConvPdf
-   // in the evaluation. It was only used get the convolutions with a given
-   // basis. We can remove it for the compiled model.
-   pdfClone->removeServer(const_cast<RooAbsReal &>(pdfClone->_model.arg()), true);
-
    // The other servers will be compiled with the original normSet, but the
    // _convSet has to be evaluated unnormalized.
    RooArgList convArgClones;


### PR DESCRIPTION
This follows up on 232a619f987f, where a unused server was removed when the RooAbsAnaConvPdf is compiled for a given normalization set.

Unfortunately, servers can't be meaningfully removed because it **always** results in a server-proxy-desync problem. If a server is removed, the corresponding `RooArgProxy` stays around as a data member of the RooAbsAnaConvPdf. When you then copy the RooAbsAnaConvPdf, the seemingly removed server is resurrected implicitly in the copy constructor of the the proxy, which leads to the confusing situation that a copy has a different server structure from the original.

This will then confuse the server redirection when deep-cloning RooAbsArgs, manifesting in a problem reported on the forum, which is fixed by this commit:

https://root-forum.cern.ch/t/redirectservers-server-not-redirected/64612/4

All other use of `RooAbsArg::removeServer()` outside the RooAbsArg destructor should also be reviewed to make sure that similar problems don't hide in other parts of the code. We should also consider deprecating that function from the public user interface, together with `RooAbsArg::replaceServer()`, which has the same problem.

(cherry picked from commit 478ad2b8079286d2f67e03f7a495571c1584b619)