### PR TITLE
net/curl: add optional AWS SigV4 authentication support to RCurlConnection

### DIFF
--- a/net/curl/CMakeLists.txt
+++ b/net/curl/CMakeLists.txt
@@ -25,4 +25,7 @@ if(NOT MSVC)
   target_compile_options(RCurlHttp PRIVATE -Wno-deprecated-declarations)
 endif()
 
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)
+add_executable(test_rcurl_tmp test_rcurl_tmp.cxx)
+target_link_libraries(test_rcurl_tmp PRIVATE RCurlHttp)

--- a/net/curl/inc/ROOT/RCurlConnection.hxx
+++ b/net/curl/inc/ROOT/RCurlConnection.hxx
@@ -16,8 +16,11 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
+
+struct curl_slist;
 
 namespace ROOT {
 namespace Internal {
@@ -25,6 +28,12 @@ namespace Internal {
 /// Encapsulates a curl easy handle and provides an interface to send HTTP HEAD and (multi-)range queries.
 class RCurlConnection {
 public:
+   struct RS3Credentials {
+      std::string fAccessKey;
+      std::string fSecretKey;
+      std::string fRegion;
+   };
+
    /// Return value for both HEAD and GET requests. In case of errors, provides the reason for the failure as code
    /// and as message.
    struct RStatus {
@@ -53,10 +62,15 @@ private:
    std::size_t fMaxNRangesPerReqest = 0;
    std::string fEscapedUrl;              ///< The URL provided in the constructor escaped according to standard rules
    std::unique_ptr<char[]> fErrorBuffer; ///< For use by libcurl
+   curl_slist *fHeaders = nullptr;       ///< Optional custom request headers
+   std::optional<RS3Credentials> fS3Credentials; ///< Optional S3 credentials
 
    void SetupErrorBuffer();
    void SetOptions();
    RResult<void> SetUrl(const std::string &url);
+   void ClearHeaders();
+   void AddHeader(const std::string &header);
+   void ApplyHeaders();
    void Perform(RStatus &status);
 
 public:
@@ -92,6 +106,7 @@ public:
 
    const std::string &GetEscapedUrl() const { return fEscapedUrl; }
 
+   void SetS3Credentials(const RS3Credentials &creds);
    void SetMaxNRangesPerRequest(std::size_t val) { fMaxNRangesPerReqest = val; }
    std::size_t GetMaxNRangesPerRequest() const { return fMaxNRangesPerReqest; }
 };

--- a/net/curl/src/RCurlConnection.cxx
+++ b/net/curl/src/RCurlConnection.cxx
@@ -592,6 +592,7 @@ ROOT::Internal::RCurlConnection::RCurlConnection(const std::string &url)
 
 ROOT::Internal::RCurlConnection::~RCurlConnection()
 {
+   ClearHeaders();
    if (fHandle)
       curl_easy_cleanup(fHandle);
 }
@@ -599,6 +600,7 @@ ROOT::Internal::RCurlConnection::~RCurlConnection()
 ROOT::Internal::RCurlConnection::RCurlConnection(RCurlConnection &&other)
 {
    std::swap(fHandle, other.fHandle);
+   std::swap(fHeaders, other.fHeaders);
    SetupErrorBuffer();
 }
 
@@ -606,8 +608,11 @@ ROOT::Internal::RCurlConnection &ROOT::Internal::RCurlConnection::RCurlConnectio
 {
    if (this == &other)
       return *this;
+   ClearHeaders();
    fHandle = other.fHandle;
    other.fHandle = nullptr;
+   fHeaders = other.fHeaders;
+   other.fHeaders = nullptr;
    SetupErrorBuffer();
    return *this;
 }
@@ -673,6 +678,33 @@ ROOT::RResult<void> ROOT::Internal::RCurlConnection::SetUrl(const std::string &u
    return RResult<void>::Success();
 }
 
+void ROOT::Internal::RCurlConnection::ClearHeaders()
+{
+   if (fHandle) {
+      auto rc = curl_easy_setopt(fHandle, CURLOPT_HTTPHEADER, NULL);
+      R__ASSERT(rc == CURLE_OK);
+   }
+   if (fHeaders) {
+      curl_slist_free_all(fHeaders);
+      fHeaders = nullptr;
+   }
+}
+
+void ROOT::Internal::RCurlConnection::AddHeader(const std::string &header)
+{
+   auto *headers = curl_slist_append(fHeaders, header.c_str());
+   if (!headers) {
+      throw RException(R__FAIL("cannot append HTTP header"));
+   }
+   fHeaders = headers;
+}
+
+void ROOT::Internal::RCurlConnection::ApplyHeaders()
+{
+   auto rc = curl_easy_setopt(fHandle, CURLOPT_HTTPHEADER, fHeaders);
+   R__ASSERT(rc == CURLE_OK);
+}
+
 void ROOT::Internal::RCurlConnection::Perform(RStatus &status)
 {
    auto rc = curl_easy_perform(fHandle);
@@ -727,7 +759,26 @@ ROOT::Internal::RCurlConnection::RStatus ROOT::Internal::RCurlConnection::SendHe
 #endif
 
    RStatus status;
+   std::string awsSigv4;
+   std::string userPwd;
+   if (fS3Credentials) {
+      awsSigv4 = "aws:amz:" + fS3Credentials->fRegion + ":s3";
+      rc = curl_easy_setopt(fHandle, CURLOPT_AWS_SIGV4, awsSigv4.c_str());
+      R__ASSERT(rc == CURLE_OK);
+
+      userPwd = fS3Credentials->fAccessKey + ":" + fS3Credentials->fSecretKey;
+      rc = curl_easy_setopt(fHandle, CURLOPT_USERPWD, userPwd.c_str());
+      R__ASSERT(rc == CURLE_OK);
+   }
+   ApplyHeaders();
    Perform(status);
+   if (fS3Credentials) {
+      rc = curl_easy_setopt(fHandle, CURLOPT_AWS_SIGV4, nullptr);
+      R__ASSERT(rc == CURLE_OK);
+      rc = curl_easy_setopt(fHandle, CURLOPT_USERPWD, nullptr);
+      R__ASSERT(rc == CURLE_OK);
+   }
+   ClearHeaders();
    if (status) {
       curl_off_t length = -1;
       rc = curl_easy_getinfo(fHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &length);
@@ -743,6 +794,7 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
 {
    if (N == 0) {
       // Pretend that we submitted a successful request
+      ClearHeaders();
       return RStatus(RStatus::kSuccess);
    }
 
@@ -758,6 +810,7 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
    const auto requestRanges = CreateRequestRanges(ranges, order);
    if (requestRanges.empty()) {
       // In this case, we know that we did not apply any displacements
+      ClearHeaders();
       return RStatus(RStatus::kSuccess);
    }
 
@@ -809,7 +862,26 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
          }
 
          transfer.fResponseCode = 0; // reset HTTP response code for the next request
+         std::string awsSigv4;
+         std::string userPwd;
+         if (fS3Credentials) {
+            awsSigv4 = "aws:amz:" + fS3Credentials->fRegion + ":s3";
+            rc = curl_easy_setopt(fHandle, CURLOPT_AWS_SIGV4, awsSigv4.c_str());
+            R__ASSERT(rc == CURLE_OK);
+
+            userPwd = fS3Credentials->fAccessKey + ":" + fS3Credentials->fSecretKey;
+            rc = curl_easy_setopt(fHandle, CURLOPT_USERPWD, userPwd.c_str());
+            R__ASSERT(rc == CURLE_OK);
+         }
+         ApplyHeaders();
          Perform(status);
+         if (fS3Credentials) {
+            rc = curl_easy_setopt(fHandle, CURLOPT_AWS_SIGV4, nullptr);
+            R__ASSERT(rc == CURLE_OK);
+            rc = curl_easy_setopt(fHandle, CURLOPT_USERPWD, nullptr);
+            R__ASSERT(rc == CURLE_OK);
+         }
+         ClearHeaders();
          if ((status.fStatusCode == RStatus::kTooManyRanges) && (batchSize > 1)) {
             batchSize /= 2;
             tryAgain = true;
@@ -830,4 +902,9 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
    ReverseDisplacements(displacements, ranges, order, static_cast<bool>(status));
 
    return status;
+}
+
+void ROOT::Internal::RCurlConnection::SetS3Credentials(const RS3Credentials &creds)
+{
+   fS3Credentials = creds;
 }


### PR DESCRIPTION
## Summary

Extend `RCurlConnection` to support optional authenticated S3 requests using **AWS Signature Version 4**.

## Implementation

- Added an `RS3Credentials` struct (access key, secret key, region) and a `SetS3Credentials()` setter.
- When credentials are provided, `SendHeadReq()` and `SendRangesReq()` configure libcurl with `CURLOPT_AWS_SIGV4` and `CURLOPT_USERPWD` before each `Perform()` call.
- Both options are reset to `nullptr` immediately after each request to avoid affecting subsequent operations.
- Authentication relies on libcurl's native SigV4 implementation; no manual signing logic is introduced.
- Requests without S3 credentials follow the existing code path and remain unaffected.

## Requirements

- Requires **libcurl ≥ 7.75.0**, which introduced support for `CURLOPT_AWS_SIGV4`.

## Testing

- Compiled ROOT (v6.39.01) from source with the modified implementation.
- Performed a standalone test calling `SendHeadReq()` on `https://example.com` without S3 credentials; the request returned `kSuccess (0)`, confirming that the non-authenticated path remains unchanged.
- Verified that credentials are conditionally applied in both `SendHeadReq()` and `SendRangesReq()`, and that curl authentication options are reset after every `Perform()` call.
- Validated both `SendHeadReq()` and `SendRangesReq()` against a local **MinIO S3-compatible server**.
- A manual `curl` verification confirmed the server returned **HTTP 206 (Partial Content)** for the requested byte range.