### PR TITLE
[Python] Move a cppyy regression test outside of Pythonization tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/string_view.py
+++ b/bindings/pyroot/pythonizations/test/string_view.py
@@ -29,26 +29,5 @@ class StringView(unittest.TestCase):
         self.assertEqual(df.GetNRuns(), 0)
         os.remove(filename)
 
-    def test_17497(self):
-        """Regression test for https://github.com/root-project/root/issues/17497"""
-        # See https://github.com/root-project/root/issues/7541 and
-        # https://bugs.llvm.org/show_bug.cgi?id=49692 :
-        # llvm JIT fails to catch exceptions on MacOS ARM, so we disable their testing
-        # Also fails on Windows 64bit for the same reason
-        if (platform.processor() != "arm" or platform.mac_ver()[0] == '') and not (platform.system() == "Windows" and platform.architecture()[0] == "64bit"):
-            ROOT.gInterpreter.Declare(r"""
-            void fun(std::string_view, std::string_view){throw std::runtime_error("std::string_view overload");}
-            void fun(std::string_view, const std::vector<std::string> &){throw std::runtime_error("const std::vector<std::string> & overload");}
-            """)
-            with self.assertRaises(cppyy.gbl.std.runtime_error):
-                ROOT.fun("", [])
-            with self.assertRaises(cppyy.gbl.std.runtime_error):
-                ROOT.fun(ROOT.std.string_view("hello world"),
-                         ROOT.std.vector[ROOT.std.string]())
-            with self.assertRaises(cppyy.gbl.std.runtime_error):
-                ROOT.fun("", ROOT.std.vector[ROOT.std.string]())
-            with self.assertRaises(cppyy.gbl.std.runtime_error):
-                ROOT.fun(ROOT.std.string_view("hello world"), [])
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follows up on https://github.com/root-project/root/pull/17536

In that PR, a regression test was introduced, that can be a standalone cppyy test, because it doesn't test anything specific to ROOT. So it should be moved from the ROOT pythonization tests to the cppyy tests.