### PR TITLE
[CMake] Allow for choosing an SDK and detect its version on OSX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,31 +12,10 @@ if(WIN32)
   cmake_policy(SET CMP0091 OLD)
   set(CMAKE_SKIP_TEST_ALL_DEPENDENCY TRUE)
 endif()
-if(CMAKE_HOST_APPLE AND (NOT CMAKE_OSX_SYSROOT OR CMAKE_OSX_SYSROOT STREQUAL ""))
-  # The SYSROOT *must* be set before the project() call
-  # TODO: The following code is *necessary* on a standard MacOS platform (e.g. an Apple MacOS machine), but may not
-  # be as necessary on other MacOS platforms (e.g. Nix). A PR removed the following code https://github.com/root-project/root/pull/19718
-  # and the CI was happy with it, but unfortunately it was working simply because during our CI run jobs something is
-  # setting the SDKROOT environment variable, which implicitly sets the CMAKE_OSX_SYSROOT variable. This was highlighted
-  # by another PR https://github.com/root-project/root/pull/19855. On a standard Apple MacOS system, where the SDKROOT
-  # variable is not set by default, the build of ROOT would fail without the following code. It is unclear what is setting
-  # the SDKROOT variable only during our CI jobs, logging to the same CI machines and launching a build manually shows
-  # the same build error.
-  find_program(XCRUN_EXECUTABLE xcrun)
-  if(EXISTS ${XCRUN_EXECUTABLE})
-    execute_process(COMMAND ${XCRUN_EXECUTABLE} --sdk macosx --show-sdk-path
-      OUTPUT_VARIABLE SDK_PATH
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT EXISTS "${SDK_PATH}")
-      message(FATAL_ERROR "Could not detect macOS SDK path")
-    endif()
 
-    set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "SDK path" FORCE)
-  else()
-    message(FATAL_ERROR "The CMAKE_OSX_SYSROOT variable is not set and the 'xcrun' executable is not available. "
-                        "This build of ROOT cannot find the correct MacOS SDK.")
-  endif()
+if(CMAKE_HOST_APPLE)
+  # Don't move this because the SDK needs to be set before "project(ROOT)"
+  include(cmake/modules/SetOSX_SDK.cmake)
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND NOT ALLOW_IN_SOURCE)

--- a/cmake/modules/SetOSX_SDK.cmake
+++ b/cmake/modules/SetOSX_SDK.cmake
@@ -1,0 +1,40 @@
+# The SDKROOT environment variable and/or CMAKE_OSX_SYSROOT CMake variable need to be set *before* any project(ROOT) call.
+# This is necessary to find (and for cling to remember) the SDK, so don't remove this unless tested with all combinations of
+# incremental builds, fresh builds, having SDKROOT set, having CMAKE_OSX_SYSROOT set, and also not having them set.
+# The CMake 4 standard of leaving it to the compiler to figure out the SDK doesn't work for Cling.
+# See https://github.com/root-project/root/pull/19718, https://github.com/root-project/root/pull/19855 for failed attempts to remove this.
+
+# To choose an SDK, one has the following options:
+# - Let xcrun choose the latest installed SDK: "cmake ..."
+# - Configure an SDK using "SDKROOT=<path> cmake ..."
+# - Set a cache variable: "cmake -DCMAKE_OSX_SYSROOT=<path> ..."
+
+if(NOT IS_DIRECTORY "${CMAKE_OSX_SYSROOT}")
+  unset(CMAKE_OSX_SYSROOT CACHE)
+  unset(CMAKE_OSX_SYSROOT)
+endif()
+
+find_program(XCRUN_EXECUTABLE xcrun)
+if(EXISTS ${XCRUN_EXECUTABLE})
+  if(NOT DEFINED "${CMAKE_OSX_SYSROOT}")
+    execute_process(COMMAND ${XCRUN_EXECUTABLE} --sdk macosx --show-sdk-path
+      OUTPUT_VARIABLE SDK_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT IS_DIRECTORY "${SDK_PATH}")
+      message(FATAL_ERROR "Could not detect macOS SDK path")
+    endif()
+    set(CMAKE_OSX_SYSROOT "${SDK_PATH}" CACHE PATH "MacOS SDK path" FORCE)
+  endif()
+
+  # Save the SDK version for ROOT to inspect it later. This is needed for LTS that live longer
+  # then the SDK they were created with.
+  execute_process(COMMAND ${XCRUN_EXECUTABLE} --sdk ${CMAKE_OSX_SYSROOT} --show-sdk-version
+    OUTPUT_VARIABLE OSX_SDK_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  mark_as_advanced(OSX_SDK_VERSION)
+endif()
+
+if(NOT IS_DIRECTORY "${CMAKE_OSX_SYSROOT}")
+  message(FATAL_ERROR "ROOT needs a path to an SDK to compile on Mac. Try setting CMAKE_OSX_SYSROOT or provide the xcrun executable.")
+endif()
+message(STATUS "Mac OS SDK version: '${OSX_SDK_VERSION}' ${CMAKE_OSX_SYSROOT}")


### PR DESCRIPTION
So far, the SDK gets chosen automatically by invoking `xcrun` if available. For v6.36, we will need to detect the SDK version as well, so here the tools to detect and/or change an SDK are added. This is intended to be backported once merged to master.

The logic to handle SDKs is now:
- If no SDK is set, use `xcrun` to find one.
- Both for an auto-detected and a user-provided SDK, check its version.
- In master, the version is only printed, but once this is backported, the SDK version becomes relevant for v6.36.

To choose an SDK, one can from here on:
1. Let `xcrun` choose the latest installed SDK: `cmake ...`
2. Configure an SDK via the environment: `SDKROOT=<path> cmake ...`
3. Set a cache variable in CMake: `cmake -DCMAKE_OSX_SYSROOT=<path> ...`

Methods 2. and 3. are what one would have to do anyway on OSX. The difference is that with method 1., ROOT internally still needs to set `CMAKE_OSX_SYSROOT` to function correctly.