### PR TITLE
[hist] Ndim: correctly set axes title from histo title

### DIFF
--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -118,6 +118,7 @@ protected:
    THnBase* RebinBase(Int_t group) const;
    THnBase* RebinBase(const Int_t* group) const;
    void ResetBase(Option_t *option= "");
+   void SetTitleImpl(const char *title, bool overrideAxesTitle);
 
    static THnBase* CreateHnAny(const char* name, const char* title,
                                const TH1* h1, Bool_t sparse,

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -71,7 +71,7 @@ THnBase::THnBase(const char* name, const char* title, const std::vector<TAxis>& 
   size_t i{};
   for (auto& a: axes)
     fAxes.AddAtAndExpand(a.Clone(), i++);
-  // Assuming SetTitle is done by TNamed.
+  SetTitleImpl(title, false);
   fAxes.SetOwner();
 }
 
@@ -1201,6 +1201,29 @@ void THnBase::SetBinEdges(Int_t idim, const Double_t* bins)
    axis->Set(axis->GetNbins(), bins);
 }
 
+
+void THnBase::SetTitleImpl(const char *title, bool overrideAxesTitle) {
+   TString titleStr = title;
+   titleStr.ReplaceAll("#;",2,"#semicolon",10);
+
+   Ssiz_t from = 0;
+   titleStr.Tokenize(fTitle, from, ";");
+   fTitle.ReplaceAll("#semicolon", 10, ";", 1);
+
+   TString axisTitle;
+   Int_t dim = 0;
+   while(titleStr.Tokenize(axisTitle, from, ";")) {
+      if (dim == fNdimensions) {
+         ::Error("THnBase::SetTitle", "Trying to assign a title to axis %d for a %d-dimensional histogram.", dim + 1, fNdimensions);
+         break;
+      }
+      if (overrideAxesTitle || (strlen(GetAxis(dim)->GetTitle()) == 0 && !overrideAxesTitle)) {
+         GetAxis(dim)->SetTitle(axisTitle);
+      }
+      dim++;
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Change (i.e. set) the title.
 ///
@@ -1213,32 +1236,7 @@ void THnBase::SetBinEdges(Int_t idim, const Double_t* bins)
 
 void THnBase::SetTitle(const char *title)
 {
-   fTitle = title;
-   fTitle.ReplaceAll("#;",2,"#semicolon",10);
-
-   Int_t endHistTitle = fTitle.First(';');
-   if (endHistTitle >= 0) {
-      // title contains a ';' so parse the axis titles
-      Int_t posTitle = endHistTitle + 1;
-      Int_t lenTitle = fTitle.Length();
-      Int_t dim = 0;
-      while (posTitle > 0 && posTitle < lenTitle && dim < fNdimensions){
-         Int_t endTitle = fTitle.Index(";", posTitle);
-         TString axisTitle = fTitle(posTitle, endTitle - posTitle);
-         axisTitle.ReplaceAll("#semicolon", 10, ";", 1);
-         GetAxis(dim)->SetTitle(axisTitle);
-         dim++;
-         if (endTitle > 0)
-            posTitle = endTitle + 1;
-         else
-            posTitle = -1;
-      }
-      // Remove axis titles from histogram title
-      fTitle.Remove(endHistTitle, lenTitle - endHistTitle);
-   }
-
-   fTitle.ReplaceAll("#semicolon", 10, ";", 1);
-
+   SetTitleImpl(title, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/test/THn.cxx
+++ b/hist/hist/test/THn.cxx
@@ -1,9 +1,10 @@
-#include "gtest/gtest.h"
-
 #include "THn.h"
 #include "THnSparse.h"
 #include "TH1.h"
 #include "TH2.h"
+
+#include "ROOT/TestSupport.hxx"
+#include "gtest/gtest.h"
 
 // Constructors for THn and THnSparse
 TEST(THn, Constructors)
@@ -213,7 +214,7 @@ TEST(THn, ErrorsOfProjection)
    EXPECT_FLOAT_EQ(proj->GetBinError(projectedBin2), 6.);
 }
 
-// https://github.com/root-project/root/issues/19366
+// #19366
 TEST(THn, CreateSparse)
 {
    Int_t bins[1] = {5};
@@ -224,4 +225,45 @@ TEST(THn, CreateSparse)
    auto hn_sparse = THnSparseD::CreateSparse("", "", &hn);
    EXPECT_EQ(hn_sparse->GetNbins(), 1);
    EXPECT_FLOAT_EQ(hn_sparse->GetSparseFractionBins(), 1. / 7); // 5 + under/overflows
+}
+
+// #21484
+TEST(THSparse, AxisTitles)
+{
+   std::vector<double> xmin = {0, 0, 0, 0, 0};
+   std::vector<double> xmax = {1, 1, 1, 1, 1};
+   std::vector<int> nbins = {1, 1, 1, 1, 1};
+   std::vector<std::string> axisTitles = {"title_0", "title_1", "title_2", "title_3", "title_4"};
+   std::string title = "title";
+   for (auto &&axisTitle : axisTitles) {
+      title += ";" + axisTitle;
+   }
+   THnSparseD h("name", title.c_str(), 5, nbins.data(), xmin.data(), xmax.data());
+   for (auto i : {0, 1, 2, 3, 4}) {
+      EXPECT_STREQ(axisTitles[i].c_str(), h.GetAxis(i)->GetTitle());
+   }
+   EXPECT_STREQ(h.GetTitle(), "title");
+
+   title += ";title_5";
+   {
+      ROOT::TestSupport::CheckDiagsRAII diags;
+      diags.optionalDiag(kError, "THnBase::SetTitle",
+                         "Trying to assign a title to axis 6 for a 5-dimensional histogram.");
+      h.SetTitle(title.c_str());
+   }
+
+   // now we check the constructor that takes in input a vector of TAxis instances.
+   std::vector<TAxis> axes = {{4, -2, 2}, {4, -2, 2}};
+   THnSparseD h1("name", "title;foo;bar", axes);
+   EXPECT_STREQ(h1.GetAxis(0)->GetTitle(), "foo");
+   EXPECT_STREQ(h1.GetAxis(1)->GetTitle(), "bar");
+
+   const auto axisTitle = "myAxis";
+   for(auto &axis : axes){
+      axis.SetTitle(axisTitle);
+   }
+   THnSparseD h2("name", "title;foo;bar", axes);
+   EXPECT_STREQ(h2.GetAxis(0)->GetTitle(), axisTitle);
+   EXPECT_STREQ(h2.GetAxis(1)->GetTitle(), axisTitle);
+
 }


### PR DESCRIPTION
and preserve axis titles if any if the c'tor is invoked passing a vector of axes.

Fixes #21484

