### PR TITLE
Skip the failing h2root test on mac beta.

### DIFF
--- a/roottest/root/hist/CMakeLists.txt
+++ b/roottest/root/hist/CMakeLists.txt
@@ -11,6 +11,13 @@ if(fortran AND CMAKE_Fortran_COMPILER AND NOT CMAKE_Fortran_COMPILER_ID STREQUAL
                     COMMAND ${CMAKE_COMMAND} -E env h2root mb4i1.hbook
                     COPY_TO_BUILDDIR mb4i1.hbook
                     OUTREF h2root.ref)
+
+  # Mask the known failure due to a read error in the file
+  if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 25.4)
+    set_tests_properties(roottest-root-hist-h2root PROPERTIES
+      SKIP_REGULAR_EXPRESSION "Error cannot open input file: mb4i1\.hbook"
+      WILL_FAIL True)
+  endif()
 endif()
 
 ROOTTEST_ADD_TESTDIRS()


### PR DESCRIPTION
This will mask the test failure on mac beta until it's resolved or disabled.

- Run the test in a subprocess. This allows for checking its output and exit status, as system-level failures of the parent always lead to a failure.
- Skip the test if the known error is encountered.
- Set the `WILL_FAIL` property. If the test passes unexpectedly, it will signal this with a failure.