### PR TITLE
[test][cppyy] Add test for string_view to Python str

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1748,6 +1748,20 @@ class TestSTLSTRING_VIEW:
         gc.collect()    # id.
 
         assert "Lorem ipsum dolor sit amet" in str(text)
+    
+    def  test03_string_view_pythonize(self):
+        """Pythonization of std::string_view"""
+
+        import cppyy
+
+        cppyy.cppdef("""
+        std::string_view s = "Hello, World!";
+        """)
+
+        from cppyy.gbl import s
+
+        assert(s == "Hello, World!")
+        assert(str(s) == "Hello, World!")
 
 
 class TestSTLDEQUE:


### PR DESCRIPTION
Adds a cppyy test for https://github.com/root-project/root/pull/19620. This simple test ensures we don't regress and see the old behaviour of string_view: `str(s) == '"Hello, World!"[13]'`