### PR TITLE
[tmva][sofie] Remove ConvertShapeToString and ConvertDynamicShapeToLength

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicBinary.hxx
@@ -127,10 +127,10 @@ public:
       }
       if (dynamicInputs & 1 && model.Verbose())
          std::cout << BinaryOperatorTrait<T, Op>::Name() << " : input " << fNA << " is dynamic "
-                   << ConvertShapeToString(fDimShapeA) << std::endl;
+                   << ConvertDimShapeToString(fDimShapeA) << std::endl;
       if (dynamicInputs & 2 && model.Verbose())
          std::cout << BinaryOperatorTrait<T, Op>::Name() << " : input " << fNB << " is dynamic "
-                   << ConvertShapeToString(fDimShapeB) << std::endl;
+                   << ConvertDimShapeToString(fDimShapeB) << std::endl;
 
       // check if need to broadcast at initialization time if shapes are known and different
       // (we could broadcast the tensor tensor to maximum values of dynamic shapes - to be done)
@@ -259,8 +259,8 @@ public:
 
          model.AddIntermediateTensor(fNY, model.GetTensorType(fNA), fDimShapeY);
          if (model.Verbose()) {
-            std::cout << BinaryOperatorTrait<T, Op>::Name() << " : " << ConvertShapeToString(fDimShapeA) << " , "
-                      << ConvertShapeToString(fDimShapeB) << " --> " << ConvertShapeToString(fDimShapeY) << std::endl;
+            std::cout << BinaryOperatorTrait<T, Op>::Name() << " : " << ConvertDimShapeToString(fDimShapeA) << " , "
+                      << ConvertDimShapeToString(fDimShapeB) << " --> " << ConvertDimShapeToString(fDimShapeY) << std::endl;
          }
       }
    }

--- a/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicNary.hxx
@@ -194,9 +194,9 @@ public:
       if (model.Verbose()) {
          std::cout << NaryOperatorTraits<T, Op>::Name() << " : ";
          if (fNInputs.size() == 2)
-            std::cout << ConvertShapeToString(fShapeInputs[0]) << " , "
-                      << ConvertShapeToString(fShapeInputs[1]);
-         std::cout << " --> " << ConvertShapeToString(fDimShapeY) << std::endl;
+            std::cout << ConvertDimShapeToString(fShapeInputs[0]) << " , "
+                      << ConvertDimShapeToString(fShapeInputs[1]);
+         std::cout << " --> " << ConvertDimShapeToString(fDimShapeY) << std::endl;
       }
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BatchNormalization.hxx
@@ -111,7 +111,7 @@ public:
 
       if (fShapeX.size() <  2 || fShapeX.size() > 4) {
          throw
-            std::runtime_error("TMVA SOFIE BatchNormalization Op input tensor " + fNX + " fnx has wrong shape : " + ConvertShapeToString(fShapeX));
+            std::runtime_error("TMVA SOFIE BatchNormalization Op input tensor " + fNX + " fnx has wrong shape : " + ConvertDimShapeToString(fShapeX));
       }
 
       fShapeY = fShapeX;

