### PR TITLE
[Python] Don't exploit garbage collection hooks for memory regulator

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -14,6 +14,7 @@
 // Standard
 #include <algorithm>
 #include <sstream>
+#include <iostream>
 
 
 //- data _____________________________________________________________________
@@ -210,6 +211,9 @@ void CPyCppyy::op_dealloc_nofree(CPPInstance* pyobj) {
 
     Cppyy::TCppType_t klass = pyobj->ObjectIsA(false /* check_smart */);
     void*& cppobj = pyobj->GetObjectRaw();
+
+    if(cppobj == nullptr)
+       std::cout << "op_dealloc_noree with nullptr" << std::endl;
 
     if (pyobj->fFlags & CPPInstance::kIsRegulated)
         MemoryRegulator::UnregisterPyObject(pyobj, (PyObject*)Py_TYPE((PyObject*)pyobj));

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -12,6 +12,7 @@
 
 // Standard
 #include <algorithm>
+#include <iostream>
 
 
 namespace CPyCppyy {
@@ -200,6 +201,7 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
     // can add already existing overloads to the set of methods.
 
         std::string resname = Cppyy::GetMethodFullName(cppmeth);
+        std::cout << "resname : " << resname << std::endl;
 
     // An initializer_list is preferred for the argument types, but should not leak into
     // the argument types. If it did, replace with vector and lookup anew.

--- a/bindings/pyroot/cppyy/cppyy/test/templates.h
+++ b/bindings/pyroot/cppyy/cppyy/test/templates.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
+#include <iostream>
 
 #ifndef _WIN32
 #include <cxxabi.h>
@@ -530,6 +531,7 @@ using testptr = Test *;
 template <typename T>
 bool testfun(T const &x)
 {
+   std::cout << "testfun " << x << std::endl;
    return !(bool)x;
 }
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1133,16 +1133,23 @@ class TestTEMPLATES:
 
         assert ns.testfun["testptr"](cppyy.bind_object(cppyy.nullptr, ns.Test))
 
+        print("step 1 done")
+
         # TODO: raises TypeError; the problem is that the type is resolved
         # from UsingPtr::Test*const& to UsingPtr::Test*& (ie. `const` is lost)
         # assert ns.testfun["UsingPtr::testptr"](cppyy.nullptr)
 
         assert ns.testptr.__name__     == "Test"
+        print("step 2 done")
         assert ns.testptr.__cpp_name__ == "UsingPtr::Test*"
+        print("step 3 done")
 
         assert cppyy.gbl.std.vector[ns.Test]
+        print("step 4 done")
         assert ns.testptr
+        print("step 5 done")
         assert cppyy.gbl.std.vector[ns.testptr]
+        print("step 6 done")
 
     @mark.xfail(strict=True)
     def test34_cstring_template_argument(self):
@@ -1410,4 +1417,4 @@ class TestTEMPLATED_CALLBACK:
 
 
 if __name__ == "__main__":
-    exit(pytest.main(args=['-v', '-ra', __file__]))
+    exit(pytest.main(args=['-sv', '-ra', __file__]))


### PR DESCRIPTION
Looking at the CPPInstance, I noticed that is claims to support cycling
garbage collection via the `Py_TPFLAGS_HAVE_GC`, but it doesn't stick
completely to the contract explained in the docs:

https://docs.python.org/3/c-api/gcsupport.html#c.PyObject_GC_Track

In particular, it breaks the constructor rules:

  * The memory for the object must be allocated using PyObject_GC_New or
    PyObject_GC_NewVar.

  * Once all the fields which may contain references to other containers
    are initialized, it must call PyObject_GC_Track().

The `tp_traverse` and `tp_clear` implementations actually do nothing
with the C Python API, so from the point of view of Python, there is no
reason to support cyclic garbage collection.

I think the CPPInstance tries to exploit the Python garbage collector to
trigger its own memory regulator code path early in `tp_clear`, but
breaking some of the Python C API contracts on the way. And the C++
object is also unregisterd from the memory regulator in `tp_dealloc`
anyway.

This might be the reason for the spurious failures in the CI, which
happen *between* two tests, hinting to garbage collector problems.
I think it's particularly problematic that the CPPInstance never
registers itself to the GC with `PyObject_GC_Track`, but then uses
`PyObject_GC_UnTrack`. That probably brings the garbage collector in a
bad state.

This reverts parts of the following CPyCppy commits from 2019:
  * https://github.com/wlav/CPyCppyy/commit/e43759a0764fab31393a9312ac53cb2cf55f8ee4
  * https://github.com/wlav/CPyCppyy/commit/29eb42eebf68add2e8bd961aa17507ab5c8c990e