### PR TITLE
Some cleanups involving GetListOfFiles()

### DIFF
--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -149,13 +149,13 @@ private:
    TBufferMergerFile(TBufferMerger &m);
 
    /** TBufferMergerFile has no default constructor. */
-   TBufferMergerFile();
+   TBufferMergerFile() = delete;
 
    /** TBufferMergerFile has no copy constructor. */
-   TBufferMergerFile(const TBufferMergerFile &);
+   TBufferMergerFile(const TBufferMergerFile &) = delete;
 
    /** TBufferMergerFile has no copy operator */
-   TBufferMergerFile &operator=(const TBufferMergerFile &);
+   TBufferMergerFile &operator=(const TBufferMergerFile &) = delete;
 
    friend class TBufferMerger;
 

--- a/io/io/src/TBufferMerger.cxx
+++ b/io/io/src/TBufferMerger.cxx
@@ -57,7 +57,6 @@ std::shared_ptr<TBufferMergerFile> TBufferMerger::GetFile()
 {
    R__LOCKGUARD(gROOTMutex);
    std::shared_ptr<TBufferMergerFile> f(new TBufferMergerFile(*this));
-   gROOT->GetListOfFiles()->Remove(f.get());
    fAttachedFiles.push_back(f);
    return f;
 }

--- a/io/io/src/TBufferMergerFile.cxx
+++ b/io/io/src/TBufferMergerFile.cxx
@@ -16,15 +16,13 @@
 namespace ROOT {
 
 TBufferMergerFile::TBufferMergerFile(TBufferMerger &m)
-   : TMemFile(m.fMerger.GetOutputFile()->GetName(), "RECREATE", "",
+   : TMemFile(m.fMerger.GetOutputFile()->GetName(), "RECREATE_WITHOUT_GLOBALREGISTRATION", "",
               m.fMerger.GetOutputFile()->GetCompressionSettings()),
      fMerger(m)
 {
 }
 
-TBufferMergerFile::~TBufferMergerFile()
-{
-}
+TBufferMergerFile::~TBufferMergerFile() = default;
 
 Int_t TBufferMergerFile::Write(const char *name, Int_t opt, Int_t bufsize)
 {

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -207,8 +207,7 @@ void TRootSnifferFull::CreateMemFile()
    TDirectory::TContext dirCtx{nullptr};
    TFile::TContext fileCtx{nullptr};
 
-   fMemFile = new TMemFile("dummy.file", "RECREATE");
-   gROOT->GetListOfFiles()->Remove(fMemFile);
+   fMemFile = new TMemFile("dummy.file", "RECREATE_WITHOUT_GLOBALREGISTRATION");
 
    TH1F *d = new TH1F("d", "d", 10, 0, 10);
    fMemFile->WriteObject(d, "h1");
@@ -348,8 +347,7 @@ Bool_t TRootSnifferFull::ProduceRootFile(const std::string &path, const std::str
    } restoreGFile;
 
    {
-      TMemFile memfile("dummy.file", "RECREATE");
-      gROOT->GetListOfFiles()->Remove(&memfile);
+      TMemFile memfile("dummy.file", "RECREATE_WITHOUT_GLOBALREGISTRATION");
 
       memfile.WriteObjectAny(obj_ptr, obj_cl, store_name);
       memfile.Close();

--- a/roottest/root/io/directory/execmanydirs.cxx
+++ b/roottest/root/io/directory/execmanydirs.cxx
@@ -32,9 +32,8 @@ void execmanydirs(int n = 200, int mode = 16 | 32 | 64) {
   }
   // systematics.emplace_back("syst_" + std::to_string(10));
 
-  std::unique_ptr<TFile> out(TFile::Open("example_manydirs.root", "RECREATE"));
-  if (mode & 256)
-    gROOT->GetListOfFiles()->Remove(out.get());
+  const char *const tfileMode = (mode & 256) ? "RECREATE_WITHOUT_GLOBALREGISTRATION" : "RECREATE";
+  std::unique_ptr<TFile> out(TFile::Open("example_manydirs.root", tfileMode));
 
   for (const auto& isample : samples) {
      for (const auto& isystematic : systematics) {

--- a/roottest/root/io/perf/directories.C
+++ b/roottest/root/io/perf/directories.C
@@ -38,25 +38,8 @@ TFile *Create(int ntop, int nsub, int nhist)
 
 void cleanup(TDirectory *dir)
 {
-   // return;
-
    gROOT->GetListOfFiles()->Remove(dir);
-   return;
-
-   TIter nextkey( dir->GetList() );
-
-   TObject *obj;
-   while ( (obj = nextkey())) {
-      if ( obj->IsA()->InheritsFrom( "TDirectory" ) ) {
-         cleanup( (TDirectory*)obj );
-      }
-   }
-   //gROOT->SetMustClean(kFALSE);
-   dir->GetList()->Delete("fast");
-   //delete dir;
-   // dir->GetListOfKeys()->Delete("fast");
 }
-
 
 void test_directories(int ntop, int nsub, int nhist)
 {


### PR DESCRIPTION
Instead of creating a TFile and immediately removing it from the global ListOfFiles, use RECREATE_WITHOUT_GLOBALREGISTRATION to never add it in the first place.

Taking the opportunity to cleanup some nearby code.