### PR TITLE
Add BVH-based navigation functions to TGeoTessellated (Improved version 2)

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -32,6 +32,7 @@ The following people have contributed to this new version:
  Silia Taider, CERN/EP-SFT,\
  Devajith Valaparambil Sreeramaswamy, CERN/EP-SFT,\
  Vassil Vassilev, Princeton,\
+ Sandro Wenzel, CERN/EP-ALICE,\
 
 ## Deprecations
 
@@ -73,6 +74,7 @@ The following people have contributed to this new version:
 ## Geometry
 
 * The list of logical volumes gets now rehashed automatically, giving an important performance improvement for setups having a large number of those.
+* `TGeoTessellated` now has efficient, BVH accelerated, navigation function implementations. This makes it possible to use `TGeoTessellated` in applications using `TGeoNavigator` (such as detector simulation).
 
 ### Extensible color schemes for geometry visualization
 ROOT now provides an extensible mechanism to assign colors and transparency to geometry volumes via the new `TGeoColorScheme` strategy class, used by `TGeoManager::DefaultColors()`.

--- a/geom/geom/inc/LinkDef1.h
+++ b/geom/geom/inc/LinkDef1.h
@@ -77,7 +77,7 @@
 #pragma link C++ class TGeoXtru + ;
 #pragma link C++ class ROOT::Geom::Vertex_t + ;
 #pragma link C++ class TGeoFacet + ;
-#pragma link C++ class TGeoTessellated + ;
+#pragma link C++ class TGeoTessellated - ;
 #pragma link C++ class TGeoShapeAssembly + ;
 #pragma link C++ class TGeoScaledShape + ;
 #pragma link C++ class TGeoVolume - ;

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -68,9 +68,17 @@ private:
    std::vector<Vertex_t> fVertices;       // List of vertices
    std::vector<TGeoFacet> fFacets;        // List of facets
    std::multimap<long, int> fVerticesMap; ///<! Temporary map used to deduplicate vertices
+   std::vector<Vertex_t> fOutwardNormals; // Vector of outward-facing normals (to be streamed !)
+
+   bool fIsClosed = false; //! to know if shape still needs closure/initialization
+   void *fBVH = nullptr;   //! BVH acceleration structure for safety and navigation
 
    TGeoTessellated(const TGeoTessellated &) = delete;
    TGeoTessellated &operator=(const TGeoTessellated &) = delete;
+
+   // bvh helper functions
+   void BuildBVH();
+   void CalculateNormals();
 
 public:
    // constructors
@@ -130,7 +138,23 @@ public:
    /// Reader from .obj format
    static TGeoTessellated *ImportFromObjFormat(const char *objfile, bool check = false, bool verbose = false);
 
-   ClassDefOverride(TGeoTessellated, 1) // tessellated shape class
+   // navigation functions used by TGeoNavigator (attention: only the iact == 3 cases implemented for now)
+   Double_t DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact = 1,
+                            Double_t step = TGeoShape::Big(), Double_t *safe = nullptr) const override;
+   Double_t DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact = 1, Double_t step = TGeoShape::Big(),
+                           Double_t *safe = nullptr) const override;
+   bool Contains(const Double_t *point) const override;
+   Double_t Safety(const Double_t *point, Bool_t in = kTRUE) const override;
+   void ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const override;
+
+   Double_t Capacity() const override;
+
+private:
+   // a safety kernel used in multiple implementations
+   template <bool closest_facet = false>
+   Double_t SafetyKernel(const Double_t *point, bool in, int *closest_facet_id = nullptr) const;
+
+   ClassDefOverride(TGeoTessellated, 2) // tessellated shape class
 };
 
 #endif

--- a/geom/geom/inc/bvh2_extra_kernels.h
+++ b/geom/geom/inc/bvh2_extra_kernels.h
@@ -1,0 +1,65 @@
+#ifndef ROOT_GEOM_BVH2_EXTRA
+
+namespace bvh::v2::extra {
+
+// reusable geometry kernels used in multiple places
+// for interaction with BVH2 structures
+
+// determines if a point is inside the bounding box
+template <typename T>
+bool contains(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   auto min = box.min;
+   auto max = box.max;
+   return (p[0] >= min[0] && p[0] <= max[0]) && (p[1] >= min[1] && p[1] <= max[1]) &&
+          (p[2] >= min[2] && p[2] <= max[2]);
+}
+
+// determines the largest squared distance of point to any of the bounding box corners
+template <typename T>
+auto RmaxSqToNode(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   // construct the 8 corners to get the maximal distance
+   const auto minCorner = box.min;
+   const auto maxCorner = box.max;
+   using Vec3 = bvh::v2::Vec<T, 3>;
+   // these are the corners of the bounding box
+   const std::array<bvh::v2::Vec<T, 3>, 8> corners{
+      Vec3{minCorner[0], minCorner[1], minCorner[2]}, Vec3{minCorner[0], minCorner[1], maxCorner[2]},
+      Vec3{minCorner[0], maxCorner[1], minCorner[2]}, Vec3{minCorner[0], maxCorner[1], maxCorner[2]},
+      Vec3{maxCorner[0], minCorner[1], minCorner[2]}, Vec3{maxCorner[0], minCorner[1], maxCorner[2]},
+      Vec3{maxCorner[0], maxCorner[1], minCorner[2]}, Vec3{maxCorner[0], maxCorner[1], maxCorner[2]}};
+
+   T Rmax_sq{0};
+   for (const auto &corner : corners) {
+      float R_sq = 0.;
+      const auto dx = corner[0] - p[0];
+      R_sq += dx * dx;
+      const auto dy = corner[1] - p[1];
+      R_sq += dy * dy;
+      const auto dz = corner[2] - p[2];
+      R_sq += dz * dz;
+      Rmax_sq = std::max(Rmax_sq, R_sq);
+   }
+   return Rmax_sq;
+};
+
+// determines the minimum squared distance of point to a bounding box ("safey square")
+template <typename T>
+auto SafetySqToNode(bvh::v2::BBox<T, 3> const &box, bvh::v2::Vec<T, 3> const &p)
+{
+   T sqDist{0.0};
+   for (int i = 0; i < 3; i++) {
+      T v = p[i];
+      if (v < box.min[i]) {
+         sqDist += (box.min[i] - v) * (box.min[i] - v);
+      } else if (v > box.max[i]) {
+         sqDist += (v - box.max[i]) * (v - box.max[i]);
+      }
+   }
+   return sqDist;
+};
+
+} // namespace bvh::v2::extra
+
+#endif

--- a/geom/geom/inc/bvh2_third_party.h
+++ b/geom/geom/inc/bvh2_third_party.h
@@ -1,0 +1,36 @@
+#ifndef ROOT_GEOM_BVH2_THIRD_PARTY
+
+// A single entry header into third-party BVH2
+// Good place to manage compiler warnings etc.
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#pragma clang diagnostic ignored "-Wpsabi"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpsabi"
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC diagnostic ignored "-Wattributes"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 5051)
+#endif
+
+#include <bvh/v2/bvh.h>
+#include <bvh/v2/vec.h>
+#include <bvh/v2/ray.h>
+#include <bvh/v2/node.h>
+#include <bvh/v2/stack.h>
+#include <bvh/v2/default_builder.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#endif

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -1,6 +1,7 @@
 // @(#)root/geom:$Id$// Author: Andrei Gheata   24/10/01
 
 // Contains() and DistFromOutside/Out() implemented by Mihaela Gheata
