### PR TITLE
[CI] Add soversion=On to Alma10 clang ninja.

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma10-clang_ninja.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-clang_ninja.txt
@@ -6,4 +6,5 @@ builtin_zlib=ON
 builtin_zstd=ON
 pythia8=ON
 r=OFF
+soversion=ON
 tmva-sofie=ON


### PR DESCRIPTION
As demonstrated by https://github.com/root-project/root/pull/21375, we need to test building with soversion.