### PR TITLE
[RF] Replace asymptotic Poisson interval with exact Garwood intervals

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -205,6 +205,28 @@ As part of this migration, the following build options are deprecated. From ROOT
   overhead in `RooAbsRealLValue::inRange()`, which is visible in many-parameter
   fits. Therefore, these functions are removed.
 
+### New implementation of `RooHistError::getPoissonInterval`
+
+**RooHistError::getPoissonInterval** was reimplemented to use an exact chi-square–based construction (Garwood interval) instead of asymptotic approximations and lookup tables.
+
+Previously:
+
+  * For `n > 100`, a hard-coded asymptotic formula was used, which was not explained in the documentation.
+  * That approximation corresponds to inverting the Poisson score test and was only correct for `nSigma = 1`.
+  * The behavior for `n > 100` was not statistically consistent because of the hard transition between exact formula and approximation, resulting in a discrete and unexpected jump in approximation bias.
+  * For small `n`, numerical root finding and a lookup table were used.
+
+Now:
+
+  * The interval is computed directly using chi-square quantiles for all `n`.
+  * The construction provides exact frequentist coverage.
+  * The implementation works consistently for arbitrary `nSigma`.
+  * The hard-coded `n > 100` threshold, lookup table, and numerical root finding were removed.
+  * For `n = 0`, a one-sided upper limit is used (with lower bound fixed at 0), consistent with the physical constraint `mu ≥ 0`.
+
+Results may differ from previous ROOT versions for `n > 100` or `nSigma != 1`.
+The new implementation is statistically consistent and recommended.
+
 ## RDataFrame
 
 - The message shown in ROOT 6.38 to inform users about change of default compression setting used by Snapshot (was 101 before 6.38, became 505 in 6.38) is now removed.

--- a/roofit/roofitcore/inc/RooHistError.h
+++ b/roofit/roofitcore/inc/RooHistError.h
@@ -37,13 +37,6 @@ public:
   static RooAbsFunc *createBinomialSum(Int_t n, Int_t m, bool eff) ;
 
 private:
-
-
-  bool getPoissonIntervalCalc(Int_t n, double &mu1, double &mu2, double nSigma= 1) const;
-  double _poissonLoLUT[1000] ;
-  double _poissonHiLUT[1000] ;
-
-  RooHistError();
   double seek(const RooAbsFunc &f, double startAt, double step, double value) const;
 
   // -----------------------------------------------------------


### PR DESCRIPTION
Closes #21438.

The previous implementation of RooHistError::getPoissonInterval used:

  * A hard-coded, undocumented, asymptotic approximation for n > 100 that didn't consider nSigma correctly
  * A lookup table for n < 1000 (for nSigma == 1)
  * Numerical root finding for the general case

The asymptotic branch used

```txt
    mu1 = n - sqrt(n + 0.25) + 0.5
    mu2 = n + sqrt(n + 0.25) + 0.5
```

which corresponds to the inversion of the Poisson score test and is only valid for nSigma = 1. The origin and validity range of this approximation were not documented, and its behavior for nSigma != 1 was undefined.

This commit replaces the previous implementation with a direct, closed-form construction using chi-square quantiles (the well-known Garwood interval which is also explained on Wikipedia [1] or table 40.3 of the PDG review book [2]).

[1] https://en.wikipedia.org/wiki/Poisson_distribution#Confidence_interval
[2] https://pdg.lbl.gov/2025/html/computer_read.html

This new implementation:

  * Provides exact frequentist coverage for all n
  * Works for arbitrary nSigma
  * Removes the hard-coded n > 100 threshold
  * Removes numerical root finding, which is expensive and therefore implied the need for this lookup table
  * Improves clarity and maintainability

No changes in public API and mathematical results, except for the nSigma != 1 fix for n > 100.