--- a/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Comparision.hxx
@@ -276,9 +276,9 @@ public:
 
          model.AddIntermediateTensor(fNY, ETensorType::BOOL, fDimShapeY);
          if (model.Verbose()) {
-            std::cout << ComparisionTrait<T, Op>::Name()  << " : " << fNX1 << "  " << ConvertShapeToString(fDimShapeX1) << " , "
-                                                          << fNX2 << "  " << ConvertShapeToString(fDimShapeX2) << " --> "
-                                                          << fNY  << "  " << ConvertShapeToString(fDimShapeY) << std::endl;
+            std::cout << ComparisionTrait<T, Op>::Name()  << " : " << fNX1 << "  " << ConvertDimShapeToString(fDimShapeX1) << " , "
+                                                          << fNX2 << "  " << ConvertDimShapeToString(fDimShapeX2) << " --> "
+                                                          << fNY  << "  " << ConvertDimShapeToString(fDimShapeY) << std::endl;
             model.PrintIntermediateTensors();
          }
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Concat.hxx
@@ -115,7 +115,7 @@
                for (size_t i = 0; i < inputs.size(); i++) {
                   if (i > 0 && inputs[i].size() != inputs[i - 1].size())
                      throw std::runtime_error("TMVA SOFIE Concat Op - input tensors have different shapes " + fInputs[i] + " : " +
-                                              ConvertShapeToString(inputs[i]) + " and " + fInputs[i-1] + " : " + ConvertShapeToString(inputs[i - 1]));
+                                              ConvertDimShapeToString(inputs[i]) + " and " + fInputs[i-1] + " : " + ConvertDimShapeToString(inputs[i - 1]));
                   for (size_t iaxis = 0; iaxis < inputs[i].size(); iaxis++) {
                      if ((int)iaxis == fAxis) {
                         // support both integer and params shape for the concatenation axis
@@ -134,8 +134,8 @@
                      }
                      else if ((!inputs[i][iaxis].isParam && !ret[iaxis].isParam) && (inputs[i][iaxis].dim != ret[iaxis].dim)) {
                         throw std::runtime_error("TMVA SOFIE Concat Op - input tensors have wrong shapes " +
-                                                 ConvertShapeToString(inputs[i]) + " and " +
-                                                 ConvertShapeToString(inputs[i - 1]));
+                                                 ConvertDimShapeToString(inputs[i]) + " and " +
+                                                 ConvertDimShapeToString(inputs[i - 1]));
                      }
                      else if (!inputs[i][iaxis].isParam && ret[iaxis].isParam){
                         // if shape is not parametric use it
@@ -240,7 +240,7 @@
                   model.AddShapeTensor(fOutput,outputData, false); // cannot be a  scalar
                   if (model.Verbose()) {
                      std::cout << "output of Concat is a shape tensor " << ConvertShapeToString(outputShape) << " : "
-                     << ConvertShapeToString(outputData) << " (shape)" <<  std::endl;
+                     << ConvertDimShapeToString(outputData) << " (shape)" <<  std::endl;
                   }
                   fIsOutputConstant = true;
                }
@@ -256,7 +256,7 @@
          std::string Generate(std::string opName) override {
             opName = "op_" + opName;
             std::stringstream out;
-            out<<"\n//--------- Concat " << opName << " --> " << fOutput << "  " << ConvertShapeToString(fOutputShape) << "\n";
+            out<<"\n//--------- Concat " << opName << " --> " << fOutput << "  " << ConvertDimShapeToString(fOutputShape) << "\n";
 
             if (fIsOutputConstant) return out.str();
 

--- a/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Constant.hxx
@@ -141,15 +141,15 @@ public:
       std::stringstream out;
       if (fIsOutputConstant) {
          if (fNX.empty())
-            out <<  "// ---- Constant (no-op) " << opName << " --> " << fNY << " " << ConvertShapeToString(fDimOutputShape) << "\n";
+            out <<  "// ---- Constant (no-op) " << opName << " --> " << fNY << " " << ConvertDimShapeToString(fDimOutputShape) << "\n";
          else
-            out << "// ---- ConstantOfShape (no-op) " << opName << " --> " << fNY << " " << ConvertShapeToString(fDimOutputShape) << "\n";
+            out << "// ---- ConstantOfShape (no-op) " << opName << " --> " << fNY << " " << ConvertDimShapeToString(fDimOutputShape) << "\n";
          return out.str();
       }
       // Only ConstantOfShape might require generation code
       // generate constant tensor according to input
 
-      out << "\n//--------- ConstantOfShape " << opName << " --> " << ConvertShapeToString(fDimOutputShape) << "\n";
+      out << "\n//--------- ConstantOfShape " << opName << " --> " << ConvertDimShapeToString(fDimOutputShape) << "\n";
        // set shape values if needed
       if (fIsUndefinedInputShape) {
          for (size_t i = 0; i < fDimOutputShape.size(); i++) {

--- a/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Conv.hxx
@@ -241,7 +241,7 @@ public:
       }
       fShapeX = model.GetDimTensorShape(fNX);
       if (fShapeX.size() < 3 || fShapeX.size()  > 5) {
-         std::cout << fNX << " : " << ConvertShapeToString(fShapeX) << std::endl;
+         std::cout << fNX << " : " << ConvertDimShapeToString(fShapeX) << std::endl;
          throw
             std::runtime_error("TMVA SOFIE Conv Op input data tensor" + fNX + " is not of 3,4 or 5 dimensions");
       }
@@ -325,8 +325,8 @@ public:
       fInputTensorNames.emplace_back(imcol);
 
       if (model.Verbose()) {
-         std::cout << "Conv - " << fDim << "  " << fNX << " : " << ConvertShapeToString(fShapeX)
-                  << " --> " << fNY << " : " << ConvertShapeToString(fShapeY) << std::endl;
+         std::cout << "Conv - " << fDim << "  " << fNX << " : " << ConvertDimShapeToString(fShapeX)
+                  << " --> " << fNY << " : " << ConvertDimShapeToString(fShapeY) << std::endl;
       }
    }
 
@@ -348,7 +348,7 @@ public:
          else
             out << SP << "{\n";
          out << SP << SP << "float * data = TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast(tensor_"
-             << fNB << ", " << ConvertShapeToString(shape) << ", " << ConvertShapeToString(fShapeY) << ");\n";
+             << fNB << ", " << ConvertShapeToString(shape) << ", " << ConvertDimShapeToString(fShapeY) << ");\n";
          out << SP << SP << "fTensor_" << fNB << ".resize(" << length << ");\n";
          out << SP << SP << "std::copy(data, data + " << length << ", fTensor_" << fNB << ".begin());\n";
          out << SP << SP << "tensor_" << fNB << " = fTensor_" << fNB << ".data();\n";

--- a/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Expand.hxx
@@ -120,8 +120,8 @@ public:
       }
       fType = ConvertTypeToString(model.GetTensorType(fNX));
       if (model.Verbose()) {
-         std::cout << "Expand - input " << fNX << " shape " << ConvertShapeToString(fShapeX) << " --> " << fNY << " shape "
-                  << ConvertShapeToString(fShapeY) << (fIsOutputConstant ? ConvertValuesToString(model.GetTensorData<T>(fNY)) + " (constant)" : "") << std::endl;
+         std::cout << "Expand - input " << fNX << " shape " << ConvertDimShapeToString(fShapeX) << " --> " << fNY << " shape "
+                  << ConvertDimShapeToString(fShapeY) << (fIsOutputConstant ? ConvertValuesToString(model.GetTensorData<T>(fNY)) + " (constant)" : "") << std::endl;
       }
    }
 
