### PR TITLE
[ci] Disable builtin zeromq and cppzmq on Fedora

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora43.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora43.txt
@@ -1,4 +1,6 @@
 CMAKE_CXX_STANDARD=23
+builtin_cppzmq=OFF
+builtin_zeromq=OFF
 builtin_zlib=ON
 builtin_zstd=ON
 experimental_adaptivecpp=ON

--- a/.github/workflows/root-ci-config/buildconfig/fedora44.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora44.txt
@@ -1,4 +1,6 @@
 CMAKE_CXX_STANDARD=23
+builtin_cppzmq=OFF
+builtin_zeromq=OFF
 builtin_zlib=ON
 builtin_zstd=ON
 experimental_adaptivecpp=ON

--- a/.github/workflows/root-ci-config/buildconfig/rawhide.txt
+++ b/.github/workflows/root-ci-config/buildconfig/rawhide.txt
@@ -1,3 +1,5 @@
+builtin_cppzmq=OFF
+builtin_zeromq=OFF
 builtin_zlib=ON
 builtin_zstd=ON
 pythia8=ON


### PR DESCRIPTION
We should test also using external ZMQ, and on Fedora it comes with the standard packages and the draft API enabled, which is what RooFit multiprocessing needs.

