### PR TITLE
[ntuple] add REntry::HasField()

### DIFF
--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -240,6 +240,8 @@ public:
 
    const std::string &GetTypeName(std::string_view fieldName) const { return GetTypeName(GetToken(fieldName)); }
 
+   bool HasField(std::string_view fieldName) const { return fFieldName2Token.count(std::string(fieldName)) > 0; }
+
    std::uint64_t GetModelId() const { return fModelId; }
    std::uint64_t GetSchemaId() const { return fSchemaId; }
 

--- a/tree/ntuple/test/ntuple_basics.cxx
+++ b/tree/ntuple/test/ntuple_basics.cxx
@@ -802,6 +802,8 @@ TEST(REntry, Basics)
    model->Freeze();
 
    auto e = model->CreateEntry();
+   EXPECT_TRUE(e->HasField("pt"));
+   EXPECT_FALSE(e->HasField("PT"));
    EXPECT_EQ(e->GetModelId(), model->GetModelId());
    EXPECT_EQ(e->GetSchemaId(), model->GetSchemaId());
    for (const auto &v : *e) {


### PR DESCRIPTION
Allows for doing this query without exception handling, i.e. without going through `GetToken()` and catching an exception.

Suggested at the ROOT users workshop.

@forthommel FYI

