### PR TITLE
[tmva][sofie] Add InstanceNormalization operator for ONNX inference

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_InstanceNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_InstanceNormalization.hxx
@@ -1,0 +1,137 @@
+#ifndef TMVA_SOFIE_ROPERATOR_INSTANCENORMALIZATION
+#define TMVA_SOFIE_ROPERATOR_INSTANCENORMALIZATION
+
+#include "TMVA/ROperator.hxx"
+#include "TMVA/RModel.hxx"
+#include "TMVA/SOFIE_common.hxx"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+/*! \class ROperator_InstanceNormalization
+    \brief Implementation of the ONNX InstanceNormalization operator.
+
+    The input X has shape (N, C, D1, ..., Dn). For every sample n and channel c,
+    the elements over the spatial dimensions D1, ..., Dn are normalized to zero
+    mean and unit variance, and then scaled and shifted with the per-channel
+    scale and B tensors, which both have shape (C):
+
+        Y[n, c, ...] = scale[c] * (X[n, c, ...] - mean[n, c]) / sqrt(var[n, c] + epsilon) + B[c]
+*/
+template <typename T>
+class ROperator_InstanceNormalization final : public ROperator {
+private:
+   float fEpsilon;
+   std::string fNInput;
+   std::string fNScale;
+   std::string fNBias;
+   std::string fNOutput;
+   std::vector<size_t> fShape;
+   std::string fType;
+
+public:
+   ROperator_InstanceNormalization() : fEpsilon(1e-5) {}
+
+   ROperator_InstanceNormalization(float epsilon, std::string nameInput, std::string nameScale, std::string nameBias,
+                                   std::string nameOutput)
+      : fEpsilon(epsilon),
+        fNInput(UTILITY::Clean_name(nameInput)),
+        fNScale(UTILITY::Clean_name(nameScale)),
+        fNBias(UTILITY::Clean_name(nameBias)),
+        fNOutput(UTILITY::Clean_name(nameOutput))
+   {
+      fInputTensorNames = {fNInput, fNScale, fNBias};
+      fOutputTensorNames = {fNOutput};
+   }
+
+   std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> inputShapes) override
+   {
+      return {inputShapes[0]};
+   }
+
+   void Initialize(RModel &model) override
+   {
+      for (const std::string &name : {fNInput, fNScale, fNBias}) {
+         if (!model.CheckIfTensorAlreadyExist(name)) {
+            throw std::runtime_error("TMVA::SOFIE - InstanceNormalization - Tensor " + name + " not found.");
+         }
+      }
+
+      fShape = model.GetTensorShape(fNInput);
+      if (fShape.size() < 3) {
+         throw std::runtime_error("TMVA::SOFIE - InstanceNormalization - Input tensor " + fNInput + " has rank " +
+                                  std::to_string(fShape.size()) + " but at least rank 3 (N, C, D1, ...) is required.");
+      }
+
+      // scale and B are 1D tensors of length C
+      const size_t channels = fShape[1];
+      for (const std::string &name : {fNScale, fNBias}) {
+         auto shape = model.GetTensorShape(name);
+         if (shape.size() != 1 || shape[0] != channels) {
+            throw std::runtime_error("TMVA::SOFIE - InstanceNormalization - Tensor " + name + " has invalid shape " +
+                                     ConvertShapeToString(shape) + ", expected " +
+                                     ConvertShapeToString(std::vector<size_t>{channels}) + ".");
+         }
+      }
+
+      fType = ConvertTypeToString(model.GetTensorType(fNInput));
+      model.AddIntermediateTensor(fNOutput, model.GetTensorType(fNInput), fShape);
+   }
+
+   std::string Generate(std::string) override
+   {
+      if (fShape.empty()) {
+         throw std::runtime_error("TMVA::SOFIE - InstanceNormalization called to generate without being initialized.");
+      }
+
+      const size_t batchSize = fShape[0];
+      const size_t channels = fShape[1];
+      size_t spatialSize = 1;
+      for (size_t i = 2; i < fShape.size(); ++i)
+         spatialSize *= fShape[i];
+
+      std::stringstream out;
+      out << "\n" << SP << "//---- InstanceNormalization " << fNOutput << "\n";
+      out << SP << "for (size_t n = 0; n < " << batchSize << "; n++) {\n";
+      out << SP << SP << "for (size_t c = 0; c < " << channels << "; c++) {\n";
+      out << SP << SP << SP << "const size_t offset = n * " << channels * spatialSize << " + c * " << spatialSize
+          << ";\n";
+
+      // Compute the mean over the spatial dimensions
+      out << SP << SP << SP << fType << " mean = 0.;\n";
+      out << SP << SP << SP << "for (size_t i = 0; i < " << spatialSize << "; i++) {\n";
+      out << SP << SP << SP << SP << "mean += tensor_" << fNInput << "[offset + i];\n";
+      out << SP << SP << SP << "}\n";
+      out << SP << SP << SP << "mean /= " << fType << "(" << spatialSize << ");\n";
+
+      // Compute the inverse standard deviation from the deviations around the mean
+      out << SP << SP << SP << fType << " sum = 0.;\n";
+      out << SP << SP << SP << "for (size_t i = 0; i < " << spatialSize << "; i++) {\n";
+      out << SP << SP << SP << SP << fType << " tmp = tensor_" << fNInput << "[offset + i] - mean;\n";
+      out << SP << SP << SP << SP << "sum += tmp * tmp;\n";
+      out << SP << SP << SP << "}\n";
+      out << SP << SP << SP << fType << " invStdDev = 1 / std::sqrt(sum / " << fType << "(" << spatialSize << ") + "
+          << std::to_string(fEpsilon) << ");\n";
+
+      // Y = scale o invStdDev (X - mean) + B
+      out << SP << SP << SP << fType << " scale = tensor_" << fNScale << "[c];\n";
+      out << SP << SP << SP << fType << " bias = tensor_" << fNBias << "[c];\n";
+      out << SP << SP << SP << "for (size_t i = 0; i < " << spatialSize << "; i++) {\n";
+      out << SP << SP << SP << SP << "tensor_" << fNOutput << "[offset + i] = scale * (tensor_" << fNInput
+          << "[offset + i] - mean) * invStdDev + bias;\n";
+      out << SP << SP << SP << "}\n";
+
+      out << SP << SP << "}\n";
+      out << SP << "}\n";
+      return out.str();
+   }
+};
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
+#endif

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -948,6 +948,33 @@ TEST(ONNX, LayerNormalization4d)
    expectNear(output, ref.f32("output0"), DEFAULT_TOLERANCE);
 }
 
