### PR TITLE
[hist] Move underflow bin before normal bins

### DIFF
--- a/hist/histv7/test/hist_axes.cxx
+++ b/hist/histv7/test/hist_axes.cxx
@@ -110,7 +110,7 @@ TEST(RAxes, ComputeGlobalIndex)
    const RAxes axes({regularAxis, variableBinAxis, categoricalAxis});
 
    {
-      const std::uint64_t Expected = (1 * (BinsY + 2) + 2) * (categories.size() + 1) + 2;
+      const std::uint64_t Expected = (2 * (BinsY + 2) + 3) * (categories.size() + 1) + 2;
       auto globalIndex = axes.ComputeGlobalIndex(std::make_tuple(1.5, 2.5, "c"));
       EXPECT_EQ(globalIndex.fIndex, Expected);
       EXPECT_TRUE(globalIndex.fValid);
@@ -122,7 +122,7 @@ TEST(RAxes, ComputeGlobalIndex)
 
    {
       // Underflow bin of the first axis.
-      const std::uint64_t Expected = (BinsX * (BinsY + 2) + 2) * (categories.size() + 1) + 2;
+      const std::uint64_t Expected = (0 * (BinsY + 2) + 3) * (categories.size() + 1) + 2;
       auto globalIndex = axes.ComputeGlobalIndex(std::make_tuple(-1, 2.5, "c"));
       EXPECT_EQ(globalIndex.fIndex, Expected);
       EXPECT_TRUE(globalIndex.fValid);
@@ -134,7 +134,7 @@ TEST(RAxes, ComputeGlobalIndex)
 
    {
       // Overflow bin of the second axis.
-      const std::uint64_t Expected = (1 * (BinsY + 2) + BinsY + 1) * (categories.size() + 1) + 2;
+      const std::uint64_t Expected = (2 * (BinsY + 2) + BinsY + 1) * (categories.size() + 1) + 2;
       auto globalIndex = axes.ComputeGlobalIndex(std::make_tuple(1.5, 42, "c"));
       EXPECT_EQ(globalIndex.fIndex, Expected);
       EXPECT_TRUE(globalIndex.fValid);
@@ -146,7 +146,7 @@ TEST(RAxes, ComputeGlobalIndex)
 
    {
       // Overflow bin of the third axis.
-      const std::uint64_t Expected = (1 * (BinsY + 2) + 2) * (categories.size() + 1) + categories.size();
+      const std::uint64_t Expected = (2 * (BinsY + 2) + 3) * (categories.size() + 1) + categories.size();
       auto globalIndex = axes.ComputeGlobalIndex(std::make_tuple(1.5, 2.5, "d"));
       EXPECT_EQ(globalIndex.fIndex, Expected);
       EXPECT_TRUE(globalIndex.fValid);

--- a/hist/histv7/test/hist_regular.cxx
+++ b/hist/histv7/test/hist_regular.cxx
@@ -62,17 +62,17 @@ TEST(RRegularAxis, ComputeLinearizedIndex)
    static constexpr double UnderflowSmall = -0.1;
    for (double underflow : {NegativeInfinity, UnderflowLarge, UnderflowSmall}) {
       auto linIndex = axis.ComputeLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_FALSE(linIndex.fValid);
    }
 
    // Exactly the lower end of the axis interval
    {
       auto linIndex = axis.ComputeLinearizedIndex(0);
-      EXPECT_EQ(linIndex.fIndex, 0);
+      EXPECT_EQ(linIndex.fIndex, 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(0);
       EXPECT_EQ(linIndex.fIndex, 0);
@@ -81,7 +81,7 @@ TEST(RRegularAxis, ComputeLinearizedIndex)
 
    for (std::size_t i = 0; i < Bins; i++) {
       auto linIndex = axis.ComputeLinearizedIndex(i + 0.5);
-      EXPECT_EQ(linIndex.fIndex, i);
+      EXPECT_EQ(linIndex.fIndex, i + 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(i + 0.5);
       EXPECT_EQ(linIndex.fIndex, i);
@@ -119,7 +119,7 @@ TEST(RRegularAxis, ComputeLinearizedIndexMin)
    const RRegularAxis axis(Bins, {-1, std::numeric_limits<double>::min()});
 
    auto linIndex = axis.ComputeLinearizedIndex(0);
-   EXPECT_EQ(linIndex.fIndex, Bins - 1);
+   EXPECT_EQ(linIndex.fIndex, Bins); // the last normal bin
    EXPECT_TRUE(linIndex.fValid);
 }
 
@@ -132,16 +132,16 @@ TEST(RRegularAxis, GetLinearizedIndex)
    {
       const auto underflow = RBinIndex::Underflow();
       auto linIndex = axis.GetLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.GetLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_FALSE(linIndex.fValid);
    }
 
    for (std::size_t i = 0; i < Bins; i++) {
       auto linIndex = axis.GetLinearizedIndex(i);
-      EXPECT_EQ(linIndex.fIndex, i);
+      EXPECT_EQ(linIndex.fIndex, i + 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.GetLinearizedIndex(i);
       EXPECT_EQ(linIndex.fIndex, i);

--- a/hist/histv7/test/hist_variable.cxx
+++ b/hist/histv7/test/hist_variable.cxx
@@ -87,16 +87,16 @@ TEST(RVariableBinAxis, ComputeLinearizedIndex)
    static constexpr double UnderflowSmall = -0.1;
    for (double underflow : {NegativeInfinity, UnderflowLarge, UnderflowSmall}) {
       auto linIndex = axis.ComputeLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_FALSE(linIndex.fValid);
    }
 
    for (std::size_t i = 0; i < Bins; i++) {
       auto linIndex = axis.ComputeLinearizedIndex(i + 0.5);
-      EXPECT_EQ(linIndex.fIndex, i);
+      EXPECT_EQ(linIndex.fIndex, i + 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(i + 0.5);
       EXPECT_EQ(linIndex.fIndex, i);
@@ -106,7 +106,7 @@ TEST(RVariableBinAxis, ComputeLinearizedIndex)
    // Exactly on the bin edges
    for (std::size_t i = 0; i < Bins; i++) {
       auto linIndex = axis.ComputeLinearizedIndex(i);
-      EXPECT_EQ(linIndex.fIndex, i);
+      EXPECT_EQ(linIndex.fIndex, i + 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.ComputeLinearizedIndex(i);
       EXPECT_EQ(linIndex.fIndex, i);
@@ -153,16 +153,16 @@ TEST(RVariableBinAxis, GetLinearizedIndex)
    {
       const auto underflow = RBinIndex::Underflow();
       auto linIndex = axis.GetLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.GetLinearizedIndex(underflow);
-      EXPECT_EQ(linIndex.fIndex, Bins);
+      EXPECT_EQ(linIndex.fIndex, 0);
       EXPECT_FALSE(linIndex.fValid);
    }
 
    for (std::size_t i = 0; i < Bins; i++) {
       auto linIndex = axis.GetLinearizedIndex(i);
-      EXPECT_EQ(linIndex.fIndex, i);
+      EXPECT_EQ(linIndex.fIndex, i + 1);
       EXPECT_TRUE(linIndex.fValid);
       linIndex = axisNoFlowBins.GetLinearizedIndex(i);
       EXPECT_EQ(linIndex.fIndex, i);


### PR DESCRIPTION
This is a bit more complicated in the code because the shift only applies if the underflow bin is enabled. It is also slower in the existing microbenchmarks, in particular with Clang. However, we need to make this change in order to support UHI's `values(flow=True)` with zero-copy buffers in the future and have the underflow bin at "the right place." Otherwise the design currently treats the memory layout as an internal implementation detail that users will not notice when using `RBinIndex`.