### PR TITLE
[ML] Fix BatchLoader::CreateTrainingBatches resetting wrong secondary buffer

### DIFF
--- a/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx
+++ b/tmva/tmva/inc/TMVA/BatchGenerator/RBatchLoader.hxx
@@ -201,7 +201,7 @@ public:
 
             // reset fPrimaryLeftoverTrainingBatch and fSecondaryLeftoverTrainingBatch
             *fPrimaryLeftoverTrainingBatch = *fSecondaryLeftoverTrainingBatch;
-            fSecondaryLeftoverValidationBatch =
+            fSecondaryLeftoverTrainingBatch =
                std::make_unique<TMVA::Experimental::RTensor<float>>(std::vector<std::size_t>{0, fNumColumns});
          }
       }
@@ -227,11 +227,11 @@ public:
                    fPrimaryLeftoverTrainingBatch->GetData() + (fBatchSize * fNumColumns), copy->GetData());
          batches.emplace_back(std::move(copy));
 
-         // exchange fPrimaryLeftoverTrainingBatch and fSecondaryLeftoverValidationBatch
+         // exchange fPrimaryLeftoverTrainingBatch and fSecondaryLeftoverTrainingBatch
          *fPrimaryLeftoverTrainingBatch = *fSecondaryLeftoverTrainingBatch;
 
-         // reset fSecondaryLeftoverValidationBatch
-         fSecondaryLeftoverValidationBatch =
+         // reset fSecondaryLeftoverTrainingBatch
+         fSecondaryLeftoverTrainingBatch =
             std::make_unique<TMVA::Experimental::RTensor<float>>(std::vector<std::size_t>{0, fNumColumns});
       }
 


### PR DESCRIPTION


# This Pull request:

## Changes or fixes:
`test14_big_data` in `rbatchgenerator_completeness` was sporadically failing across multiple platforms with different errors depending on which random parameters were drawn (for `entries_in_rdf`, `chunk_size` and `batch_size`):
- wrong batch shape at the remainder batch
- missing entries

Both failures are caused by a small bug in `RBatchLoader::CreateTrainingBatches`, which, if we had a overflow in `fPrimaryLeftoverTrainingBatch`, was correctly promoting `fSecondaryLeftoverTrainingBatch` to primary but incorrectly resetting `fSecondaryLeftoverValidationBatch` afterwards (instead of `fSecondaryLeftoverTrainingBatch`), meaning that the training secondary leftover buffer was never cleared and with certain random combinations of parameters would cause issues.

We don't see this in master because the `RBatchLoader` was refactored in #20998


## Checklist:

- [x] tested changes locally

