### PR TITLE
[Python] Don't rely on heuristic memory policy when passing ownership

### DIFF
--- a/bindings/pyroot/pythonizations/python/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/python/CMakeLists.txt
@@ -39,6 +39,7 @@ if(roofit)
         ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
         ROOT/_pythonization/_roofit/_roomcstudy.py
         ROOT/_pythonization/_roofit/_roomsgservice.py
+        ROOT/_pythonization/_roofit/_rooplot.py
         ROOT/_pythonization/_roofit/_rooprodpdf.py
         ROOT/_pythonization/_roofit/_roorealvar.py
         ROOT/_pythonization/_roofit/_roosimultaneous.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_memory_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_memory_utils.py
@@ -63,3 +63,28 @@ def _SetDirectory_SetOwnership(self, dir):
         import ROOT
 
         ROOT.SetOwnership(self, False)
+
+
+def declare_cpp_owned_arg(position, name, positional_args, keyword_args, condition=lambda _: True):
+    """
+    Helper function to drop Python ownership of a specific function argument
+    with a given position and name, referring to the C++ signature.
+
+    positional_args and keyword_args should be the usual args and kwargs passed
+    to the function, and condition is an optional condition on which the Python
+    ownership is dropped.
+    """
+    import ROOT
+
+    # has to match the C++ argument name
+    if name in keyword_args:
+        arg = keyword_args[name]
+    elif len(positional_args) > position:
+        arg = positional_args[0]
+    else:
+        # This can happen if the function was called with too few arguments.
+        # In that case we should not do anything.
+        return
+
+    if condition(arg):
+        ROOT.SetOwnership(arg, False)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
@@ -40,6 +40,7 @@ from ._rooglobalfunc import (
 from ._roojsonfactorywstool import RooJSONFactoryWSTool
 from ._roomcstudy import RooMCStudy
 from ._roomsgservice import RooMsgService
+from ._rooplot import RooPlot
 from ._rooprodpdf import RooProdPdf
 from ._roorealvar import RooRealVar
 from ._roosimultaneous import RooSimultaneous
@@ -69,6 +70,7 @@ python_classes = [
     RooJSONFactoryWSTool,
     RooMCStudy,
     RooMsgService,
+    RooPlot,
     RooProdPdf,
     RooRealVar,
     RooSimultaneous,

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
@@ -31,13 +31,19 @@ def _pack_cmd_args(*args, **kwargs):
     assert len(kwargs) == 0
 
     # Put RooCmdArgs in a RooLinkedList
-    cmdList = ROOT.RooLinkedList()
+    cmd_list = ROOT.RooLinkedList()
     for cmd in args:
         if not isinstance(cmd, ROOT.RooCmdArg):
             raise TypeError("This function only takes RooFit command arguments.")
-        cmdList.Add(cmd)
+        cmd_list.Add(cmd)
 
-    return cmdList
+    # The RooLinkedList passed to functions like fitTo() is expected to be
+    # non-owning. To make sure that the RooCmdArgs live long enough, we attach
+    # them as an attribute of the output list, such that the Python reference
+    # counter doesn't hit zero.
+    cmd_list._owning_pylist = args
+
+    return cmd_list
 
 
 class RooAbsPdf(RooAbsReal):

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooplot.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooplot.py
@@ -1,0 +1,19 @@
+# Authors:
+# * Jonas Rembser 09/2023
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+
+class RooPlot(object):
+    def addObject(self, *args, **kwargs):
+        from ROOT._pythonization._memory_utils import declare_cpp_owned_arg
+
+        # Python should transfer the ownership to the RooPlot
+        declare_cpp_owned_arg(0, "obj", args, kwargs)
+
+        return self._addObject(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
@@ -93,10 +93,25 @@ def _iter_pyz(self):
         yield o
 
 
+def _TCollection_Add(self, *args, **kwargs):
+    from ROOT._pythonization._memory_utils import declare_cpp_owned_arg
+
+    def condition(_):
+        return self.IsOwner()
+
+    declare_cpp_owned_arg(0, "obj", args, kwargs, condition=condition)
+
+    self._Add(*args, **kwargs)
+
+
 @pythonization('TCollection')
 def pythonize_tcollection(klass):
     # Parameters:
     # klass: class to be pythonized
+
+    # Pythonize Add()
+    klass._Add = klass.Add
+    klass.Add = _TCollection_Add
 
     # Add Python lists methods
     klass.append = klass.Add

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tgraph.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tgraph.py
@@ -181,6 +181,8 @@ canvas.SaveAs("tgraph_comparison.pdf")
 
 import ROOT
 
+from . import pythonization
+
 
 def set_size(self, buf):
     # Parameters:
@@ -214,3 +216,19 @@ comp = ROOT._cppyy.py.compose_method(
 # Add the composite to the list of pythonizors
 ROOT._cppyy.py.add_pythonization(comp)
 
+def _TMultiGraph_Add(self, *args, **kwargs):
+    """
+    The TMultiGraph always takes ownership of the added graphs.
+    """
+    from ROOT._pythonization._memory_utils import declare_cpp_owned_arg
+
+    declare_cpp_owned_arg(0, "graph", args, kwargs)
+
+    self._Add(*args, **kwargs)
+
+
+@pythonization("TMultiGraph")
+def pythonize_tmultigraph(klass):
+    # Pythonizations for TMultiGraph::Add
+    klass._Add = klass.Add
+    klass.Add = _TMultiGraph_Add

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tseqcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tseqcollection.py
@@ -241,10 +241,29 @@ def _index_pyz(self, val):
     return idx
 
 
+def _TSeqCollection_AddAt(self, *args, **kwargs):
+    from ROOT._pythonization._memory_utils import declare_cpp_owned_arg
+
+    def condition(_):
+        return self.IsOwner()
+
+    declare_cpp_owned_arg(0, "obj", args, kwargs, condition=condition)
+
+    self._AddAt(*args, **kwargs)
+
+
 @pythonization('TSeqCollection')
 def pythonize_tseqcollection(klass):
+    from ROOT._pythonization._tcollection import _TCollection_Add
+
     # Parameters:
     # klass: class to be pythonized
+
+    # Pythonize Add() methods
+    klass._Add = klass.Add
+    klass.Add = _TCollection_Add
+    klass._AddAt = klass.AddAt
+    klass.AddAt = _TSeqCollection_AddAt
 
     # Item access methods
     klass.__getitem__ = _getitem_pyz
@@ -257,3 +276,17 @@ def pythonize_tseqcollection(klass):
     klass.reverse = _reverse_pyz
     klass.sort    = _sort_pyz
     klass.index   = _index_pyz
+
+
+@pythonization("TList")
+def pythonize_tlist(klass):
+    from ROOT._pythonization._tcollection import _TCollection_Add
+
+    # Parameters:
+    # klass: class to be pythonized
+
+    # Pythonize Add() methods
+    klass._Add = klass.Add
+    klass.Add = _TCollection_Add
+    klass._AddAt = klass.AddAt
+    klass.AddAt = _TSeqCollection_AddAt


### PR DESCRIPTION
If an interface is meant to be used for passing ownership, this should be implemented with an explicit Pythonization instead of relying on heuristics in cppyy, because the heuristics result in many false positives for ownership transfer, manifesting as memory leaks.

We would like to avoid using the heuristic memory policy in the future, and this change is done in preparation for that.

This commit has absolutely no effect on the behavor of the ROOT Python interface at this point, because it's redundant with the heuristic memory policy. But these Pythonization will be important once the strict memory policy is the default.

This is a spinoff from https://github.com/root-project/root/pull/13593