### PR TITLE
[v6.38][win] Fix warning C4477

### DIFF
--- a/roottest/root/io/customCollection/execWriteCustomCollection.cxx
+++ b/roottest/root/io/customCollection/execWriteCustomCollection.cxx
@@ -23,7 +23,7 @@ public:
    void Fill(unsigned long seed) {
       T obj;
       for(size_t i = 0; i < seed; ++i) {
-         obj.SetName(TString::Format("name%zu_%lu",i,seed));
+         obj.SetName(TString::Format("name%zu_%lu", i, seed));
          obj.fId = i;
          fValues.push_back(obj);
       }
@@ -43,7 +43,7 @@ public:
    void Fill(unsigned long seed) {
       Content obj;
       for(size_t i = 0; i < seed; ++i) {
-         obj.SetName(TString::Format("name%zu_%lu",i,seed));
+         obj.SetName(TString::Format("name%zu_%lu", i, seed));
          obj.fId = i;
          fValues.push_back(obj);
       }


### PR DESCRIPTION
Fix several warning C4477: 'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 1 has type 'size_t'
