### PR TITLE
[CMake] Use OUTPUT_NAME if defined in ROOT_GENERATE_DICTIONARY

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -528,7 +528,13 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     if (NOT ${ARG_MODULE} STREQUAL ${library_target_name})
 #      message(AUTHOR_WARNING "The MODULE argument ${ARG_MODULE} and the deduced library name "
 #        "${library_target_name} mismatch. Deduction stem: ${dictionary}.")
-      set(library_target_name ${ARG_MODULE})
+      get_target_property(custom_name ${ARG_MODULE} OUTPUT_NAME)
+      if(NOT custom_name STREQUAL "custom_name-NOTFOUND")
+        # if the OUTPUT_NAME propery has been set, use that as library_target_name
+        set(library_target_name ${custom_name})
+      else()
+        set(library_target_name ${ARG_MODULE})
+      endif()
     endif()
   endif(ARG_MODULE)
 


### PR DESCRIPTION
# This Pull request:

Fixes the logic used to infer the base name used to generate the `libXXX.dylib|so`, `libXXX_rdict.pcm` and `libXXX.rootmap` when using the `MODULE` option of the `ROOT_GENERATE_DICTIONARY` CMake macro, in the case where the `OUTPUT_NAME` of XXX has been set prior to the call to ROOT_GENERATE_DICTIONARY. 

## Checklist:

- [X ] tested changes locally
- [ ] updated the docs (if necessary) => not necessary (?)
