### PR TITLE
[CI] Limit the number of Linux build cache updates running in parallel.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -473,17 +473,9 @@ jobs:
       POST_INSTALL_DIR: /github/home/ROOT-CI/PostInstall
 
     steps:
-      - name: Configure large ccache
-        if: ${{ matrix.is_special }}
+      - name: Configure ccache
         run: |
-          ccache -o max_size=5G
-          ccache -p || true
-          ccache -s || true
-
-      - name: Configure small ccache
-        if: ${{ !matrix.is_special }}
-        run: |
-          ccache -o max_size=1.5G
+          ccache -o max_size=${{ matrix.is_special && '5G' || '1.5G' }}
           ccache -p || true
           ccache -s || true
 


### PR DESCRIPTION
Similar to what was done for MacOS, a concurrency group is introduced for Linux builds. It's unique for PRs, but for updates of the build cache, only one job is running at any time.

This reduces the background load on the Linux CI.