### PR TITLE
[Python] Add wheels warning message at the end of `ROOT/__init__.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ ROOT_BUILD_INTERNAL_DIRNAME = "mock_site_packages"
 
 def _patch_root_init():
     warning_patch = '''
+
 import warnings
 import textwrap
 
@@ -48,7 +49,7 @@ This distribution of ROOT is in alpha stage. Feedback is welcome and appreciated
     with open(root_init_path) as init_file:
         full_init_text = init_file.read()
 
-    new_init_text = warning_patch + full_init_text
+    new_init_text = full_init_text + warning_patch
     with open(root_init_path, "w") as init_file:
         init_file.write(new_init_text)
 


### PR DESCRIPTION
This should fix the errors in the Python wheel nightlies:

```python
  File "/tmp/tmp44coezg8/lib/ROOT/__init__.py", line 20
    from __future__ import annotations
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: from __future__ imports must occur at the beginning of the file
```