### PR TITLE
Fix macOS build failure with older SDKs in QuartzWindow.mm

### DIFF
--- a/graf2d/cocoa/src/QuartzWindow.mm
+++ b/graf2d/cocoa/src/QuartzWindow.mm
@@ -2615,13 +2615,17 @@ void print_mask_info(ULong_t mask)
 //______________________________________________________________________________
 - (void)didAddSubview:(NSView *)subview
 {
-    self.clipsToBounds = YES;
+    [super didAddSubview:subview];
+    self.wantsLayer = YES;
+    self.layer.masksToBounds = YES;
 }
 
 //______________________________________________________________________________
 - (void)willRemoveSubview:(NSView *)subview
 {
-    self.clipsToBounds = self.subviews.count > 1;
+    [super willRemoveSubview:subview];
+    self.wantsLayer = YES;
+    self.layer.masksToBounds = self.subviews.count > 1;
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
`NSView.clipsToBounds` is not declared in `NSView.h` in older macOS SDKs such as MacOSX11.0.sdk. This causes a build failure when compiling with these SDKs, as used by conda-forge:

```
QuartzWindow.mm:2618:10: error: property 'clipsToBounds' not found on object of type 'QuartzView *'
 2618 |     self.clipsToBounds = YES;
      |          ^
QuartzWindow.mm:2624:10: error: property 'clipsToBounds' not found on object of type 'QuartzView *'
 2624 |     self.clipsToBounds = self.subviews.count > 1;
      |          ^
2 errors generated.
```

Failing conda-forge build: https://github.com/conda-forge/root-feedstock/pull/335

This PR replaces `self.clipsToBounds = <value>` with the equivalent `self.layer.masksToBounds = <value>`, guarded by `self.wantsLayer = YES` to ensure the view is layer-backed. `layer.masksToBounds` is the Core Animation equivalent and is available across all SDK versions.

Additionally, the overridden `didAddSubview:` and `willRemoveSubview:` methods now call their `super` implementations, which is standard practice when overriding these NSView methods.