+// 2026-01: Revision to use BVH for navigation functions by Sandro Wenzel
 
 /*************************************************************************
  * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
@@ -29,10 +30,20 @@ for the composing faces.
 #include "TBuffer3D.h"
 #include "TBuffer3DTypes.h"
 #include "TMath.h"
+#include "TBuffer.h"
 
 #include <array>
 #include <vector>
 
+// include the Third-party BVH headers
+#include <bvh2_third_party.h>
+// some kernels on top of BVH
+#include <bvh2_extra_kernels.h>
+
+#include <cmath>
+#include <limits>
+
+ClassImp(TGeoTessellated);
 
 using Vertex_t = Tessellated::Vertex_t;
 
@@ -174,8 +185,6 @@ bool TGeoTessellated::AddFacet(const Vertex_t &pt0, const Vertex_t &pt1, const V
    fNseg += 3;
    fFacets.emplace_back(ind[0], ind[1], ind[2]);
 
-   if (fNfacets > 0 && GetNfacets() == fNfacets)
-      CloseShape();
    return true;
 }
 
@@ -319,11 +328,26 @@ bool TGeoTessellated::FacetCheck(int ifacet) const
 
 void TGeoTessellated::CloseShape(bool check, bool fixFlipped, bool verbose)
 {
+   if (fIsClosed && fBVH) {
+      return;
+   }
    // Compute bounding box
    fDefined = true;
    fNvert = fVertices.size();
    fNfacets = fFacets.size();
    ComputeBBox();
+
+   BuildBVH();
+   if (fOutwardNormals.size() == 0) {
+      CalculateNormals();
+   } else {
+      // short check if the normal container is of correct size
+      if (fOutwardNormals.size() != fFacets.size()) {
+         std::cerr << "Inconsistency in normal container";
+      }
+   }
+   fIsClosed = true;
+
    // Cleanup the vertex map
    std::multimap<long, int>().swap(fVerticesMap);
 
@@ -532,6 +556,9 @@ void TGeoTessellated::ResizeCenter(double maxsize)
    Vector3_t origin(fOrigin[0], fOrigin[1], fOrigin[2]);
    double maxedge = TMath::Max(TMath::Max(fDX, fDY), fDZ);
    double scale = maxsize / maxedge;
+   constexpr double kTol = 1e-12;
+   const bool modified = (std::abs(scale - 1.0) > kTol) || (std::abs(origin[0]) > kTol) ||
+                         (std::abs(origin[1]) > kTol) || (std::abs(origin[2]) > kTol);
    for (size_t i = 0; i < fVertices.size(); ++i) {
       fVertices[i] = scale * (fVertices[i] - origin);
    }
@@ -539,6 +566,10 @@ void TGeoTessellated::ResizeCenter(double maxsize)
    fDX *= scale;
    fDY *= scale;
    fDZ *= scale;
+   if (modified) {
+      BuildBVH();
+      CalculateNormals();
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -702,4 +733,669 @@ TGeoTessellated *TGeoTessellated::ImportFromObjFormat(const char *objfile, bool 
    tsl->CloseShape(check, true, verbose);
    tsl->Print();
    return tsl;
+}
+
+// implementation of some geometry helper functions in anonymous namespace
+namespace {
+
+using Vertex_t = Tessellated::Vertex_t;
+// The classic Moeller-Trumbore ray triangle-intersection kernel:
+// - Compute triangle edges e1, e2
+// - Compute determinant det
+// - Reject parallel rays
+// - Compute barycentric coordinates u, v
+// - Compute ray parameter t
+double rayTriangle(const Vertex_t &orig, const Vertex_t &dir, const Vertex_t &v0, const Vertex_t &v1,
+                   const Vertex_t &v2, double rayEPS = 1e-8)
+{
+   constexpr double EPS = 1e-8;
+   const double INF = std::numeric_limits<double>::infinity();
+   Vertex_t e1{v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]};
+   Vertex_t e2{v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]};
+   auto p = Vertex_t::Cross(dir, e2);
+   auto det = e1.Dot(p);
+   if (std::abs(det) <= EPS) {
+      return INF;
+   }
+
+   Vertex_t tvec{orig[0] - v0[0], orig[1] - v0[1], orig[2] - v0[2]};
+   auto invDet = 1.0 / det;
+   auto u = tvec.Dot(p) * invDet;
+   if (u < 0.0 || u > 1.0) {
+      return INF;
+   }
+   auto q = Vertex_t::Cross(tvec, e1);
+   auto v = dir.Dot(q) * invDet;
+   if (v < 0.0 || u + v > 1.0) {
+      return INF;
+   }
+   auto t = e2.Dot(q) * invDet;
+   return (t > rayEPS) ? t : INF;
+}
+
+template <typename T = float>
+struct Vec3f {
+   T x, y, z;
+   Vec3f(T x_, T y_, T z_) : x(x_), y(y_), z(z_){};
+};
+
+template <typename T>
+inline Vec3f<T> operator-(const Vec3f<T> &a, const Vec3f<T> &b)
+{
+   return {a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+template <typename T>
+inline Vec3f<T> cross(const Vec3f<T> &a, const Vec3f<T> &b)
+{
+   return {a.y * b.z - a.z * b.y, a.z * b.x - a.x * b.z, a.x * b.y - a.y * b.x};
+}
+
+template <typename T>
+inline T dot(const Vec3f<T> &a, const Vec3f<T> &b)
+{
+   return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+// Kernel to get closest/shortest distance between a point and a triangl (a,b,c).
+// Performed by default in float since Safety can be approximate.
+// Project point onto triangle plane
+// If projection lies inside → distance to plane
+// Otherwise compute min distance to the three edges
+// Return squared distance
+template <typename T = float>
+T pointTriangleDistSq(const Vec3f<T> &p, const Vec3f<T> &a, const Vec3f<T> &b, const Vec3f<T> &c)
+{
+   // Edges
+   Vec3f<T> ab = b - a;
+   Vec3f<T> ac = c - a;
+   Vec3f<T> ap = p - a;
+
+   auto d1 = dot(ab, ap);
+   auto d2 = dot(ac, ap);
+   if (d1 <= T(0.0) && d2 <= T(0.0)) {
+      return dot(ap, ap); // barycentric (1,0,0)
+   }
+
+   Vec3f<T> bp = p - b;
+   auto d3 = dot(ab, bp);
+   auto d4 = dot(ac, bp);
+   if (d3 >= T(0.0) && d4 <= d3) {
+      return dot(bp, bp); // (0,1,0)
+   }
+
+   T vc = d1 * d4 - d3 * d2;
+   if (vc <= 0.0f && d1 >= 0.0f && d3 <= 0.0f) {
+      T v = d1 / (d1 - d3);
+      Vec3f<T> proj = {a.x + v * ab.x, a.y + v * ab.y, a.z + v * ab.z};
+      Vec3f<T> d = p - proj;
+      return dot(d, d); // edge AB
+   }
+
+   Vec3f<T> cp = p - c;
+   T d5 = dot(ab, cp);
+   T d6 = dot(ac, cp);
+   if (d6 >= T(0.0f) && d5 <= d6) {
+      return dot(cp, cp); // (0,0,1)
+   }
+
+   T vb = d5 * d2 - d1 * d6;
+   if (vb <= 0.0f && d2 >= 0.0f && d6 <= 0.0f) {
+      T w = d2 / (d2 - d6);
+      Vec3f<T> proj = {a.x + w * ac.x, a.y + w * ac.y, a.z + w * ac.z};
+      Vec3f<T> d = p - proj;
+      return dot(d, d); // edge AC
+   }
+
+   T va = d3 * d6 - d5 * d4;
+   if (va <= 0.0f && (d4 - d3) >= 0.0f && (d5 - d6) >= 0.0f) {
+      T w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+      Vec3f<T> proj = {b.x + w * (c.x - b.x), b.y + w * (c.y - b.y), b.z + w * (c.z - b.z)};
+      Vec3f<T> d = p - proj;
+      return dot(d, d); // edge BC
+   }
+
+   // Inside face region
+   T denom = T(1.0f) / (va + vb + vc);
+   T v = vb * denom;
+   T w = vc * denom;
+
+   Vec3f<T> proj = {a.x + ab.x * v + ac.x * w, a.y + ab.y * v + ac.y * w, a.z + ab.z * v + ac.z * w};
+
+   Vec3f<T> d = p - proj;
+   return dot(d, d);
+}
+
+template <typename T>
+inline Vec3f<T> normalize(const Vec3f<T> &v)
+{
+   T len2 = dot(v, v);
+   if (len2 == T(0.0f)) {
+      std::cerr << "Degnerate triangle. Cannot determine normal";
+      return {0, 0, 0};
+   }
+   T invLen = T(1.0f) / std::sqrt(len2);
+   return {v.x * invLen, v.y * invLen, v.z * invLen};
+}
+
+template <typename T>
+inline Vec3f<T> triangleNormal(const Vec3f<T> &a, const Vec3f<T> &b, const Vec3f<T> &c)
+{
+   const Vec3f<T> e1 = b - a;
+   const Vec3f<T> e2 = c - a;
+   return normalize(cross(e1, e2));
+}
+
+} // end anonymous namespace
+
+////////////////////////////////////////////////////////////////////////////////
+/// DistFromOutside
+
+Double_t TGeoTessellated::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t /*iact*/, Double_t stepmax,
+                                          Double_t * /*safe*/) const
+{
+   // use the BVH intersector in combination with leaf ray-triangle testing
+   double local_step = Big(); // we need this otherwise the lambda get's confused
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   using Ray = bvh::v2::Ray<Scalar, 3>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+   if (!mybvh) {
+      assert(false);
+      return -1.;
+   }
+
+   auto truncate_roundup = [](double orig) {
+      float epsilon = std::numeric_limits<float>::epsilon() * std::fabs(orig);
+      // Add the bias to x before assigning it to y
+      return static_cast<float>(orig + epsilon);
+   };
+
+   // let's do very quick checks against the top node
+   const auto topnode_bbox = mybvh->get_root().get_bbox();
+   if ((-point[0] + topnode_bbox.min[0]) > stepmax) {
+      return Big();
+   }
+   if ((-point[1] + topnode_bbox.min[1]) > stepmax) {
+      return Big();
+   }
+   if ((-point[2] + topnode_bbox.min[2]) > stepmax) {
+      return Big();
+   }
+   if ((point[0] - topnode_bbox.max[0]) > stepmax) {
+      return Big();
+   }
+   if ((point[1] - topnode_bbox.max[1]) > stepmax) {
+      return Big();
+   }
+   if ((point[2] - topnode_bbox.max[2]) > stepmax) {
+      return Big();
+   }
+
+   // the ray used for bvh interaction
+   Ray ray(Vec3(point[0], point[1], point[2]), // origin
+           Vec3(dir[0], dir[1], dir[2]),       // direction
+           0.0f,                               // minimum distance (could give stepmax ?)
+           truncate_roundup(local_step));
+
+   static constexpr bool use_robust_traversal = true;
+
+   Vertex_t dir_v{dir[0], dir[1], dir[2]};
+   // Traverse the BVH and apply concrete object intersection in BVH leafs
+   bvh::v2::GrowingStack<Bvh::Index> stack;
+   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+      for (size_t prim_id = begin; prim_id < end; ++prim_id) {
+         auto objectid = mybvh->prim_ids[prim_id];
+         const auto &facet = fFacets[objectid];
+         const auto &n = fOutwardNormals[objectid];
+
+         // quick normal test. Coming from outside, the dot product must be negative
+         if (n.Dot(dir_v) > 0.) {
+            continue;
+         }
+
+         auto thisdist = rayTriangle(Vertex_t(point[0], point[1], point[2]), dir_v, fVertices[facet[0]],
+                                     fVertices[facet[1]], fVertices[facet[2]], 0.);
+
+         if (thisdist < local_step) {
+            local_step = thisdist;
+         }
+      }
+      return false; // go on after this
+   });
+
+   return local_step;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// DistFromOutside
+
+Double_t TGeoTessellated::DistFromInside(const Double_t *point, const Double_t *dir, Int_t /*iact*/,
+                                         Double_t /*stepmax*/, Double_t * /*safe*/) const
+{
+   // use the BVH intersector in combination with leaf ray-triangle testing
+   double local_step = Big(); // we need this otherwise the lambda get's confused
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   using Ray = bvh::v2::Ray<Scalar, 3>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+   if (!mybvh) {
+      assert(false);
+      return -1.;
+   }
+
+   auto truncate_roundup = [](double orig) {
+      float epsilon = std::numeric_limits<float>::epsilon() * std::fabs(orig);
+      // Add the bias to x before assigning it to y
+      return static_cast<float>(orig + epsilon);
+   };
+
+   // the ray used for bvh interaction
+   Ray ray(Vec3(point[0], point[1], point[2]), // origin
+           Vec3(dir[0], dir[1], dir[2]),       // direction
+           0.,                                 // minimum distance (could give stepmax ?)
+           truncate_roundup(local_step));
+
+   static constexpr bool use_robust_traversal = true;
+
+   Vertex_t dir_v{dir[0], dir[1], dir[2]};
+   // Traverse the BVH and apply concrete object intersection in BVH leafs
+   bvh::v2::GrowingStack<Bvh::Index> stack;
+   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+      for (size_t prim_id = begin; prim_id < end; ++prim_id) {
+         auto objectid = mybvh->prim_ids[prim_id];
+         auto facet = fFacets[objectid];
+         const auto &n = fOutwardNormals[objectid];
+
+         // Only exiting surfaces are relevant (from inside--> dot product must be positive)
+         if (n.Dot(dir_v) <= 0.) {
+            continue;
+         }
+
+         const auto &v0 = fVertices[facet[0]];
+         const auto &v1 = fVertices[facet[1]];
+         const auto &v2 = fVertices[facet[2]];
+
+         const double t = rayTriangle(Vertex_t{point[0], point[1], point[2]}, dir_v, v0, v1, v2, 0.);
+         if (t < local_step) {
+            local_step = t;
+         }
+      }
+      return false; // go on after this
+   });
+
+   return local_step;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Capacity
+
+Double_t TGeoTessellated::Capacity() const
+{
+   // For explanation of the following algorithm see:
+   // https://en.wikipedia.org/wiki/Polyhedron#Volume
+   // http://wwwf.imperial.ac.uk/~rn/centroid.pdf
+
+   double vol = 0.0;
+   for (size_t i = 0; i < fFacets.size(); ++i) {
+      auto &facet = fFacets[i];
+      auto a = fVertices[facet[0]];
+      auto b = fVertices[facet[1]];
+      auto c = fVertices[facet[2]];
+      vol +=
+         a[0] * (b[1] * c[2] - b[2] * c[1]) + b[0] * (c[1] * a[2] - c[2] * a[1]) + c[0] * (a[1] * b[2] - a[2] * b[1]);
+   }
+   return vol / 6.0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// BuildBVH
+
+void TGeoTessellated::BuildBVH()
+{
+   using Scalar = float;
+   using BBox = bvh::v2::BBox<Scalar, 3>;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   // helper determining axis aligned bounding box from a facet;
+   auto GetBoundingBox = [this](TGeoFacet const &facet) {
+#ifndef NDEBUG
+      const auto nvertices = facet.GetNvert();
+      assert(nvertices == 3); // for now only triangles
+#endif
+      const auto &v1 = fVertices[facet[0]];
+      const auto &v2 = fVertices[facet[1]];
+      const auto &v3 = fVertices[facet[2]];
+      BBox bbox;
+      bbox.min[0] = std::min(std::min(v1[0], v2[0]), v3[0]) - 0.001f;
+      bbox.min[1] = std::min(std::min(v1[1], v2[1]), v3[1]) - 0.001f;
+      bbox.min[2] = std::min(std::min(v1[2], v2[2]), v3[2]) - 0.001f;
+      bbox.max[0] = std::max(std::max(v1[0], v2[0]), v3[0]) + 0.001f;
+      bbox.max[1] = std::max(std::max(v1[1], v2[1]), v3[1]) + 0.001f;
+      bbox.max[2] = std::max(std::max(v1[2], v2[2]), v3[2]) + 0.001f;
+      return bbox;
+   };
+
+   // we need bounding boxes enclosing the primitives and centers of primitives
+   // (replaced here by centers of bounding boxes) to build the bvh
+   std::vector<BBox> bboxes;
+   std::vector<Vec3> centers;
+
+   int nd = fFacets.size();
+   bboxes.reserve(nd);
+   centers.reserve(nd);
+
+   for (int i = 0; i < nd; ++i) {
+      auto &facet = fFacets[i];
+
+      // fetch the bounding box of this node and add to the vector of bounding boxes
+      (bboxes).push_back(GetBoundingBox(facet));
+      centers.emplace_back((bboxes).back().get_center());
+   }
+
+   // check if some previous object is registered and delete if necessary
+   if (fBVH) {
+      delete (Bvh *)fBVH;
+      fBVH = nullptr;
+   }
+
+   // create the bvh
+   typename bvh::v2::DefaultBuilder<Node>::Config config;
+   config.quality = bvh::v2::DefaultBuilder<Node>::Quality::High;
+   auto bvh = bvh::v2::DefaultBuilder<Node>::build(bboxes, centers, config);
+   auto bvhptr = new Bvh;
+   *bvhptr = std::move(bvh); // copy structure
+   fBVH = (void *)(bvhptr);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Contains
+
+bool TGeoTessellated::Contains(Double_t const *point) const
+{
+   // we do the parity test
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+   using Ray = bvh::v2::Ray<Scalar, 3>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+   if (!mybvh) {
+      assert(false);
+      return false;
+   }
+
+   auto truncate_roundup = [](double orig) {
+      float epsilon = std::numeric_limits<float>::epsilon() * std::fabs(orig);
+      // Add the bias to x before assigning it to y
+      return static_cast<float>(orig + epsilon);
+   };
+
+   // let's do very quick checks against the top node
+   if (!TGeoBBox::Contains(point)) {
+      return false;
+   }
+
+   // An arbitrary test direction.
+   // Doesn't need to be normalized and probes all normals. Also ensuring to be skewed somewhat
+   // without evident symmetries.
+   Vertex_t test_dir{1.0, 1.41421356237, 1.73205080757};
+
+   double local_step = Big();
+   // the ray used for bvh interaction
+   Ray ray(Vec3(point[0], point[1], point[2]),          // origin
+           Vec3(test_dir[0], test_dir[1], test_dir[2]), // direction
+           0.0f,                                        // minimum distance (could give stepmax ?)
+           truncate_roundup(local_step));
+
+   static constexpr bool use_robust_traversal = true;
+
+   // Traverse the BVH and apply concrete object intersection in BVH leafs
+   bvh::v2::GrowingStack<Bvh::Index> stack;
+   size_t crossings = 0;
+   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+      for (size_t prim_id = begin; prim_id < end; ++prim_id) {
+         auto objectid = mybvh->prim_ids[prim_id];
+         auto &facet = fFacets[objectid];
+
+         // for the parity test, we probe all crossing surfaces
+         const auto &v0 = fVertices[facet[0]];
+         const auto &v1 = fVertices[facet[1]];
+         const auto &v2 = fVertices[facet[2]];
+
+         const double t = rayTriangle(Vertex_t(point[0], point[1], point[2]), test_dir, v0, v1, v2, 0.);
+
+         if (t != std::numeric_limits<double>::infinity()) {
+            ++crossings;
+         }
+      }
+      return false;
+   });
+
+   return crossings & 1;
+}
+
+namespace {
+
+// Helper classes/structs used for priority queue - BVH traversal
+// structure keeping cost (value) for a BVH index
+struct BVHPrioElement {
+   size_t bvh_node_id;
+   float value;
+};
+
+// A priority queue for BVHPrioElement with an additional clear method
+// for quick reset. We intentionally derive from std::priority_queue here to expose a
+// clear() convenience method via access to the protected container `c`.
+// This is internal, non-polymorphic code and relies on standard-library
+// implementation details that are stable across supported platforms.
+template <typename Comparator>
+class BVHPrioQueue : public std::priority_queue<BVHPrioElement, std::vector<BVHPrioElement>, Comparator> {
+public:
+   using std::priority_queue<BVHPrioElement, std::vector<BVHPrioElement>,
+                             Comparator>::priority_queue; // constructor inclusion
+
+   // convenience method to quickly clear/reset the queue (instead of having to pop one by one)
+   void clear() { this->c.clear(); }
+};
+
+} // namespace
+
+/// a reusable safety kernel, which optionally returns the closest face
+template <bool returnFace>
+inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, int *closest_facet_id) const
+{
+   // This is the classic traversal/pruning of a BVH based on priority queue search
+
+   float smallest_safety_sq = TGeoShape::Big();
+
+   using Scalar = float;
+   using Vec3 = bvh::v2::Vec<Scalar, 3>;
+   using Node = bvh::v2::Node<Scalar, 3>;
+   using Bvh = bvh::v2::Bvh<Node>;
+
+   // let's fetch the bvh
+   auto mybvh = (Bvh *)fBVH;
+
+   // testpoint object in float for quick BVH interaction
+   Vec3 testpoint(point[0], point[1], point[2]);
+
+   auto currnode = mybvh->nodes[0]; // we start from the top BVH node
+   // we do a quick check on the top node (in case we are outside shape)
+   bool outside_top = false;
+   if (!in) {
+      outside_top = !bvh::v2::extra::contains(currnode.get_bbox(), testpoint);
+      if (outside_top) {
+         const auto safety_sq_to_top = bvh::v2::extra::SafetySqToNode(currnode.get_bbox(), testpoint);
+         // we simply return safety to the outer bounding box as an estimate
+         return std::sqrt(safety_sq_to_top);
+      }
+   }
+
+   // comparator bringing out "smallest" value on top
+   auto cmp = [](BVHPrioElement a, BVHPrioElement b) { return a.value > b.value; };
+   static thread_local BVHPrioQueue<decltype(cmp)> queue(cmp);
+   queue.clear();
+
+   // algorithm is based on standard iterative tree traversal with priority queues
+   float current_safety_to_node_sq = 0.f;
+
+   if (returnFace) {
+      *closest_facet_id = -1;
+   }
+
+   do {
+      if (currnode.is_leaf()) {
+         // we are in a leaf node and actually talk to a face/triangular primitive
+         const auto begin_prim_id = currnode.index.first_id();
+         const auto end_prim_id = begin_prim_id + currnode.index.prim_count();
+
+         for (auto p_id = begin_prim_id; p_id < end_prim_id; p_id++) {
+            const auto object_id = mybvh->prim_ids[p_id];
+
+            const auto &facet = fFacets[object_id];
+            const auto &v1 = fVertices[facet[0]];
+            const auto &v2 = fVertices[facet[1]];
+            const auto &v3 = fVertices[facet[2]];
+
+            auto thissafetySQ =
+               pointTriangleDistSq(Vec3f<float>(point[0], point[1], point[2]), Vec3f<float>(v1[0], v1[1], v1[2]),
+                                   Vec3f<float>(v2[0], v2[1], v2[2]), Vec3f<float>(v3[0], v3[1], v3[2]));
+
+            if (thissafetySQ < smallest_safety_sq) {
+               smallest_safety_sq = thissafetySQ;
+               if (returnFace) {
+                  *closest_facet_id = object_id;
+               }
+            }
+         }
+      } else {
+         // not a leave node ... for further traversal,
+         // we inject the children into priority queue based on distance to it's bounding box
+         const auto leftchild_id = currnode.index.first_id();
+         const auto rightchild_id = leftchild_id + 1;
+
+         for (size_t childid : {leftchild_id, rightchild_id}) {
+            if (childid >= mybvh->nodes.size()) {
+               continue;
+            }
+
+            const auto &node = mybvh->nodes[childid];
+            const auto inside = bvh::v2::extra::contains(node.get_bbox(), testpoint);
+
+            if (inside) {
+               // this must be further considered because we are inside the bounding box
+               queue.push(BVHPrioElement{childid, -1.});
+            } else {
+               auto safety_to_node_square = bvh::v2::extra::SafetySqToNode(node.get_bbox(), testpoint);
+               if (safety_to_node_square <= smallest_safety_sq) {
+                  // this should be further considered
+                  queue.push(BVHPrioElement{childid, safety_to_node_square});
+               }
+            }
+         }
+      }
+
+      if (queue.size() > 0) {
+         auto currElement = queue.top();
+         currnode = mybvh->nodes[currElement.bvh_node_id];
+         current_safety_to_node_sq = currElement.value;
+         queue.pop();
+      } else {
+         break;
+      }
+   } while (current_safety_to_node_sq <= smallest_safety_sq);
+
+   return std::nextafter(std::sqrt(smallest_safety_sq), 0.0f);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Safety
+
+Double_t TGeoTessellated::Safety(const Double_t *point, Bool_t in) const
+{
+   // we could use some caching here (in future) since queries to the solid will likely
+   // be made with some locality
+
+   // fall-back to precise safety kernel
+   return SafetyKernel<false>(point, in);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// ComputeNormal interface
+
+void TGeoTessellated::ComputeNormal(const Double_t *point, const Double_t *dir, Double_t *norm) const
+{
+   // We take the approach to identify closest facet to the point via safety
+   // and returning the normal from this face.
+
+   // TODO: Before doing that we could check for cached points from other queries
+
+   // use safety kernel
+   int closest_face_id = -1;
+   SafetyKernel<true>(point, true, &closest_face_id);
+
+   if (closest_face_id < 0) {
+      norm[0] = 1.;
+      norm[1] = 0.;
+      norm[2] = 0.;
+      return;
+   }
+
+   const auto &n = fOutwardNormals[closest_face_id];
+   norm[0] = n[0];
+   norm[1] = n[1];
+   norm[2] = n[2];
+
+   // change sign depending on dir
+   if (norm[0] * dir[0] + norm[1] * dir[1] + norm[2] * dir[2] < 0) {
+      norm[0] = -norm[0];
+      norm[1] = -norm[1];
+      norm[2] = -norm[2];
+   }
+   return;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Custom streamer which performs Closing on read.
+/// Recalculation of BVH and normals is fast
+
+void TGeoTessellated::Streamer(TBuffer &b)
+{
+   if (b.IsReading()) {
+      b.ReadClassBuffer(TGeoTessellated::Class(), this);
+      CloseShape(false); // close shape but do not re-perform checks
+   } else {
+      b.WriteClassBuffer(TGeoTessellated::Class(), this);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Calculate the normals
+
+void TGeoTessellated::CalculateNormals()
+{
+   fOutwardNormals.clear();
+   for (auto &facet : fFacets) {
+      auto &v1 = fVertices[facet[0]];
+      auto &v2 = fVertices[facet[1]];
+      auto &v3 = fVertices[facet[2]];
+      using Vec3d = Vec3f<double>;
+      auto norm = triangleNormal(Vec3d{v1[0], v1[1], v1[2]}, Vec3d{v2[0], v2[1], v2[2]}, Vec3d{v3[0], v3[1], v3[2]});
+      fOutwardNormals.emplace_back(Vertex_t{norm.x, norm.y, norm.z});
+   }
 }

--- a/geom/geomchecker/src/TGeoChecker.cxx
+++ b/geom/geomchecker/src/TGeoChecker.cxx
@@ -2041,6 +2041,12 @@ void TGeoChecker::ShapeDistances(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t dx = ((TGeoBBox *)shape)->GetDX();
    Double_t dy = ((TGeoBBox *)shape)->GetDY();
    Double_t dz = ((TGeoBBox *)shape)->GetDZ();
+   // the box might be displaced
+   auto origin_p = ((TGeoBBox *)shape)->GetOrigin();
+   Double_t ox = origin_p[0];
+   Double_t oy = origin_p[1];
+   Double_t oz = origin_p[2];
+
    Double_t dmax = 2. * TMath::Sqrt(dx * dx + dy * dy + dz * dz);
    Double_t d1, d2, dmove, dnext;
    Int_t itot = 0;
@@ -2065,9 +2071,9 @@ void TGeoChecker::ShapeDistances(TGeoShape *shape, Int_t nsamples, Option_t *)
    while (itot < nsamples) {
       Bool_t inside = kFALSE;
       while (!inside) {
-         point[0] = gRandom->Uniform(-dx, dx);
-         point[1] = gRandom->Uniform(-dy, dy);
-         point[2] = gRandom->Uniform(-dz, dz);
+         point[0] = ox + gRandom->Uniform(-dx, dx);
+         point[1] = oy + gRandom->Uniform(-dy, dy);
+         point[2] = oz + gRandom->Uniform(-dz, dz);
          inside = shape->Contains(point);
       }
       itot++;
@@ -2210,6 +2216,12 @@ void TGeoChecker::ShapeSafety(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t dx = ((TGeoBBox *)shape)->GetDX();
    Double_t dy = ((TGeoBBox *)shape)->GetDY();
    Double_t dz = ((TGeoBBox *)shape)->GetDZ();
+   // the box might be displaced
+   auto origin_p = ((TGeoBBox *)shape)->GetOrigin();
+   Double_t ox = origin_p[0];
+   Double_t oy = origin_p[1];
+   Double_t oz = origin_p[2];
+
    // Number of tracks shot for every point inside the shape
    const Int_t kNtracks = 1000;
    Int_t n10 = nsamples / 10;
@@ -2227,9 +2239,9 @@ void TGeoChecker::ShapeSafety(TGeoShape *shape, Int_t nsamples, Option_t *)
    Int_t itot = 0;
    while (itot < nsamples) {
       Bool_t inside = kFALSE;
-      point[0] = gRandom->Uniform(-2 * dx, 2 * dx);
-      point[1] = gRandom->Uniform(-2 * dy, 2 * dy);
-      point[2] = gRandom->Uniform(-2 * dz, 2 * dz);
+      point[0] = ox + gRandom->Uniform(-2 * dx, 2 * dx);
+      point[1] = oy + gRandom->Uniform(-2 * dy, 2 * dy);
+      point[2] = oz + gRandom->Uniform(-2 * dz, 2 * dz);
       inside = shape->Contains(point);
       Double_t safe = shape->Safety(point, inside);
       itot++;
@@ -2284,6 +2296,12 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
    Double_t dx = ((TGeoBBox *)shape)->GetDX();
    Double_t dy = ((TGeoBBox *)shape)->GetDY();
    Double_t dz = ((TGeoBBox *)shape)->GetDZ();
+   // the box might be displaced
+   auto origin_p = ((TGeoBBox *)shape)->GetOrigin();
+   Double_t ox = origin_p[0];
+   Double_t oy = origin_p[1];
+   Double_t oz = origin_p[2];
+
    Double_t dmax = 2. * TMath::Sqrt(dx * dx + dy * dy + dz * dz);
    // Number of tracks shot for every point inside the shape
    const Int_t kNtracks = 1000;
@@ -2297,9 +2315,9 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
    while (itot < nsamples) {
       Bool_t inside = kFALSE;
       while (!inside) {
-         spoint[3 * itot] = gRandom->Uniform(-dx, dx);
-         spoint[3 * itot + 1] = gRandom->Uniform(-dy, dy);
-         spoint[3 * itot + 2] = gRandom->Uniform(-dz, dz);
+         spoint[3 * itot] = ox + gRandom->Uniform(-dx, dx);
+         spoint[3 * itot + 1] = oy + gRandom->Uniform(-dy, dy);
+         spoint[3 * itot + 2] = oz + gRandom->Uniform(-dz, dz);
          inside = shape->Contains(&spoint[3 * itot]);
       }
       phi = 2 * TMath::Pi() * gRandom->Rndm();
@@ -2338,6 +2356,12 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
          if (errcnt > 0)
             break;
          dist = shape->DistFromInside(point, dir, 3);
+         if (dist > dmax) {
+            // distance is bigger than from bounding box
+            // should not happen for point inside
+            printf("Error DistFromInside Too large(%19.15f, %19.15f, %19.15f, %19.15f, %19.15f, %19.15f) =%g\n",
+                   point[0], point[1], point[2], dir[0], dir[1], dir[2], dist);
+         }
          for (Int_t j = 0; j < 3; j++) {
             newpoint[j] = point[j] + dist * dir[j];
          }
@@ -2421,7 +2445,7 @@ void TGeoChecker::ShapeNormal(TGeoShape *shape, Int_t nsamples, Option_t *)
             dir[1] = TMath::Sin(theta) * TMath::Sin(phi);
             dir[2] = TMath::Cos(theta);
             ndotd = dir[0] * norm[0] + dir[1] * norm[1] + dir[2] * norm[2];
-            if (ndotd < 0)
+            if (ndotd <= 0)
                break; // backwards, still inside shape
          }
          if ((itot % 10) == 0)

--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -13,3 +13,6 @@ if(gdml)
     test_boolean_extrusion.cxx
     LIBRARIES Geom GeomChecker)
 endif()
+ROOT_ADD_GTEST(tessellated
+  test_tessellated.cxx
+  LIBRARIES Geom)

--- a/geom/test/test_tessellated.cxx
+++ b/geom/test/test_tessellated.cxx
@@ -1,0 +1,280 @@
+// A unit test for TGeoTessellated, ported from existing test in VecGeom
+// Sandro Wenzel
+
+#include <gtest/gtest.h>
+
+#include <TGeoTessellated.h>
+#include <TGeoShape.h>
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <memory>
+
+namespace {
+
+using Vtx = TGeoTessellated::Vertex_t;
+
+constexpr double kTol = 1e-12;
+
+// ----------------------------- helpers ----------------------------------------
+
+inline std::array<double, 3> P(double x, double y, double z)
+{
+   return {x, y, z};
+}
+
+inline std::array<double, 3> Unit(const std::array<double, 3> &v)
+{
+   const double n = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+   if (n == 0.0)
+      return {0.0, 0.0, 0.0};
+   return {v[0] / n, v[1] / n, v[2] / n};
+}
+
+inline void ExpectNearVec3(const std::array<double, 3> &a, const std::array<double, 3> &b, double tol = kTol)
+{
+   EXPECT_NEAR(a[0], b[0], tol);
+   EXPECT_NEAR(a[1], b[1], tol);
+   EXPECT_NEAR(a[2], b[2], tol);
+}
+
+inline std::array<double, 3>
+NormalAt(const TGeoShape &s, const std::array<double, 3> &p, const std::array<double, 3> &dir_hint)
+{
+   double n[3] = {0.0, 0.0, 0.0};
+   s.ComputeNormal(p.data(), dir_hint.data(), n);
+   return {n[0], n[1], n[2]};
+}
+
+// mapping VecGeom style DistanceToOut(p,v) ~ ROOT/TGeo DistFromInside(p,v,...)
+inline double
+DistanceToOut(const TGeoShape &s, const std::array<double, 3> &p, const std::array<double, 3> &v, int iact = 3)
+{
+   return s.DistFromInside(p.data(), v.data(), iact, /*step=*/TGeoShape::Big(), /*safe=*/nullptr);
+}
+
+// mapping VecGeom style DistanceToIn(p,v) ~ ROOT/TGeo DistFromOutside(p,v,...)
+inline double
+DistanceToIn(const TGeoShape &s, const std::array<double, 3> &p, const std::array<double, 3> &v, int iact = 3)
+{
+   return s.DistFromOutside(p.data(), v.data(), iact, /*step=*/TGeoShape::Big(), /*safe=*/nullptr);
+}
+
+// Add a quad facet as 2 triangles preserving the winding of (A,B,C,D)
+inline void AddQuadAsTriangles(TGeoTessellated &tsl, const Vtx &A, const Vtx &B, const Vtx &C, const Vtx &D)
+{
+   // Split along diagonal A-C:
+   //   (A,B,C) and (A,C,D) keeps the same rotation as the original quad order.
+   EXPECT_TRUE(tsl.AddFacet(A, B, C));
+   EXPECT_TRUE(tsl.AddFacet(A, C, D));
+}
+
+// ------------------------- test case geometry builder -------------------------------
+TGeoTessellated *
+CreateTrdLikeTessellated_Triangles(const char *name, double x1, double x2, double y1, double y2, double z)
+{
+   auto *tsl = new TGeoTessellated(name);
+
+   const Vtx tA(-x2, y2, z), tB(-x2, -y2, z), tC(x2, -y2, z), tD(x2, y2, z);
+   const Vtx bA(-x1, y1, -z), bB(x1, y1, -z), bC(x1, -y1, -z), bD(-x1, -y1, -z);
+
+   // Top (+z)
+   AddQuadAsTriangles(*tsl, tA, tB, tC, tD);
+   // Bottom (-z)
+   AddQuadAsTriangles(*tsl, bA, bB, bC, bD);
+   // Front (-y)
+   AddQuadAsTriangles(*tsl, tB, bD, bC, tC);
+   // Right (+x)
+   AddQuadAsTriangles(*tsl, tC, bC, bB, tD);
+   // Back (+y)
+   AddQuadAsTriangles(*tsl, tD, bB, bA, tA);
+   // Left (-x)
+   AddQuadAsTriangles(*tsl, tA, bA, bD, tB);
+
+   tsl->CloseShape(/*check=*/true, /*fixFlipped=*/true, /*verbose=*/false);
+   return tsl;
+}
+
+} // namespace
+
+TEST(TGeoTessellated, TrdLike_CoreNavigation)
+{
+   // Representative points (ported)
+   const auto pzero = P(0, 0, 0);
+
+   const auto pbigx = P(100, 0, 0);
+   const auto pbigy = P(0, 100, 0);
+   const auto pbigz = P(0, 0, 100);
+   const auto pbigmx = P(-100, 0, 0);
+   const auto pbigmy = P(0, -100, 0);
+   const auto pbigmz = P(0, 0, -100);
+
+   const auto vx = P(1, 0, 0);
+   const auto vy = P(0, 1, 0);
+   const auto vz = P(0, 0, 1);
+   const auto vmx = P(-1, 0, 0);
+   const auto vmy = P(0, -1, 0);
+   const auto vmz = P(0, 0, -1);
+
+   const auto vxy = P(1 / std::sqrt(2.0), 1 / std::sqrt(2.0), 0);
+
+   // Solids (ported)
+   std::unique_ptr<TGeoTessellated> tsl1(CreateTrdLikeTessellated_Triangles("Test Box #1", 20, 20, 30, 30, 40));
+   std::unique_ptr<TGeoTessellated> tsl2(CreateTrdLikeTessellated_Triangles("Test Trd", 10, 30, 20, 40, 40));
+   std::unique_ptr<TGeoTessellated> tsl3(CreateTrdLikeTessellated_Triangles("BABAR Trd", 0.14999999999999999,
+                                                                            0.14999999999999999, 24.707000000000001,
+                                                                            24.707000000000001, 22.699999999999999));
+
+   ASSERT_TRUE(tsl1->IsDefined());
+   ASSERT_TRUE(tsl2->IsDefined());
+   ASSERT_TRUE(tsl3->IsDefined());
+
+   // 6 quads -> 12 triangles
+   EXPECT_EQ(tsl1->GetNfacets(), 12);
+   EXPECT_EQ(tsl2->GetNfacets(), 12);
+
+   // Volume
+   EXPECT_NEAR(tsl1->Capacity(), 8.0 * 20.0 * 30.0 * 40.0, 1e-9);
+
+   // "Inside" checks using TGeo convention: Contains(p) -> bool
+   EXPECT_TRUE(tsl1->Contains(pzero.data()));
+   EXPECT_FALSE(tsl1->Contains(pbigz.data()));
+
+   EXPECT_TRUE(tsl2->Contains(pzero.data()));
+   EXPECT_FALSE(tsl2->Contains(pbigz.data()));
+
+   // Surface normals (ComputeNormal) at face centers to avoid edge/corner ambiguity
+   {
+      const auto px = P(20, 0, 0);
+      const auto nx = P(-20, 0, 0);
+      const auto py = P(0, 30, 0);
+      const auto ny = P(0, -30, 0);
+      const auto pz = P(0, 0, 40);
+      const auto nz = P(0, 0, -40);
+
+      ExpectNearVec3(NormalAt(*tsl1, px, vx), vx);
+      ExpectNearVec3(NormalAt(*tsl1, nx, vmx), vmx);
+      ExpectNearVec3(NormalAt(*tsl1, py, vy), vy);
+      ExpectNearVec3(NormalAt(*tsl1, ny, vmy), vmy);
+      ExpectNearVec3(NormalAt(*tsl1, pz, vz), vz);
+      ExpectNearVec3(NormalAt(*tsl1, nz, vmz), vmz);
+   }
+
+   const double cosa = 4.0 / std::sqrt(17.0);
+   const double sina = 1.0 / std::sqrt(17.0);
+   {
+      // Use points on the side planes (face centers) matching the tsl1-style coordinates.
+      const auto px = P(20, 0, 0);
+      const auto nx = P(-20, 0, 0);
+      const auto py = P(0, 30, 0);
+      const auto ny = P(0, -30, 0);
+
+      ExpectNearVec3(NormalAt(*tsl2, px, vx), P(cosa, 0.0, -sina));
+      ExpectNearVec3(NormalAt(*tsl2, nx, vmx), P(-cosa, 0.0, -sina));
+      ExpectNearVec3(NormalAt(*tsl2, py, vy), P(0.0, cosa, -sina));
+      ExpectNearVec3(NormalAt(*tsl2, ny, vmy), P(0.0, -cosa, -sina));
+
+      // Top/bottom should remain axis-aligned
+      const auto pz = P(0, 0, 40);
+      const auto nz = P(0, 0, -40);
+      ExpectNearVec3(NormalAt(*tsl2, pz, vz), vz);
+      ExpectNearVec3(NormalAt(*tsl2, nz, vmz), vmz);
+   }
+
+   // DistanceToOut from inside points (TGeo: DistFromInside)
+   {
+      const double d = DistanceToOut(*tsl1, pzero, vx);
+      EXPECT_NEAR(d, 20.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl1, P(pzero[0] + d * vx[0], pzero[1] + d * vx[1], pzero[2] + d * vx[2]), vx), vx);
+   }
+   {
+      const double d = DistanceToOut(*tsl1, pzero, vy);
+      EXPECT_NEAR(d, 30.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl1, P(pzero[0] + d * vy[0], pzero[1] + d * vy[1], pzero[2] + d * vy[2]), vy), vy);
+   }
+   {
+      const double d = DistanceToOut(*tsl1, pzero, vz);
+      EXPECT_NEAR(d, 40.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl1, P(pzero[0] + d * vz[0], pzero[1] + d * vz[1], pzero[2] + d * vz[2]), vz), vz);
+   }
+   EXPECT_NEAR(DistanceToOut(*tsl1, pzero, vxy), std::sqrt(800.0), 1e-9);
+
+   // tsl2 (ported expectations)
+   {
+      const double d = DistanceToOut(*tsl2, pzero, vx);
+      EXPECT_NEAR(d, 20.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl2, P(pzero[0] + d * vx[0], pzero[1] + d * vx[1], pzero[2] + d * vx[2]), vx),
+                     P(cosa, 0.0, -sina));
+   }
+   {
+      const double d = DistanceToOut(*tsl2, pzero, vy);
+      EXPECT_NEAR(d, 30.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl2, P(pzero[0] + d * vy[0], pzero[1] + d * vy[1], pzero[2] + d * vy[2]), vy),
+                     P(0.0, cosa, -sina));
+   }
+   {
+      const double d = DistanceToOut(*tsl2, pzero, vz);
+      EXPECT_NEAR(d, 40.0, 1e-9);
+      ExpectNearVec3(NormalAt(*tsl2, P(pzero[0] + d * vz[0], pzero[1] + d * vz[1], pzero[2] + d * vz[2]), vz), vz);
+   }
+   EXPECT_NEAR(DistanceToOut(*tsl2, pzero, vxy), std::sqrt(800.0), 1e-9);
+
+   // DistanceToIn from outside points (TGeo: DistFromOutside)
+   const double kInf = TGeoShape::Big();
+
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigx, vmx), 80.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigmx, vx), 80.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigy, vmy), 70.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigmy, vy), 70.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigz, vmz), 60.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl1, pbigmz, vz), 60.0, 1e-9);
+
+   // Miss cases (ported intent)
+   EXPECT_DOUBLE_EQ(DistanceToIn(*tsl1, pbigx, vxy), kInf);
+   EXPECT_DOUBLE_EQ(DistanceToIn(*tsl1, pbigmx, vxy), kInf);
+
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigx, vmx), 80.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigmx, vx), 80.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigy, vmy), 70.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigmy, vy), 70.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigz, vmz), 60.0, 1e-9);
+   EXPECT_NEAR(DistanceToIn(*tsl2, pbigmz, vz), 60.0, 1e-9);
+
+   EXPECT_DOUBLE_EQ(DistanceToIn(*tsl2, pbigx, vxy), kInf);
+   EXPECT_DOUBLE_EQ(DistanceToIn(*tsl2, pbigmx, vxy), kInf);
+
+   // BABAR regression (ported)
+   {
+      const auto pb = P(0.15000000000000185, -22.048743592955137, 2.4268539333219472);
+      const auto vb = Unit(P(-0.76165597579890043, 0.64364445891356026, -0.074515708658524193));
+      const double d = DistanceToIn(*tsl3, pb, vb);
+      EXPECT_NEAR(d, 0.0, 1e-9);
+   }
+
+   // Extent / cached bbox checks (TGeo accessors)
+   {
+      const double *o = tsl1->GetOrigin();
+      EXPECT_NEAR(o[0] - tsl1->GetDX(), -20.0, 1e-9);
+      EXPECT_NEAR(o[0] + tsl1->GetDX(), 20.0, 1e-9);
+      EXPECT_NEAR(o[1] - tsl1->GetDY(), -30.0, 1e-9);
+      EXPECT_NEAR(o[1] + tsl1->GetDY(), 30.0, 1e-9);
+      EXPECT_NEAR(o[2] - tsl1->GetDZ(), -40.0, 1e-9);
+      EXPECT_NEAR(o[2] + tsl1->GetDZ(), 40.0, 1e-9);
+   }
+   {
+      const double *o = tsl2->GetOrigin();
+      EXPECT_NEAR(o[0] - tsl2->GetDX(), -30.0, 1e-9);
+      EXPECT_NEAR(o[0] + tsl2->GetDX(), 30.0, 1e-9);
+      EXPECT_NEAR(o[1] - tsl2->GetDY(), -40.0, 1e-9);
+      EXPECT_NEAR(o[1] + tsl2->GetDY(), 40.0, 1e-9);
+      EXPECT_NEAR(o[2] - tsl2->GetDZ(), -40.0, 1e-9);
+      EXPECT_NEAR(o[2] + tsl2->GetDZ(), 40.0, 1e-9);
+   }
+}
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This commit adds implementations of the navigation interfaces required by TGeoNavigator to TGeoTessellated.

