### PR TITLE
[RF][HS3] Fix compiler warning in RooJSONFactoryWSTool

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1239,7 +1239,8 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool importAllDepen
             ok = imp->importArg(this, p);
          } catch (const std::exception &e) {
             std::stringstream ss;
-            ss << "RooJSONFactoryWSTool() failed. The importer " << typeid(*imp).name()
+            const auto *ptr = imp.get();
+            ss << "RooJSONFactoryWSTool() failed. The importer " << typeid(*ptr).name()
                << " emitted and error: " << e.what() << std::endl;
             RooJSONFactoryWSTool::error(ss.str());
          }


### PR DESCRIPTION
This fixes the following warning when building with Clang:
```txt
[3589/3608] Building CXX object roofit...HS3.dir/src/RooJSONFactoryWSTool.cxx.o
<root_src>/roofit/hs3/src/RooJSONFactoryWSTool.cxx:1242:76: warning: expression with side effects will be evaluated despite being used as an operand to 'typeid' [-Wpotentially-evaluated-expression]
 1242 |             ss << "RooJSONFactoryWSTool() failed. The importer " << typeid(*imp).name()
      |                                                                            ^
1 warning generated.
```