### PR TITLE
[interop] Avoid usage of `<filesystem>`

### DIFF
--- a/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
+++ b/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
@@ -54,10 +54,6 @@ if(NOT WIN32 AND NOT EMSCRIPTEN)
   list(APPEND link_libs dl)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-  list(APPEND link_libs stdc++fs)
-endif()
-
 # Get rid of libLLVM-X.so which is appended to the list of static libraries.
 if (LLVM_LINK_LLVM_DYLIB)
   set(new_libs ${link_libs})

--- a/interpreter/CppInterOp/lib/CppInterOp/CppInterOp.cpp
+++ b/interpreter/CppInterOp/lib/CppInterOp/CppInterOp.cpp
@@ -74,7 +74,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <deque>
-#include <filesystem>
 #include <iostream>
 #include <iterator>
 #include <map>
@@ -3338,8 +3337,7 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
   llvm::Triple T(llvm::sys::getProcessTriple());
-  namespace fs = std::filesystem;
-  if ((!fs::is_directory(ResourceDir)) && (T.isOSDarwin() || T.isOSLinux()))
+  if ((!sys::fs::is_directory(ResourceDir)) && (T.isOSDarwin() || T.isOSLinux()))
     ResourceDir = DetectResourceDir();
 
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),


### PR DESCRIPTION
It requires linking `libstdc++fs` for older versions of the standard library, and the same function is provided by LLVM.