### PR TITLE
[ci] Apply last-2-commits diff logic to ruff formatting

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -96,7 +96,7 @@ jobs:
               end=$((start + length))
               diff_command+="ruff format --diff --range $start-$end $file && "
               apply_command+="ruff format --range $start-$end $file && "
-            done < <(git diff --unified=0 origin/$GITHUB_BASE_REF "$file" | grep '^@@' | sed -E 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2-\4/')
+            done < <(git diff --unified=0 HEAD~1 -- "$file" | grep '^@@' | sed -E 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2-\4/')
           done
 
           if [ -n "$diff_command" ]; then


### PR DESCRIPTION
PR #21068 switched ruff to diff the last two commits instead of `origin/<base>`, but formatting still used `origin/<base>` (which no longer existed in the local history). 
This PR aligns formatting with the new logic.