+TEST(ONNX, InstanceNormalization)
+{
+   SofieReference ref = readReference("InstanceNormalization");
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "InstanceNormalization", ref.f32("input0"));
+
+   expectNear(output, ref.f32("output0"), DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, InstanceNormalization3d)
+{
+   SofieReference ref = readReference("InstanceNormalization3d");
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "InstanceNormalization3d", ref.f32("input0"));
+
+   expectNear(output, ref.f32("output0"), DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, InstanceNormalizationEpsilon)
+{
+   SofieReference ref = readReference("InstanceNormalizationEpsilon");
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "InstanceNormalizationEpsilon", ref.f32("input0"));
+
+   expectNear(output, ref.f32("output0"), DEFAULT_TOLERANCE);
+}
+
 TEST(ONNX, Equal)
 {
    SofieReference ref = readReference("Equal");

--- a/tmva/sofie/test/generate_input_models.py
+++ b/tmva/sofie/test/generate_input_models.py
@@ -1642,6 +1642,61 @@ def make_HardSwish():
     return _model(graph, opset=14, ir_version=13)
 
 
+def _instance_normalization(shape, scale, bias, **kwargs):
+    """InstanceNormalization graph over an input of the given shape. scale and
+    B are per-channel initializers of length shape[1]."""
+    channels = shape[1]
+    nodes = [
+        helper.make_node('InstanceNormalization', ['X', 'scale', 'B'], ['Y'], **kwargs),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'InstanceNormalization',
+        inputs=[
+            _vi('X', FLOAT, shape),
+            _vi('scale', FLOAT, [channels]),
+            _vi('B', FLOAT, [channels]),
+        ],
+        outputs=[
+            _vi('Y', FLOAT, shape),
+        ],
+        initializer=[
+            _tensor('scale', FLOAT, [channels], scale),
+            _tensor('B', FLOAT, [channels], bias),
+        ],
+    )
+    return _model(graph, opset=17, ir_version=8)
+
+
+def make_InstanceNormalization():
+    """Ops: InstanceNormalization"""
+    # Batch and channel size both > 1, so that a wrong per-instance offset or a
+    # scale/bias indexed by the wrong axis does not go unnoticed.
+    return _instance_normalization([2, 3, 4, 5],
+                                   scale=[0.5, 1.0, -2.0],
+                                   bias=[0.0, 0.25, -1.5])
+
+
+def make_InstanceNormalization3d():
+    """Ops: InstanceNormalization"""
+    # Rank 3 (N, C, D): exercises a spatial size that is not a product of
+    # several dimensions.
+    return _instance_normalization([2, 2, 6],
+                                   scale=[1.5, -0.5],
+                                   bias=[1.0, 2.0])
+
+
+def make_InstanceNormalizationEpsilon():
+    """Ops: InstanceNormalization"""
+    # Non-default epsilon, combined with the small-variance input in
+    # TEST_INPUTS, so that the attribute dominates the result and a parser that
+    # ignored it would be caught.
+    return _instance_normalization([1, 2, 3, 3],
+                                   scale=[1.0, 1.0],
+                                   bias=[0.0, 0.0],
+                                   epsilon=0.01)
+
+
 def make_IsInf():
     """Ops: IsInf"""
     nodes = [
@@ -4741,6 +4796,9 @@ MODELS = {
     'GreaterOrEqual': make_GreaterOrEqual,
     'HardSigmoid': make_HardSigmoid,
     'HardSwish': make_HardSwish,
+    'InstanceNormalization': make_InstanceNormalization,
+    'InstanceNormalization3d': make_InstanceNormalization3d,
+    'InstanceNormalizationEpsilon': make_InstanceNormalizationEpsilon,
     'IsInf': make_IsInf,
     'LSTMBatchwise': make_LSTMBatchwise,
     'LSTMBidirectional': make_LSTMBidirectional,
@@ -4940,6 +4998,21 @@ TEST_INPUTS = {
     ],
     'HardSigmoid': [f32([1.0, -2.0, 3.0, 0.5, -1.0, 2.0], (6,))],
     'HardSwish': [f32([1.0, -2.0, 3.0, 0.5, -1.0, 2.0], (6,))],
+    # Per (n, c) slice a different mean and variance, so that a normalization
+    # that mixed up instances or channels would not cancel out.
+    'InstanceNormalization': [
+        f32(np.arange(120.0) * 0.1 - 6.0 + (np.arange(120.0) % 7), (2, 3, 4, 5)),
+    ],
+    'InstanceNormalization3d': [
+        f32([1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+             -1.0, -3.0, 0.0, 2.0, -2.0, 4.0,
+             10.0, 10.0, 10.0, 10.0, 10.0, 11.0,
+             0.5, -0.5, 1.5, -1.5, 2.5, -2.5], (2, 2, 6)),
+    ],
+    # Small variance (~2e-3), comparable to the model's epsilon of 0.01.
+    'InstanceNormalizationEpsilon': [
+        f32((np.arange(18.0) % 5 - 2.0) * 0.025, (1, 2, 3, 3)),
+    ],
     'LSTMBatchwise': [f32(np.arange(1.0, 7.0), (3, 1, 2))],
     'LSTMBidirectional': [f32(np.arange(1.0, 7.0), (3, 1, 2))],
     'LSTMDefaults': [f32(np.arange(1.0, 7.0), (3, 1, 2))],

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -53,6 +53,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser
     src/ParseErf.cxx
     src/ParseRange.cxx
     src/ParseLayerNormalization.cxx
+    src/ParseInstanceNormalization.cxx
     src/ParseExpand.cxx
     src/ParseGather.cxx
     src/ParseGatherND.cxx

--- a/tmva/sofie_parsers/src/ParseInstanceNormalization.cxx
+++ b/tmva/sofie_parsers/src/ParseInstanceNormalization.cxx
@@ -1,0 +1,52 @@
+#include "TMVA/RModelParser_ONNX.hxx"
+#include "TMVA/ROperator_InstanceNormalization.hxx"
+#include "onnx_proto3.pb.h"
+
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+ParserFuncSignature ParseInstanceNormalization = [](RModelParser_ONNX &parser,
+                                                    const onnx::NodeProto &nodeproto) -> std::unique_ptr<ROperator> {
+   ETensorType input_type = ETensorType::UNDEFINED;
+   const std::string input_name = nodeproto.input(0);
+   if (parser.IsRegisteredTensorType(input_name)) {
+      input_type = parser.GetTensorType(input_name);
+   } else {
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser InstanceNormalization op has input tensor " + input_name +
+                               " but its type is not yet registered");
+   }
+
+   float epsilon = 1e-5;
+   for (int64_t i = 0; i < nodeproto.attribute_size(); i++) {
+      if (nodeproto.attribute(i).name() == "epsilon") {
+         epsilon = nodeproto.attribute(i).f();
+      }
+   }
+
+   // Inputs: X (0), scale (1), B (2)
+   const std::string name_scale = nodeproto.input(1);
+   const std::string name_bias = nodeproto.input(2);
+   const std::string output_name = nodeproto.output(0);
+
+   std::unique_ptr<ROperator> op;
+   switch (input_type) {
+   case ETensorType::FLOAT:
+      op.reset(new ROperator_InstanceNormalization<float>(epsilon, input_name, name_scale, name_bias, output_name));
+      break;
+   default:
+      throw std::runtime_error("TMVA::SOFIE ONNX parser Operator with input type " + ConvertTypeToString(input_type) +
+                               " not supported.");
+      break;
+   }
+
+   if (!parser.IsRegisteredTensorType(output_name)) {
+      parser.RegisterTensorType(output_name, input_type);
+   }
+
+   return op;
+};
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -84,6 +84,7 @@ extern ParserFuncSignature ParseExpand;
 extern ParserFuncSignature ParseShape;
 extern ParserFuncSignature ParseMatMul;
 extern ParserFuncSignature ParseLayerNormalization;
+extern ParserFuncSignature ParseInstanceNormalization;
 extern ParserFuncSignature ParseGather;
 extern ParserFuncSignature ParseGatherND;
 extern ParserFuncSignature ParseErf;
@@ -377,6 +378,7 @@ RModelParser_ONNX::RModelParser_ONNX() noexcept : fOperatorsMapImpl(std::make_un
    RegisterOperator("Tile", ParseTile);
    RegisterOperator("Split", ParseSplit);
    RegisterOperator("If", ParseIf);
+   RegisterOperator("InstanceNormalization", ParseInstanceNormalization);
    RegisterOperator("Pad", ParsePad);
    RegisterOperator("Where", ParseWhere);
    RegisterOperator("Einsum", ParseEinsum);


### PR DESCRIPTION
Add ROperator_InstanceNormalization, implementing the ONNX InstanceNormalization operator: for every sample and channel of an input of shape (N, C, D1, ..., Dn), the elements over the spatial dimensions are normalized to zero mean and unit variance, then scaled and shifted with the per-channel scale and B tensors.

The operator is registered in RModelParser_ONNX through a new ParseInstanceNormalization.cxx, following the one-file-per-operator convention of the other operators. Only static shapes and float inputs are supported; other input types are rejected with an error, as in ParseLayerNormalization.

Three models are added to generate_input_models.py, with their expected outputs computed by onnx's ReferenceEvaluator:

 * InstanceNormalization, of shape (2, 3, 4, 5) with asymmetric scale and bias, so that a wrong per-instance offset or a scale indexed on the wrong axis does not cancel out,
 * InstanceNormalization3d, of rank 3, where the spatial size is not a product of several dimensions,
 * InstanceNormalizationEpsilon, with a non-default epsilon of 0.01 and a small-variance input, so that the attribute dominates the result.

Two mutations of the operator were checked to be caught by these tests: ignoring the epsilon attribute fails InstanceNormalizationEpsilon, and indexing the scale by the wrong axis fails the other two.

🤖 Done with the help of AI.