### PR TITLE
[Python] Don't rely on possible memory leaks in T(Seq)Collection tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
@@ -11,14 +11,16 @@ class TCollectionListMethods(unittest.TestCase):
 
     num_elems = 3
 
+    _global_objects = []
+
     # Helpers
     def create_tcollection(self):
         c = ROOT.TList()
         for _ in range(self.num_elems):
             o = ROOT.TObject()
-            # Prevent immediate deletion of C++ TObjects
-            ROOT.SetOwnership(o, False)
             c.Add(o)
+            # To prevent deletion of the objects (TList is by default non-owning)
+            self._global_objects.append(o)
 
         return c
 
@@ -44,6 +46,10 @@ class TCollectionListMethods(unittest.TestCase):
         # Check that `o` is indeed the last element
         self.assertEqual(o, itc.Next())
 
+        # Clear before the added element might be garbage collected,
+        # to avoid dangling pointer access.
+        c.Clear()
+
     def test_remove(self):
         c = ROOT.TList()
 
@@ -68,6 +74,8 @@ class TCollectionListMethods(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             c.remove(o1)
+
+        c.Clear()
 
     def test_extend(self):
         c1 = self.create_tcollection()
@@ -104,6 +112,8 @@ class TCollectionListMethods(unittest.TestCase):
 
         self.assertEqual(c.count(o1), 2)
         self.assertEqual(c.count(o2), 1)
+
+        c.Clear()
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
@@ -12,14 +12,16 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
     num_elems = 3
 
+    _global_objects = []
+
     # Helpers
     def create_tseqcollection(self):
         sc = ROOT.TList()
         for _ in range(self.num_elems):
             o = ROOT.TObject()
-            # Prevent immediate deletion of C++ TObjects
-            ROOT.SetOwnership(o, False)
             sc.Add(o)
+            # To prevent deletion of the objects (TList is by default non-owning)
+            self._global_objects.append(o)
 
         return sc
 

--- a/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
@@ -11,11 +11,16 @@ class TSeqCollectionListMethods(unittest.TestCase):
 
     num_elems = 3
 
+    _global_objects = []
+
     # Helpers
     def create_tseqcollection(self):
         sc = ROOT.TList()
         for i in reversed(range(self.num_elems)):
-            sc.Add(ROOT.TObjString(str(i)))
+            o = ROOT.TObjString(str(i))
+            sc.Add(o)
+            # To prevent deletion of the objects (TList is by default non-owning)
+            self._global_objects.append(o)
 
         return sc
 
@@ -48,6 +53,10 @@ class TSeqCollectionListMethods(unittest.TestCase):
         sc.insert(self.num_elems + 4, o4)
         self.assertEqual(sc.GetEntries(), self.num_elems + 4)
         self.assertEqual(sc.At(self.num_elems + 3), o4)
+
+        # Clear before the added element might be garbage collected,
+        # to avoid dangling pointer access.
+        sc.Clear()
 
     def test_pop(self):
         sc = self.create_tseqcollection()
@@ -82,8 +91,10 @@ class TSeqCollectionListMethods(unittest.TestCase):
         with self.assertRaises(TypeError):
             sc2.pop(1.0)
 
-        # Pop a repeated element
-        sc2.append(ROOT.TObjString("2"))
+        # Pop a repeated element.
+        # Keep Python reference so the added element lives beyond the sc2.pop() call:
+        new_elem = ROOT.TObjString("2")
+        sc2.append(new_elem)
         elem = sc2.pop()
         self.assertEqual(sc2.At(0), elem)
 


### PR DESCRIPTION
Some unit tests rely on the behavior that when adding object to `TLists`, Python ownership is always dropped, resulting in memory leaks if the ownership is not correctly handled on the C++ side.

To make these unit tests transparently ready for the moment where the ownership is handled correctly, this commit suggests to use some global lists that keep around Python references until the end of the test. So the effect on the lifetime is the same as having the "controlled" memory leaks.

Spinoff from:
  * https://github.com/root-project/root/pull/13593