### PR TITLE
[Python] Clear TList in tseqcollection_itemaccess.py:test_delitem

### DIFF
--- a/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
@@ -125,6 +125,10 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         with self.assertRaises(TypeError):
             sc[1.0] = ROOT.TObject()
 
+        # Clear before the added element might be garbage collected,
+        # to avoid dangling pointer access.
+        sc.Clear()
+
     def test_setitem_slice(self):
         sc1 = self.create_tseqcollection()
         sc2 = self.create_tseqcollection()
@@ -238,6 +242,8 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             del sc[1.0]
+
+        sc.Clear()
 
     def test_delitem_slice(self):
         # Delete all items


### PR DESCRIPTION
Clear the TList at the end of the `test_delitem` unit test in tseqcollection_itemaccess.py to make sure the contained list elements are still alive when the list is cleared. Otherwise, the elements might be deleted before the containing list, depending on the order or garbage collection.

Spinoff from https://github.com/root-project/root/pull/13593