### PR TITLE
[tmva][sofie] Fix NonZero to define max output shape value in the Session constructor

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -25,7 +25,9 @@ public:
    virtual std::vector<ETensorType> TypeInference(std::vector<ETensorType>) { return {}; };
    virtual void Initialize(RModel&) = 0;
    virtual std::string Generate(std::string OpName) = 0;  //expect unique opName for each operator within the same RModel
-   // generate initialization code for session constructor
+   // generate code for Session constructor before tensor allocation
+   virtual std::string GenerateSessionCtorCode() { return "";}
+   // generate initialization code for session constructor after tensor allocations
    virtual std::string GenerateInitCode() { return "";}
    // generate some specific declaration code for Session
    virtual std::string GenerateDeclCode() { return "";}

--- a/tmva/sofie/inc/TMVA/ROperator_NonZero.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_NonZero.hxx
@@ -93,7 +93,16 @@ public:
          fShapeY[0] = fShapeX.size();
 
          // identify as -1 since we will declare maximum as size of input
-         fShapeY[1] = Dim{std::string("v_NonZero_") + fNX, static_cast<size_t>(-1)};
+         // auto inputLength = ConvertDimShapeToLength(fShapeX);
+         // // case X is Dim, becomes complicated to know the maximum. Shuld be allocated dynamically
+         // size_t inputLength = 0;
+         // if (!model.IsDynamicTensor(fNX)) {
+         //    inputLength = ConvertShapeToLength(ConvertShapeToInt(fShapeX));
+         // else
+         //    inputLength = static_cast<size_t>(-1);   // flag -1 to define shape correctly
+
+         // flag -1 to define the shape variable in the constructor code and not in the constructor signature
+         fShapeY[1] = Dim{std::string("v_NonZero_") + fNX, static_cast<size_t>(-1) };
 
          model.AddIntermediateTensor(fNY, ETensorType::INT64, fShapeY);
          if (model.Verbose()) {
@@ -101,7 +110,7 @@ public:
          }
       }
    }
-   std::string GenerateSessionMembersCode(std::string /*opName*/) override {
+   std::string GenerateSessionCtorCode() override {
       if (fIsOutputConstant) return "";
       // define output value used as max non zero with max size = input shape * N
       auto inputLength = ConvertDimShapeToLength(fShapeX);
@@ -133,7 +142,7 @@ public:
 
       // loop on input indices
       out << SP << "size_t offset_" << opName << " = 0;\n";
-      out << SP << vnonzero << " = 0;\n";
+      out << SP << "size_t " << vnonzero << " = 0;\n";
       for (size_t j = 0; j < dims; j++) {
          std::string index = "i_" + std::to_string(j);
          for (size_t k = 0; k <= j; k++) out << SP;

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1152,6 +1152,11 @@ void RModel::GenerateSessionCode()
       }
       fGC += ") {\n";
 
+      // add some code required in session constructor
+      for (size_t id = 0; id < fOperators.size(); id++) {
+         fGC += fOperators[id]->GenerateSessionCtorCode();
+      }
+
       // initializing dynamic parameters
       if (!fDimShapeNames.empty()) {
          fGC += "\n\n";


### PR DESCRIPTION


The maximum value of the output shape (the number of non zero elements) does not need to be defined as Session data member but can be defined in the Session constructor. This requires adding a new function in ROperator, GenerateSessionCtorCode to add the code defining the max value. We cannot use GenerateInitCode, because this is used for code that is executed after having allocated the dynamic tensors.

This Pull request replaces #21452 
