### PR TITLE
refactor typedefpointertoclassobject to not participate in Cyclic GC

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -401,9 +401,8 @@ static PyObject* meta_getattro(PyObject* pyclass, PyObject* pyname)
                     Cppyy::TCppType_t tcl = Cppyy::GetScope(clean);
                     if (tcl) {
                         typedefpointertoclassobject* tpc =
-                            PyObject_GC_New(typedefpointertoclassobject, &TypedefPointerToClass_Type);
+                            PyObject_New(typedefpointertoclassobject, &TypedefPointerToClass_Type);
                         tpc->fCppType = tcl;
-                        tpc->fDict = PyDict_New();
                         attr = (PyObject*)tpc;
                     }
                 }

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -144,7 +144,7 @@ PyTypeObject TypedefPointerToClass_Type = {
     0,                              // tp_dict
     0,                              // tp_descr_get
     0,                              // tp_descr_set
-    offsetof(typedefpointertoclassobject, fDict), // tp_dictoffset
+    0,                              // tp_dictoffset
     0,                              // tp_init
     0,                              // tp_alloc
     0,                              // tp_new

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.h
@@ -43,11 +43,6 @@ inline bool RefInt_CheckExact(T* object)
 struct typedefpointertoclassobject {
     PyObject_HEAD
     Cppyy::TCppType_t fCppType;
-    PyObject*         fDict;
-
-    ~typedefpointertoclassobject() {
-        Py_DECREF(fDict);
-    }
 };
 
 extern PyTypeObject TypedefPointerToClass_Type;


### PR DESCRIPTION
Taken from https://github.com/compiler-research/CPyCppyy/pull/132

Might fix the sporadic failures.