### PR TITLE
[df] Avoid false positive warning with gcc 15 in `dataframe_vecops.cxx`

### DIFF
--- a/tree/dataframe/test/dataframe_vecops.cxx
+++ b/tree/dataframe/test/dataframe_vecops.cxx
@@ -83,7 +83,9 @@ void MakeTreeWithBools(const std::string &treename, const std::string &fname)
    var_arr[1] = false;
    arr[0] = true;
    arr[1] = false;
-   vec = {true, false};
+   vec.resize(n);
+   vec[0] = true;
+   vec[1] = false;
    t.Fill();
 
    n = 1000;


### PR DESCRIPTION
Avoid false positive warning with gcc 15 related to libstdc++ `std::vector<bool>`:

```txt
[2200/2997] Building CXX object tree/dataframe/test/CMakeFiles/dataframe_vecops.dir/dataframe_vecops.cxx.o
In file included from /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/string:53,
                 from /home/rembserj/code/root/root_src/core/meta/inc/TSchemaHelper.h:17,
                 from /home/rembserj/code/root/root_src/core/meta/inc/TGenericClassInfo.h:21,
                 from /home/rembserj/code/root/root_src/core/base/inc/Rtypes.h:200,
                 from /home/rembserj/code/root/root_src/core/base/inc/TObject.h:17,
                 from /home/rembserj/code/root/root_src/core/base/inc/TNamed.h:25,
                 from /home/rembserj/code/root/root_src/core/base/inc/TDirectory.h:24,
                 from /home/rembserj/code/root/root_src/core/base/inc/TROOT.h:28,
                 from /home/rembserj/code/root/root_src/tree/dataframe/inc/ROOT/RDataFrame.hxx:19,
                 from /home/rembserj/code/root/root_src/tree/dataframe/test/dataframe_vecops.cxx:1:
In function ‘constexpr _OutIter std::__copy_move_a2(_InIter, _Sent, _OutIter) [with bool _IsMove = false; _InIter = long unsigned int*; _Sent = long unsigned int*; _OutIter = long unsigned int*]’,
    inlined from ‘constexpr _OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_algobase.h:492:42,
    inlined from ‘constexpr _OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_algobase.h:500:31,
    inlined from ‘constexpr _OI std::copy(_II, _II, _OI) [with _II = long unsigned int*; _OI = long unsigned int*]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_algobase.h:642:7,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::_M_copy_aligned(const_iterator, const_iterator, iterator) [with _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_bvector.h:1547:28,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_insert_range(iterator, _ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/vector.tcc:1183:33,
    inlined from ‘constexpr std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::insert(const_iterator, _InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_bvector.h:1311:19,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::_M_assign_aux(_ForwardIterator, _ForwardIterator, std::forward_iterator_tag) [with _ForwardIterator = const bool*; _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_bvector.h:1684:14,
    inlined from ‘constexpr void std::vector<bool, _Alloc>::assign(_InputIterator, _InputIterator) [with _InputIterator = const bool*; <template-parameter-2-2> = void; _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_bvector.h:1010:17,
    inlined from ‘constexpr std::vector<bool, _Alloc>& std::vector<bool, _Alloc>::operator=(std::initializer_list<bool>) [with _Alloc = std::allocator<bool>]’ at /nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_bvector.h:990:14,
    inlined from ‘void MakeTreeWithBools(const std::string&, const std::string&)’ at /home/rembserj/code/root/root_src/tree/dataframe/test/dataframe_vecops.cxx:86:22:
/nix/store/z813adlzklalxq8v186i80j8k67x3zkc-gfortran-15.2.0/include/c++/15.2.0/bits/stl_algobase.h:426:32: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] [-Warray-bounds=]
  426 |               __builtin_memmove(_GLIBCXX_TO_ADDR(__result),
      |               ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  427 |                                 _GLIBCXX_TO_ADDR(__first),
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
  428 |                                 __n * sizeof(*__first));
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unused-command-line-argument’ may have been intended to silence earlier diagnostics
```