### PR TITLE
[test] Test that import ROOT does not implicitly import cppyy

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 # Test ROOT module
 ROOT_ADD_PYUNITTEST(pyroot_root_module root_module.py)
+ROOT_ADD_PYUNITTEST(pyroot_root_no_implicit_cppyy root_no_implicit_cppyy.py)
 
 # @pythonization decorator
 ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)

--- a/bindings/pyroot/pythonizations/test/root_no_implicit_cppyy.py
+++ b/bindings/pyroot/pythonizations/test/root_no_implicit_cppyy.py
@@ -1,0 +1,26 @@
+import unittest
+
+
+class ROOTNoImplicitCppyy(unittest.TestCase):
+    """
+    Test that import ROOT does not implicitly import cppyy.
+
+    This test lives standalone in a separate file so that it does not get interference from other tests that may import
+    parts of ROOT which involve initialization of the C++ runtime.
+    """
+
+    def test_no_implicit_cppyy_import(self):
+        import sys
+
+        import ROOT
+
+        self.assertFalse("cppyy" in sys.modules)
+
+        # Call some attribute that would initialize the C++ runtime
+        ROOT.gInterpreter
+
+        self.assertTrue("cppyy" in sys.modules)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a test after the recent improvements of the ROOT Python package.