### PR TITLE
[Python] Explicitly drop ownership of arguments to `TH2Poly::AddBin()`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
@@ -60,6 +60,17 @@ def _FillWithArrayTH2(self, *args):
     return self.FillN(n, x, y, weights)
 
 
+def _TH2Poly_AddBin(self, *args, **kwargs):
+    """
+    The TH2Poly always takes ownership of the added bin objects.
+    """
+    from ROOT._pythonization._memory_utils import declare_cpp_owned_arg
+
+    declare_cpp_owned_arg(0, "poly", args, kwargs)
+
+    self._AddBin(*args, **kwargs)
+
+
 # The constructors need to be pythonized for each derived class separately:
 _th2_derived_classes_to_pythonize = [
     "TH2C",
@@ -89,3 +100,9 @@ for klass in _th2_derived_classes_to_pythonize:
     def _enable_numpy_fill(klass):
         klass._Fill = klass.Fill
         klass.Fill = _FillWithArrayTH2
+
+
+@pythonization("TH2Poly")
+def _pythonize_th2poly(klass):
+    klass._AddBin = klass.AddBin
+    klass.AddBin = _TH2Poly_AddBin

--- a/bindings/pyroot/pythonizations/test/th2.py
+++ b/bindings/pyroot/pythonizations/test/th2.py
@@ -54,5 +54,42 @@ class TH2Operations(unittest.TestCase):
         self.assertAlmostEqual(hscaled.GetBinContent(1, 1), 4.0)
 
 
+class TH2Poly(unittest.TestCase):
+    """
+    Test TH2Poly.
+    """
+
+    def test_add_bin_ownership(self):
+        """Verify that Python releases the ownership of the objects passed to TH2Poly::AddBin()"""
+        h2p = ROOT.TH2Poly()
+
+        def add_bins():
+
+            n = 4
+
+            g1 = ROOT.TGraph(n)
+            for i, x, y in zip(range(n), [0.0, 1.0, 1.0, 0.0], [0.0, 0.0, 1.0, 1.0]):
+                g1.SetPoint(i, x, y)
+
+            g2 = ROOT.TGraph(n)
+            for i, x, y in zip(range(n), [1.0, 2.0, 2.0, 1.0], [0.0, 0.0, 1.0, 1.0]):
+                g2.SetPoint(i, x, y)
+
+            g3 = ROOT.TGraph(n)
+            for i, x, y in zip(range(n), [0.0, 1.0, 1.0, 0.0], [1.0, 1.0, 2.0, 2.0]):
+                g3.SetPoint(i, x, y)
+
+            h2p.AddBin(g1)
+            h2p.AddBin(g2)
+            h2p.AddBin(g3)
+
+        add_bins()
+
+        # Fill some values
+        h2p.Fill(0.5, 0.5, 2)
+        h2p.Fill(1.5, 0.5, 5)
+        h2p.Fill(0.5, 1.5, 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This follows up on 7ac08ad74a5d, ensuring the object ownership is also handled correctly in `TH2Poly::AddBin()`.

This is motivated by usage of `TH2Poly` in CMSSW unit tests, and a ROOT unit test that covers the same usage pattern is now added as well.

Spinoff from https://github.com/root-project/root/pull/13593