### PR TITLE
[io] adjust array length checks in text-based buffers

### DIFF
--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -3346,11 +3346,9 @@ void TBufferJSON::JsonWriteFastArray(const T *arr, Long64_t arrsize, const char 
       fValue.Append("[]");
       return;
    }
-   constexpr Int_t dataWidth = 1; // at least 1
-   const Int_t maxElements = (std::numeric_limits<Int_t>::max() - Length())/dataWidth;
-   if (arrsize > maxElements)
-   {
-      Fatal("JsonWriteFastArray", "Not enough space left in the buffer (1GB limit). %lld elements is greater than the max left of %d", arrsize, maxElements);
+   const Int_t maxElements = std::numeric_limits<Int_t>::max();
+   if (arrsize > maxElements) {
+      Fatal("JsonWriteFastArray", "Array larger than 2^31 elements cannot be stored in JSON");
       return; // In case the user re-routes the error handler to not die when Fatal is called
    }
 

--- a/io/sql/src/TBufferSQL2.cxx
+++ b/io/sql/src/TBufferSQL2.cxx
@@ -1376,15 +1376,12 @@ Int_t TBufferSQL2::SqlReadArraySize()
 template <typename T>
 R__ALWAYS_INLINE void TBufferSQL2::SqlWriteArray(T *arr, Long64_t arrsize, Bool_t withsize)
 {
-   constexpr Int_t dataWidth = 1; // at least 1
-   const Int_t maxElements = (std::numeric_limits<Int_t>::max() - Length())/dataWidth;
-   if (arrsize < 0 || arrsize > maxElements)
-   {
-      Fatal("SqlWriteArray", "Not enough space left in the buffer (1GB limit). %lld elements is greater than the max left of %d", arrsize, maxElements);
-      return; // In case the user re-routes the error handler to not die when Fatal is called
-   }
    if (!withsize && (arrsize <= 0))
       return;
+   if (arrsize > std::numeric_limits<Int_t>::max()) {
+      Fatal("SqlWriteArray", "Array larger than 2^31 elements cannot be stored in SQL");
+      return; // In case the user re-routes the error handler to not die when Fatal is called
+   }
    PushStack()->SetArray(withsize ? arrsize : -1);
    Int_t indx = 0;
    if (fCompressLevel > 0) {

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -2160,16 +2160,13 @@ void TBufferXML::WriteArray(const Double_t *d, Int_t n)
 template <typename T>
 R__ALWAYS_INLINE void TBufferXML::XmlWriteFastArray(const T *arr, Long64_t n)
 {
-   constexpr Int_t dataWidth = 1; // at least 1
-   const Int_t maxElements = (std::numeric_limits<Int_t>::max() - Length())/dataWidth;
-   if (n < 0 || n > maxElements)
-   {
-      Fatal("XmlWriteFastArray", "Not enough space left in the buffer (1GB limit). %lld elements is greater than the max left of %d", n, maxElements);
-      return; // In case the user re-routes the error handler to not die when Fatal is called
-   }
    BeforeIOoperation();
    if (n <= 0)
       return;
+   if (n > std::numeric_limits<Int_t>::max()) {
+      Fatal("XmlWriteFastArray", "Array larger than 2^31 elements cannot be stored in XML");
+      return; // In case the user re-routes the error handler to not die when Fatal is called
+   }
    XMLNodePointer_t arrnode = CreateItemNode(xmlio::Array);
    PushStack(arrnode);
    XmlWriteArrayContent(arr, n);


### PR DESCRIPTION
@pcanal @ferdymercury 

Seems to be I overseen your PR https://github.com/root-project/root/pull/14627

Text-based buffers do not have 1GB limitation for object store. 
But all kind of loops over array indexes made with `Int_t` so elements count can not be larger than max int value.
So only this limit is important.  

In JSON array compression can produce small output string from large but empty array.
Overflow of output string buffer (for JSON or XML) is handled by `TString::Append()` method and should not play role here.

One can adjust error messages in `TBufferFile` and `TBufferSQL` - while you checks 2GB and not 1GB limit.