### PR TITLE
Implement #url in TLatex

### DIFF
--- a/core/base/inc/TVirtualPS.h
+++ b/core/base/inc/TVirtualPS.h
@@ -62,6 +62,7 @@ public:
    virtual void  Open(const char *filename, Int_t type=-111) = 0;
    virtual void  Text(Double_t x, Double_t y, const char *string) = 0;
    virtual void  Text(Double_t x, Double_t y, const wchar_t *string) = 0;
+   virtual void  TextUrl(Double_t x, Double_t y, const char *string, const char *url) = 0;
    virtual void  SetColor(Float_t r, Float_t g, Float_t b) = 0;
 
    virtual void  PrintFast(Int_t nch, const char *string="");

--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -195,6 +195,7 @@ public:
    virtual void     PaintText(Double_t x, Double_t y, const wchar_t *text) = 0;
    virtual void     PaintTextNDC(Double_t u, Double_t v, const char *text) = 0;
    virtual void     PaintTextNDC(Double_t u, Double_t v, const wchar_t *text) = 0;
+   virtual void     PaintTextUrl(Double_t x, Double_t y, const char *text, const char *url) = 0;
    virtual Double_t PixeltoX(Double_t px) = 0;
    virtual Double_t PixeltoY(Double_t py) = 0;
    virtual void     PixeltoXY(Double_t xpixel, Double_t ypixel, Double_t &x, Double_t &y) = 0;

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -307,6 +307,7 @@ public:
    void              PaintText(Double_t x, Double_t y, const wchar_t *text) override;
    void              PaintTextNDC(Double_t u, Double_t v, const char *text) override;
    void              PaintTextNDC(Double_t u, Double_t v, const wchar_t *text) override;
