### PR TITLE
[cling] Use resolved executable path for clang Driver

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1478,7 +1478,7 @@ namespace {
     }
 
     llvm::Triple TheTriple(llvm::sys::getProcessTriple());
-    clang::driver::Driver Drvr(argv[0], TheTriple.getTriple(), *Diags);
+    clang::driver::Driver Drvr(ClingBin, TheTriple.getTriple(), *Diags);
     //Drvr.setWarnMissingInput(false);
     Drvr.setCheckInputsExist(false); // think foo.C(12)
     llvm::ArrayRef<const char*>RF(&(argvCompile[0]), argvCompile.size());


### PR DESCRIPTION
When ROOT passes "cling4root" as argv[0] to cling, the clang Driver computes InstalledDir as empty, causing GCC installation detection to scan "/" instead of the actual prefix. This prevents automatic sysroot detection on conda-forge, where the GCC installation and sysroot are at predictable locations relative to the binary.

Use the resolved executable path (ClingBin, obtained via GetExecutablePath/proc/self/exe) for the Driver constructor so it can correctly find the GCC installation and compute the sysroot.

This is an upstream of patch https://github.com/conda-forge/root-feedstock/blob/main/recipe/patches/0018-Use-resolved-executable-path-for-clang-Driver.patch

Credits go to Chris Burr