### PR TITLE
[core] Protect a string search from running out of bounds.

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1598,16 +1598,16 @@ static void ResolveTypedefImpl(const char *tname,
    }
    // In Windows, we might have 'class const ...' as name,
    // (never 'const class ...'), so skip the leading 'class ', if any
-   if (strncmp(tname+cursor,"class ",6) == 0) {
+   if (cursor < len && strncmp(tname+cursor,"class ",6) == 0) {
       cursor += 6;
    }
-   if (strncmp(tname+cursor,"const ",6) == 0) {
+   if (cursor < len && strncmp(tname+cursor,"const ",6) == 0) {
       cursor += 6;
       if (modified) result += "const ";
       constprefix = true;
    }
 
-   if (len > 2 && strncmp(tname+cursor,"::",2) == 0) {
+   if (len > 2 && cursor < len && strncmp(tname+cursor,"::",2) == 0) {
       cursor += 2;
    }
 
@@ -1754,7 +1754,7 @@ static void ResolveTypedefImpl(const char *tname,
             while ((cursor+1)<len && tname[cursor+1] == ' ') ++cursor;
 
             auto next = cursor+1;
-            if (strncmp(tname+next,"const",5) == 0 && ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == ']'))
+            if (next < len && strncmp(tname+next,"const",5) == 0 && ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == ']'))
             {
                // A first const after the type needs to be move in the front.
                if (!modified) {
@@ -1790,7 +1790,7 @@ static void ResolveTypedefImpl(const char *tname,
             if (tname[cursor] != ' ') end_of_type = cursor;
             // check and skip const (followed by *,&, ,) ... what about followed by ':','['?
             auto next = cursor+1;
-            if (strncmp(tname+next,"const",5) == 0) {
+            if (next < len && strncmp(tname+next,"const",5) == 0) {
                if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>' || tname[next+5] == ')' || tname[next+5] == '[') {
                   next += 5;
                }
@@ -1799,7 +1799,7 @@ static void ResolveTypedefImpl(const char *tname,
                    (tname[next] == ' ' || tname[next] == '*' || tname[next] == '&')) {
                ++next;
                // check and skip const (followed by *,&, ,) ... what about followed by ':','['?
-               if (strncmp(tname+next,"const",5) == 0) {
+               if (next < len && strncmp(tname+next,"const",5) == 0) {
                   if ((next+5)==len || tname[next+5] == ' ' || tname[next+5] == '*' || tname[next+5] == '&' || tname[next+5] == ',' || tname[next+5] == '>'|| tname[next+5] == ')' || tname[next+5] == '[') {
                      next += 5;
                   }


### PR DESCRIPTION
When running gtest-tree-ntuple-ntuple-type-name in address sanitizer, the check for the "const" qualifier ran out of bounds, because the cursor in TClassEdit.cxx:1793 was already at the end of the string, and "next" was one character after its end:
```
"std::vector<Double32_t[3]   > [10 ]  "
                                       ^
```
strcmp isn't designed for this case, so this commit adds length checks
before all "strcmp(base+offset, ...)" patterns.

I believe the test worked because the garbage that's read in memory is almost always ` != 'c'` ('o', 'n', ...), and so the comparison is (usually) guaranteed to fail -- until it doesn't.