### PR TITLE
[RF] Remove all RooDirItem::appendToDir calls.

### DIFF
--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -124,7 +124,6 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgSe
 
   registerWeightArraysToDataStore();
 
-  appendToDir(this,true) ;
   TRACE_CREATE;
 }
 
@@ -354,9 +353,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
   } else {
 
     // Initialize empty
-    initialize() ;
-    appendToDir(this,true) ;
-
+    initialize();
   }
 
   registerWeightArraysToDataStore();
@@ -377,8 +374,7 @@ void RooDataHist::importTH1(const RooArgList& vars, const TH1& histo, double wgt
   adjustBinning(vars, histo, offset) ;
 
   // Initialize internal data structure
-  initialize() ;
-  appendToDir(this,true) ;
+  initialize();
 
   // Define x,y,z as 1st, 2nd and 3rd observable
   RooRealVar* xvar = static_cast<RooRealVar*>(_vars.find(vars.at(0)->GetName())) ;
@@ -533,9 +529,8 @@ void RooDataHist::importTH1Set(const RooArgList& vars, RooCategory& indexCat, st
 
   // Initialize internal data structure
   if (!init) {
-    initialize() ;
-    appendToDir(this,true) ;
-    init = true ;
+     initialize();
+     init = true;
   }
 
   // Define x,y,z as 1st, 2nd and 3rd observable
@@ -644,7 +639,6 @@ void RooDataHist::importDHistSet(const RooArgList & /*vars*/, RooCategory &index
    }
 
    initialize();
-   appendToDir(this, true);
 
    for (const auto &diter : dmap) {
       std::string const &label = diter.first;
@@ -904,8 +898,6 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
   }
 
   registerWeightArraysToDataStore();
-
- appendToDir(this,true) ;
 }
 
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -374,8 +374,6 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
       }
     }
 
-    appendToDir(this,true) ;
-
     // Initialize RooDataSet with optional weight variable
     initialize(nullptr) ;
 
@@ -450,8 +448,6 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
       }
     }
 
-    appendToDir(this,true) ;
-
     // Initialize RooDataSet with optional weight variable
     initialize(wgtVarName);
 
@@ -523,11 +519,9 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
 RooDataSet::RooDataSet(RooDataSet const & other, const char* newname) :
   RooAbsData(other,newname), RooDirItem()
 {
-  appendToDir(this,true) ;
-  initialize(other._wgtVar?other._wgtVar->GetName():nullptr);
-  TRACE_CREATE;
+   initialize(other._wgtVar ? other._wgtVar->GetName() : nullptr);
+   TRACE_CREATE;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return an empty clone of this dataset. If vars is not null, only the variables in vars

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -61,12 +61,7 @@ using std::ostream, std::string, std::pair, std::vector, std::setw;
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with name and title
 
-RooFitResult::RooFitResult(const char *name, const char *title) : TNamed(name, title)
-{
-   if (name)
-      appendToDir(this, true);
-}
-
+RooFitResult::RooFitResult(const char *name, const char *title) : TNamed(name, title) {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
@@ -99,10 +94,8 @@ RooFitResult::RooFitResult(const RooFitResult &other)
      _Lt = std::make_unique<TMatrix>(*other._Lt);
   if (other._VM) _VM = new TMatrixDSym(*other._VM) ;
   if (other._CM) _CM = new TMatrixDSym(*other._CM) ;
-  if (other._GC) _GC = new TVectorD(*other._GC) ;
-
-  if (GetName())
-    appendToDir(this, true);
+  if (other._GC)
+     _GC = new TVectorD(*other._GC);
 }
 
 


### PR DESCRIPTION
In view of ROOT 7, I studied the effects of `RooDirItem`-derived classes. Since at least 5 years, RooDataHist, RooDataSet and RooFitResult were calling `RooDirItem::appendToDir(this, true)`. This has no effect, since `forceMemoryResident==true`.
Here, all these calls that don't have any effect are removed to make more obvious that no automatic registration is happening.