@@ -143,7 +143,7 @@ public:
          throw std::runtime_error("TMVA SOFIE Expand Op called to Generate without being initialized first");
       }
       std::stringstream out;
-      out << SP << "\n//------ Expand " << opName << " --> " << ConvertShapeToString(fShapeY) << "\n";
+      out << SP << "\n//------ Expand " << opName << " --> " << ConvertDimShapeToString(fShapeY) << "\n";
       // need to declare shape parameters for non initialized shapes
       if (!fInitializedShape) {
          for (size_t i = 0; i < fShapeDim.size(); i++) {
@@ -153,7 +153,7 @@ public:
       // No need to broadcast A if it's an initialized tensor or shapes are the same
       if (!fInitialized && fShapeX != fShapeY) {
          out << SP << "// Broadcasting uninitialized tensor " << fNX << "\n";
-         out << SP << "TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast(tensor_" << fNX << ", " << ConvertShapeToString(fShapeX) << ", " << ConvertShapeToString(fShapeY)
+         out << SP << "TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast(tensor_" << fNX << ", " << ConvertDimShapeToString(fShapeX) << ", " << ConvertDimShapeToString(fShapeY)
                    << ", tensor_"<<fNY<<");\n";
       }
       return out.str();

--- a/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gather.hxx
@@ -54,8 +54,8 @@ public:
       }
       fShapeX = model.GetDimTensorShape(fNX);
       if (model.Verbose())
-         std::cout << "Gather - initial shape " << ConvertShapeToString(fShapeX) << " shape of indices "
-               << ConvertShapeToString(model.GetDimTensorShape(fNIndices)) << std::endl;
+         std::cout << "Gather - initial shape " << ConvertDimShapeToString(fShapeX) << " shape of indices "
+               << ConvertDimShapeToString(model.GetDimTensorShape(fNIndices)) << std::endl;
       //  fShapeIndices can be  dynamic
       fShapeIndices = model.GetDimTensorShape(fNIndices);
       size_t q = fShapeIndices.size();
@@ -86,7 +86,7 @@ public:
       }
       // Output shape
       if (model.Verbose())
