### PR TITLE
Replace shell `which` with ROOT's `Which()` in stack trace generation

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -2516,7 +2516,14 @@ void TUnixSystem::StackTrace()
                if (name[0] != '/') noPath = kTRUE;
                if (name.Contains(".so") || name.Contains(".sl")) noShare = kFALSE;
                if (noShare) offset = addr;
-               if (noPath)  name = "`which " + name + "`";
+               if (noPath) {
+                  char *fullpath = noShare ? Which(Getenv("PATH"), name, kExecutePermission)
+                                           : Which(GetDynamicPath(), name, kReadPermission);
+                  if (fullpath) {
+                     name = fullpath;
+                     delete [] fullpath;
+                  }
+               }
                snprintf(buffer, sizeof(buffer), "%s -e %s 0x%016lx", addr2line, name.Data(), offset);
 #endif
                if (FILE *pf = ::popen(buffer, "r")) {


### PR DESCRIPTION
In `TUnixSystem::StackTrace()`, when a library name from `dladdr()` lacks a full path, the code previously used shell backtick-executed `which` inside the `popen()` call to `addr2line`. The `which` command is not POSIX and is unavailable in minimal container images, causing stack trace generation to fail with `sh: line 1: which: command not found`.

Replace with ROOT's own `Which()` function, searching `PATH` for executables and the dynamic library path for shared libraries.