### PR TITLE
[RF] Remove `final` keyword from RooFit pdf classes

### DIFF
--- a/roofit/roofit/inc/RooCrystalBall.h
+++ b/roofit/roofit/inc/RooCrystalBall.h
@@ -8,7 +8,7 @@
 
 #include <memory>
 
-class RooCrystalBall final : public RooAbsPdf {
+class RooCrystalBall : public RooAbsPdf {
 public:
    RooCrystalBall() {};
 

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -21,7 +21,7 @@
 
 class RooRealVar;
 
-class RooJohnson final : public RooAbsPdf {
+class RooJohnson : public RooAbsPdf {
 public:
   RooJohnson() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 


### PR DESCRIPTION
In some cases, it makes sense for users to derive from existing RooFit pdfs, so we should not unnecessarily prevent this with the `final` keyword in the class definition.