### PR TITLE
[RNT] Fix a mismatched tags warning.

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
@@ -228,8 +228,8 @@ struct RNTupleLocatorHelper<RNTupleLocatorObject64> {
 /// Note that we use a representation optimized for memory consumption that slightly differs from the on-disk
 /// representation.
 class RNTupleLocator {
-   friend class Internal::RNTupleLocatorHelper<std::uint64_t>;
-   friend class Internal::RNTupleLocatorHelper<RNTupleLocatorObject64>;
+   friend struct Internal::RNTupleLocatorHelper<std::uint64_t>;
+   friend struct Internal::RNTupleLocatorHelper<RNTupleLocatorObject64>;
 
 public:
    /// Values for the _Type_ field in non-disk locators.  Serializable types must have the MSb == 0; see


### PR DESCRIPTION
Fix the following warning in clang21:
```
    RNTupleTypes.hxx:231:11: warning: class 'RNTupleLocatorHelper' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
      231 |    friend class Internal::RNTupleLocatorHelper<std::uint64_t>;
          |           ^
    RNTupleTypes.hxx:215:8: note: previous use is here
      215 | struct RNTupleLocatorHelper<std::uint64_t> {
          |        ^
```