### PR TITLE
[ntuple] detect runtime member streamers via TRealData

### DIFF
--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -186,6 +186,19 @@ ROOT::RClassField::RClassField(std::string_view fieldName, TClass *classp)
        ROOT::Internal::ERNTupleSerializationMode::kForceStreamerMode) {
       throw RException(R__FAIL(GetTypeName() + " has streamer mode enforced, not supported as native RNTuple class"));
    }
+   // Detect custom streamers set on individual members at runtime via
+   // TClass::SetMemberStreamer() or TClass::AdoptMemberStreamer().
+   // CanSplit() only checks for custom streamers set at compile time (fHasCustomStreamerMember),
+   // but runtime streamers are stored in TRealData and must be checked here.
+   if (!fClass->GetListOfRealData()) {
+      fClass->BuildRealData();
+   }
+   for (auto realMember : ROOT::Detail::TRangeStaticCast<TRealData>(*fClass->GetListOfRealData())) {
+      if (realMember->GetStreamer()) {
+         throw RException(R__FAIL(std::string(GetTypeName()) + " has member " + realMember->GetName() +
+                                  " with a custom streamer; not supported natively in RNTuple"));
+      }
+   }
 
    if (!(fClass->ClassProperty() & kClassHasExplicitCtor))
       fTraits |= kTraitTriviallyConstructible;

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -460,4 +460,11 @@ struct ExampleMC {
 };
 } // namespace v2
 
+// Test class for runtime member streamers set via TClass::SetMemberStreamer
+struct MemberWithCustomStreamer {
+   int fNormal = 0;
+   int fCustom = 0;
+   ClassDefNV(MemberWithCustomStreamer, 2);
+};
+
 #endif

--- a/tree/ntuple/test/CustomStructLinkDef.h
+++ b/tree/ntuple/test/CustomStructLinkDef.h
@@ -175,4 +175,6 @@
 #pragma read sourceClass = "v1::ExampleMC" source = "v1::Vector3D fSpin" version="[1-]" targetClass = \
    "v2::ExampleMC" target = "fHelicity" code = "{ fHelicity = onfile.fSpin.fZ; }"
 
+#pragma link C++ class MemberWithCustomStreamer+;
+
 #endif

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -5,6 +5,7 @@
 #include <TObject.h>
 #include <TRef.h>
 #include <TRotation.h>
+#include <TBuffer.h>
 #include <TVirtualStreamerInfo.h>
 
 #include <memory>
@@ -465,4 +466,33 @@ TEST(RNTuple, StreamerInfoRecords)
          EXPECT_EQ(std::get<1>(t)[0], field->GetClass()->GetName());
       }
    }
+}
+
+// Detect custom streamers set on class members at runtime via TClass::SetMemberStreamer.
+TEST(RNTuple, MemberWithCustomStreamer)
+{
+   auto cl = TClass::GetClass("MemberWithCustomStreamer");
+   ASSERT_NE(cl, nullptr);
+
+   // CanSplit() should be true initially (it only checks compile-time properties)
+   EXPECT_TRUE(cl->CanSplit());
+
+   // Without member streamer: field creation succeeds
+   RFieldBase::Create("f", "MemberWithCustomStreamer").Unwrap();
+
+   // Set a custom streamer on the "fCustom" member at runtime
+   cl->SetMemberStreamer("fCustom", [](TBuffer &b, void *obj, Int_t) {
+      int *val = static_cast<int *>(obj);
+      if (b.IsReading()) {
+         b >> *val;
+      } else {
+         b << *val;
+      }
+   });
+
+   // CanSplit() remains true because you can still split (in TTree) even if a data member has a custom member.
+   EXPECT_TRUE(cl->CanSplit());
+
+   // After setting member streamer: field creation should throw
+   EXPECT_THROW(RFieldBase::Create("f", "MemberWithCustomStreamer").Unwrap(), ROOT::RException);
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

When a class member has a custom streamer set at runtime via `TClass::SetMemberStreamer()` or  `TClass::AdoptMemberStreamer()`,

`RFieldBase::Create()` now detects this by iterating `TRealData` and checking `TRealData::GetStreamer()`. 

If any member has a custom streamer, an RStreamerField is used instead of RClassField, preventing the class from being split into columns which would bypass the member's custom serialization logic.

## Checklist:

- [x] tested changes locally

This PR fixes #20448