### PR TITLE
[df] Integration of `RHistEngine` filling

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -36,6 +36,7 @@
 #ifdef R__HAS_ROOT7
 #include <ROOT/RHist.hxx>
 #include <ROOT/RHistConcurrentFiller.hxx>
+#include <ROOT/RHistEngine.hxx>
 #include <ROOT/RWeight.hxx>
 #endif
 
@@ -534,6 +535,53 @@ public:
          context->Flush();
       }
    }
+
+   std::string GetActionName() { return "Hist"; }
+};
+
+template <typename BinContentType, bool WithWeight = false>
+class R__CLING_PTRCHECK(off) RHistEngineFillHelper
+   : public ROOT::Detail::RDF::RActionImpl<RHistEngineFillHelper<BinContentType, WithWeight>> {
+public:
+   using Result_t = ROOT::Experimental::RHistEngine<BinContentType>;
+
+private:
+   std::shared_ptr<Result_t> fHist;
+
+public:
+   RHistEngineFillHelper(std::shared_ptr<ROOT::Experimental::RHistEngine<BinContentType>> h) : fHist(h) {}
+   RHistEngineFillHelper(const RHistEngineFillHelper &) = delete;
+   RHistEngineFillHelper(RHistEngineFillHelper &&) = default;
+   RHistEngineFillHelper &operator=(const RHistEngineFillHelper &) = delete;
+   RHistEngineFillHelper &operator=(RHistEngineFillHelper &&) = default;
+   ~RHistEngineFillHelper() = default;
+
+   std::shared_ptr<Result_t> GetResultPtr() const { return fHist; }
+
+   void Initialize() {}
+   void InitTask(TTreeReader *, unsigned int) {}
+
+   template <typename... ColumnTypes, const std::size_t... I>
+   void ExecWithWeight(const std::tuple<const ColumnTypes &...> &columnValues, std::index_sequence<I...>)
+   {
+      // Build a tuple of const references with the actual arguments, stripping the weight and avoiding copies.
+      std::tuple<const std::tuple_element_t<I, std::tuple<ColumnTypes...>> &...> args(std::get<I>(columnValues)...);
+      ROOT::Experimental::RWeight weight(std::get<sizeof...(ColumnTypes) - 1>(columnValues));
+      fHist->FillAtomic(args, weight);
+   }
+
+   template <typename... ColumnTypes>
+   void Exec(unsigned int, const ColumnTypes &...columnValues)
+   {
+      if constexpr (WithWeight) {
+         auto t = std::forward_as_tuple(columnValues...);
+         ExecWithWeight(t, std::make_index_sequence<sizeof...(ColumnTypes) - 1>());
+      } else {
+         fHist->FillAtomic(columnValues...);
+      }
+   }
+
+   void Finalize() {}
 
    std::string GetActionName() { return "Hist"; }
 };

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -198,6 +198,30 @@ BuildAction(const ColumnNames_t &columnList, const std::shared_ptr<ROOT::Experim
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
    return std::make_unique<Action_t>(Helper_t(h, nSlots), columnList, std::move(prevNode), colRegister);
 }
+
+// Action for RHistEngine using FillAtomic without weights
+template <typename... ColTypes, typename BinContentType, typename PrevNodeType>
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &columnList, const std::shared_ptr<ROOT::Experimental::RHistEngine<BinContentType>> &h,
+            const unsigned int, std::shared_ptr<PrevNodeType> prevNode, ActionTags::Hist,
+            const RColumnRegister &colRegister)
+{
+   using Helper_t = RHistEngineFillHelper<BinContentType>;
+   using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
+   return std::make_unique<Action_t>(Helper_t(h), columnList, std::move(prevNode), colRegister);
+}
+
+// Action for RHistEngine using FillAtomic with weights
+template <typename... ColTypes, typename BinContentType, typename PrevNodeType>
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &columnList, const std::shared_ptr<ROOT::Experimental::RHistEngine<BinContentType>> &h,
+            const unsigned int, std::shared_ptr<PrevNodeType> prevNode, ActionTags::HistWithWeight,
+            const RColumnRegister &colRegister)
+{
+   using Helper_t = RHistEngineFillHelper<BinContentType, true>;
+   using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
+   return std::make_unique<Action_t>(Helper_t(h), columnList, std::move(prevNode), colRegister);
+}
 #endif
 
 template <typename... ColTypes, typename PrevNodeType>


### PR DESCRIPTION
Compared to `RHist` filling, we only support user-created objects.