### PR TITLE
[math] Include `algorithm` before using std::copy

### DIFF
--- a/math/genvector/inc/Math/GenVector/LorentzRotation.h
+++ b/math/genvector/inc/Math/GenVector/LorentzRotation.h
@@ -34,6 +34,8 @@
 #include "Math/GenVector/BoostY.h"
 #include "Math/GenVector/BoostZ.h"
 
+#include <algorithm>
+
 namespace ROOT {
 
   namespace Math {

--- a/math/mathmore/inc/Math/GSLSimAnnealing.h
+++ b/math/mathmore/inc/Math/GSLSimAnnealing.h
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <algorithm>
 
 namespace ROOT {
 


### PR DESCRIPTION
# This Pull request:

For v6.36, this change is needed for the current `mac-beta` to compile. Instead of just adding the commit in https://github.com/root-project/root/pull/21376, I thought it would be better to merge this in master and then backport.

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

