### PR TITLE
Support Python 3.14 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ numpy
 pandas
 
 # TMVA: SOFIE
-dm-sonnet # used for GNNs
-graph_nets
+dm-sonnet ; python_version < "3.14" # used for GNNs
+graph_nets ; python_version < "3.14"
 onnx
 onnxscript
 packaging
 
 # TMVA: PyMVA interfaces
 scikit-learn
-tensorflow
+tensorflow ; python_version < "3.14"
 torch
 xgboost
 


### PR DESCRIPTION
Python 3.14 is out for a few months now and will also be shipped with the upcoming Fedora 44, so it's time to make our requirements.txt work with Python 3.14.

This is achieved by making the packages conditional that don't support Python 3.14 yet, which are TensorFlow and packages built around the TensorFlow ecosystem.