### PR TITLE
[tree] Clear error when calling CopyTree on a chain with friends

### DIFF
--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -86,6 +86,7 @@ public:
    TFriendElement *AddFriend(TTree* chain, const char* alias = "", bool warn = false) override;
    void      Browse(TBrowser*) override;
    virtual void      CanDeleteRefs(bool flag = true);
+   virtual TTree    *CopyTree(const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0) override;
    virtual void      CreatePackets();
    void      DirectoryAutoAdd(TDirectory *) override;
    Long64_t  Draw(const char* varexp, const TCut& selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0) override;

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -752,6 +752,24 @@ void TChain::CanDeleteRefs(bool flag /* = true */)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Copy a tree with selection.
+///
+/// See the documentation of TTree::CopyTree
+///
+/// ### Known limitations for TChain
+///   - This method is not supported if used on an instance with friends
+
+TTree* TChain::CopyTree(const char* selection, Option_t* option /* = 0 */, Long64_t nentries /* = TTree::kMaxEntries */, Long64_t firstentry /* = 0 */)
+{
+   // A clear error for ROOT-10778
+   if (GetListOfFriends()) {
+      Error("CopyTree","TChain::CopyTree is not supported if the TChain instance has friends.");
+      return nullptr;
+   }
+   return this->TTree::CopyTree(selection, option, nentries, firstentry);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Initialize the packet descriptor string.
 
 void TChain::CreatePackets()

--- a/tree/tree/test/TChainRegressions.cxx
+++ b/tree/tree/test/TChainRegressions.cxx
@@ -6,9 +6,22 @@
 #include <TSystem.h>
 #include <TTree.h>
 
+#include "ROOT/TestSupport.hxx"
 #include "gtest/gtest.h"
 
 class TTreeCache;
+
+// ROOT-10778
+TEST(TChain, CopyTreeWithFriends)
+{
+   TChain ch1("chain1");
+   TChain ch2("chain2");
+   ch1.AddFriend(&ch2);
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kError, "TChain::CopyTree",
+                      "TChain::CopyTree is not supported if the TChain instance has friends.");
+   ch1.CopyTree("");
+}
 
 // https://its.cern.ch/jira/browse/ROOT-7973
 TEST(TChain, WrongCacheReadTwoTrees)


### PR DESCRIPTION
Addresses [ROOT-10778](https://its.cern.ch/jira/browse/ROOT-10778) by printing a clear, meaningful message about an unsupported operation being carried out.

