### PR TITLE
Disable the gl gradient tutorials on mac beta.

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -730,6 +730,13 @@ foreach(t ${tutorials})
   if(${t} IN_LIST multithreaded)
     set_tests_properties(tutorial-${tname} PROPERTIES PROCESSORS ${NProcessors})
   endif()
+
+  if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 25.4 AND tname MATCHES "gl-.*grad")
+    # ROOT-21367
+    # On mac beta, there is a stack corruption (suspected to be a compiler bug) that may fail these tests
+    set_tests_properties(tutorial-${tname} PROPERTIES DISABLED True)
+    message(NOTICE "Disabling tutorial ${tname} for mac beta")
+  endif()
 endforeach()
 
 if(root7 AND MSVC)


### PR DESCRIPTION
Due to a stack corruption, the tutorials fail frequently. It is suspected to be a compiler bug, so they will be disabled until a new XCode version gets released.

This is tracked in #21367.