### PR TITLE
[build] Disable building hsimple when cross-compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,22 +581,25 @@ endif()
 ROOT_ADD_TEST_SUBDIRECTORY(tutorials)
 
 #---hsimple.root---------(use the executable for clearer dependencies and proper return code)---
-add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
-add_dependencies(hsimple onepcm)
-add_custom_command(OUTPUT tutorials/hsimple.root
-                   VERBATIM
-                   COMMAND
-                     ${CMAKE_COMMAND} -E env
-                     ROOT_INCLUDE_PATH=${DEFAULT_ROOT_INCLUDE_PATH}
-                     ROOTIGNOREPREFIX=1
-                     ROOT_HIST=0
-                     $<TARGET_FILE:root.exe> -q -b -n
-                       -e ".L ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C"
-                       -e "hsimple();"
-                       -e return
-                   WORKING_DIRECTORY tutorials
-                   DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts)
-install(FILES ${CMAKE_BINARY_DIR}/tutorials/hsimple.root DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)
+# We can't build hsimple when cross compiling
+if(NOT CMAKE_CROSSCOMPILING)
+  add_custom_target(hsimple ALL DEPENDS tutorials/hsimple.root)
+  add_dependencies(hsimple onepcm)
+  add_custom_command(OUTPUT tutorials/hsimple.root
+                    VERBATIM
+                    COMMAND
+                      ${CMAKE_COMMAND} -E env
+                      ROOT_INCLUDE_PATH=${DEFAULT_ROOT_INCLUDE_PATH}
+                      ROOTIGNOREPREFIX=1
+                      ROOT_HIST=0
+                      $<TARGET_FILE:root.exe> -q -b -n
+                        -e ".L ${CMAKE_SOURCE_DIR}/tutorials/hsimple.C"
+                        -e "hsimple();"
+                        -e return
+                    WORKING_DIRECTORY tutorials
+                    DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts)
+  install(FILES ${CMAKE_BINARY_DIR}/tutorials/hsimple.root DESTINATION ${CMAKE_INSTALL_TUTDIR} COMPONENT tests)
+endif()
 
 if(runtime_cxxmodules)
   add_dependencies(hsimple modules_idx)


### PR DESCRIPTION
This is an upstream of https://github.com/conda-forge/root-feedstock/blob/df86316b299d8214d3181d76c31925696f076d5e/recipe/patches/0007-Disable-hsimple.root-generation-if-cross-compiling.patch
