### PR TITLE
[cmake][interop] add dynamic check for libstdc++fs

### DIFF
--- a/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
+++ b/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
@@ -54,8 +54,8 @@ if(NOT WIN32 AND NOT EMSCRIPTEN)
   list(APPEND link_libs dl)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-  list(APPEND link_libs stdc++fs)
+if(ROOT_NEED_STDCXXFS)
+    list(APPEND link_libs stdc++fs)
 endif()
 
 # Get rid of libLLVM-X.so which is appended to the list of static libraries.


### PR DESCRIPTION
<del>Based on https://github.com/root-project/root/commit/957ac3356492765c14098525840bcd56f120da67: Looking at the compiler version is not enough to know if we really need to link against stdc++fs:
"Whether linking with libstdc++fs is needed depends on the version of libstdc++, not on the compiler. For example, it is possible to use an older library with a newer compiler, or with another compiler that follows a different versioning scheme (for example Clang)."
https://github.com/root-project/root/commit/594a2b88edda17fbcba3a70893959a23ed4e1941 broke some Clang builds as the need to link against stdc++fs was not a GCC issue, but to do with the libstdc++ version. This adds a dynamic check in the same fashion as in ROOT, but in CppInterOp so that standalone builds do not suffer from the same issue.</del>

The same dynamic check if a source compiles doesn't seem to work in CppInterOp's cmake. I will investigate further, for now updating the check to use ROOT_NEED_STDCXXFS

@hahnjo can you test if this commit fixes your build?