### PR TITLE
Support Home/End keys in ROOT prompt on rxvt-unicode

### DIFF
--- a/core/textinput/src/textinput/StreamReaderUnix.cpp
+++ b/core/textinput/src/textinput/StreamReaderUnix.cpp
@@ -216,6 +216,8 @@ namespace textinput {
       gExtKeyMap['[']['4']['~'] = InputData::kEIEnd;
       gExtKeyMap['[']['5']['~'] = InputData::kEIPgUp;
       gExtKeyMap['[']['6']['~'] = InputData::kEIPgDown;
+      gExtKeyMap['[']['7']['~'] = InputData::kEIHome; // urxvt
+      gExtKeyMap['[']['8']['~'] = InputData::kEIEnd;  // urxvt
       gExtKeyMap['[']['1'][';']['5']['A'].Set(InputData::kEIUp,
                                          InputData::kModCtrl);
       gExtKeyMap['[']['1'][';']['5']['B'].Set(InputData::kEIDown,


### PR DESCRIPTION
Closes JIRA ticket https://its.cern.ch/jira/browse/ROOT-10988

Thanks to Joao Pedro Athayde Marcondes De Andre for the patch, which was tested on rxvt-unicode (aka. urxvt) version 9.31.