### PR TITLE
Add SetT, SetX, SetY, and SetZ methods to LorentzVector

### DIFF
--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -707,6 +707,10 @@ Pt (or rho) refers to transverse momentum, whereas eta refers to pseudorapidity.
        LorentzVector<CoordSystem>& SetPx ( Scalar a )  { fCoordinates.SetPx (a); return *this; }
        LorentzVector<CoordSystem>& SetPy ( Scalar a )  { fCoordinates.SetPy (a); return *this; }
        LorentzVector<CoordSystem>& SetPz ( Scalar a )  { fCoordinates.SetPz (a); return *this; }
+       LorentzVector<CoordSystem> &SetT(Scalar a) { return SetE(a); }
+       LorentzVector<CoordSystem> &SetX(Scalar a) { return SetPx(a); }
+       LorentzVector<CoordSystem> &SetY(Scalar a) { return SetPy(a); }
+       LorentzVector<CoordSystem> &SetZ(Scalar a) { return SetPz(a); }
 
     private:
 


### PR DESCRIPTION
This PR adds `SetT`, `SetX`, `SetY`, and `SetZ` aliases to the `SetE`, `SetPx`, `SetPy`, `SetPz` methods used in the cartesian internal coordinates system definitions (e.g. `ROOT::Math::PxPyPzE4D` & `ROOT::Math::PxPyPzM4D`) to allow a more intuitive use of the `ROOT::Math::XYZTVector` and `ROOT::Math::XYZTVectorF` objects accessors.

## Changes or fixes:
New setters added to the LorentzVector object API.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

