### PR TITLE
[gpad] do not overwrite the title of the last PDF page when closing

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5472,7 +5472,7 @@ void TPad::Print(const char *filename, Option_t *option)
       if (titlePos != kNPOS) {
          gVirtualPS->SetTitle(opt.Data()+titlePos+6);
          opt.Replace(titlePos,opt.Length(),"pdf");
-      } else {
+      } else if (!ccloseb) {
          gVirtualPS->SetTitle("PDF");
       }
       if (mustClose) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

[gpad] do not overwrite the title of the last PDF page when closing unless explicitly passing the Title flag in the close command.

Fixes https://github.com/root-project/root/issues/21244


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

