### PR TITLE
[ci] Enable `tmva-pymva` on Alma 9 march native platform

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma9-march_native.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma9-march_native.txt
@@ -7,6 +7,7 @@ builtin_veccore=ON
 builtin_zlib=ON
 builtin_zstd=ON
 pythia8=ON
+tmva-pymva=ON
 tmva-sofie=ON
 veccore=ON
 vc=ON


### PR DESCRIPTION
We should have at least one CI configuration that tests `tmva-pymva`, to avoid the code becoming dysfunctional.

It is a different question if we want to enable the PyMVA features for all of our binaries again, as we are generally trying to keep the set of ROOT features that call from C++ into Python minimal.

The proposed solution to get test coverage without changing the feature set in the binaries is to enable `tmva-pymva` for one of the special builds, like `alma9-march_native`.