### PR TITLE
[Tree] Emit error before crashing when reading type w/ no dictionary

### DIFF
--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -130,4 +130,22 @@ public:
    Bool_t IsValid() const;
 };
 
+
+namespace ROOT::Internal::TEmulatedProxyHelpers {
+inline void PrintWriteStlWithoutProxyMsg(const char *where, const char *clName, const char *BranchName)
+{
+   const char *writeStlWithoutProxyMsg =
+      "The class requested (%s) for the branch \"%s\" "
+      "is an instance of an stl collection and does not have a compiled CollectionProxy. "
+      "Please generate the dictionary for this collection (%s) to avoid writing corrupted data.";
+   // This error message is repeated several times in the code. We write it once.
+   Error(where, writeStlWithoutProxyMsg, clName, BranchName, clName);
+}
+
+inline bool HasEmulatedProxy(TClass *cl){
+   return cl && cl->GetCollectionProxy() && dynamic_cast<TEmulatedCollectionProxy *>(cl->GetCollectionProxy());
+}
+} // namespace ROOT::Internal::TEmulatedProxyHelpers
+
+
 #endif

--- a/roottest/root/tree/reader/CMakeLists.txt
+++ b/roottest/root/tree/reader/CMakeLists.txt
@@ -1,3 +1,13 @@
+# 10524
+ROOTTEST_ADD_TEST(CreateWarnNoDictFile
+                  MACRO CreateWarnNoDictFile.C+
+                  FIXTURES_SETUP root-tree-reader-WarnNoDict-fixture)
+
+ROOTTEST_ADD_TEST(WarnNoDict
+                  MACRO WarnNoDict.C
+                  ERRREF WarnNoDict.eref
+                  FIXTURES_REQUIRED root-tree-reader-WarnNoDict-fixture)
+
 # ROOT-10046
 ROOTTEST_ADD_TEST(oddName
                   COPY_TO_BUILDDIR root-10046.root

--- a/roottest/root/tree/reader/CreateWarnNoDictFile.C
+++ b/roottest/root/tree/reader/CreateWarnNoDictFile.C
@@ -1,0 +1,36 @@
+#ifndef __CreateWarnNoDictFile__
+#define __CreateWarnNoDictFile__
+
+#include "TClass.h"
+#include "TFile.h"
+#include "TTree.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#ifdef __ROOTCLING__
+#pragma link C++ class std::map<std::string, bool>+;
+#endif
+
+int CreateWarnNoDictFile() 
+{
+
+   using rareType = std::map<std::string, bool>;
+   auto c = TClass::GetClass<rareType>();
+
+   const auto fName = "warnNoDict.root";
+   const auto tName = "t";
+   const auto colName = "col";
+
+   auto f = std::make_unique<TFile>(fName, "RECREATE");
+   auto t = std::make_unique<TTree>(tName, "test tree");
+   rareType o;
+   o["foo"] = true;
+   t->Branch(colName, &o);
+   t->Fill();
+   t->Write();
+   return 0;
+}
+
+#endif

--- a/roottest/root/tree/reader/WarnNoDict.C
+++ b/roottest/root/tree/reader/WarnNoDict.C
@@ -1,0 +1,24 @@
+void CheckDict(TClass *c)
+{
+   if (c->HasDictionary()) {
+      std::cerr << "Class " << c->GetName() << " has a dictionary and it should not." << std::endl;
+   }
+}
+
+void WarnNoDict()
+{
+   const auto fName = "warnNoDict.root";
+   const auto tName = "t";
+   const auto colName = "col";
+
+   using rareType = std::map<std::string, bool>;
+   auto c = TClass::GetClass<rareType>();
+   CheckDict(c);
+
+   TFile f(fName);
+   CheckDict(c);
+
+   auto t = f.Get<TTree>(tName);
+   TTreeReader r(t);
+   TTreeReaderValue<rareType> rv(r, colName);
+}

--- a/roottest/root/tree/reader/WarnNoDict.eref
+++ b/roottest/root/tree/reader/WarnNoDict.eref
@@ -1,0 +1,1 @@
+Error in <TTreeReaderValueBase>: The class requested (map<string,bool>) for the branch "col" is an instance of an stl collection and does not have a compiled CollectionProxy. Please generate the dictionary for this collection (map<string,bool>) to avoid writing corrupted data.

--- a/tree/treeplayer/src/TTreeReaderValue.cxx
+++ b/tree/treeplayer/src/TTreeReaderValue.cxx
@@ -18,6 +18,7 @@
 #include "TBranchSTL.h"
 #include "TBranchObject.h"
 #include "TBranchProxyDirector.h"
+#include "TEmulatedCollectionProxy.h"
 #include "TClassEdit.h"
 #include "TEnum.h"
 #include "TFriendElement.h"
@@ -63,6 +64,11 @@ ROOT::Internal::TTreeReaderValueBase::TTreeReaderValueBase(TTreeReader *reader /
      fDict(dict),
      fOpaqueRead(opaqueRead)
 {
+   auto * cl = dynamic_cast<TClass *>(dict);
+   using namespace ROOT::Internal::TEmulatedProxyHelpers;
+   if (cl && HasEmulatedProxy(cl)) {
+      PrintWriteStlWithoutProxyMsg("TTreeReaderValueBase", cl->GetName(), branchname);
+   }
    RegisterWithTreeReader();
 }
 


### PR DESCRIPTION
as TTree would do.

Fixes #10254