As a result, TGeoTessellated can now be used in applications that rely on this navigator, such as VMC-based GEANT simulations.

The implementation is based on fast Bounding Volume Hierarchy (BVH) queries introduced in a recent TGeoParallelWorld rewrite.

The BVH is only exposed to the internal implementation. It is not streamed to disk for now and therefore needs to be reinitialized when reading from TBuffer. For this reason, a custom streamer for TGeoTessellated is proposed.

The implementation shows very good performance, being multiple times faster than comparable implementations in Geant4 or VecGeom. The latter were also used to validate the algorithms. Navigation functionality has additionally been tested at a high level using VecGeom’s XRayNavigationBenchmarker.

Note that this is an initial implementation and should be considered beta quality. The following limitations and remarks apply:

- DistFromInside and DistFromOutside do not implement all `iact=` cases. Only `iact == 3` is supported, which is the case actually used by TGeoNavigator.

- Only triangular faces supported at this stage but generalization is straightforward. (Users can also make sure to only add triangles).

- The algorithms have not yet been validated in large-scale production environments.

- Further optimization seem possible and will be done in future commits.

This work is motivated by the need to GEANT-simulate detector prototypes from CAD models in ALICE. ALICE is using TGeo.

Finally, the commit also fixes some minor bugs in the TGeoChecker with respect to bounding box origins, previously not taken into account.

Slight refactoring of TGeoParallelWorld to make use of utility functions used both in TGeoTessellated as well as in TGeoParallelWorld.

