### PR TITLE
[tmva][sofie] Don't allocate small constant vectors on the stack

### DIFF
--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -697,33 +697,26 @@ std::string GenerateConstantTensorCode(const std::pair<std::string, InitializedT
    std::stringstream strs;
    std::string type = ConvertTypeToString(t.second.type());
    size_t length = ConvertShapeToLength(t.second.shape());
-   // avoid using stack sizes for constant tensors to reduce compilation time
-   // also for weights which can be broadcasted do not use stack but allocate as a std::vector
-   bool allocateOnStack = (length > 100 || t.second.IsWeightTensor()) ? false : true;
 
    const T *data = t.second.data<T>();
 
    // and check if all values are the same
    bool sameData = false;
    // for non stack allocation check if data are the same
-   if (!allocateOnStack && length > 1) {
+   if (length > 1) {
       size_t idx = 1;
       do {
          sameData = (data[idx] == data[idx - 1]);
          idx++;
       } while (sameData && idx < length);
    }
-   if (allocateOnStack) {
-      strs << type << " tensor_" << t.first << "[" << length << "] = " << ConvertValuesToString(length, data) << ";\n";
-   } else {
-      strs << "std::vector<" << type << "> fTensor_" << t.first << " = ";
-      if (sameData)
-         strs << "std::vector<" << type << ">(" << length << ", " << ConvertValToString(data[0]) << ");\n";
-      else {
-         strs << ConvertValuesToString(length, data) << ";\n";
-      }
-      strs << type << " * tensor_" + t.first + " = fTensor_" + t.first + ".data();\n";
+   strs << "std::vector<" << type << "> fTensor_" << t.first << " = ";
+   if (sameData)
+      strs << "std::vector<" << type << ">(" << length << ", " << ConvertValToString(data[0]) << ");\n";
+   else {
+      strs << ConvertValuesToString(length, data) << ";\n";
    }
+   strs << type << " * tensor_" + t.first + " = fTensor_" + t.first + ".data();\n";
    return strs.str();
 }
 


### PR DESCRIPTION
It simplifies the code a bit if we don't have separate treatment of larger and smaller (n < 100) constant vectors. It's also not that meaningful to have a magic size threshold per vector that also doesn't help avoiding large stack allocations. The mechanism is mute when there are many small constant tensors, so we might as well get rid of it to keep things simple.