### PR TITLE
fix: remove Py_single_input macro redefinition in PyMethodBase.h

### DIFF
--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -34,7 +34,6 @@ class TH1D;
 #ifndef PyObject_HEAD
 struct _object;
 typedef _object PyObject;
-#define Py_single_input 256
 #endif
 
 namespace TMVA {
@@ -111,7 +110,7 @@ namespace TMVA {
       PyObject *fPyReturn; // python return data
 
    protected:
-      void PyRunString(TString code, TString errorMessage="Failed to run python code", int start=Py_single_input); // runs python code from string in local namespace with error handling
+      void PyRunString(TString code, TString errorMessage="Failed to run python code", int start=256 /* Py_single_input */); // runs python code from string in local namespace with error handling
 
    private:
       static PyObject *fModuleBuiltin;


### PR DESCRIPTION
- Remove the `#define Py_single_input 256` from the public header `PyMethodBase.h` to avoid a `-Wmacro-redefined` warning when CPython's `compile.h` is included after the precompiled header already defines the macro
- Replace the `Py_single_input` default argument in `PyRunString` with the literal value `256` and a comment

Fixes https://github.com/conda-forge/root-feedstock/issues/342