+   void              PaintTextUrl(Double_t x, Double_t y, const char *text, const char *url) override;
    virtual TPad     *Pick(Int_t px, Int_t py, TObjLink *&pickobj);
    Double_t          PixeltoX(Double_t px) override;
    Double_t          PixeltoY(Double_t py) override;

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4778,6 +4778,20 @@ void TPad::PaintText(Double_t x, Double_t y, const wchar_t *text)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Paint text with URL in CurrentPad World coordinates.
+
+void TPad::PaintTextUrl(Double_t x, Double_t y, const char *text, const char *url)
+{
+   Modified();
+
+   if (!gPad->IsBatch() && GetPainter())
+      GetPainter()->DrawText(x, y, text, TVirtualPadPainter::kClear);
+
+   if (gVirtualPS) gVirtualPS->TextUrl(x, y, text, url);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Paint text in CurrentPad NDC coordinates.
 
 void TPad::PaintTextNDC(Double_t u, Double_t v, const char *text)

--- a/graf2d/postscript/inc/TImageDump.h
+++ b/graf2d/postscript/inc/TImageDump.h
@@ -49,6 +49,7 @@ public:
    void  Open(const char *filename, Int_t type = -111) override;
    void  Text(Double_t x, Double_t y, const char *string) override;
    void  Text(Double_t x, Double_t y, const wchar_t *string) override;
+   void  TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
    void  SetColor(Float_t r, Float_t g, Float_t b) override;
    void *GetStream() const override { return (void*)fImage; }
    void  SetType(Int_t type = -111) override { fType = type; }

--- a/graf2d/postscript/inc/TPDF.h
+++ b/graf2d/postscript/inc/TPDF.h
@@ -103,6 +103,7 @@ public:
    void     SetTextColor(Color_t cindex=1) override;
    void     Text(Double_t x, Double_t y, const char *string) override;
    void     Text(Double_t, Double_t, const wchar_t *) override;
+   void     TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
    void     TextNDC(Double_t u, Double_t v, const char *string);
    void     TextNDC(Double_t, Double_t, const wchar_t *);
    void     WriteCompressedBuffer();

--- a/graf2d/postscript/inc/TPostScript.h
+++ b/graf2d/postscript/inc/TPostScript.h
@@ -129,6 +129,7 @@ public:
    void  SetColor(Int_t color = 1);
    void  SetColor(Float_t r, Float_t g, Float_t b) override;
    void  Text(Double_t x, Double_t y, const char *string) override;
+   void  TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
    void  Text(Double_t x, Double_t y, const wchar_t *string) override;
    void  TextNDC(Double_t u, Double_t v, const char *string);
    void  TextNDC(Double_t u, Double_t v, const wchar_t *string);

--- a/graf2d/postscript/inc/TSVG.h
+++ b/graf2d/postscript/inc/TSVG.h
@@ -77,6 +77,7 @@ public:
    void  SetTextColor(Color_t cindex=1) override;
    void  Text(Double_t x, Double_t y, const char *string)  override;
    void  Text(Double_t, Double_t, const wchar_t *) override {}
+   void  TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
    void  TextNDC(Double_t u, Double_t v, const char *string);
    void  TextNDC(Double_t, Double_t, const wchar_t *) {}
    void  WriteReal(Float_t r, Bool_t space=kTRUE) override;

--- a/graf2d/postscript/inc/TTeXDump.h
+++ b/graf2d/postscript/inc/TTeXDump.h
@@ -70,6 +70,7 @@ public:
    void    SetTextColor(Color_t cindex=1) override;
    void    Text(Double_t x, Double_t y, const char *string) override;
    void    Text(Double_t, Double_t, const wchar_t *) override {}
+   void    TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
    void    TextNDC(Double_t u, Double_t v, const char *string);
    void    TextNDC(Double_t, Double_t, const wchar_t *) {}
    Float_t UtoTeX(Double_t u);

--- a/graf2d/postscript/src/TImageDump.cxx
+++ b/graf2d/postscript/src/TImageDump.cxx
@@ -890,6 +890,14 @@ void TImageDump::Text(Double_t x, Double_t y, const wchar_t *chars)
    fImage->DrawText(&t, XtoPixel(x), YtoPixel(y));
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Draw text with URL. Same as Text.
+///
+
+void TImageDump::TextUrl(Double_t x, Double_t y, const char *chars, const char *)
+{
+   Text(x, y, chars);
+}
 
 ////////////////////////// CellArray code ////////////////////////////////////
 static UInt_t *gCellArrayColors = nullptr;

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -2346,6 +2346,15 @@ void TPDF::Text(Double_t, Double_t, const wchar_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw text with URL. Same as Text.
+///
+
+void TPDF::TextUrl(Double_t x, Double_t y, const char *chars, const char *)
+{
+   Text(x, y, chars);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Write a string of characters in NDC
 
 void TPDF::TextNDC(Double_t u, Double_t v, const char *chars)

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -2983,6 +2983,15 @@ void TPostScript::Text(Double_t xx, Double_t yy, const wchar_t *chars)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw text with URL. Same as Text.
+///
+
+void TPostScript::TextUrl(Double_t x, Double_t y, const char *chars, const char *)
+{
+   Text(x, y, chars);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Write a string of characters in NDC
 
 void TPostScript::TextNDC(Double_t u, Double_t v, const char *chars)

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1513,6 +1513,23 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw text with URL.
+///
+
+void TSVG::TextUrl(Double_t x, Double_t y, const char *chars, const char *url)
+{
+   PrintStr("@");
+   PrintFast(9,"<a href=\"");
+   PrintStr(url);
+   PrintFast(2,"\">");
+   PrintStr("@");
+   Text(x, y, chars);
+   PrintStr("@");
+   PrintFast(4,"</a>");
+   PrintStr("@");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Write a string of characters in NDC
 
 void TSVG::TextNDC(Double_t u, Double_t v, const char *chars)

--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -852,6 +852,15 @@ void TTeXDump::Text(Double_t x, Double_t y, const char *chars)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Draw text with URL. Same as Text.
+///
+
+void TTeXDump::TextUrl(Double_t x, Double_t y, const char *chars, const char *)
+{
+   Text(x, y, chars);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Write a string of characters in NDC
 
 void TTeXDump::TextNDC(Double_t u, Double_t v, const char *chars)

--- a/gui/webgui6/inc/TWebPS.h
+++ b/gui/webgui6/inc/TWebPS.h
@@ -57,6 +57,7 @@ public:
    void DrawPS(Int_t n, Double_t *xw, Double_t *yw) override;
    void Text(Double_t x, Double_t y, const char *str) override;
    void Text(Double_t x, Double_t y, const wchar_t *str) override;
+   void TextUrl(Double_t x, Double_t y, const char *string, const char *url) override;
 
 private:
    //Let's make this clear:

--- a/gui/webgui6/src/TWebPS.cxx
+++ b/gui/webgui6/src/TWebPS.cxx
@@ -130,3 +130,8 @@ void TWebPS::Text(Double_t x, Double_t y, const wchar_t *)
    buf[0] = x;
    buf[1] = y;
 }
+
+void TWebPS::TextUrl(Double_t x, Double_t y, const char *chars, const char *)
+{
+   Text(x, y, chars);
+}

--- a/tutorials/visualisation/webcanv/latex_url.cxx
+++ b/tutorials/visualisation/webcanv/latex_url.cxx
@@ -1,14 +1,16 @@
 /// \file
 /// \ingroup tutorial_webcanv
 /// \notebook -js
-/// Use of interactive URL links inside TLatex.
+/// Demonstrates how to use interactive URL links in TLatex.
 ///
-/// JSROOT now supports '#url[link]{label}' syntax
-/// It can be combined with any other latex commands like color ot font.
-/// While TLatex used in many places, one can add external links to histogram title,
-/// axis title, legend entry and so on.
+/// JSROOT and standard SVG output support the syntax '#url[link]{label}'.
+/// This can be combined with other LaTeX commands, such as color or font settings.
 ///
-/// Functionality available only in web-based graphics
+/// Since TLatex is used in many contexts, external links can be added to
+/// histogram titles, axis titles, legend entries, and more.
+///
+/// This functionality is available only in web-based graphics and
+/// standard SVG output.
 ///
 /// \macro_image (tcanvas_js)
 /// \macro_code
@@ -19,11 +21,10 @@ void latex_url()
 {
    auto c1 = new TCanvas("c1", "Use of #url in TLatex", 1200, 800);
 
-   if (!gROOT->IsBatch() && !c1->IsWeb())
-      ::Warning("latex_url.cxx", "macro may not work without enabling web-based canvas");
-
    auto latex = new TLatex(0.5, 0.5, "Link on #color[4]{#url[https://root.cern]{root.cern}} web site");
    latex->SetTextSize(0.1);
    latex->SetTextAlign(22);
+   latex->SetTextAngle(30.);
    c1->Add(latex);
+   c1->Print("c1.svg");
 }


### PR DESCRIPTION
# This Pull request:

Implements `#url` in TLatex. This is a follow of this request:  https://github.com/root-project/root/issues/16512
#url was already implemented for JSROOT. It is now available in TLatex for SVG output.

## Checklist:

- [ X] tested changes locally
- [ X] updated the docs (if necessary)
