### PR TITLE
[ML] Refactor the data loader headers

### DIFF
--- a/tree/ml/CMakeLists.txt
+++ b/tree/ml/CMakeLists.txt
@@ -12,7 +12,11 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTMLDataLoader
     ROOT/ML/RFlat2DMatrixOperators.hxx
     ROOT/ML/RDatasetLoader.hxx
     ROOT/ML/RSampler.hxx
-  NO_SOURCES
+  SOURCES
+    src/RBatchLoader.cxx
+    src/RChunkConstructor.cxx
+    src/RFlat2DMatrixOperators.cxx
+    src/RSampler.cxx
   DEPENDENCIES
     ROOTDataFrame
 )

--- a/tree/ml/inc/ROOT/ML/RBatchGenerator.hxx
+++ b/tree/ml/inc/ROOT/ML/RBatchGenerator.hxx
@@ -16,23 +16,20 @@
 #ifndef ROOT_INTERNAL_ML_RBATCHGENERATOR
 #define ROOT_INTERNAL_ML_RBATCHGENERATOR
 
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ROOT/ML/RBatchLoader.hxx"
+#include "ROOT/ML/RChunkLoader.hxx"
+#include "ROOT/ML/RDatasetLoader.hxx"
 #include "ROOT/ML/RFlat2DMatrix.hxx"
 #include "ROOT/ML/RFlat2DMatrixOperators.hxx"
 #include "ROOT/ML/RSampler.hxx"
-#include "ROOT/RDF/RDatasetSpec.hxx"
-
-#include "ROOT/ML/RDatasetLoader.hxx"
-#include "ROOT/ML/RChunkLoader.hxx"
-#include "ROOT/ML/RBatchLoader.hxx"
-#include "TROOT.h"
-
-#include <cmath>
-#include <memory>
-#include <mutex>
-#include <random>
-#include <thread>
-#include <variant>
-#include <vector>
+#include "ROOT/RDF/InterfaceUtils.hxx"
 
 // Empty namespace to create a hook for the Pythonization
 namespace ROOT::Experimental::ML {

--- a/tree/ml/inc/ROOT/ML/RBatchLoader.hxx
+++ b/tree/ml/inc/ROOT/ML/RBatchLoader.hxx
@@ -16,14 +16,12 @@
 #ifndef ROOT_INTERNAL_ML_RBATCHLOADER
 #define ROOT_INTERNAL_ML_RBATCHLOADER
 
-#include <vector>
-#include <memory>
-#include <numeric>
-
-// Imports for threading
-#include <queue>
-#include <mutex>
 #include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <vector>
 
 #include "ROOT/ML/RFlat2DMatrix.hxx"
 
@@ -70,223 +68,16 @@ private:
 public:
    RBatchLoader(std::size_t batchSize, const std::vector<std::string> &cols, std::mutex &sharedMutex,
                 std::condition_variable &sharedCV, const std::vector<std::size_t> &vecSizes = {},
-                std::size_t numEntries = 0, bool dropRemainder = false)
-      : fBatchSize(batchSize),
-        fCols(cols),
-        fLock(sharedMutex),
-        fCV(sharedCV),
-        fVecSizes(vecSizes),
-        fNumEntries(numEntries),
-        fDropRemainder(dropRemainder)
-   {
-      fSumVecSizes = std::accumulate(fVecSizes.begin(), fVecSizes.end(), 0);
-      fNumColumns = fCols.size() + fSumVecSizes - fVecSizes.size();
+                std::size_t numEntries = 0, bool dropRemainder = false);
 
-      if (fBatchSize == 0) {
-         fBatchSize = fNumEntries;
-      }
+   void Activate();
+   void DeActivate();
+   void Reset();
+   void MarkProducerDone();
 
-      fLeftoverBatchSize = fNumEntries % fBatchSize;
-      fNumFullBatches = fNumEntries / fBatchSize;
-
-      std::size_t numLeftoverBatches = fLeftoverBatchSize == 0 ? 0 : 1;
-
-      if (fDropRemainder) {
-         fNumBatches = fNumFullBatches;
-      } else {
-         fNumBatches = fNumFullBatches + numLeftoverBatches;
-      }
-
-      fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-      fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-   }
-
-   /// \brief Activate the batchloader. This means that batches can be created and loaded.
-   void Activate()
-   {
-      {
-         std::lock_guard<std::mutex> lock(fLock);
-         if (fIsActive)
-            return;
-         fIsActive = true;
-         fProducerDone = false;
-      }
-
-      fCV.notify_all();
-   }
-
-   /// \brief DeActivate the batchloader. This means that no more batches are created.
-   /// Batches can still be returned if they are already loaded.
-   void DeActivate()
-   {
-      {
-         std::lock_guard<std::mutex> lock(fLock);
-         if (!fIsActive)
-            return;
-         fIsActive = false;
-      }
-
-      fCV.notify_all();
-   }
-
-   /// \brief Return a batch of data as a unique pointer.
-   /// After the batch has been processed, it should be destroyed.
-   /// \param[in] chunkTensor Tensor with the data from the chunk
-   /// \param[in] idxs Index of batch in the chunk
-   /// \return Batch
-   std::unique_ptr<RFlat2DMatrix> CreateBatch(RFlat2DMatrix &chunkTensor, std::size_t idxs)
-   {
-      auto batch = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
-      std::copy(chunkTensor.GetData() + (idxs * fBatchSize * fNumColumns),
-                chunkTensor.GetData() + ((idxs + 1) * fBatchSize * fNumColumns), batch->GetData());
-
-      return batch;
-   }
-
-   /// \brief Loading the batch from the queue.
-   /// \return Batch
-   RFlat2DMatrix GetBatch()
-   {
-      std::unique_lock<std::mutex> lock(fLock);
-
-      // Wait until:
-      //  - there is data in the queue
-      //  - or producer declares "done"
-      //  - or we are deactivated
-      fCV.wait(lock, [&] { return !fBatchQueue.empty() || fProducerDone || !fIsActive; });
-
-      if (fBatchQueue.empty()) {
-         // producer done and no queued data -> end-of-epoch signal
-         fCurrentBatch = std::make_unique<RFlat2DMatrix>();
-         return *fCurrentBatch;
-      }
-
-      fCurrentBatch = std::move(fBatchQueue.front());
-      fBatchQueue.pop();
-      // Notify the loading thread that the queue has drained
-      fCV.notify_all();
-
-      return *fCurrentBatch;
-   }
-
-   /// \brief Creating the batches from a chunk and add them to the queue.
-   /// \param[in] chunkTensor Tensor with the data from the chunk
-   /// \param[in] isLastBatch Check if the batch in the chunk is the last one
-   void CreateBatches(RFlat2DMatrix &chunkTensor, bool isLastBatch)
-   {
-      std::size_t chunkSize = chunkTensor.GetRows();
-      std::size_t numCols = chunkTensor.GetCols();
-      std::size_t numBatches = chunkSize / fBatchSize;
-      std::size_t leftoverBatchSize = chunkSize % fBatchSize;
-
-      // create a vector of batches
-      std::vector<std::unique_ptr<RFlat2DMatrix>> batches;
-
-      // fill the full batches from the chunk into a vector
-      for (std::size_t i = 0; i < numBatches; i++) {
-         batches.emplace_back(CreateBatch(chunkTensor, i));
-      }
-
-      // copy the remaining entries from the chunk into a leftover batch
-      RFlat2DMatrix LeftoverBatch(leftoverBatchSize, numCols);
-      std::copy(chunkTensor.GetData() + (numBatches * fBatchSize * numCols),
-                chunkTensor.GetData() + (numBatches * fBatchSize * numCols + leftoverBatchSize * numCols),
-                LeftoverBatch.GetData());
-
-      // calculate how many empty slots are left in fPrimaryLeftoverBatch
-      std::size_t PrimaryLeftoverSize = fPrimaryLeftoverBatch->GetRows();
-      std::size_t emptySlots = fBatchSize - PrimaryLeftoverSize;
-
-      // copy LeftoverBatch to end of fPrimaryLeftoverBatch
-      if (emptySlots >= leftoverBatchSize) {
-         fPrimaryLeftoverBatch->Resize(PrimaryLeftoverSize + leftoverBatchSize, numCols);
-         std::copy(LeftoverBatch.GetData(), LeftoverBatch.GetData() + (leftoverBatchSize * fNumColumns),
-                   fPrimaryLeftoverBatch->GetData() + (PrimaryLeftoverSize * numCols));
-
-         // copy LeftoverBatch to end of fPrimaryLeftoverBatch and add it to the batch
-         if (emptySlots == leftoverBatchSize) {
-            auto copy = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
-            std::copy(fPrimaryLeftoverBatch->GetData(), fPrimaryLeftoverBatch->GetData() + (fBatchSize * fNumColumns),
-                      copy->GetData());
-            batches.emplace_back(std::move(copy));
-
-            // reset fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
-            *fPrimaryLeftoverBatch = *fSecondaryLeftoverBatch;
-            fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-         }
-      }
-
-      // copy LeftoverBatch to both fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
-      else if (emptySlots < leftoverBatchSize) {
-         // copy the first part of LeftoverBatch to end of fPrimaryLeftoverTrainingBatch
-         fPrimaryLeftoverBatch->Resize(fBatchSize, numCols);
-         std::copy(LeftoverBatch.GetData(), LeftoverBatch.GetData() + (emptySlots * numCols),
-                   fPrimaryLeftoverBatch->GetData() + (PrimaryLeftoverSize * numCols));
-
-         // copy the last part of LeftoverBatch to the end of fSecondaryLeftoverBatch
-         fSecondaryLeftoverBatch->Resize(leftoverBatchSize - emptySlots, numCols);
-         std::copy(LeftoverBatch.GetData() + (emptySlots * numCols),
-                   LeftoverBatch.GetData() + (leftoverBatchSize * numCols), fSecondaryLeftoverBatch->GetData());
-
-         // add fPrimaryLeftoverBatch to the batch vector
-         auto copy = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
-         std::copy(fPrimaryLeftoverBatch->GetData(), fPrimaryLeftoverBatch->GetData() + (fBatchSize * fNumColumns),
-                   copy->GetData());
-         batches.emplace_back(std::move(copy));
-
-         // exchange fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
-         *fPrimaryLeftoverBatch = *fSecondaryLeftoverBatch;
-         // reset fSecondaryLeftoverTrainingBatch
-         fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-      }
-
-      // copy the content of fPrimaryLeftoverBatch to the leftover batch from the chunk
-      if (isLastBatch) {
-         if (!fDropRemainder && fLeftoverBatchSize > 0) {
-            auto copy = std::make_unique<RFlat2DMatrix>(fLeftoverBatchSize, fNumColumns);
-            std::copy(fPrimaryLeftoverBatch->GetData(),
-                      fPrimaryLeftoverBatch->GetData() + (fLeftoverBatchSize * fNumColumns), copy->GetData());
-            batches.emplace_back(std::move(copy));
-         }
-
-         fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-         fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-      }
-
-      {
-         std::lock_guard<std::mutex> lock(fLock);
-         for (auto &batch : batches) {
-            fBatchQueue.push(std::move(batch));
-         }
-      }
-
-      fCV.notify_all();
-   }
-
-   /// \brief Reset the batchloader state.
-   void Reset()
-   {
-      {
-         std::lock_guard<std::mutex> lock(fLock);
-
-         while (!fBatchQueue.empty()) {
-            fBatchQueue.pop();
-         }
-
-         fCurrentBatch.reset();
-         fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-         fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
-      }
-
-      fCV.notify_all();
-   }
-
-   /// \brief Signal that the producer has finished pushing all batches for this epoch.
-   void MarkProducerDone()
-   {
-      fProducerDone = true;
-      fCV.notify_all();
-   }
+   std::unique_ptr<RFlat2DMatrix> CreateBatch(RFlat2DMatrix &chunkTensor, std::size_t idxs);
+   RFlat2DMatrix GetBatch();
+   void CreateBatches(RFlat2DMatrix &chunkTensor, bool isLastBatch);
 
    bool isProducerDone() { return fProducerDone; }
    std::size_t GetNumBatches() { return fNumBatches; }

