### PR TITLE
[net] Correctly restore gFile.

### DIFF
--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -342,7 +342,10 @@ Bool_t TRootSnifferFull::ProduceRootFile(const std::string &path, const std::str
    }
 
    TDirectory::TContext dirCtx{nullptr};
-   TFile::TContext fileCtx{nullptr};
+   struct RestoreGFile {
+      TFile *oldFile{gFile};
+      ~RestoreGFile() { gFile = oldFile; }
+   } restoreGFile;
 
    {
       TMemFile memfile("dummy.file", "RECREATE");


### PR DESCRIPTION
In the previous attempt to use TContext, TFile::TContext was used in an attempt to restore gFile. This, however, only restores gDirectory, and was therefore redundant with TDirectory::TContext.

To restore `gFile`, a specialised struct is needed.