-         std::cout << "Gather: q and r " << q << " " << r << " shape indices " << ConvertShapeToString(fShapeIndices) << std::endl;
+         std::cout << "Gather: q and r " << q << " " << r << " shape indices " << ConvertDimShapeToString(fShapeIndices) << std::endl;
 
       if (fShapeY.empty()) {
          fShapeY.resize(q + r - 1);
@@ -128,15 +128,15 @@ public:
             // shapeY can be scalar or vector of size1
             model.AddShapeTensor(fNY, outputData, fShapeY.size() == 0);
             if (model.Verbose())
-               std::cout << "Gather: " << fNX << " " << ConvertShapeToString(fShapeX) << " -> " << fNY << " with shape " << ConvertShapeToString(fShapeY)
-                   << " and values " << ConvertShapeToString(outputData) << " (shape) " << std::endl;
+               std::cout << "Gather: " << fNX << " " << ConvertDimShapeToString(fShapeX) << " -> " << fNY << " with shape " << ConvertDimShapeToString(fShapeY)
+                   << " and values " << ConvertDimShapeToString(outputData) << " (shape) " << std::endl;
          } else {
             int64_t value = static_cast<int64_t>(outputData[0].dim);
             auto shapeY = ConvertShapeToInt(fShapeY);
             model.AddConstantTensor(fNY, shapeY, &value);
             fIsOutputConstant = true;
             if (model.Verbose())
-               std::cout << "Gather: " << fNX << " " << ConvertShapeToString(fShapeX) << " -> " << fNY << " with shape " << ConvertShapeToString(fShapeY)
+               std::cout << "Gather: " << fNX << " " << ConvertDimShapeToString(fShapeX) << " -> " << fNY << " with shape " << ConvertDimShapeToString(fShapeY)
                    << " and values {" << value <<  "} (constant) " << std::endl;
          }
       }
@@ -145,15 +145,15 @@ public:
          model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShapeY);
          fType = ConvertTypeToString(model.GetTensorType(fNX));
          if (model.Verbose())
-               std::cout <<  "Gather: input " << fNX << " " << ConvertShapeToString(fShapeX) << " indices " << fNIndices << ConvertShapeToString(fShapeIndices)
-                         << " -> " << fNY << " with shape " << ConvertShapeToString(fShapeY) << std::endl;
+               std::cout <<  "Gather: input " << fNX << " " << ConvertDimShapeToString(fShapeX) << " indices " << fNIndices << ConvertDimShapeToString(fShapeIndices)
+                         << " -> " << fNY << " with shape " << ConvertDimShapeToString(fShapeY) << std::endl;
       }
    }
 
    std::string Generate(std::string opName) override {
       opName = "op_" + opName;
       std::stringstream out;
-      out << "//--------- Gather " << opName << " --> " << fNY << "  " << ConvertShapeToString(fShapeY) << "\n";
+      out << "//--------- Gather " << opName << " --> " << fNY << "  " << ConvertDimShapeToString(fShapeY) << "\n";
       if (fIsOutputConstant) {
          // no code to generate here for constant output. Tensor output is defined in Session constructor
          out << "//--------------------(constant)----------\n";

--- a/tmva/sofie/inc/TMVA/ROperator_GatherND.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_GatherND.hxx
@@ -44,8 +44,8 @@ public:
       }
       fShapeX = model.GetDimTensorShape(fNX);
       if (model.Verbose())
-         std::cout << "GatherND - initial shape " << ConvertShapeToString(fShapeX) << " shape of indices "
-               << ConvertShapeToString(model.GetDimTensorShape(fNIndices)) << std::endl;
+         std::cout << "GatherND - initial shape " << ConvertDimShapeToString(fShapeX) << " shape of indices "
+               << ConvertDimShapeToString(model.GetDimTensorShape(fNIndices)) << std::endl;
       //  fShapeIndices can be  dynamic
       fShapeIndices = model.GetDimTensorShape(fNIndices);
       size_t q = fShapeIndices.size();
@@ -64,8 +64,8 @@ public:
       if (fBatchDims > 0) {
          for (size_t i = 0; i < fBatchDims; i++) {
             if (fShapeX[i] != fShapeIndices[i]) {
-               std::cout << " input shape " << ConvertShapeToString(fShapeX) << " "
-                         << " index shape " << ConvertShapeToString(fShapeIndices) << std::endl;
+               std::cout << " input shape " << ConvertDimShapeToString(fShapeX) << " "
+                         << " index shape " << ConvertDimShapeToString(fShapeIndices) << std::endl;
                throw std::runtime_error("TMVA SOFIE GatherND : invalid input or index shape for " + std::to_string(i));
             }
          }
@@ -89,9 +89,9 @@ public:
       fShapeY = std::vector<Dim>(fShapeIndices.begin(), fShapeIndices.end() - 1);
       fShapeY.insert(fShapeY.end(), fShapeX.begin() + fBatchDims + last_index_shape, fShapeX.end());
       if (fShapeY.size() != output_rank) {
-         std::cout << " input shape " << ConvertShapeToString(fShapeX) << " "
-                         << " index shape " << ConvertShapeToString(fShapeIndices)
-                         << " output shape " << ConvertShapeToString(fShapeY)
+         std::cout << " input shape " << ConvertDimShapeToString(fShapeX) << " "
+                         << " index shape " << ConvertDimShapeToString(fShapeIndices)
+                         << " output shape " << ConvertDimShapeToString(fShapeY)
                          << " and output rank should be " << output_rank << std::endl;
          throw std::runtime_error("TMVA SOFIE GatherND : Something is wrong in initialization ");
       }
@@ -101,8 +101,8 @@ public:
          model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShapeY);
          fType = ConvertTypeToString(model.GetTensorType(fNX));
          if (model.Verbose())
-               std::cout <<  "GatherND: input " << fNX << " " << ConvertShapeToString(fShapeX) << " indices " << fNIndices << ConvertShapeToString(fShapeIndices)
-                         << " -> " << fNY << " with shape " << ConvertShapeToString(fShapeY) << std::endl;
+               std::cout <<  "GatherND: input " << fNX << " " << ConvertDimShapeToString(fShapeX) << " indices " << fNIndices << ConvertDimShapeToString(fShapeIndices)
+                         << " -> " << fNY << " with shape " << ConvertDimShapeToString(fShapeY) << std::endl;
       }
 
 
