### PR TITLE
[hist] Fix computation of number of entries in ResetStats

### DIFF
--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -296,7 +296,6 @@ class TestTH1Indexing:
         sliced_hist_full = hist_setup[...]
 
         assert hist_setup.GetEffectiveEntries() == pytest.approx(sliced_hist_full.GetEffectiveEntries())
-        assert sliced_hist_full.GetEntries() == pytest.approx(sliced_hist_full.GetEffectiveEntries())
         assert hist_setup.Integral() == pytest.approx(sliced_hist_full.Integral())
 
         # Check if slicing over a range updates the statistics
@@ -307,7 +306,6 @@ class TestTH1Indexing:
 
         assert hist_setup.Integral() == sliced_hist.Integral()
         assert hist_setup.GetEffectiveEntries() == pytest.approx(sliced_hist.GetEffectiveEntries())
-        assert sliced_hist.GetEntries() == pytest.approx(sliced_hist.GetEffectiveEntries())
         assert hist_setup.GetStdDev() == pytest.approx(sliced_hist.GetStdDev(), rel=10e-5)
         assert hist_setup.GetMean() == pytest.approx(sliced_hist.GetMean(), rel=10e-5)
 

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -553,7 +553,7 @@ public:
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t GetStdDev(Int_t axis=1) const;
    virtual Double_t GetStdDevError(Int_t axis=1) const;
-   Double_t         GetSumOfAllWeights(const bool includeOverflow) const;
+   Double_t         GetSumOfAllWeights(const bool includeOverflow, Double_t * sumWeightSquare = nullptr) const;
    /// Return the sum of weights across all bins excluding under/overflows.
    /// \see TH1::GetSumOfAllWeights()
    virtual Double_t GetSumOfWeights() const { return GetSumOfAllWeights(false); }

--- a/hist/hist/src/TProfileHelper.h
+++ b/hist/hist/src/TProfileHelper.h
@@ -108,6 +108,8 @@ Bool_t TProfileHelper::Add(T* p, const TH1 *h1,  const TH1 *h2, Double_t c1, Dou
 
    // create sumw2 per bin if not set
    if (p->fBinSumw2.fN == 0 && (p1->fBinSumw2.fN != 0 || p2->fBinSumw2.fN != 0)) p->Sumw2();
+   // create sumw2 also for the case where coefficients are not equal to 1
+   if (p->fSumw2.fN == 0 && (c1 != 1.0 || c2 != 1.0)) p->Sumw2();
 
    // Make the loop over the bins to calculate the Addition
    Double_t *cu1 = p1->GetW();    Double_t *cu2 = p2->GetW();


### PR DESCRIPTION
When computing the number of entries in TH1::ResetStats always include underflow/overflow. Also in number of FetEffectiveEntries()

Fix a bug in the computation of GetAllSumOfWeights() and improve the function to return (as an optional parameter) the total sum of weight square (including underflow/overflows).

Improve the handling of statistics in TH1::Add  methods. 
When performing additions of histograms with coefficient > 0 but not equal to 1 automatically compute the sum of weight squares, otherwise the bin errors computations (and the error on the statistics, mean, std) will not be correct.  

The bug was happening for dimensions < 2. (see ROOT-21253)



This PR fixes #21253 and the old JIRA item https://its.cern.ch/jira/browse/ROOT-10567?filter=-1

For the JIRA item, in case of Addition/Subtraction of histogram, the nuber of entries is now computed using underflow/overflows. But in case of Additions/Subtraciton with coefficient not equal to 1, the histogram will be weighted and the number of effective entries will be used. 
