### PR TITLE
[Math] Add custom derivative for `digamma` function

### DIFF
--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -34,8 +34,7 @@
 
 #include <stdexcept>
 
-namespace clad {
-namespace custom_derivatives {
+namespace clad::custom_derivatives {
 namespace TMath {
 template <typename T>
 ValueAndPushforward<T, T> Abs_pushforward(T x, T d_x)
@@ -222,8 +221,7 @@ ValueAndPushforward<Double_t, Double_t> Ln10_pushforward()
 #endif
 } // namespace TMath
 
-namespace ROOT {
-namespace Math {
+namespace ROOT::Math {
 
 inline void landau_pdf_pullback(double x, double xi, double x0, double d_out, double *d_x, double *d_xi, double *d_x0)
 {
@@ -1092,13 +1090,16 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
    }
 }
 
+inline ValueAndPushforward<double, double> digamma_pushforward(double x, double d_x)
+{
+   return {::ROOT::Math::digamma(x), ::ROOT::Math::trigamma(x) * d_x};
+}
+
 #endif // R__HAS_MATHMORE
 
-} // namespace Math
-} // namespace ROOT
+} // namespace ROOT::Math
 
-} // namespace custom_derivatives
-} // namespace clad
+} // namespace clad::custom_derivatives
 
 // Forward declare BLAS functions.
 extern "C" void sgemm_(const char *transa, const char *transb, const int *m, const int *n, const int *k,

--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -205,20 +205,6 @@ ValueAndPushforward<T, T> TanH_pushforward(T x, T d_x)
    return {::TMath::TanH(x), (1. / ::TMath::Sq(::TMath::CosH(x))) * d_x};
 }
 
-#ifdef WIN32
-// Additional custom derivatives that can be removed
-// after Issue #12108 in ROOT is resolved
-// constexpr is removed
-ValueAndPushforward<Double_t, Double_t> Pi_pushforward()
-{
-   return {3.1415926535897931, 0.};
-}
-// constexpr is removed
-ValueAndPushforward<Double_t, Double_t> Ln10_pushforward()
-{
-   return {2.3025850929940459, 0.};
-}
-#endif
 } // namespace TMath
 
 namespace ROOT::Math {

--- a/math/mathmore/inc/Math/SpecFuncMathMore.h
+++ b/math/mathmore/inc/Math/SpecFuncMathMore.h
@@ -874,6 +874,7 @@ namespace Math {
    double wigner_9j(int two_ja, int two_jb, int two_jc, int two_jd, int two_je, int two_jf, int two_jg, int two_jh, int two_ji);
 
    double digamma(double x);
+   double trigamma(double x);
 
 
 } // namespace Math

--- a/math/mathmore/src/SpecFuncMathMore.cxx
+++ b/math/mathmore/src/SpecFuncMathMore.cxx
@@ -482,5 +482,10 @@ double digamma(double x)
    return gsl_sf_psi(x);
 }
 
+double trigamma(double x)
+{
+   return gsl_sf_psi_1(x);
+}
+
 } // namespace Math
 } // namespace ROOT


### PR DESCRIPTION
The `digamma` function is important because it's the derivative of the log of the gamma function, which is widely used in likelihood fits because it appears in the Poisson distribution. If we want analytical Hessians for RooFit likelihoods - as promised in the ROOT plan of work -, we also need to provide the analytical derivative of the digamma function, which is the trigamma function. Fortunately, we can find it in the GNU scientific library:

https://www.gnu.org/software/gsl/doc/html/specfunc.html#trigamma-function