### PR TITLE
[roottest] Assert that an Hbook file is open when testing.

### DIFF
--- a/roottest/root/hist/THbookFile.cxx
+++ b/roottest/root/hist/THbookFile.cxx
@@ -6,6 +6,7 @@
 TEST(THbookFile, ReadTH1)
 {
    THbookFile file("mb4i1.hbook");
+   ASSERT_TRUE(file.IsOpen());
    EXPECT_STREQ(file.GetCurDir(), "//lun10");
    EXPECT_EQ(file.GetListOfKeys()->size(), 9);
 


### PR DESCRIPTION
The test was unconditionally reading the file, but this might fail when it's run from the wrong directory.

