### PR TITLE
[net] testParallelMergingFile: enable thread safety

### DIFF
--- a/net/net/test/testParallelMergingFile.cxx
+++ b/net/net/test/testParallelMergingFile.cxx
@@ -13,6 +13,7 @@
 #include "TParallelMergingFile.h"
 #include "TServerSocket.h"
 #include "TFileMerger.h"
+#include "TROOT.h"
 
 enum EStatusKind {
    // These values are dictated by TParallelMergingFile::UploadAndReset().
@@ -94,6 +95,8 @@ static void Server(std::unique_ptr<TServerSocket> ss, const std::string &outFile
 
 TEST(TParallelMergingFile, UploadAndResetNonTObject)
 {
+   ROOT::EnableThreadSafety();
+   
    TString sockPath = "parallelMergeTest";
    FILE *dummy = gSystem->TempFileName(sockPath);
    if (!dummy) {


### PR DESCRIPTION
Tentative fix for the sporadic crash we get in this test. On my machine it seems to solve the issue.