@@ -176,7 +176,7 @@ public:
       }
       opName = "op_" + opName;
       std::stringstream out;
-      out << "//--------- GatherND " << opName << " --> " << ConvertShapeToString(fShapeY) << "\n";
+      out << "//--------- GatherND " << opName << " --> " << ConvertDimShapeToString(fShapeY) << "\n";
       // The shape of the output is q + r - 1
       size_t r = fShapeX.size();
       // Indices of shape q

--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -264,7 +264,7 @@ namespace SOFIE{
          if (model.Verbose()){
             std::cout << "Gemm (or MatMul) " << " ---> " << fNY << " shape ";
             if (fIsDynamic)
-               std::cout << ConvertShapeToString(fShapeY) << std::endl;
+               std::cout << ConvertDimShapeToString(fShapeY) << std::endl;
             else
                std::cout << ConvertShapeToString(shapeY) << std::endl;
          }
@@ -279,8 +279,8 @@ namespace SOFIE{
             throw std::runtime_error("TMVA SOFIE Gemm Op called to Generate without being initialized first");
          }
          std::stringstream out;
-         out << "\n//--------- Gemm " << opName << " " << ConvertShapeToString(fShapeA) << " * " << ConvertShapeToString(fShapeB)
-             << " -> " << ConvertShapeToString(fShapeY) << "\n";
+         out << "\n//--------- Gemm " << opName << " " << ConvertDimShapeToString(fShapeA) << " * " << ConvertDimShapeToString(fShapeB)
+             << " -> " << ConvertDimShapeToString(fShapeY) << "\n";
          // need to consider case A and B have dim > 2 (for MatMul)
          int64_t dimA = fShapeA.size();
          int64_t dimB = fShapeB.size();

--- a/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_LayerNormalization.hxx
@@ -178,7 +178,7 @@ public:
          out << SP << "// Broadcasting the bias of LayerNormalization op\n";
          out << SP << "{\n";
          out << SP << SP << "float* data = TMVA::Experimental::SOFIE::UTILITY::UnidirectionalBroadcast(tensor_";
-         out << fNB << ", " << ConvertShapeToString(fShapeB) << ", " << ConvertShapeToString(fShapeX) << ");\n";
+         out << fNB << ", " << ConvertDimShapeToString(fShapeB) << ", " << ConvertDimShapeToString(fShapeX) << ");\n";
          out << SP << "std::copy(data, data + " << fLength << ", tensor_" << fNBroadcastedB << ");\n";
          out << SP << "delete[] data;\n";
          out << SP << "}\n";

--- a/tmva/sofie/inc/TMVA/ROperator_NonZero.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_NonZero.hxx
@@ -97,7 +97,7 @@ public:
 
          model.AddIntermediateTensor(fNY, ETensorType::INT64, fShapeY);
          if (model.Verbose()) {
-            std::cout << "NonZero : " << fNX << " -> " << fNY << " " << ConvertShapeToString(fShapeY) << std::endl;
+            std::cout << "NonZero : " << fNX << " -> " << fNY << " " << ConvertDimShapeToString(fShapeY) << std::endl;
          }
       }
    }

