### PR TITLE
Move handling of Cocoa option after FreeType

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -100,18 +100,6 @@ if(NOT shared)
   endif()
 endif()
 
-
-#---Check for Cocoa/Quartz graphics backend (MacOS X only)---------------------------
-if(cocoa)
-  if(APPLE)
-    set(x11 OFF CACHE BOOL "Disabled because cocoa requested (${x11_description})" FORCE)
-    set(builtin_freetype ON CACHE BOOL "Enabled because needed for Cocoa graphics (${builtin_freetype_description})" FORCE)
-  else()
-    message(STATUS "Cocoa option can only be enabled on MacOSX platform")
-    set(cocoa OFF CACHE BOOL "Disabled because only available on MacOSX (${cocoa_description})" FORCE)
-  endif()
-endif()
-
 #---Check for Zlib ------------------------------------------------------------------
 if(NOT builtin_zlib)
   message(STATUS "Looking for ZLib")
@@ -283,6 +271,18 @@ if(builtin_freetype)
   set(FREETYPE_INCLUDE_DIRS ${FREETYPE_INCLUDE_DIR})
   set(FREETYPE_LIBRARIES ${FREETYPE_LIBRARY})
   set(FREETYPE_TARGET FREETYPE)
+endif()
+
+#---Check for Cocoa/Quartz graphics backend (MacOS X only)---------------------------
+# Note that this check happens *after* the above check for FreeType because that
+# library is needed for builds on Apple with Cocoa graphics
+if(cocoa)
+  if(APPLE)
+    set(x11 OFF CACHE BOOL "Disabled because cocoa requested (${x11_description})" FORCE)
+  else()
+    message(STATUS "Cocoa option can only be enabled on MacOSX platform")
+    set(cocoa OFF CACHE BOOL "Disabled because only available on MacOSX (${cocoa_description})" FORCE)
+  endif()
 endif()
 
 #---Check for PCRE-------------------------------------------------------------------


### PR DESCRIPTION
When building on Apple with Cocoa graphics, FreeType is required. Previously, there were two separate ways to check for FreeType availability:

* The "standard" checks for builtins, forcing availability when `fail-on-missing` is ON, otherwise falling back to activating the builtin if the external package is not found
* An injected check in the section related to Cocoa, which happened before the section for the builtin, which practically meant that on Apple with Cocoa enabled ROOT was always built with the builtin FreeType library.

This commit proposes to move the section related to Cocoa after the section related to FreeType. This way, the build on Cocoa can only:

* Fail if FreeType is not found, when `fail-on-missing` is ON
* Use the FreeType seen by the rest of the build, the result of the checks in the FreeType section.

As a result, MacOS builds can also now use an externally provided FreeType, useful e.g. for conda-forge builds.

This commit removes the need for the following conda-forge patch: https://github.com/conda-forge/root-feedstock/blob/df86316b299d8214d3181d76c31925696f076d5e/recipe/patches/0009-disable-builtin-freetype-macos.patch