### PR TITLE
[ML] Remove invalid Reshape() call on output tensor in RSampler

### DIFF
--- a/tree/ml/inc/ROOT/ML/RSampler.hxx
+++ b/tree/ml/inc/ROOT/ML/RSampler.hxx
@@ -146,7 +146,6 @@ public:
       }
 
       std::size_t cols = fDatasets[0].GetCols();
-      ShuffledTensor.Reshape(fNumEntries, cols);
       RFlat2DMatrix SampledTensor(fNumEntries, cols);
       RFlat2DMatrix UndersampledMajorTensor(fNumResampledMajor, cols);
 
@@ -170,7 +169,6 @@ public:
       SampleWithReplacement(fNumResampledMinor, fNumMinor);
 
       std::size_t cols = fDatasets[0].GetCols();
-      ShuffledTensor.Reshape(fNumEntries, cols);
       RFlat2DMatrix SampledTensor(fNumEntries, cols);
       RFlat2DMatrix OversampledMinorTensor(fNumResampledMinor, cols);
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
`RandomOver/UnderSampler` takes `RFlat2DMatrix &ShuffledTensor` which may be default-constructed (size 0 at that point) and calls `Reshape()` on it, which will fail when it reaches the line `assert(rows * cols == fRVec.size());`, as it does not allocate storage.

The call is also unnecessary: few lines below that, the function calls `ShuffleTensor()` which which always resizes the output tensor internally (calls `Resize(rows, cols)`) 

So this PR removed the `Reshape()` call and relies on `ShuffleTensor()` to size the output tensor correctly.

> [!NOTE]
> The assertion was triggered after moving the sampler implementation from header to source file in  #21397

