### PR TITLE
[RF] Support resetting data for codegen likelihoods

### DIFF
--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -320,7 +320,7 @@ void codegenImpl(RooAddition &arg, CodegenContext &ctx)
             result += '+';
          continue;
       }
-      result += ctx.buildFunction(*component, ctx.outputSizes()) + "(params, obs, xlArr)";
+      result += ctx.buildFunction(*component, ctx.dependsOnData()) + "(params, obs, xlArr)";
       ++i;
       if (i < arg.list().size())
          result += '+';


### PR DESCRIPTION
Refactor the code generated by RooFit "codegen" to encode the lengths and offsets of the observables in the "observables" input array for the likelihood function.

This makes it possible to re-use the generated likelihood code for different datasets, and we can support `RooAbsArg::setData()` for codegen and the AD-generated gradients.