### PR TITLE
[CMake] Remove the netxng variable.

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -167,7 +167,7 @@ else()
   set(useoldwebfile yes)
 endif()
 
-set(buildnetxng ${value${netxng}})
+set(buildnetxng ${value${xrootd}})
 
 set(buildcurl ${value${curl}})
 set(curllibdir ${CURL_LIBRARY_DIR})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1050,11 +1050,6 @@ if(xrootd AND NOT TARGET XRootD::XrdCl)
   set_target_properties(XRootD::XrdUtils PROPERTIES IMPORTED_LOCATION ${XROOTD_UTILS_LIBRARIES})
 endif()
 
-#---check if netxng can be built-------------------------------
-if(xrootd)
-  set(netxng ON)
-endif()
-
 #---make sure non-builtin xrootd is not using builtin_openssl-----------
 if(xrootd AND NOT builtin_xrootd AND builtin_openssl)
   if(fail-on-missing)

--- a/net/CMakeLists.txt
+++ b/net/CMakeLists.txt
@@ -19,7 +19,7 @@ if(curl)
    add_subdirectory(curl)
 endif()
 
-if(netxng)
+if(xrootd)
    add_subdirectory(netxng)
 endif()
 


### PR DESCRIPTION
This variable is always equal to xrootd, so it was redundant.