### PR TITLE
[Python] Correctly set `__cpp_name__` attributes of RooDecay classes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodecays.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodecays.py
@@ -27,6 +27,8 @@ class RooDecay(object):
     \endcode
     """
 
+    __cpp_name__ = "RooDecay"
+
     @cpp_signature(
         "RooDecay(const char *name, const char *title, RooRealVar& t, RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;"
     )
@@ -37,6 +39,9 @@ class RooDecay(object):
 
 
 class RooBDecay(object):
+
+    __cpp_name__ = "RooBDecay"
+
     @cpp_signature(
         "RooBDecay(const char *name, const char *title, RooRealVar& t,"
         "    RooAbsReal& tau, RooAbsReal& dgamma,    RooAbsReal& f0,"
@@ -50,6 +55,9 @@ class RooBDecay(object):
 
 
 class RooBCPGenDecay(object):
+
+    __cpp_name__ = "RooBCPGenDecay"
+
     @cpp_signature(
         "RooBCPGenDecay(const char *name, const char *title, RooRealVar& t, RooAbsCategory& tag,"
         "    RooAbsReal& tau, RooAbsReal& dm, RooAbsReal& avgMistag, RooAbsReal& a, RooAbsReal& b,"
@@ -62,6 +70,9 @@ class RooBCPGenDecay(object):
 
 
 class RooBCPEffDecay(object):
+
+    __cpp_name__ = "RooBCPEffDecay"
+
     @cpp_signature(
         "RooBCPEffDecay(const char *name, const char *title, RooRealVar& t, RooAbsCategory& tag,"
         "    RooAbsReal& tau, RooAbsReal& dm, RooAbsReal& avgMistag, RooAbsReal& CPeigenval,"
@@ -75,6 +86,9 @@ class RooBCPEffDecay(object):
 
 
 class RooBMixDecay(object):
+
+    __cpp_name__ = "RooBMixDecay"
+
     @cpp_signature(
         "RooBMixDecay(const char *name, const char *title, RooRealVar& t, RooAbsCategory& mixState,"
         "    RooAbsCategory& tagFlav, RooAbsReal& tau, RooAbsReal& dm, RooAbsReal& mistag, "


### PR DESCRIPTION
This follows up on commit 11d29d9f6, where I removed some unused local variables in the constructor, but accidentally also the `__cpp_name__` class data member of `class RooDecay` that is actually needed to build the docs.

This commit is re-adding it, and also correctly sets the `__cpp_name__` member for the derived classes.