### PR TITLE
[graf2d] Change TCanvas arguments to canvas size

### DIFF
--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -99,18 +99,18 @@ public:
 
    TCanvas(Bool_t build=kTRUE);
    TCanvas(const char *name, const char *title="", Int_t form=1);
-   TCanvas(const char *name, const char *title, Int_t ww, Int_t wh);
+   TCanvas(const char *name, const char *title, Int_t cw, Int_t ch);
    TCanvas(const char *name, const char *title, Int_t wtopx, Int_t wtopy,
-           Int_t ww, Int_t wh);
-   TCanvas(const char *name, Int_t ww, Int_t wh, Int_t winid);
+           Int_t cw, Int_t ch);
+   TCanvas(const char *name, Int_t cw, Int_t ch, Int_t winid);
    ~TCanvas() override;
 
    //-- used by friend TThread class
    void Constructor();
    void Constructor(const char *name, const char *title, Int_t form);
-   void Constructor(const char *name, const char *title, Int_t ww, Int_t wh);
+   void Constructor(const char *name, const char *title, Int_t cw, Int_t ch);
    void Constructor(const char *name, const char *title,
-           Int_t wtopx, Int_t wtopy, Int_t ww, Int_t wh);
+           Int_t wtopx, Int_t wtopy, Int_t cw, Int_t ch);
    void Destructor();
 
    TVirtualPad      *cd(Int_t subpadnumber=0) override;
@@ -123,7 +123,7 @@ public:
    TObject          *DrawClone(Option_t *option="") const override; // *MENU*
    virtual TObject  *DrawClonePad(); // *MENU*
    virtual void      EditorBar();
-   void              EmbedInto(Int_t winid, Int_t ww, Int_t wh);
+   void              EmbedInto(Int_t winid, Int_t cw, Int_t ch);
    void              EnterLeave(TPad *prevSelPad, TObject *prevSelObj);
    void              FeedbackMode(Bool_t set);
    void              Flush();
@@ -203,7 +203,7 @@ public:
    void              SetWindowPosition(Int_t x, Int_t y);
    void              SetWindowSize(UInt_t ww, UInt_t wh);
    void              SetCanvasImp(TCanvasImp *i);
-   void              SetCanvasSize(UInt_t ww, UInt_t wh) override; // *MENU*
+   void              SetCanvasSize(UInt_t cw, UInt_t ch) override; // *MENU*
    void              SetHighLightColor(Color_t col) { fHighLightColor = col; }
    void              SetSelected(TObject *obj) override;
    void              SetClickSelected(TObject *obj) { fClickSelected = obj; }


### PR DESCRIPTION
In the current ROOT, `TCanvas` constructor arguments were the window size. It caused some issues when the canvas created in batch and interactive mode as a result had different sizes, and some manual workarounds were required. It then also causes issue with saving resized canvas to macro as in the batch mode the size change was not preserved. Some of the discussions are https://root-forum.cern.ch/t/title-and-label-size-scaling-inconsistent-behaviour/64168 and https://root-forum.cern.ch/t/set-tcanvas-size-in-batch-mode/6626 and also #11004. Since the window decorations sizes are known and hardcoded one can reverse the old logic of determining the canvas size from window, to determine window size from canvas.

# This Pull request:
* changes meaning of arguments for `TCanvas` constructors
* provides consistent canvas size between interactive and batch mode
## Changes or fixes:
* `TCanvas` constructor arguments `ww` and `wh` renamed to `cw` and `ch` - now, their meaning is the canvas size, not the window size
* loginc inside `TCanvas` class to handle the new login
## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #11004 

