### PR TITLE
[RF] Fix ownership problems in RooFixedProdPdf

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2177,6 +2177,15 @@ RooFixedProdPdf::RooFixedProdPdf(std::unique_ptr<RooProdPdf> &&prodPdf, RooArgSe
    auto cache = _prodPdf->createCacheElem(&_normSet, nullptr);
    _isRearranged = cache->_isRearranged;
 
+   // We don't want to carry the full cache object around, so we let it go out
+   // of scope and transfer the ownership of the args that we actually need.
+   cache->_ownedList.releaseOwnership();
+   cache->_numList.releaseOwnership();
+   cache->_denList.releaseOwnership();
+   addOwnedComponents(cache->_ownedList);
+   addOwnedComponents(cache->_numList);
+   addOwnedComponents(cache->_denList);
+
    // The actual servers for a given normalization set depend on whether the
    // cache is rearranged or not. See RooProdPdf::calculate to see
    // which args in the cache are used directly.
@@ -2187,19 +2196,8 @@ RooFixedProdPdf::RooFixedProdPdf(std::unique_ptr<RooProdPdf> &&prodPdf, RooArgSe
       addOwnedComponents(std::move(cache->_rearrangedDen));
       return;
    }
-   // We don't want to carry the full cache object around, so we let it go out
-   // of scope and transfer the ownership of the args that we actually need.
-   cache->_ownedList.releaseOwnership();
-   std::vector<std::unique_ptr<RooAbsArg>> owned;
-   for (RooAbsArg *arg : cache->_ownedList) {
-      owned.emplace_back(arg);
-   }
    for (RooAbsArg *arg : cache->_partList) {
       _servers.add(*arg);
-      auto found = std::find_if(owned.begin(), owned.end(), [&](auto const &ptr) { return arg == ptr.get(); });
-      if (found != owned.end()) {
-         addOwnedComponents(std::move(owned[std::distance(owned.begin(), found)]));
-      }
    }
 }
 


### PR DESCRIPTION
This is a followup on 101beeb8a9fa7e0d7, where the RooFit objects owned by the `RooProdPdf::CacheElem` are transferred to the `RooFixedProdPdf`.

Since there was a data member `CacheElem::_ownedList`, I was misled into thinking that the other collections are non-owning. This is not the case, as the elements of `_numList` and `_denList` are all added with `RooAbsCollection::addOwned()`. So the ownership also has to be transferred from these collections.

Finally, the control flow is fixed up such that the ownership transfer is done before an early return, and also the ownership for all objects in the owned collections is transferred unconditionally. That's because some objects are only unconditionally required as dependencies of the top-level RooAbsArgs in the chache element.

This fixes a crash when running the reproducer in GitHub issue #16673 with ROOT master.

Needs to be backported to 6.38 and 6.36