### PR TITLE
Fix LIB_CORE_NAME mismatch when soversion is enabled

### DIFF
--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -228,7 +228,15 @@ if(ROOT_NEED_STDCXXFS)
 endif()
 
 # This code about the LIB_CORE_NAME define is important for TROOT::GetSharedLibDir()
-set(full_core_filename $<TARGET_FILE_NAME:Core>)
+# On Linux, dl_iterate_phdr reports loaded libraries by their SONAME
+# (e.g. libCore.so.6.38), not their full filename (libCore.so.6.38.02).
+# On macOS, _dyld_get_image_name returns the actual filename.
+# LIB_CORE_NAME must match what the dynamic linker reports.
+if(soversion AND NOT APPLE)
+  set(full_core_filename $<TARGET_SONAME_FILE_NAME:Core>)
+else()
+  set(full_core_filename $<TARGET_FILE_NAME:Core>)
+endif()
 
 # Absolue CMAKE_INSTALL_<dir> paths are discouraged in CMake, but some
 # packagers use them anyway. So we support it.


### PR DESCRIPTION
When `soversion=ON`, `TROOT::GetSharedLibDir()` fails to find `libCore` on Linux because `LIB_CORE_NAME` (set to `TARGET_FILE_NAME`, e.g. `libCore.so.6.38.02`) doesn't match what `dl_iterate_phdr` reports (the SONAME, e.g. `libCore.so.6.38`).

This causes ROOT to fail to locate its library directory, breaking pre-compiled module loading and causing cling to attempt recompiling modules from source at runtime.

Discovered via the conda-forge ROOT build which enables `soversion=ON`.

The fix uses `TARGET_SONAME_FILE_NAME` when `soversion` is enabled on Linux. On macOS, `_dyld_get_image_name` returns the actual filename so `TARGET_FILE_NAME` remains correct.

Introduced by ff7e63177e9b91ddf7bed88fb429339528137a3d.