### PR TITLE
[rfile] set default compression to 505 and allow setting compression on Recreate

### DIFF
--- a/io/io/inc/ROOT/RFile.hxx
+++ b/io/io/inc/ROOT/RFile.hxx
@@ -8,6 +8,7 @@
 #ifndef ROOT7_RFile
 #define ROOT7_RFile
 
+#include <Compression.h>
 #include <ROOT/RError.hxx>
 
 #include <deque>
@@ -268,6 +269,14 @@ public:
       kListRecursive = 1 << 2,
    };
 
+   struct RRecreateOptions {
+      /// See core/zip/inc/Compression.h for the meaning of the `compression` argument.
+      /// Default compression is 505 (ZSTD level 10).
+      int fCompressionSettings = ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose;
+
+      RRecreateOptions();
+   };
+
    // This is arbitrary, but it's useful to avoid pathological cases
    static constexpr int kMaxPathNesting = 1000;
 
@@ -280,7 +289,7 @@ public:
    /// Opens the file for reading/writing, overwriting it if it already exists.
    /// \throw ROOT::RException if a file could not be created at `path` (e.g. if the specified
    /// directory tree does not exist).
-   static std::unique_ptr<RFile> Recreate(std::string_view path);
+   static std::unique_ptr<RFile> Recreate(std::string_view path, const RRecreateOptions &opts = RRecreateOptions());
 
    /// Opens the file for updating, creating a new one if it doesn't exist.
    /// \throw ROOT::RException if the file at `path` could neither be read nor created

--- a/io/io/src/RFile.cxx
+++ b/io/io/src/RFile.cxx
@@ -8,6 +8,7 @@
 #include "ROOT/RFile.hxx"
 
 #include <ROOT/StringUtils.hxx>
+#include <ROOT/RLogger.hxx>
 #include <ROOT/RError.hxx>
 
 #include <Byteswap.h>
@@ -221,10 +222,11 @@ std::unique_ptr<RFile> RFile::Update(std::string_view path)
    return rfile;
 }
 
-std::unique_ptr<RFile> RFile::Recreate(std::string_view path)
+std::unique_ptr<RFile> RFile::Recreate(std::string_view path, const RRecreateOptions &opts)
 {
    TDirectory::TContext ctx(nullptr); // XXX: probably not thread safe?
-   auto tfile = std::unique_ptr<TFile>(TFile::Open(std::string(path).c_str(), "RECREATE_WITHOUT_GLOBALREGISTRATION"));
+   auto tfile = std::unique_ptr<TFile>(
+      TFile::Open(std::string(path).c_str(), "RECREATE_WITHOUT_GLOBALREGISTRATION", "", opts.fCompressionSettings));
    EnsureFileOpenAndBinary(tfile.get(), path);
 
    auto rfile = std::unique_ptr<RFile>(new RFile(std::move(tfile)));
@@ -565,3 +567,5 @@ TFile *ROOT::Experimental::Internal::GetRFileTFile(RFile &file)
 {
    return file.fFile.get();
 }
+
+RFile::RRecreateOptions::RRecreateOptions() = default;

--- a/io/io/test/rfile.cxx
+++ b/io/io/test/rfile.cxx
@@ -810,3 +810,29 @@ TEST(RFile, TTreeNoDoubleFree)
    // destructed once during writing, once during reading.
    EXPECT_EQ(TTreeDestructorCounter::GetTimesDestructed(), 2);
 }
+
+TEST(RFile, Compression)
+{
+   FileRaii fileGuard("test_rfile_compression.root");
+
+   {
+      auto file = RFile::Recreate(fileGuard.GetPath());
+      std::string s = "foo";
+      file->Put("foo", s);
+   }
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
+      EXPECT_EQ(file->GetCompressionSettings(), ROOT::RCompressionSetting::EDefaults::kUseGeneralPurpose);
+   }
+   {
+      auto opts = RFile::RRecreateOptions();
+      opts.fCompressionSettings = 0;
+      auto file = RFile::Recreate(fileGuard.GetPath(), opts);
+      std::string s = "foo";
+      file->Put("foo", s);
+   }
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
+      EXPECT_EQ(file->GetCompressionSettings(), 0);
+   }
+}


### PR DESCRIPTION
Note that `GetCompressionSettings()` is not provided at this time because it has ambiguous semantics and we need to decide if we want to provide it at all.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


