### PR TITLE
Mask a "DISPLAY not set" warning in TTabComTests.

### DIFF
--- a/core/rint/test/TTabComTests.cxx
+++ b/core/rint/test/TTabComTests.cxx
@@ -92,6 +92,7 @@ TEST(TTabComTests, CompleteTH1)
    {
       ROOT::TestSupport::CheckDiagsRAII diagRAII;
       diagRAII.optionalDiag(kError, "", "libGed[.so | .dll | .dylib | .sl | .dl | .a] does not exist in", false);
+      diagRAII.optionalDiag(kWarning, "TUnixSystem::SetDisplay", "DISPLAY not set", false); // When tested over ssh
       if (0 == gSystem->Load("libGed")) {
          expected += " TH1Editor";
       }


### PR DESCRIPTION
When running the test via ssh -X, it might issue the warning about the DISPLAY variable not being set, which leads to a test failure.