--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -142,7 +142,7 @@ public:
 
 
       if (model.Verbose()) {
-         std::cout << "Range -> output is " << fNOutput << " : " << ConvertShapeToString(fShape);
+         std::cout << "Range -> output is " << fNOutput << " : " << ConvertDimShapeToString(fShape);
          if (fIsOutputConstant) std::cout << " : " << ConvertValuesToString(model.GetTensorData<T>(fNOutput));
          std::cout << std::endl;
       }

--- a/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
@@ -113,7 +113,7 @@ public:
       fShapeY = DoShapeInference(fShapeX);
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShapeY);
       if (model.Verbose()){
-         std::cout << Name() << " : " << fNX << " -> " << fNY << " shape " << ConvertShapeToString(fShapeY) << std::endl;
+         std::cout << Name() << " : " << fNX << " -> " << fNY << " shape " << ConvertDimShapeToString(fShapeY) << std::endl;
       }
       model.AddNeededStdLib("algorithm");
    }

--- a/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Relu.hxx
@@ -47,7 +47,7 @@ public:
 
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShape);
       if (model.Verbose()) {
-         std::cout << "Relu : " << fNX << " -> " << fNY << " " << ConvertShapeToString(fShape) << std::endl;
+         std::cout << "Relu : " << fNX << " -> " << fNY << " " << ConvertDimShapeToString(fShape) << std::endl;
       }
    }
 
@@ -58,7 +58,7 @@ public:
          throw std::runtime_error("TMVA SOFIE Operator Relu called to Generate without being initialized first");
       }
       std::stringstream out;
-      auto length = ConvertDynamicShapeToLength(fShape);
+      auto length = ConvertDimShapeToLength(fShape);
       out << "\n//------ RELU\n";
       out << SP << "for (int id = 0; id < " << length << " ; id++){\n";
       out << SP << SP << "tensor_" << fNY << "[id] = ((tensor_" << fNX << "[id] > 0 )? tensor_" << fNX << "[id] : 0);\n";

--- a/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reshape.hxx
@@ -168,11 +168,11 @@ public:
          }
 
          if (fVerbose)
-            std::cout << "Reshape: correct output shape  to " << ConvertShapeToString(output_shape) << std::endl;
+            std::cout << "Reshape: correct output shape  to " << ConvertDimShapeToString(output_shape) << std::endl;
 
          if (!fDimInput && ConvertDimShapeToLength(output_shape) != ConvertDimShapeToLength(input_shape)) {
-            throw std::runtime_error("TMVA Reshape Op : Invalid  shapes : " + ConvertShapeToString(input_shape) +
-                                     ConvertShapeToString(output_shape));
+            throw std::runtime_error("TMVA Reshape Op : Invalid  shapes : " + ConvertDimShapeToString(input_shape) +
+                                     ConvertDimShapeToString(output_shape));
          }
          ret.push_back(output_shape);
 
@@ -208,7 +208,7 @@ public:
                   axes[i] += input_shape.size();
                if (!(output_shape[axes[i]] == Dim{1}))
                   throw std::runtime_error("TMVA Squeeze Op : Invalid  axis value " + std::to_string(axes[i]) +
-                                           " for " + ConvertShapeToString(output_shape));
+                                           " for " + ConvertDimShapeToString(output_shape));
             }
             // for calling vector::erase we must sort axes in decreasing order to avoid
             std::sort(axes.begin(), axes.end(), std::greater<int>());
@@ -310,7 +310,7 @@ public:
             throw std::runtime_error("TMVA Reshape Op : Invalid Input/Output lengths");
          model.AddConstantTensor<int64_t>(fNOutput, o_shape, inputData);
          if (model.Verbose()) {
-            std::cout << Name() << " : " << fNData << " " << ConvertShapeToString(fShapeInput) << " -->  " << fNOutput << " (constant) " << ConvertShapeToString(fShapeOutput)  << " : " <<
+            std::cout << Name() << " : " << fNData << " " << ConvertDimShapeToString(fShapeInput) << " -->  " << fNOutput << " (constant) " << ConvertDimShapeToString(fShapeOutput)  << " : " <<
             ConvertValuesToString(ConvertShapeToLength(o_shape), inputData) << std::endl;
          }
       }
