### PR TITLE
[RDF] Restore stream precision and width when ProgressBar in use.

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -199,16 +199,27 @@ std::pair<std::size_t, std::chrono::seconds> ProgressHelper::RecordEvtCountAndTi
 namespace {
 
 struct RestoreStreamState {
-   RestoreStreamState(std::ostream &stream) : fStream(stream), fFlags(stream.flags()), fFillChar(stream.fill()) {}
+   RestoreStreamState(std::ostream &stream)
+      : fStream(stream),
+        fFlags(stream.flags()),
+        fFillChar(stream.fill()),
+        fPrecision{stream.precision()},
+        fWidth{stream.width()}
+   {
+   }
    ~RestoreStreamState()
    {
       fStream.flags(fFlags);
       fStream.fill(fFillChar);
+      fStream.precision(fPrecision);
+      fStream.width(fWidth);
    }
 
    std::ostream &fStream;
    std::ios_base::fmtflags fFlags;
    std::ostream::char_type fFillChar;
+   std::streamsize fPrecision;
+   std::streamsize fWidth;
 };
 
 /// Format std::chrono::seconds as `1:30m`.


### PR DESCRIPTION
As a followup to #14611, restore also precision and width of the streams.

This was reported in:
https://root-forum.cern.ch/t/rdf-progress-bar-changes-printout-precision/