### PR TITLE
Allow hash tables for  TGeo volumes to rehash automatically

### DIFF
--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -770,8 +770,8 @@ Int_t TGeoManager::AddVolume(TGeoVolume *volume)
    }
    volume->SetNumber(uid);
    if (!fHashVolumes) {
-      fHashVolumes = new THashList(256,3);
-      fHashGVolumes = new THashList(256,3);
+      fHashVolumes = new THashList(256, 3);
+      fHashGVolumes = new THashList(256, 3);
    }
    TObjArray *list = fVolumes;
    if (!volume->GetShape() || volume->IsRunTime() || volume->IsVolumeMulti()) {


### PR DESCRIPTION
Current TGeoVolume::AddVolume is a performance bottleneck in creation of large geometry models (eg, the idea detector geometry model for fcc studies). Allowing the hash tables to automatically rehash (as is already done for other hash tables) speeds up the entire xml processing and detector geometry creation(using dd4hep) by about 4x for this detector.

I believe only TGeoManager::AddVolume is used in my testing.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