@@ -320,15 +320,15 @@ public:
          auto inputData = model.GetShapeTensorValues(fNData);
          model.AddShapeTensor(fNOutput, inputData);
          if (model.Verbose()) {
-            std::cout << Name() << " : " << fNData << " " << ConvertShapeToString(fShapeInput) << " -->  " << fNOutput << " (shape) " << ConvertShapeToString(fShapeOutput)  << " : " <<
-            ConvertShapeToString(inputData) << std::endl;
+            std::cout << Name() << " : " << fNData << " " << ConvertDimShapeToString(fShapeInput) << " -->  " << fNOutput << " (shape) " << ConvertDimShapeToString(fShapeOutput)  << " : " <<
+            ConvertDimShapeToString(inputData) << std::endl;
          }
       }
       else {
          // non-constant case
          model.AddIntermediateTensor(fNOutput, model.GetTensorType(fNData), fShapeOutput);
          if (model.Verbose())
-            std::cout << Name() << " : " << fNData << " " << ConvertShapeToString(fShapeInput) << " -->  "<< fNOutput << "  " << ConvertShapeToString(fShapeOutput)  << std::endl;
+            std::cout << Name() << " : " << fNData << " " << ConvertDimShapeToString(fShapeInput) << " -->  "<< fNOutput << "  " << ConvertDimShapeToString(fShapeOutput)  << std::endl;
       }
    }
 
@@ -344,7 +344,7 @@ public:
       else if (fOpMode == Unsqueeze)
          opType = "Unsquueze";
 
-      out << SP << "///--------" << opType << " operator " << opName << " --> " << ConvertShapeToString(fShapeOutput) << "\n";
+      out << SP << "///--------" << opType << " operator " << opName << " --> " << ConvertDimShapeToString(fShapeOutput) << "\n";
 
       // in case of dynamic output shape we need to set the shape value from input shape tensor
       // and take case of the zero values

--- a/tmva/sofie/inc/TMVA/ROperator_ScatterElements.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_ScatterElements.hxx
@@ -78,9 +78,9 @@ public:
       fShapeI = model.GetDimTensorShape(fNI);
       auto shapeU = model.GetDimTensorShape(fNU);
       if (model.Verbose()) {
-         std::cout << "ScatterElements: input: " << ConvertShapeToString(fShapeX)
-                                                << " indices " << ConvertShapeToString(fShapeI)
-                                                << " update " <<  ConvertShapeToString(shapeU) << std::endl;
+         std::cout << "ScatterElements: input: " << ConvertDimShapeToString(fShapeX)
+                                                << " indices " << ConvertDimShapeToString(fShapeI)
+                                                << " update " <<  ConvertDimShapeToString(shapeU) << std::endl;
       }
       if (!model.IsDynamicTensor(fNI) && !model.IsDynamicTensor(fNU)) {
          if (shapeU != fShapeI)

--- a/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Slice.hxx
@@ -328,7 +328,7 @@ public:
 
          model.AddConstantTensor<int64_t>(fNOutput, ConvertShapeToInt(fShapeOutput), outputData.data());
          if (model.Verbose()) {
-            std::cout << "Slice: output is a constant tensor " << ConvertShapeToString(fShapeOutput) << " : "
+            std::cout << "Slice: output is a constant tensor " << ConvertDimShapeToString(fShapeOutput) << " : "
                      << ConvertValuesToString(outputData) << std::endl;
          }
       }
@@ -349,8 +349,8 @@ public:
          if (fIdentitySlice)  model.AddAliasTensor(fNOutput, fNData);
 
          if (model.Verbose()) {
-            std::cout << "Slice " << fNData << "  " << ConvertShapeToString(fShapeInput)
-                      << "---> " << fNOutput << " " <<  ConvertShapeToString(fShapeOutput);
+            std::cout << "Slice " << fNData << "  " << ConvertDimShapeToString(fShapeInput)
+                      << "---> " << fNOutput << " " <<  ConvertDimShapeToString(fShapeOutput);
             if (fIdentitySlice) std::cout << " (using alias tensor since slice is an identity) ";
             std::cout << std::endl;
 

--- a/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Softmax.hxx
@@ -51,7 +51,7 @@ public:
       model.AddIntermediateTensor(fNY, model.GetTensorType(fNX), fShape);
       fType = ConvertTypeToString(model.GetTensorType(fNX));
       if (model.Verbose()) {
-         std::cout << "Softmax -> " << fNY << " " << ConvertShapeToString(fShape) << std::endl;
+         std::cout << "Softmax -> " << fNY << " " << ConvertDimShapeToString(fShape) << std::endl;
       }
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_Split.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Split.hxx
@@ -106,9 +106,9 @@ public:
 
 
       if (model.Verbose()) {
-         std::cout << "Split - input shape " << ConvertShapeToString(fInputShape) << " --> ";
+         std::cout << "Split - input shape " << ConvertDimShapeToString(fInputShape) << " --> ";
          for (auto & s : fOutputShapes)
-            std::cout << ConvertShapeToString(s) << "  ";
+            std::cout << ConvertDimShapeToString(s) << "  ";
          std::cout << std::endl;
       }
    }

