### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/graf2d/asimage/src/libAfterImage/libjpeg/jdpostct.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jdpostct.c
@@ -132,6 +132,11 @@ post_process_1pass (j_decompress_ptr cinfo,
   my_post_ptr post = (my_post_ptr) cinfo->post;
   JDIMENSION num_rows, max_rows;
 
+  /* read_and_discard_scanlines may call it with rows "available", but no buffer */
+  if (output_buf == NULL) {
+    return;
+  }
+
   /* Fill the buffer, but not more than what we can dump out in one go. */
   /* Note we rely on the upsampler to detect bottom of image. */
   max_rows = out_rows_avail - *out_row_ctr;

--- a/graf2d/asimage/src/libAfterImage/libjpeg/jquant1.c
+++ b/graf2d/asimage/src/libAfterImage/libjpeg/jquant1.c
@@ -528,6 +528,10 @@ quantize_ord_dither (j_decompress_ptr cinfo, JSAMPARRAY input_buf,
   JDIMENSION col;
   JDIMENSION width = cinfo->output_width;
 
+  if (output_buf == NULL && num_rows) {
+    ERREXIT(cinfo, JERR_BAD_PARAM);
+  }
+
   for (row = 0; row < num_rows; row++) {
     /* Initialize output values to 0 so can process components separately */
     jzero_far((void FAR *) output_buf[row],


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in graf2d/asimage/src/libAfterImage/libjpeg/jdpostct.c which was cloned from libjpeg-turbo/libjpeg-turbo but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2017-15232.

### Proposed Fix
Apply the same patch as the one in libjpeg-turbo/libjpeg-turbo to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2017-15232
https://github.com/libjpeg-turbo/libjpeg-turbo/commit/1ecd9a5729d78518397889a630e3534bd9d963a8