### PR TITLE
[ntuple] remove DAOS "caging" feature

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
@@ -253,7 +253,7 @@ private:
    static constexpr std::uint64_t kMaskReservedBit = 1ull << 60;
 
    /// To save memory, we use the most significant bits to store the locator type (file, DAOS, zero page,
-   /// unkown, kTestLocatorType) as well as the one "reserved bit" that we currently process, the DAOS cage bit.
+   /// unkown, kTestLocatorType) as well as one "reserved bit" that can be used in future locators.
    /// Consequently, we can only store sizes up to 60 bits (1 EB), which in practice won't be an issue.
    std::uint64_t fFlagsAndNBytes = 0;
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`;
@@ -272,7 +272,7 @@ public:
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.
    ELocatorType GetType() const;
-   /// The only currently supported reserved bit is the DAOS cage bit.
+   /// We currently only support one of the 8 available reserved bits (none are used so far).
    std::uint8_t GetReserved() const { return (fFlagsAndNBytes & kMaskReservedBit) > 0; }
 
    void SetNBytesOnStorage(std::uint64_t nBytesOnStorage);

--- a/tree/ntuple/inc/ROOT/RNTupleWriteOptionsDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriteOptionsDaos.hxx
@@ -35,9 +35,6 @@ namespace Experimental {
 // clang-format on
 class RNTupleWriteOptionsDaos : public ROOT::RNTupleWriteOptions {
    std::string fObjectClass{"SX"};
-   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 16MiB by default.
-   /// A `fMaxCageSize` of 0 disables the caging mechanism.
-   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fMaxUnzippedPageSize;
 
 public:
    ~RNTupleWriteOptionsDaos() override = default;
@@ -51,12 +48,6 @@ public:
    /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
    /// the OC_ prefix.
    void SetObjectClass(const std::string &val) { fObjectClass = val; }
-
-   uint32_t GetMaxCageSize() const { return fMaxCageSize; }
-   /// Set the upper bound for page concatenation into cages, in bytes. It is assumed
-   /// that cage size will be no smaller than the approximate uncompressed page size.
-   /// To disable page concatenation, set this value to 0.
-   void SetMaxCageSize(uint32_t cageSz) { fMaxCageSize = cageSz; }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -42,10 +42,6 @@ using ntuple_index_t = std::uint32_t;
 class RDaosPool;
 class RDaosContainer;
 class RPageAllocatorHeap;
-enum EDaosLocatorFlags {
-   // Indicates that the referenced page is "caged", i.e. it is stored in a larger blob that contains multiple pages.
-   kCagedPage = 0x01,
-};
 
 // clang-format off
 /**
@@ -119,7 +115,6 @@ private:
 
    RDaosNTupleAnchor fNTupleAnchor;
    ntuple_index_t fNTupleIndex{0};
-   uint32_t fCageSizeLimit{};
 
 protected:
    using RPagePersistentSink::InitImpl;


### PR DESCRIPTION
The caging feature allowed packing multiple pages of the same column into a single object. With the adaptive page sizes, this feature is not really needed anymore. Removal simplifies the code quite a bit.

Fixes #15783
