### PR TITLE
[graf2d] Fix Setting window size in batch mode

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -2149,7 +2149,7 @@ void TCanvas::SetWindowPosition(Int_t x, Int_t y)
 void TCanvas::SetWindowSize(UInt_t ww, UInt_t wh)
 {
    if (fBatch && !IsWeb())
-      SetCanvasSize((ww + fCw) / 2, (wh + fCh) / 2);
+      SetCanvasSize(ww, wh);
    else if (fCanvasImp)
       fCanvasImp->SetWindowSize(ww, wh);
 }


### PR DESCRIPTION
The current implementation doesn't make sense at all? Was it some accidentally committed code?

@linev It was your commit? Was it mistake?

```
771c44692bcb graf2d/gpad/src/TCanvas.cxx (Sergey Linev      2023-07-06 16:42:42 +0200 2151)    if (fBatch && !IsWeb())
d023aecbdda4 graf2d/gpad/src/TCanvas.cxx (Sergey Linev      2020-05-04 19:06:00 +0200 2152)       SetCanvasSize((ww + fCw) / 2, (wh + fCh) / 2);
d023aecbdda4 graf2d/gpad/src/TCanvas.cxx (Sergey Linev      2020-05-04 19:06:00 +0200 2153)    else if (fCanvasImp)
d023aecbdda4 graf2d/gpad/src/TCanvas.cxx (Sergey Linev      2020-05-04 19:06:00 +0200 2154)       fCanvasImp->SetWindowSize(ww, wh);
```
- [x] tested changes locally
- [ ] updated the docs (if necessary)
