### PR TITLE
[rdf] Fix compilation errors on Windows (c++17)

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -295,7 +295,7 @@ void ProgressHelper::PrintProgressAndStats(std::ostream &stream, std::size_t cur
    buffer << "[";
    if (fUseShellColours)
       buffer << "\033[35m";
-   buffer << "Elapsed: " << elapsedSeconds << "  ";
+   buffer << "Elapsed: " << elapsedSeconds.count() << "  ";
    if (fUseShellColours)
       buffer << "\033[0m";
    buffer << "files: " << currentFileIdx << " / " << fTotalFiles << "  ";
@@ -337,7 +337,7 @@ void ProgressHelper::PrintProgressAndStats(std::ostream &stream, std::size_t cur
          remainingSeconds =
             std::chrono::seconds{static_cast<long long>(elapsedSeconds.count() / completion - elapsedSeconds.count())};
       }
-      buffer << "  remaining ca.: " << remainingSeconds;
+      buffer << "  remaining ca.: " << remainingSeconds.count();
 
       if (fUseShellColours)
          buffer << "\033[0m";
@@ -367,7 +367,7 @@ void ProgressHelper::PrintStatsFinal() const
    if (fUseShellColours)
       stream << "\033[35m";
    stream << "["
-          << "Total elapsed time: " << elapsedSeconds << "  ";
+          << "Total elapsed time: " << elapsedSeconds.count() << "  ";
    if (fUseShellColours)
       stream << "\033[0m";
    stream << "processed files: " << fTotalFiles << "  ";


### PR DESCRIPTION
Fix the following error on Windows with `/std:c++17`:
RDFHelpers.cxx(340,14): error C2679: binary '<<': no operator found which takes a right-hand operand of type 'std::chrono::seconds' (or there is no acceptable conversion)
Prior to C++20, the standard library did not provide a direct operator << overload for std::chrono
