### PR TITLE
[Python] Avoid side effects in libROOTPythonizations initialization 

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -162,6 +162,9 @@ class ROOTFacade(types.ModuleType):
         from ._application import PyROOTApplication
         from ._pythonization import _register_pythonizations, pythonization
 
+        # signal policy: don't abort interpreter in interactive mode
+        cppyy._backend.SetGlobalSignalPolicy(not cppyy.gbl.ROOT.GetROOT().IsBatch())
+
         self.__dict__["_cppyy"] = cppyy
 
         # Expose some functionality from CPyCppyy extension module

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -172,8 +172,6 @@ struct module_state {
    PyObject *error;
 };
 
-using namespace CPyCppyy;
-
 #define GETSTATE(m) ((struct module_state *)PyModule_GetState(m))
 
 static int rootmodule_traverse(PyObject *m, visitproc visit, void *arg)
@@ -205,12 +203,6 @@ extern "C" PyObject *PyInit_libROOTPythonizations()
 
    // keep gRootModule, but do not increase its reference count even as it is borrowed,
    // or a self-referencing cycle would be created
-
-   // Make sure the interpreter is initialized once gROOT has been initialized
-   TInterpreter::Instance();
-
-   // signal policy: don't abort interpreter in interactive mode
-   CallContext::SetGlobalPolicy(CallContext::kProtected, !gROOT->IsBatch());
 
    return gRootModule;
 }


### PR DESCRIPTION
There are some side effects when importing the ROOT CPython extension
that we should better avoid, so that all active initialization is
centralized in `ROOTFacade._finalSetup()`.

Like this, it will be easier for us and our users to keep track of what
the differences between the base cppyy and the ROOT C++ runtime are.

That should help explaining to our users that they usually don't need to
import cppyy directly,

In particular, the extra reference directly contradicted a comment a few lines
further up:

> keep gRootModule, but do not increase its reference count