### PR TITLE
[RF] Fix a memory corruption when initialising a TMatrix.

### DIFF
--- a/roofit/roofitcore/test/testRooMinimizer.cxx
+++ b/roofit/roofitcore/test/testRooMinimizer.cxx
@@ -110,7 +110,11 @@ TEST_P(EvalBackendParametrizedTest, RF601)
       std::vector<double> valsRef{0.45212322018672196, 2.746677666046311};
       std::vector<double> errorsRef{0.11175880034776256, 0.31839226266447529};
       std::vector<double> globalCC{0.84401375662480127, 0.84401375662480116, 0.};
-      std::vector<double> corrsV{1.0, 0.84401326379874853, 0, 0.84401326379874853, 1., 0., 0., 0.};
+      // clang-format off
+      std::vector<double> corrsV{1., 0.84401326379874853, 0,
+                                 0.84401326379874853, 1., 0.,
+                                 0., 0., 1.};
+      // clang-format on
 
       RooArgList constParams;
       RooArgList{mean, sigma_g2}.snapshot(constParams, false);


### PR DESCRIPTION
I stumbled over an address sanitizer error when a TMatrix was initialised. It turns out that it got initialised with one element too few, so the element `[2][2]` was initialised with random stack memory. Since it seems to be a correlation matrix and the element of the diagonal was missing, I added a `1.`, but please check if that's the correct value.