--- a/tree/ml/inc/ROOT/ML/RChunkConstructor.hxx
+++ b/tree/ml/inc/ROOT/ML/RChunkConstructor.hxx
@@ -11,13 +11,10 @@
 #ifndef ROOT_INTERNAL_ML_RCHUNKCONSTRUCTOR
 #define ROOT_INTERNAL_ML_RCHUNKCONSTRUCTOR
 
+#include <utility>
 #include <vector>
 
-#include "ROOT/RDataFrame.hxx"
-#include "ROOT/RDF/Utils.hxx"
-#include "ROOT/RVec.hxx"
-
-#include "ROOT/RLogger.hxx"
+#include "Rtypes.h"
 
 namespace ROOT::Experimental::Internal::ML {
 /**
@@ -105,133 +102,11 @@ struct RChunkConstructor {
 
    std::vector<std::size_t> ChunksSizes;
 
-   RChunkConstructor(const std::size_t numEntries, const std::size_t chunkSize, const std::size_t blockSize)
-      : fNumEntries(numEntries), fChunkSize(chunkSize), fBlockSize(blockSize)
-   {
-      // size of full and leftover chunks
-      SizeOfFullChunk = chunkSize;
-      SizeOfLeftoverChunk = fNumEntries % SizeOfFullChunk;
+   RChunkConstructor(const std::size_t numEntries, const std::size_t chunkSize, const std::size_t blockSize);
 
-      // size of full and leftover blocks in a full and leftover chunk
-      SizeOfFullBlockInFullChunk = blockSize;
-      SizeOfLeftoverBlockInFullChunk = SizeOfFullChunk % blockSize;
-      SizeOfFullBlockInLeftoverChunk = blockSize;
-      SizeOfLeftoverBlockInLeftoverChunk = SizeOfLeftoverChunk % blockSize;
-
-      // number of full, leftover and total chunks
-      FullChunks = numEntries / SizeOfFullChunk;
-      LeftoverChunks = SizeOfLeftoverChunk == 0 ? 0 : 1;
-      Chunks = FullChunks + LeftoverChunks;
-
-      // number of full, leftover and total blocks in a full chunk
-      FullBlocksPerFullChunk = SizeOfFullChunk / blockSize;
-      LeftoverBlocksPerFullChunk = SizeOfLeftoverBlockInFullChunk == 0 ? 0 : 1;
-      BlockPerFullChunk = FullBlocksPerFullChunk + LeftoverBlocksPerFullChunk;
-
-      // number of full, leftover and total blocks in the leftover chunk
-      FullBlocksPerLeftoverChunk = SizeOfLeftoverChunk / blockSize;
-      LeftoverBlocksPerLeftoverChunk = SizeOfLeftoverBlockInLeftoverChunk == 0 ? 0 : 1;
-      BlockPerLeftoverChunk = FullBlocksPerLeftoverChunk + LeftoverBlocksPerLeftoverChunk;
-
-      // total number of full and leftover blocks in the full chunks
-      FullBlocksInFullChunks = FullBlocksPerFullChunk * FullChunks;
-      LeftoverBlocksInFullChunks = LeftoverBlocksPerFullChunk * FullChunks;
-
-      // total number of full and leftover blocks in the leftover chunks
-      FullBlocksInLeftoverChunks = FullBlocksPerLeftoverChunk * LeftoverChunks;
-      LeftoverBlocksInLeftoverChunks = LeftoverBlocksPerLeftoverChunk * LeftoverChunks;
-
-      // vector of the different block sizes
-      SizeOfBlocks = {SizeOfFullBlockInFullChunk, SizeOfLeftoverBlockInFullChunk, SizeOfFullBlockInLeftoverChunk,
-                      SizeOfLeftoverBlockInLeftoverChunk};
-
-      // vector with the number of the different block
-      NumberOfDifferentBlocks = {FullBlocksInFullChunks, LeftoverBlocksInFullChunks, FullBlocksInLeftoverChunks,
-                                 LeftoverBlocksInLeftoverChunks};
-
-      // total number of blocks
-      NumberOfBlocks = std::accumulate(NumberOfDifferentBlocks.begin(), NumberOfDifferentBlocks.end(), 0);
-   };
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Group the blocks based on the block type (full or leftover) based on the size of the block.
-   void DistributeBlockIntervals()
-   {
-
-      std::vector<std::vector<std::pair<Long_t, Long_t>> *> TypesOfBlockIntervals = {
-         &FullBlockIntervalsInFullChunks, &LeftoverBlockIntervalsInFullChunks, &FullBlockIntervalsInLeftoverChunks,
-         &LeftoverBlockIntervalsInLeftoverChunks};
-
-      std::vector<std::size_t> IndexOfDifferentBlocks(NumberOfDifferentBlocks.size());
-      std::partial_sum(NumberOfDifferentBlocks.begin(), NumberOfDifferentBlocks.end(), IndexOfDifferentBlocks.begin());
-      IndexOfDifferentBlocks.insert(IndexOfDifferentBlocks.begin(), 0);
-
-      for (size_t i = 0; i < TypesOfBlockIntervals.size(); ++i) {
-         size_t start = IndexOfDifferentBlocks[i];
-         size_t end = IndexOfDifferentBlocks[i + 1];
-
-         TypesOfBlockIntervals[i]->insert(TypesOfBlockIntervals[i]->begin(), BlockIntervals.begin() + start,
-                                          BlockIntervals.begin() + end);
-      }
-   }
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Creates chunks from the dataset consisting of blocks with the begin and end entry.
-   void CreateChunksIntervals()
-   {
-
-      ChunksIntervals.resize(Chunks);
-      for (size_t i = 0; i < FullChunks; i++) {
-
-         size_t start_FullBlock = FullBlocksPerFullChunk * i;
-         size_t end_FullBlock = FullBlocksPerFullChunk * (i + 1);
-
-         size_t start_LeftoverBlock = LeftoverBlocksPerFullChunk * i;
-         size_t end_LeftoverBlock = LeftoverBlocksPerFullChunk * (i + 1);
-
-         ChunksIntervals[i].insert(ChunksIntervals[i].end(), FullBlockIntervalsInFullChunks.begin() + start_FullBlock,
-                                   FullBlockIntervalsInFullChunks.begin() + end_FullBlock);
-         ChunksIntervals[i].insert(ChunksIntervals[i].end(),
-                                   LeftoverBlockIntervalsInFullChunks.begin() + start_LeftoverBlock,
-                                   LeftoverBlockIntervalsInFullChunks.begin() + end_LeftoverBlock);
-      }
-
-      for (size_t i = 0; i < LeftoverChunks; i++) {
-
-         size_t j = i + FullChunks;
-         size_t start_FullBlock = FullBlocksPerLeftoverChunk * i;
-         size_t end_FullBlock = FullBlocksPerLeftoverChunk * (i + 1);
-
-         size_t start_LeftoverBlock = LeftoverBlocksPerLeftoverChunk * i;
-         size_t end_LeftoverBlock = LeftoverBlocksPerLeftoverChunk * (i + 1);
-
-         ChunksIntervals[j].insert(ChunksIntervals[j].end(),
-                                   FullBlockIntervalsInLeftoverChunks.begin() + start_FullBlock,
-                                   FullBlockIntervalsInLeftoverChunks.begin() + end_FullBlock);
-         ChunksIntervals[j].insert(ChunksIntervals[j].end(),
-                                   LeftoverBlockIntervalsInLeftoverChunks.begin() + start_LeftoverBlock,
-                                   LeftoverBlockIntervalsInLeftoverChunks.begin() + end_LeftoverBlock);
-      }
-   }
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Fills a vector with the size of every chunk from the dataset
-   void SizeOfChunks()
-   {
-
-      for (size_t i = 0; i < Chunks; i++) {
-         std::size_t chunkSize = 0;
-         for (size_t j = 0; j < ChunksIntervals[i].size(); j++) {
-            std::size_t start = ChunksIntervals[i][j].first;
-            std::size_t end = ChunksIntervals[i][j].second;
-
-            std::size_t intervalSize = end - start;
-            chunkSize += intervalSize;
-         }
-
-         ChunksSizes.insert(ChunksSizes.end(), chunkSize);
-      }
-   }
+   void DistributeBlockIntervals();
+   void CreateChunksIntervals();
+   void SizeOfChunks();
 };
 } // namespace ROOT::Experimental::Internal::ML
 

--- a/tree/ml/inc/ROOT/ML/RChunkLoader.hxx
+++ b/tree/ml/inc/ROOT/ML/RChunkLoader.hxx
@@ -15,16 +15,23 @@
 #ifndef ROOT_INTERNAL_ML_RCHUNKLOADER
 #define ROOT_INTERNAL_ML_RCHUNKLOADER
 
-#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <numeric>
 #include <random>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "ROOT/ML/RChunkConstructor.hxx"
-#include "ROOT/RDataFrame.hxx"
-#include "ROOT/RDF/Utils.hxx"
 #include "ROOT/ML/RFlat2DMatrix.hxx"
 #include "ROOT/ML/RFlat2DMatrixOperators.hxx"
-
-#include "ROOT/RLogger.hxx"
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDF/Utils.hxx"
 
 namespace ROOT::Experimental::Internal::ML {
 /**

--- a/tree/ml/inc/ROOT/ML/RDatasetLoader.hxx
+++ b/tree/ml/inc/ROOT/ML/RDatasetLoader.hxx
@@ -11,16 +11,17 @@
 #ifndef ROOT_INTERNAL_ML_RDATASETLOADER
 #define ROOT_INTERNAL_ML_RDATASETLOADER
 
+#include <algorithm>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
 #include <vector>
-#include <random>
 
-#include "ROOT/RDataFrame.hxx"
 #include "ROOT/ML/RFlat2DMatrix.hxx"
 #include "ROOT/ML/RFlat2DMatrixOperators.hxx"
+#include "ROOT/RDataFrame.hxx"
 #include "ROOT/RDF/Utils.hxx"
-#include "ROOT/RVec.hxx"
-
-#include "ROOT/RLogger.hxx"
 
 namespace ROOT::Experimental::Internal::ML {
 

--- a/tree/ml/inc/ROOT/ML/RFlat2DMatrix.hxx
+++ b/tree/ml/inc/ROOT/ML/RFlat2DMatrix.hxx
@@ -1,8 +1,8 @@
 #ifndef ROOT_INTERNAL_ML_RFLAT2DMATRIX
 #define ROOT_INTERNAL_ML_RFLAT2DMATRIX
 
-#include <utility>
 #include <cassert>
+#include <utility>
 
 #include "ROOT/RVec.hxx"
 

--- a/tree/ml/inc/ROOT/ML/RFlat2DMatrixOperators.hxx
+++ b/tree/ml/inc/ROOT/ML/RFlat2DMatrixOperators.hxx
@@ -11,10 +11,12 @@
 #ifndef ROOT_INTERNAL_ML_RFLAT2DMATRIXOPERATORS
 #define ROOT_INTERNAL_ML_RFLAT2DMATRIXOPERATORS
 
-#include <random>
-#include <algorithm>
+#include <vector>
 
-#include "ROOT/ML/RFlat2DMatrix.hxx"
+// Forward decl
+namespace ROOT::Experimental::Internal::ML {
+struct RFlat2DMatrix;
+} // namespace ROOT::Experimental::Internal::ML
 
 namespace ROOT::Experimental::Internal::ML {
 /**
@@ -31,77 +33,14 @@ private:
 public:
    RFlat2DMatrixOperators(bool shuffle = true, const std::size_t setSeed = 0) : fShuffle(shuffle), fSetSeed(setSeed) {}
 
-   void ShuffleTensor(RFlat2DMatrix &ShuffledTensor, RFlat2DMatrix &Tensor)
-   {
-      if (fShuffle) {
-         std::random_device rd;
-         std::mt19937 g;
+   ~RFlat2DMatrixOperators();
 
-         if (fSetSeed == 0) {
-            g.seed(rd());
-         } else {
-            g.seed(fSetSeed);
-         }
-
-         std::size_t rows = Tensor.GetRows();
-         std::size_t cols = Tensor.GetCols();
-         ShuffledTensor.Resize(rows, cols);
-
-         // make an identity permutation map
-         std::vector<Long_t> indices(rows);
-         std::iota(indices.begin(), indices.end(), 0);
-
-         // shuffle the identity permutation to create a new permutation
-         std::shuffle(indices.begin(), indices.end(), g);
-
-         // shuffle data in the tensor with the permutation map defined above
-         for (std::size_t i = 0; i < rows; i++) {
-            std::copy(Tensor.GetData() + indices[i] * cols, Tensor.GetData() + (indices[i] + 1) * cols,
-                      ShuffledTensor.GetData() + i * cols);
-         }
-      } else {
-         ShuffledTensor = Tensor;
-      }
-   }
+   void ShuffleTensor(RFlat2DMatrix &ShuffledTensor, RFlat2DMatrix &Tensor);
 
    void
-   SliceTensor(RFlat2DMatrix &SlicedTensor, RFlat2DMatrix &Tensor, const std::vector<std::vector<std::size_t>> &slice)
-   {
-      const auto &rowSlice = slice[0];
-      const auto &colSlice = slice[1];
+   SliceTensor(RFlat2DMatrix &SlicedTensor, RFlat2DMatrix &Tensor, const std::vector<std::vector<std::size_t>> &slice);
 
-      std::size_t rowStart = rowSlice[0];
-      std::size_t rowEnd = rowSlice[1];
-      std::size_t colStart = colSlice[0];
-      std::size_t colEnd = colSlice[1];
-
-      std::size_t rows = rowEnd - rowStart;
-      std::size_t cols = colEnd - colStart;
-
-      SlicedTensor.Resize(rows, cols);
-      std::copy(Tensor.GetData() + rowStart * cols, Tensor.GetData() + rowStart * cols + rows * cols,
-                SlicedTensor.GetData());
-   }
-
-   void ConcatenateTensors(RFlat2DMatrix &ConcatTensor, const std::vector<RFlat2DMatrix> &Tensors)
-   {
-      std::size_t cols = Tensors[0].GetCols();
-      std::size_t rows = 0;
-
-      for (const auto &t : Tensors) {
-         rows += t.GetRows();
-      }
-
-      ConcatTensor.Resize(rows, cols);
-
-      std::size_t index = 0;
-      for (std::size_t i = 0; i < Tensors.size(); i++) {
-         std::size_t tensorRows = Tensors[i].GetRows();
-         std::copy(Tensors[i].GetData(), Tensors[i].GetData() + tensorRows * cols,
-                   ConcatTensor.GetData() + index * cols);
-         index += tensorRows;
-      }
-   }
+   void ConcatenateTensors(RFlat2DMatrix &ConcatTensor, const std::vector<RFlat2DMatrix> &Tensors);
 };
 
 } // namespace ROOT::Experimental::Internal::ML

--- a/tree/ml/inc/ROOT/ML/RSampler.hxx
+++ b/tree/ml/inc/ROOT/ML/RSampler.hxx
@@ -11,15 +11,16 @@
 #ifndef ROOT_INTERNAL_ML_RSAMPLER
 #define ROOT_INTERNAL_ML_RSAMPLER
 
+#include <memory>
+#include <string>
 #include <vector>
-#include <random>
-#include <algorithm>
 
-#include "ROOT/RDataFrame.hxx"
-#include "ROOT/RDF/Utils.hxx"
-#include "ROOT/RVec.hxx"
-#include "ROOT/ML/RFlat2DMatrixOperators.hxx"
-#include "ROOT/RLogger.hxx"
+#include "ROOT/ML/RFlat2DMatrix.hxx"
+
+// Forward decls
+namespace ROOT::Experimental::Internal::ML {
+class RFlat2DMatrixOperators;
+}
 
 namespace ROOT::Experimental::Internal::ML {
 /**
@@ -51,200 +52,25 @@ private:
 
 public:
    RSampler(std::vector<RFlat2DMatrix> &datasets, const std::string &sampleType, float sampleRatio,
-            bool replacement = false, bool shuffle = true, std::size_t setSeed = 0)
-      : fDatasets(datasets),
-        fSampleType(sampleType),
-        fSampleRatio(sampleRatio),
-        fReplacement(replacement),
-        fShuffle(shuffle),
-        fSetSeed(setSeed)
-   {
-      fTensorOperators = std::make_unique<RFlat2DMatrixOperators>(fShuffle, fSetSeed);
+            bool replacement = false, bool shuffle = true, std::size_t setSeed = 0);
 
-      // setup the sampler for the datasets
-      SetupSampler();
-   }
+   ~RSampler();
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Calculate fNumEntries and major/minor variables
-   void SetupSampler()
-   {
-      if (fSampleType == "undersampling") {
-         SetupRandomUndersampler();
-      } else if (fSampleType == "oversampling") {
-         SetupRandomOversampler();
-      }
-   }
+   void SetupSampler();
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Collection of sampling types
-   /// \param[in] SampledTensor Tensor with all the sampled entries
-   void Sampler(RFlat2DMatrix &SampledTensor)
-   {
-      if (fSampleType == "undersampling") {
-         RandomUndersampler(SampledTensor);
-      } else if (fSampleType == "oversampling") {
-         RandomOversampler(SampledTensor);
-      }
-   }
+   void Sampler(RFlat2DMatrix &SampledTensor);
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Calculate fNumEntries and major/minor variables for the random undersampler
-   void SetupRandomUndersampler()
-   {
-      if (fDatasets[0].GetRows() > fDatasets[1].GetRows()) {
-         fMajor = 0;
-         fMinor = 1;
-      } else {
-         fMajor = 1;
-         fMinor = 0;
-      }
+   void SetupRandomUndersampler();
 
-      fNumMajor = fDatasets[fMajor].GetRows();
-      fNumMinor = fDatasets[fMinor].GetRows();
-      fNumResampledMajor = static_cast<std::size_t>(fNumMinor / fSampleRatio);
-      if (!fReplacement && fNumResampledMajor > fNumMajor) {
-         auto minRatio = std::to_string(std::round(double(fNumMinor) / double(fNumMajor) * 100.0) / 100.0);
-         minRatio.erase(minRatio.find('.') + 3);
-         throw std::invalid_argument(
-            "The sampling_ratio is too low: not enough entries in the majority class to sample from.\n"
-            "Choose sampling_ratio > " +
-            minRatio + " or set replacement to True.");
-      }
-      fNumEntries = fNumMinor + fNumResampledMajor;
-   }
+   void SetupRandomOversampler();
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Calculate fNumEntries and major/minor variables for the random oversampler
-   void SetupRandomOversampler()
-   {
-      if (fDatasets[0].GetRows() > fDatasets[1].GetRows()) {
-         fMajor = 0;
-         fMinor = 1;
-      } else {
-         fMajor = 1;
-         fMinor = 0;
-      }
+   void RandomUndersampler(RFlat2DMatrix &ShuffledTensor);
 
-      fNumMajor = fDatasets[fMajor].GetRows();
-      fNumMinor = fDatasets[fMinor].GetRows();
-      fNumResampledMinor = static_cast<std::size_t>(fSampleRatio * fNumMajor);
-      fNumEntries = fNumMajor + fNumResampledMinor;
-   }
+   void RandomOversampler(RFlat2DMatrix &ShuffledTensor);
 
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Undersample entries randomly from the majority dataset
-   /// \param[in] SampledTensor Tensor with all the sampled entries
-   void RandomUndersampler(RFlat2DMatrix &ShuffledTensor)
-   {
-      if (fReplacement) {
-         SampleWithReplacement(fNumResampledMajor, fNumMajor);
-      }
+   void SampleWithReplacement(std::size_t n_samples, std::size_t max);
 
-      else {
-         SampleWithoutReplacement(fNumResampledMajor, fNumMajor);
-      }
-
-      std::size_t cols = fDatasets[0].GetCols();
-      RFlat2DMatrix SampledTensor(fNumEntries, cols);
-      RFlat2DMatrix UndersampledMajorTensor(fNumResampledMajor, cols);
-
-      std::size_t index = 0;
-      for (std::size_t i = 0; i < fNumResampledMajor; i++) {
-         std::copy(fDatasets[fMajor].GetData() + fSamples[i] * cols,
-                   fDatasets[fMajor].GetData() + (fSamples[i] + 1) * cols,
-                   UndersampledMajorTensor.GetData() + index * cols);
-         index++;
-      }
-
-      fTensorOperators->ConcatenateTensors(SampledTensor, {UndersampledMajorTensor, fDatasets[fMinor]});
-      fTensorOperators->ShuffleTensor(ShuffledTensor, SampledTensor);
-   }
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Oversample entries randomly from the minority dataset
-   /// \param[in] SampledTensor Tensor with all the sampled entries
-   void RandomOversampler(RFlat2DMatrix &ShuffledTensor)
-   {
-      SampleWithReplacement(fNumResampledMinor, fNumMinor);
-
-      std::size_t cols = fDatasets[0].GetCols();
-      RFlat2DMatrix SampledTensor(fNumEntries, cols);
-      RFlat2DMatrix OversampledMinorTensor(fNumResampledMinor, cols);
-
-      std::size_t index = 0;
-      for (std::size_t i = 0; i < fNumResampledMinor; i++) {
-         std::copy(fDatasets[fMinor].GetData() + fSamples[i] * cols,
-                   fDatasets[fMinor].GetData() + (fSamples[i] + 1) * cols,
-                   OversampledMinorTensor.GetData() + index * cols);
-         index++;
-      }
-
-      fTensorOperators->ConcatenateTensors(SampledTensor, {OversampledMinorTensor, fDatasets[fMajor]});
-      fTensorOperators->ShuffleTensor(ShuffledTensor, SampledTensor);
-   }
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Add indices with replacement to fSamples
-   /// \param[in] n_samples Number of indices to sample
-   /// \param[in] max Max index of the sample distribution
-   void SampleWithReplacement(std::size_t n_samples, std::size_t max)
-   {
-      std::uniform_int_distribution<> dist(0, max - 1);
-      fSamples.clear();
-      fSamples.reserve(n_samples);
-      for (std::size_t i = 0; i < n_samples; ++i) {
-         std::size_t sample;
-         if (fShuffle) {
-            std::random_device rd;
-            std::mt19937 g;
-
-            if (fSetSeed == 0) {
-               g.seed(rd());
-            } else {
-               g.seed(fSetSeed);
-            }
-
-            sample = dist(g);
-         }
-
-         else {
-            sample = i % max;
-         }
-         fSamples.push_back(sample);
-      }
-   }
-
-   //////////////////////////////////////////////////////////////////////////
-   /// \brief Add indices without replacement to fSamples
-   /// \param[in] n_samples Number of indices to sample
-   /// \param[in] max Max index of the sample distribution
-   void SampleWithoutReplacement(std::size_t n_samples, std::size_t max)
-   {
-      std::vector<std::size_t> UniqueSamples;
-      UniqueSamples.reserve(max);
-      fSamples.clear();
-      fSamples.reserve(n_samples);
-
-      for (std::size_t i = 0; i < max; ++i)
-         UniqueSamples.push_back(i);
-
-      if (fShuffle) {
-         std::random_device rd;
-         std::mt19937 g;
-
-         if (fSetSeed == 0) {
-            g.seed(rd());
-         } else {
-            g.seed(fSetSeed);
-         }
-         std::shuffle(UniqueSamples.begin(), UniqueSamples.end(), g);
-      }
-
-      for (std::size_t i = 0; i < n_samples; ++i) {
-         fSamples.push_back(UniqueSamples[i]);
-      }
-   }
+   void SampleWithoutReplacement(std::size_t n_samples, std::size_t max);
 
    std::size_t GetNumEntries() { return fNumEntries; }
 };

--- a/tree/ml/src/RBatchLoader.cxx
+++ b/tree/ml/src/RBatchLoader.cxx
@@ -1,0 +1,230 @@
+
+#include "ROOT/ML/RBatchLoader.hxx"
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
+
+namespace ROOT::Experimental::Internal::ML {
+
+RBatchLoader::RBatchLoader(std::size_t batchSize, const std::vector<std::string> &cols, std::mutex &sharedMutex,
+                           std::condition_variable &sharedCV, const std::vector<std::size_t> &vecSizes,
+                           std::size_t numEntries, bool dropRemainder)
+   : fBatchSize(batchSize),
+     fCols(cols),
+     fLock(sharedMutex),
+     fCV(sharedCV),
+     fVecSizes(vecSizes),
+     fNumEntries(numEntries),
+     fDropRemainder(dropRemainder)
+{
+   fSumVecSizes = std::accumulate(fVecSizes.begin(), fVecSizes.end(), 0);
+   fNumColumns = fCols.size() + fSumVecSizes - fVecSizes.size();
+
+   if (fBatchSize == 0) {
+      fBatchSize = fNumEntries;
+   }
+
+   fLeftoverBatchSize = fNumEntries % fBatchSize;
+   fNumFullBatches = fNumEntries / fBatchSize;
+
+   std::size_t numLeftoverBatches = fLeftoverBatchSize == 0 ? 0 : 1;
+
+   if (fDropRemainder) {
+      fNumBatches = fNumFullBatches;
+   } else {
+      fNumBatches = fNumFullBatches + numLeftoverBatches;
+   }
+
+   fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+   fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+}
+
+/// \brief Activate the batchloader. This means that batches can be created and loaded.
+void RBatchLoader::Activate()
+{
+   {
+      std::lock_guard<std::mutex> lock(fLock);
+      if (fIsActive)
+         return;
+      fIsActive = true;
+      fProducerDone = false;
+   }
+
+   fCV.notify_all();
+}
+
+/// \brief DeActivate the batchloader. This means that no more batches are created.
+/// Batches can still be returned if they are already loaded.
+void RBatchLoader::DeActivate()
+{
+   {
+      std::lock_guard<std::mutex> lock(fLock);
+      if (!fIsActive)
+         return;
+      fIsActive = false;
+   }
+
+   fCV.notify_all();
+}
+
+/// \brief Reset the batchloader state.
+void RBatchLoader::Reset()
+{
+   {
+      std::lock_guard<std::mutex> lock(fLock);
+
+      while (!fBatchQueue.empty()) {
+         fBatchQueue.pop();
+      }
+
+      fCurrentBatch.reset();
+      fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+      fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+   }
+
+   fCV.notify_all();
+}
+
+/// \brief Signal that the producer has finished pushing all batches for this epoch.
+void RBatchLoader::MarkProducerDone()
+{
+   fProducerDone = true;
+   fCV.notify_all();
+}
+
+/// \brief Return a batch of data as a unique pointer.
+/// After the batch has been processed, it should be destroyed.
+/// \param[in] chunkTensor Tensor with the data from the chunk
+/// \param[in] idxs Index of batch in the chunk
+/// \return Batch
+std::unique_ptr<RFlat2DMatrix> RBatchLoader::CreateBatch(RFlat2DMatrix &chunkTensor, std::size_t idxs)
+{
+   auto batch = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
+   std::copy(chunkTensor.GetData() + (idxs * fBatchSize * fNumColumns),
+             chunkTensor.GetData() + ((idxs + 1) * fBatchSize * fNumColumns), batch->GetData());
+
+   return batch;
+}
+
+/// \brief Loading the batch from the queue.
+/// \return Batch
+RFlat2DMatrix RBatchLoader::GetBatch()
+{
+   std::unique_lock<std::mutex> lock(fLock);
+
+   // Wait until:
+   //  - there is data in the queue
+   //  - or producer declares "done"
+   //  - or we are deactivated
+   fCV.wait(lock, [&] { return !fBatchQueue.empty() || fProducerDone || !fIsActive; });
+
+   if (fBatchQueue.empty()) {
+      // producer done and no queued data -> end-of-epoch signal
+      fCurrentBatch = std::make_unique<RFlat2DMatrix>();
+      return *fCurrentBatch;
+   }
+
+   fCurrentBatch = std::move(fBatchQueue.front());
+   fBatchQueue.pop();
+   // Notify the loading thread that the queue has drained
+   fCV.notify_all();
+
+   return *fCurrentBatch;
+}
+
+/// \brief Creating the batches from a chunk and add them to the queue.
+/// \param[in] chunkTensor Tensor with the data from the chunk
+/// \param[in] isLastBatch Check if the batch in the chunk is the last one
+void RBatchLoader::CreateBatches(RFlat2DMatrix &chunkTensor, bool isLastBatch)
+{
+   std::size_t chunkSize = chunkTensor.GetRows();
+   std::size_t numCols = chunkTensor.GetCols();
+   std::size_t numBatches = chunkSize / fBatchSize;
+   std::size_t leftoverBatchSize = chunkSize % fBatchSize;
+
+   // create a vector of batches
+   std::vector<std::unique_ptr<RFlat2DMatrix>> batches;
+
+   // fill the full batches from the chunk into a vector
+   for (std::size_t i = 0; i < numBatches; i++) {
+      batches.emplace_back(CreateBatch(chunkTensor, i));
+   }
+
+   // copy the remaining entries from the chunk into a leftover batch
+   RFlat2DMatrix LeftoverBatch(leftoverBatchSize, numCols);
+   std::copy(chunkTensor.GetData() + (numBatches * fBatchSize * numCols),
+             chunkTensor.GetData() + (numBatches * fBatchSize * numCols + leftoverBatchSize * numCols),
+             LeftoverBatch.GetData());
+
+   // calculate how many empty slots are left in fPrimaryLeftoverBatch
+   std::size_t PrimaryLeftoverSize = fPrimaryLeftoverBatch->GetRows();
+   std::size_t emptySlots = fBatchSize - PrimaryLeftoverSize;
+
+   // copy LeftoverBatch to end of fPrimaryLeftoverBatch
+   if (emptySlots >= leftoverBatchSize) {
+      fPrimaryLeftoverBatch->Resize(PrimaryLeftoverSize + leftoverBatchSize, numCols);
+      std::copy(LeftoverBatch.GetData(), LeftoverBatch.GetData() + (leftoverBatchSize * fNumColumns),
+                fPrimaryLeftoverBatch->GetData() + (PrimaryLeftoverSize * numCols));
+
+      // copy LeftoverBatch to end of fPrimaryLeftoverBatch and add it to the batch
+      if (emptySlots == leftoverBatchSize) {
+         auto copy = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
+         std::copy(fPrimaryLeftoverBatch->GetData(), fPrimaryLeftoverBatch->GetData() + (fBatchSize * fNumColumns),
+                   copy->GetData());
+         batches.emplace_back(std::move(copy));
+
+         // reset fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
+         *fPrimaryLeftoverBatch = *fSecondaryLeftoverBatch;
+         fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+      }
+   }
+
+   // copy LeftoverBatch to both fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
+   else if (emptySlots < leftoverBatchSize) {
+      // copy the first part of LeftoverBatch to end of fPrimaryLeftoverTrainingBatch
+      fPrimaryLeftoverBatch->Resize(fBatchSize, numCols);
+      std::copy(LeftoverBatch.GetData(), LeftoverBatch.GetData() + (emptySlots * numCols),
+                fPrimaryLeftoverBatch->GetData() + (PrimaryLeftoverSize * numCols));
+
+      // copy the last part of LeftoverBatch to the end of fSecondaryLeftoverBatch
+      fSecondaryLeftoverBatch->Resize(leftoverBatchSize - emptySlots, numCols);
+      std::copy(LeftoverBatch.GetData() + (emptySlots * numCols),
+                LeftoverBatch.GetData() + (leftoverBatchSize * numCols), fSecondaryLeftoverBatch->GetData());
+
+      // add fPrimaryLeftoverBatch to the batch vector
+      auto copy = std::make_unique<RFlat2DMatrix>(fBatchSize, fNumColumns);
+      std::copy(fPrimaryLeftoverBatch->GetData(), fPrimaryLeftoverBatch->GetData() + (fBatchSize * fNumColumns),
+                copy->GetData());
+      batches.emplace_back(std::move(copy));
+
+      // exchange fPrimaryLeftoverBatch and fSecondaryLeftoverBatch
+      *fPrimaryLeftoverBatch = *fSecondaryLeftoverBatch;
+      // reset fSecondaryLeftoverTrainingBatch
+      fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+   }
+
+   // copy the content of fPrimaryLeftoverBatch to the leftover batch from the chunk
+   if (isLastBatch) {
+      if (!fDropRemainder && fLeftoverBatchSize > 0) {
+         auto copy = std::make_unique<RFlat2DMatrix>(fLeftoverBatchSize, fNumColumns);
+         std::copy(fPrimaryLeftoverBatch->GetData(),
+                   fPrimaryLeftoverBatch->GetData() + (fLeftoverBatchSize * fNumColumns), copy->GetData());
+         batches.emplace_back(std::move(copy));
+      }
+
+      fPrimaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+      fSecondaryLeftoverBatch = std::make_unique<RFlat2DMatrix>();
+   }
+
+   {
+      std::lock_guard<std::mutex> lock(fLock);
+      for (auto &batch : batches) {
+         fBatchQueue.push(std::move(batch));
+      }
+   }
+
+   fCV.notify_all();
+}
+
+} // namespace ROOT::Experimental::Internal::ML

--- a/tree/ml/src/RChunkConstructor.cxx
+++ b/tree/ml/src/RChunkConstructor.cxx
@@ -1,0 +1,134 @@
+#include "ROOT/ML/RChunkConstructor.hxx"
+
+#include <numeric>
+
+namespace ROOT::Experimental::Internal::ML {
+
+RChunkConstructor::RChunkConstructor(const std::size_t numEntries, const std::size_t chunkSize,
+                                     const std::size_t blockSize)
+   : fNumEntries(numEntries), fChunkSize(chunkSize), fBlockSize(blockSize)
+{
+   // size of full and leftover chunks
+   SizeOfFullChunk = chunkSize;
+   SizeOfLeftoverChunk = fNumEntries % SizeOfFullChunk;
+
+   // size of full and leftover blocks in a full and leftover chunk
+   SizeOfFullBlockInFullChunk = blockSize;
+   SizeOfLeftoverBlockInFullChunk = SizeOfFullChunk % blockSize;
+   SizeOfFullBlockInLeftoverChunk = blockSize;
+   SizeOfLeftoverBlockInLeftoverChunk = SizeOfLeftoverChunk % blockSize;
+
+   // number of full, leftover and total chunks
+   FullChunks = numEntries / SizeOfFullChunk;
+   LeftoverChunks = SizeOfLeftoverChunk == 0 ? 0 : 1;
+   Chunks = FullChunks + LeftoverChunks;
+
+   // number of full, leftover and total blocks in a full chunk
+   FullBlocksPerFullChunk = SizeOfFullChunk / blockSize;
+   LeftoverBlocksPerFullChunk = SizeOfLeftoverBlockInFullChunk == 0 ? 0 : 1;
+   BlockPerFullChunk = FullBlocksPerFullChunk + LeftoverBlocksPerFullChunk;
+
+   // number of full, leftover and total blocks in the leftover chunk
+   FullBlocksPerLeftoverChunk = SizeOfLeftoverChunk / blockSize;
+   LeftoverBlocksPerLeftoverChunk = SizeOfLeftoverBlockInLeftoverChunk == 0 ? 0 : 1;
+   BlockPerLeftoverChunk = FullBlocksPerLeftoverChunk + LeftoverBlocksPerLeftoverChunk;
+
+   // total number of full and leftover blocks in the full chunks
+   FullBlocksInFullChunks = FullBlocksPerFullChunk * FullChunks;
+   LeftoverBlocksInFullChunks = LeftoverBlocksPerFullChunk * FullChunks;
+
+   // total number of full and leftover blocks in the leftover chunks
+   FullBlocksInLeftoverChunks = FullBlocksPerLeftoverChunk * LeftoverChunks;
+   LeftoverBlocksInLeftoverChunks = LeftoverBlocksPerLeftoverChunk * LeftoverChunks;
+
+   // vector of the different block sizes
+   SizeOfBlocks = {SizeOfFullBlockInFullChunk, SizeOfLeftoverBlockInFullChunk, SizeOfFullBlockInLeftoverChunk,
+                   SizeOfLeftoverBlockInLeftoverChunk};
+
+   // vector with the number of the different block
+   NumberOfDifferentBlocks = {FullBlocksInFullChunks, LeftoverBlocksInFullChunks, FullBlocksInLeftoverChunks,
+                              LeftoverBlocksInLeftoverChunks};
+
+   // total number of blocks
+   NumberOfBlocks = std::accumulate(NumberOfDifferentBlocks.begin(), NumberOfDifferentBlocks.end(), 0);
+};
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Group the blocks based on the block type (full or leftover) based on the size of the block.
+void RChunkConstructor::DistributeBlockIntervals()
+{
+
+   std::vector<std::vector<std::pair<Long_t, Long_t>> *> TypesOfBlockIntervals = {
+      &FullBlockIntervalsInFullChunks, &LeftoverBlockIntervalsInFullChunks, &FullBlockIntervalsInLeftoverChunks,
+      &LeftoverBlockIntervalsInLeftoverChunks};
+
+   std::vector<std::size_t> IndexOfDifferentBlocks(NumberOfDifferentBlocks.size());
+   std::partial_sum(NumberOfDifferentBlocks.begin(), NumberOfDifferentBlocks.end(), IndexOfDifferentBlocks.begin());
+   IndexOfDifferentBlocks.insert(IndexOfDifferentBlocks.begin(), 0);
+
+   for (size_t i = 0; i < TypesOfBlockIntervals.size(); ++i) {
+      size_t start = IndexOfDifferentBlocks[i];
+      size_t end = IndexOfDifferentBlocks[i + 1];
+
+      TypesOfBlockIntervals[i]->insert(TypesOfBlockIntervals[i]->begin(), BlockIntervals.begin() + start,
+                                       BlockIntervals.begin() + end);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Creates chunks from the dataset consisting of blocks with the begin and end entry.
+void RChunkConstructor::CreateChunksIntervals()
+{
+
+   ChunksIntervals.resize(Chunks);
+   for (size_t i = 0; i < FullChunks; i++) {
+
+      size_t start_FullBlock = FullBlocksPerFullChunk * i;
+      size_t end_FullBlock = FullBlocksPerFullChunk * (i + 1);
+
+      size_t start_LeftoverBlock = LeftoverBlocksPerFullChunk * i;
+      size_t end_LeftoverBlock = LeftoverBlocksPerFullChunk * (i + 1);
+
+      ChunksIntervals[i].insert(ChunksIntervals[i].end(), FullBlockIntervalsInFullChunks.begin() + start_FullBlock,
+                                FullBlockIntervalsInFullChunks.begin() + end_FullBlock);
+      ChunksIntervals[i].insert(ChunksIntervals[i].end(),
+                                LeftoverBlockIntervalsInFullChunks.begin() + start_LeftoverBlock,
+                                LeftoverBlockIntervalsInFullChunks.begin() + end_LeftoverBlock);
+   }
+
+   for (size_t i = 0; i < LeftoverChunks; i++) {
+
+      size_t j = i + FullChunks;
+      size_t start_FullBlock = FullBlocksPerLeftoverChunk * i;
+      size_t end_FullBlock = FullBlocksPerLeftoverChunk * (i + 1);
+
+      size_t start_LeftoverBlock = LeftoverBlocksPerLeftoverChunk * i;
+      size_t end_LeftoverBlock = LeftoverBlocksPerLeftoverChunk * (i + 1);
+
+      ChunksIntervals[j].insert(ChunksIntervals[j].end(), FullBlockIntervalsInLeftoverChunks.begin() + start_FullBlock,
+                                FullBlockIntervalsInLeftoverChunks.begin() + end_FullBlock);
+      ChunksIntervals[j].insert(ChunksIntervals[j].end(),
+                                LeftoverBlockIntervalsInLeftoverChunks.begin() + start_LeftoverBlock,
+                                LeftoverBlockIntervalsInLeftoverChunks.begin() + end_LeftoverBlock);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Fills a vector with the size of every chunk from the dataset
+void RChunkConstructor::SizeOfChunks()
+{
+
+   for (size_t i = 0; i < Chunks; i++) {
+      std::size_t chunkSize = 0;
+      for (size_t j = 0; j < ChunksIntervals[i].size(); j++) {
+         std::size_t start = ChunksIntervals[i][j].first;
+         std::size_t end = ChunksIntervals[i][j].second;
+
+         std::size_t intervalSize = end - start;
+         chunkSize += intervalSize;
+      }
+
+      ChunksSizes.insert(ChunksSizes.end(), chunkSize);
+   }
+}
+} // namespace ROOT::Experimental::Internal::ML

--- a/tree/ml/src/RFlat2DMatrixOperators.cxx
+++ b/tree/ml/src/RFlat2DMatrixOperators.cxx
@@ -1,0 +1,84 @@
+#include "ROOT/ML/RFlat2DMatrixOperators.hxx"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+
+#include "ROOT/ML/RFlat2DMatrix.hxx"
+#include "Rtypes.h"
+
+namespace ROOT::Experimental::Internal::ML {
+
+RFlat2DMatrixOperators::~RFlat2DMatrixOperators() = default;
+
+void RFlat2DMatrixOperators::ShuffleTensor(RFlat2DMatrix &ShuffledTensor, RFlat2DMatrix &Tensor)
+{
+   if (fShuffle) {
+      std::random_device rd;
+      std::mt19937 g;
+
+      if (fSetSeed == 0) {
+         g.seed(rd());
+      } else {
+         g.seed(fSetSeed);
+      }
+
+      std::size_t rows = Tensor.GetRows();
+      std::size_t cols = Tensor.GetCols();
+      ShuffledTensor.Resize(rows, cols);
+
+      // make an identity permutation map
+      std::vector<Long_t> indices(rows);
+      std::iota(indices.begin(), indices.end(), 0);
+
+      // shuffle the identity permutation to create a new permutation
+      std::shuffle(indices.begin(), indices.end(), g);
+
+      // shuffle data in the tensor with the permutation map defined above
+      for (std::size_t i = 0; i < rows; i++) {
+         std::copy(Tensor.GetData() + indices[i] * cols, Tensor.GetData() + (indices[i] + 1) * cols,
+                   ShuffledTensor.GetData() + i * cols);
+      }
+   } else {
+      ShuffledTensor = Tensor;
+   }
+}
+
+void RFlat2DMatrixOperators::SliceTensor(RFlat2DMatrix &SlicedTensor, RFlat2DMatrix &Tensor,
+                                         const std::vector<std::vector<std::size_t>> &slice)
+{
+   const auto &rowSlice = slice[0];
+   const auto &colSlice = slice[1];
+
+   std::size_t rowStart = rowSlice[0];
+   std::size_t rowEnd = rowSlice[1];
+   std::size_t colStart = colSlice[0];
+   std::size_t colEnd = colSlice[1];
+
+   std::size_t rows = rowEnd - rowStart;
+   std::size_t cols = colEnd - colStart;
+
+   SlicedTensor.Resize(rows, cols);
+   std::copy(Tensor.GetData() + rowStart * cols, Tensor.GetData() + rowStart * cols + rows * cols,
+             SlicedTensor.GetData());
+}
+
+void RFlat2DMatrixOperators::ConcatenateTensors(RFlat2DMatrix &ConcatTensor, const std::vector<RFlat2DMatrix> &Tensors)
+{
+   std::size_t cols = Tensors[0].GetCols();
+   std::size_t rows = 0;
+
+   for (const auto &t : Tensors) {
+      rows += t.GetRows();
+   }
+
+   ConcatTensor.Resize(rows, cols);
+
+   std::size_t index = 0;
+   for (std::size_t i = 0; i < Tensors.size(); i++) {
+      std::size_t tensorRows = Tensors[i].GetRows();
+      std::copy(Tensors[i].GetData(), Tensors[i].GetData() + tensorRows * cols, ConcatTensor.GetData() + index * cols);
+      index += tensorRows;
+   }
+}
+} // namespace ROOT::Experimental::Internal::ML

--- a/tree/ml/src/RSampler.cxx
+++ b/tree/ml/src/RSampler.cxx
@@ -1,0 +1,210 @@
+#include "ROOT/ML/RSampler.hxx"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <stdexcept>
+
+#include "ROOT/ML/RFlat2DMatrixOperators.hxx"
+
+namespace ROOT::Experimental::Internal::ML {
+
+RSampler::~RSampler() = default;
+
+RSampler::RSampler(std::vector<RFlat2DMatrix> &datasets, const std::string &sampleType, float sampleRatio,
+                   bool replacement, bool shuffle, std::size_t setSeed)
+   : fDatasets(datasets),
+     fSampleType(sampleType),
+     fSampleRatio(sampleRatio),
+     fReplacement(replacement),
+     fShuffle(shuffle),
+     fSetSeed(setSeed)
+{
+   fTensorOperators = std::make_unique<RFlat2DMatrixOperators>(fShuffle, fSetSeed);
+
+   // setup the sampler for the datasets
+   SetupSampler();
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Calculate fNumEntries and major/minor variables
+void RSampler::SetupSampler()
+{
+   if (fSampleType == "undersampling") {
+      SetupRandomUndersampler();
+   } else if (fSampleType == "oversampling") {
+      SetupRandomOversampler();
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Collection of sampling types
+/// \param[in] SampledTensor Tensor with all the sampled entries
+void RSampler::Sampler(RFlat2DMatrix &SampledTensor)
+{
+   if (fSampleType == "undersampling") {
+      RandomUndersampler(SampledTensor);
+   } else if (fSampleType == "oversampling") {
+      RandomOversampler(SampledTensor);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Calculate fNumEntries and major/minor variables for the random undersampler
+void RSampler::SetupRandomUndersampler()
+{
+   if (fDatasets[0].GetRows() > fDatasets[1].GetRows()) {
+      fMajor = 0;
+      fMinor = 1;
+   } else {
+      fMajor = 1;
+      fMinor = 0;
+   }
+
+   fNumMajor = fDatasets[fMajor].GetRows();
+   fNumMinor = fDatasets[fMinor].GetRows();
+   fNumResampledMajor = static_cast<std::size_t>(fNumMinor / fSampleRatio);
+   if (!fReplacement && fNumResampledMajor > fNumMajor) {
+      auto minRatio = std::to_string(std::round(double(fNumMinor) / double(fNumMajor) * 100.0) / 100.0);
+      minRatio.erase(minRatio.find('.') + 3);
+      throw std::invalid_argument(
+         "The sampling_ratio is too low: not enough entries in the majority class to sample from.\n"
+         "Choose sampling_ratio > " +
+         minRatio + " or set replacement to True.");
+   }
+   fNumEntries = fNumMinor + fNumResampledMajor;
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Calculate fNumEntries and major/minor variables for the random oversampler
+void RSampler::SetupRandomOversampler()
+{
+   if (fDatasets[0].GetRows() > fDatasets[1].GetRows()) {
+      fMajor = 0;
+      fMinor = 1;
+   } else {
+      fMajor = 1;
+      fMinor = 0;
+   }
+
+   fNumMajor = fDatasets[fMajor].GetRows();
+   fNumMinor = fDatasets[fMinor].GetRows();
+   fNumResampledMinor = static_cast<std::size_t>(fSampleRatio * fNumMajor);
+   fNumEntries = fNumMajor + fNumResampledMinor;
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Undersample entries randomly from the majority dataset
+/// \param[in] SampledTensor Tensor with all the sampled entries
+void RSampler::RandomUndersampler(RFlat2DMatrix &ShuffledTensor)
+{
+   if (fReplacement) {
+      SampleWithReplacement(fNumResampledMajor, fNumMajor);
+   }
+
+   else {
+      SampleWithoutReplacement(fNumResampledMajor, fNumMajor);
+   }
+
+   std::size_t cols = fDatasets[0].GetCols();
+   RFlat2DMatrix SampledTensor(fNumEntries, cols);
+   RFlat2DMatrix UndersampledMajorTensor(fNumResampledMajor, cols);
+
+   std::size_t index = 0;
+   for (std::size_t i = 0; i < fNumResampledMajor; i++) {
+      std::copy(fDatasets[fMajor].GetData() + fSamples[i] * cols,
+                fDatasets[fMajor].GetData() + (fSamples[i] + 1) * cols,
+                UndersampledMajorTensor.GetData() + index * cols);
+      index++;
+   }
+
+   fTensorOperators->ConcatenateTensors(SampledTensor, {UndersampledMajorTensor, fDatasets[fMinor]});
+   fTensorOperators->ShuffleTensor(ShuffledTensor, SampledTensor);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Oversample entries randomly from the minority dataset
+/// \param[in] SampledTensor Tensor with all the sampled entries
+void RSampler::RandomOversampler(RFlat2DMatrix &ShuffledTensor)
+{
+   SampleWithReplacement(fNumResampledMinor, fNumMinor);
+
+   std::size_t cols = fDatasets[0].GetCols();
+   RFlat2DMatrix SampledTensor(fNumEntries, cols);
+   RFlat2DMatrix OversampledMinorTensor(fNumResampledMinor, cols);
+
+   std::size_t index = 0;
+   for (std::size_t i = 0; i < fNumResampledMinor; i++) {
+      std::copy(fDatasets[fMinor].GetData() + fSamples[i] * cols,
+                fDatasets[fMinor].GetData() + (fSamples[i] + 1) * cols,
+                OversampledMinorTensor.GetData() + index * cols);
+      index++;
+   }
+
+   fTensorOperators->ConcatenateTensors(SampledTensor, {OversampledMinorTensor, fDatasets[fMajor]});
+   fTensorOperators->ShuffleTensor(ShuffledTensor, SampledTensor);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Add indices with replacement to fSamples
+/// \param[in] n_samples Number of indices to sample
+/// \param[in] max Max index of the sample distribution
+void RSampler::SampleWithReplacement(std::size_t n_samples, std::size_t max)
+{
+   std::uniform_int_distribution<> dist(0, max - 1);
+   fSamples.clear();
+   fSamples.reserve(n_samples);
+   for (std::size_t i = 0; i < n_samples; ++i) {
+      std::size_t sample;
+      if (fShuffle) {
+         std::random_device rd;
+         std::mt19937 g;
+
+         if (fSetSeed == 0) {
+            g.seed(rd());
+         } else {
+            g.seed(fSetSeed);
+         }
+
+         sample = dist(g);
+      }
+
+      else {
+         sample = i % max;
+      }
+      fSamples.push_back(sample);
+   }
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// \brief Add indices without replacement to fSamples
+/// \param[in] n_samples Number of indices to sample
+/// \param[in] max Max index of the sample distribution
+void RSampler::SampleWithoutReplacement(std::size_t n_samples, std::size_t max)
+{
+   std::vector<std::size_t> UniqueSamples;
+   UniqueSamples.reserve(max);
+   fSamples.clear();
+   fSamples.reserve(n_samples);
+
+   for (std::size_t i = 0; i < max; ++i)
+      UniqueSamples.push_back(i);
+
+   if (fShuffle) {
+      std::random_device rd;
+      std::mt19937 g;
+
+      if (fSetSeed == 0) {
+         g.seed(rd());
+      } else {
+         g.seed(fSetSeed);
+      }
+      std::shuffle(UniqueSamples.begin(), UniqueSamples.end(), g);
+   }
+
+   for (std::size_t i = 0; i < n_samples; ++i) {
+      fSamples.push_back(UniqueSamples[i]);
+   }
+}
+
+} // namespace ROOT::Experimental::Internal::ML


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This PR reorganizes the data loader headers, and refactors some of the includes, into the following structure:

- `tree/ml/inc/ROOT/ML/RBatchGenerator.hxx` not split (templated)
- `tree/ml/inc/ROOT/ML/RBatchLoader.hxx` split into
    - `tree/ml/inc/ROOT/ML/RBatchLoader.hxx`
    - `tree/ml/src/RBatchLoader.cxx`
- `tree/ml/inc/ROOT/ML/RChunkConstructor.hxx` split into
    - `tree/ml/inc/ROOT/ML/RChunkConstructor.hxx`
    - `tree/ml/src/RChunkConstructor.cxx`
- `tree/ml/inc/ROOT/ML/RChunkLoader.hxx` not split (templated)
- `tree/ml/inc/ROOT/ML/RDatasetLoader.hxx` not split (templated)
- `tree/ml/inc/ROOT/ML/RFlat2DMatrix.hxx` not split (not templated but trivial, mostly contains one liners)
- `tree/ml/inc/ROOT/ML/RFlat2DMatrixOperators.hxx` split into
    - `tree/ml/inc/ROOT/ML/RFlat2DMatrixOperators.hxx`
    - `tree/ml/src/RFlat2DMatrixOperators.cxx`
- `tree/ml/inc/ROOT/ML/RSampler.hxx` split into
    - `tree/ml/inc/ROOT/ML/RSampler.hxx`
    - `tree/ml/src/RSampler.cxx`



## Checklist:

- [x] tested changes locally
