### PR TITLE
[roottest] Use RPATH instead of setting LD_LIBRARY_PATH

### DIFF
--- a/roottest/root/ntuple/makeproject/rntuple/CMakeLists.txt
+++ b/roottest/root/ntuple/makeproject/rntuple/CMakeLists.txt
@@ -51,10 +51,24 @@ ROOTTEST_GENERATE_EXECUTABLE(
 target_include_directories(read_rntuple PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_directories(read_rntuple PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/librntuplestltest)
 
+if(MSVC)
+  set(_env ENVIRONMENT PATH=${CMAKE_CURRENT_BINARY_DIR}/librntuplestltest)
+endif()
+
 # Need to also explicitly set the LD_LIBRARY_PATH (at least on MacOS), so that
 # the generated library with the custom class can be loaded by the read test.
 ROOTTEST_ADD_TEST(read_rntuple
                   EXEC ./read_rntuple
                   FIXTURES_REQUIRED read_rntuple_executable
-                  # PATH is used on Windows to find libraries for loading
-                  ENVIRONMENT ${ld_library_path}=${CMAKE_CURRENT_BINARY_DIR}/librntuplestltest)
+                  ${_env})
+
+# Use RPATH instead of LD_LIBRARY_PATH so we don't have to change environment
+# variables in the build environment.
+if(NOT MSVC)
+  if(APPLE)
+    set(new_rpath "@loader_path/librntuplestltest")
+  else()
+    set(new_rpath "$ORIGIN/librntuplestltest")
+  endif()
+  set_property(TARGET read_rntuple APPEND PROPERTY BUILD_RPATH "${new_rpath}")
+endif()

--- a/roottest/root/ntuple/makeproject/ttree/CMakeLists.txt
+++ b/roottest/root/ntuple/makeproject/ttree/CMakeLists.txt
@@ -52,10 +52,24 @@ ROOTTEST_GENERATE_EXECUTABLE(
 target_include_directories(read_ttree PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_directories(read_ttree PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/libttreestltest)
 
+if(MSVC)
+  set(_env ENVIRONMENT PATH=${CMAKE_CURRENT_BINARY_DIR}/librntuplestltest)
+endif()
+
 # Need to also explicitly set the LD_LIBRARY_PATH (at least on MacOS), so that
 # the generated library with the custom class can be loaded by the read test.
 ROOTTEST_ADD_TEST(read_ttree
                   EXEC ./read_ttree
                   FIXTURES_REQUIRED makeproject_read_ttree_executable
-                  # PATH is used on Windows to find libraries for loading
-                  ENVIRONMENT ${ld_library_path}=${CMAKE_CURRENT_BINARY_DIR}/libttreestltest)
+                  ${_env})
+
+# Use RPATH instead of LD_LIBRARY_PATH so we don't have to change environment
+# variables in the build environment.
+if(NOT MSVC)
+  if(APPLE)
+    set(new_rpath "@loader_path/librntuplestltest")
+  else()
+    set(new_rpath "$ORIGIN/librntuplestltest")
+  endif()
+  set_property(TARGET read_ttree APPEND PROPERTY BUILD_RPATH "${new_rpath}")
+endif()


### PR DESCRIPTION
This avoids overwriting the LD_LIBRARY_PATH from the build environment.

Closes #21076.