--- a/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_TopK.hxx
@@ -84,8 +84,8 @@ public:
       fType = ConvertTypeToString(model.GetTensorType(fNX));
 
       if (model.Verbose()) {
-         std::cout << "TopK " << fNX << "  " << ConvertShapeToString(fShapeX)
-                      << "---> " << fNVal << " " <<  ConvertShapeToString(fShapeY) << std::endl;
+         std::cout << "TopK " << fNX << "  " << ConvertDimShapeToString(fShapeX)
+                      << "---> " << fNVal << " " <<  ConvertDimShapeToString(fShapeY) << std::endl;
       }
    }
 

--- a/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
@@ -119,7 +119,7 @@ public:
       } else {
          model.AddIntermediateTensor(fNOutput, model.GetTensorType(fNData), fShapeOutput);
          if (model.Verbose()) {
-            std::cout << "Transpose ---> " << fNOutput << " " <<  ConvertShapeToString(fShapeOutput) << std::endl;
+            std::cout << "Transpose ---> " << fNOutput << " " <<  ConvertDimShapeToString(fShapeOutput) << std::endl;
          }
       }
    }

--- a/tmva/sofie/inc/TMVA/ROperator_Where.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Where.hxx
@@ -219,7 +219,7 @@ public:
          }
          if (fIsOutputConstant && model.Verbose())
             std::cout << "Where op ---> " << fNY << "  " << ConvertShapeToString(fShapeY) << " : "
-               << ((dataY.size() > 0) ? ConvertValuesToString(dataY) : ConvertShapeToString(shapeDataY) )
+               << ((dataY.size() > 0) ? ConvertValuesToString(dataY) : ConvertDimShapeToString(shapeDataY) )
                << ((dataY.size() > 0) ? " (constant)" : " (shape)") << std::endl;
 
          // output is a constant tensor

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -208,12 +208,8 @@ std::size_t ConvertShapeToLength(const std::vector<size_t> & shape);
 
 std::string ConvertShapeToString(const std::vector<size_t> & shape);
 std::string ConvertDimShapeToString(const std::vector<Dim> & shape);
-std::string ConvertShapeToString(const std::vector<Dim> & shape);
-
-
 
 std::string ConvertDimShapeToLength(const std::vector<Dim> & shape);
-std::string ConvertDynamicShapeToLength(const std::vector<Dim> & shape);
 
 
 template<class T>

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -573,7 +573,7 @@ void RModel::Initialize(const std::map<std::string, size_t> & inputParams, bool 
       auto shape = ConvertShapeToInt(input.second.shape);
       if (verbose)
          std::cout << "converting input shape for " << input.first << " " << ConvertShapeToString(shape) << " from "
-            << ConvertShapeToString(input.second.shape) << std::endl;
+            << ConvertDimShapeToString(input.second.shape) << std::endl;
       if (!shape.empty()) {
          // case shape is defined (not parametric) we add the tensor in the fReadyInputTensorInfos map and
          // we remove the tensor from the fInputTensorInfo where th eold parametric shape was stored
@@ -1572,7 +1572,7 @@ void RModel::PrintOutputTensors() const {
         std::cout << "Tensor name: \"" << it << "\"\t";
         try {
          auto shape = GetDimTensorShape(it);
-         std::cout << "with shape: " << ConvertShapeToString(shape) << std::endl;
+         std::cout << "with shape: " << ConvertDimShapeToString(shape) << std::endl;
         } catch (...) {
           std::cout << "with shape not yet defined" << std::endl;
         }

--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -169,12 +169,6 @@ std::string ConvertDimShapeToLength(const std::vector<Dim> & shape) {
    }
    return length;
 }
-std::string ConvertShapeToString(const std::vector<Dim> & shape) {
-   return ConvertDimShapeToString(shape);
-}
-std::string ConvertDynamicShapeToLength(const std::vector<Dim> & shape) {
-   return ConvertDimShapeToLength(shape);
-}
 
 
 namespace{


### PR DESCRIPTION
Remove the redundant `ConvertShapeToString` and
`ConvertDynamicShapeToLength` functions, because there are alternatives
with more expressive names: `ConvertDimShapeToString` and
`ConvertDimShapeToLength`. Having the same functions with different
names is just confusing.