### PR TITLE
Fix argument passing conventions in h2root.

### DIFF
--- a/main/src/h2root.cxx
+++ b/main/src/h2root.cxx
@@ -134,11 +134,7 @@ void MAIN__() {}
 
 // As recommended in
 // https://gcc.gnu.org/onlinedocs/gfortran/Argument-passing-conventions.html
-#if __GNUC__ > 7
-typedef size_t fortran_charlen_t;
-#else
-typedef int fortran_charlen_t;
-#endif
+using fortran_charlen_t = size_t;
 
 #else
 # define hlimit  HLIMIT
@@ -329,11 +325,11 @@ int main(int argc, char **argv)
 
    int lun = 10;
 #ifndef WIN32
-   // "px" is a string being changed to "pxc" in the fortran side; since it's a temporary on C's side,
-   // we need a buffer of at least 3 chars on Cs side, too. Predefine it as a extra variable "px " since that way
-   // the space will be replaced by 'c' on the preallocated memory, instead of appending a new char (new memory) to "px".
-   auto opt = PASSCHAR("px ");
-   hropen(lun,PASSCHAR("example"),PASSCHAR(file_in),opt,record_size,ier,7,strlen(file_in),2);
+   // Reminder: Argument passing convention is that string lengths go as hidden arguments
+   // at the end of the argument list.
+   constexpr auto chdir = "example";
+   constexpr auto opt = "px";
+   hropen(lun, chdir, file_in, opt, record_size, ier, strlen(chdir), strlen(file_in), strlen(opt));
 #else
    hropen(lun,PASSCHAR("example"),PASSCHAR(file_in),PASSCHAR("px"),record_size,ier);
 #endif


### PR DESCRIPTION
When variable-length strings are passed into functions compiled by gfortran, the lengths of the strings have to be passed at the end of the argument list as `size_t` (since gcc 7). With clang, where the `__GNUC__` macro could expand to funny values, we were passing `int` on the C side, making fortran interpret the string lengths wrongly.

fixes #19329
