### PR TITLE
[SOFIE] Fix Clean_name() to replace dots with underscores

### DIFF
--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -14,9 +14,10 @@ namespace SOFIE {
 /// @brief  Convert shape from integer format to dynamic one (based on Dim)
 /// @param shape
 /// @return shape based on Dim
-std::vector<Dim> ConvertShapeToDim(const std::vector<size_t> & shape){
+std::vector<Dim> ConvertShapeToDim(const std::vector<size_t> &shape)
+{
    std::vector<Dim> ret_shape(shape.size());
-   for (size_t i =0; i < shape.size(); i++){
+   for (size_t i = 0; i < shape.size(); i++) {
       ret_shape[i].dim = shape[i];
    }
    return ret_shape;
@@ -25,21 +26,22 @@ std::vector<Dim> ConvertShapeToDim(const std::vector<size_t> & shape){
 /// @brief Convert shape based on Dim to integer format
 /// @param shape
 /// @return shape based on integer. Return an empty shape in case shape is dynamic (has a parameter)
-std::vector<size_t> ConvertShapeToInt(const std::vector<Dim> & shape){
+std::vector<size_t> ConvertShapeToInt(const std::vector<Dim> &shape)
+{
    std::vector<size_t> ret_shape(shape.size());
-   for (size_t i =0; i < shape.size(); i++){
+   for (size_t i = 0; i < shape.size(); i++) {
       if (shape[i].isParam) {
          // try converting to integer in case string is a number >=0
          int val = -1;
          try {
             val = std::stoi(shape[i].param);
-            if (val >= 0) ret_shape[i] = static_cast<size_t>(val);
+            if (val >= 0)
+               ret_shape[i] = static_cast<size_t>(val);
             else {
                ret_shape.clear();
                break;
             }
-         }
-         catch (const std::invalid_argument& ) {
+         } catch (const std::invalid_argument &) {
             ret_shape.clear();
             break;
          }
@@ -50,105 +52,111 @@ std::vector<size_t> ConvertShapeToInt(const std::vector<Dim> & shape){
    return ret_shape;
 }
 
-
-std::size_t ConvertShapeToLength(const std::vector<size_t> & shape){
+std::size_t ConvertShapeToLength(const std::vector<size_t> &shape)
+{
    // Empty shape represent scalar values, so we return a length=1
    std::size_t fLength = 1;
-   for (auto& dim: shape) fLength *= dim;
+   for (auto &dim : shape)
+      fLength *= dim;
    return fLength;
 }
 
-std::string ConvertTypeToString(ETensorType type){
-   switch(type){
-      case ETensorType::FLOAT : {
-         return "float";
-      }
-      case ETensorType::INT8 : {
-         return "int8_t";
-      }
-      case ETensorType::INT16 : {
-         return "int16_t";
-      }
-      case ETensorType::INT32 : {
-         return "int32_t";
-      }
-      case ETensorType::INT64 : {
-         return "int64_t";
-      }
-      case ETensorType::UINT8 : {
-         return "uint8_t";
-      }
-      case ETensorType::UINT16 : {
-         return "uint16_t";
-      }
-      case ETensorType::UINT32 : {
-         return "uint32_t";
-      }
-      case ETensorType::UINT64 : {
-         return "uint64_t";
-      }
-      case ETensorType::DOUBLE : {
-         return "double";
-      }
-      case ETensorType::BOOL : {
-         return "uint8_t";
-      }
-      default:{
-         return "other_" + std::to_string( (int) type);
-      }
+std::string ConvertTypeToString(ETensorType type)
+{
+   switch (type) {
+   case ETensorType::FLOAT: {
+      return "float";
+   }
+   case ETensorType::INT8: {
+      return "int8_t";
+   }
+   case ETensorType::INT16: {
+      return "int16_t";
+   }
+   case ETensorType::INT32: {
+      return "int32_t";
+   }
+   case ETensorType::INT64: {
+      return "int64_t";
+   }
+   case ETensorType::UINT8: {
+      return "uint8_t";
+   }
+   case ETensorType::UINT16: {
+      return "uint16_t";
+   }
+   case ETensorType::UINT32: {
+      return "uint32_t";
+   }
+   case ETensorType::UINT64: {
+      return "uint64_t";
+   }
+   case ETensorType::DOUBLE: {
+      return "double";
+   }
+   case ETensorType::BOOL: {
+      return "uint8_t";
+   }
+   default: {
+      return "other_" + std::to_string((int)type);
+   }
    }
 }
 
-ETensorType ConvertStringToType(std::string type){
-   if(type == "float32" || type == "float" || type == "Float"){
-     return ETensorType::FLOAT;
-   }
-   else if(type == "int64" || type == "int64_t"){
-     return ETensorType::INT64;
-   }
-   else if (type == "double" || type == "float64"){
+ETensorType ConvertStringToType(std::string type)
+{
+   if (type == "float32" || type == "float" || type == "Float") {
+      return ETensorType::FLOAT;
+   } else if (type == "int64" || type == "int64_t") {
+      return ETensorType::INT64;
+   } else if (type == "double" || type == "float64") {
       return ETensorType::DOUBLE;
-   }
-   else if (type == "bool" ){
+   } else if (type == "bool") {
       return ETensorType::BOOL;
-   }
-   else{
+   } else {
       return ETensorType::UNDEFINED;
    }
 }
 
-std::string ConvertShapeToString(const std::vector<size_t> & shape) {
+std::string ConvertShapeToString(const std::vector<size_t> &shape)
+{
    std::stringstream out;
    out << "{ ";
    for (size_t i = 0; i < shape.size(); i++) {
       out << shape[i];
-      if (i < shape.size()-1) out << " , ";
+      if (i < shape.size() - 1)
+         out << " , ";
    }
    out << " }";
    return out.str();
 }
 
-std::string ConvertDimShapeToString(const std::vector<Dim> & shape) {
+std::string ConvertDimShapeToString(const std::vector<Dim> &shape)
+{
    std::stringstream out;
    out << "{ ";
    for (size_t i = 0; i < shape.size(); i++) {
       out << shape[i];
-      if (i < shape.size()-1) out << " , ";
+      if (i < shape.size() - 1)
+         out << " , ";
    }
    out << " }";
    return out.str();
 }
 
-std::string ConvertDimShapeToLength(const std::vector<Dim> & shape) {
+std::string ConvertDimShapeToLength(const std::vector<Dim> &shape)
+{
    // convert generic shape to a string
    // multiply all the integer specified dimensions of the shape
    std::string length;
    // case of empty vectors return 1
-   if (shape.empty()) return "1";
+   if (shape.empty())
+      return "1";
    int64_t int_length = -1;
    for (size_t i = 0; i < shape.size(); i++) {
       if (shape[i].isParam) {
-         if (!length.empty()) length += " * ";
+         if (!length.empty())
+            length += " * ";
          length += shape[i].param;
       } else {
          if (int_length == -1)
@@ -169,38 +177,43 @@ std::string ConvertDimShapeToLength(const std::vector<Dim> & shape) {
    }
    return length;
 }
-std::string ConvertShapeToString(const std::vector<Dim> & shape) {
+std::string ConvertShapeToString(const std::vector<Dim> &shape)
+{
    return ConvertDimShapeToString(shape);
 }
-std::string ConvertDynamicShapeToLength(const std::vector<Dim> & shape) {
+std::string ConvertDynamicShapeToLength(const std::vector<Dim> &shape)
+{
    return ConvertDimShapeToLength(shape);
 }
 
-
-namespace{
-template<typename T>
-static inline void copy_vector_data(int_t no_of_copies, int_t input_size, T* input, T* target){  //only visible within this translation unit
+namespace {
+template <typename T>
+static inline void copy_vector_data(int_t no_of_copies, int_t input_size, T *input, T *target)
+{ // only visible within this translation unit
    std::memcpy(target, input, input_size * sizeof(T));
    int_t already_copied = 1;
 
-   while (already_copied * 2 <= no_of_copies){
+   while (already_copied * 2 <= no_of_copies) {
       std::memcpy(target + already_copied * input_size, target, already_copied * input_size * sizeof(T));
       already_copied *= 2;
    }
 
-   if (already_copied < no_of_copies){
-      std::memcpy(target + already_copied * input_size, target, (no_of_copies - already_copied) * input_size * sizeof(T));
+   if (already_copied < no_of_copies) {
+      std::memcpy(target + already_copied * input_size, target,
+                  (no_of_copies - already_copied) * input_size * sizeof(T));
    }
 }
-}
+} // namespace
 
-bool IsInteger(const std::string & s) {
+bool IsInteger(const std::string &s)
+{
    int value;
    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
    return ec == std::errc() && ptr == s.data() + s.size();
 }
 
-bool UTILITY::AreSameShape(const std::vector<size_t>& shapeA, const std::vector<size_t>& shapeB) {
+bool UTILITY::AreSameShape(const std::vector<size_t> &shapeA, const std::vector<size_t> &shapeB)
+{
    if (shapeA.size() != shapeB.size()) {
       return false;
    }
@@ -211,19 +224,22 @@ bool UTILITY::AreSameShape(const std::vector<size_t>& shapeA, const std::vector<
    }
    return true;
 }
-bool UTILITY::AreSameShape(const std::vector<size_t>& shapeA, const std::vector<Dim>& shapeB) {
+bool UTILITY::AreSameShape(const std::vector<size_t> &shapeA, const std::vector<Dim> &shapeB)
+{
    if (shapeA.size() != shapeB.size()) {
       return false;
    }
    for (size_t dim = 0; dim < shapeA.size(); dim++) {
-      if (shapeB[dim].isParam) return false;
+      if (shapeB[dim].isParam)
+         return false;
       if (shapeA[dim] != shapeB[dim].dim) {
          return false;
       }
    }
    return true;
 }
-bool UTILITY::AreSameShape(const std::vector<Dim>& shapeA, const std::vector<Dim>& shapeB) {
+bool UTILITY::AreSameShape(const std::vector<Dim> &shapeA, const std::vector<Dim> &shapeB)
+{
    if (shapeA.size() != shapeB.size()) {
       return false;
    }
@@ -235,11 +251,10 @@ bool UTILITY::AreSameShape(const std::vector<Dim>& shapeA, const std::vector<Dim
    return true;
 }
 
-std::vector<size_t>  UTILITY::MultidirectionalBroadcastShape(std::vector<std::vector<size_t>> shape)
+std::vector<size_t> UTILITY::MultidirectionalBroadcastShape(std::vector<std::vector<size_t>> shape)
 {
    if (shape.size() < 2) {
-      throw
-         std::runtime_error("TMVA::SOFIE - MultidirectionalBroadcastShape requires at least 2 input shapes.");
+      throw std::runtime_error("TMVA::SOFIE - MultidirectionalBroadcastShape requires at least 2 input shapes.");
    }
    // Number of input shapes to broadcast
    size_t n = shape.size();
@@ -303,13 +318,12 @@ std::vector<size_t>  UTILITY::MultidirectionalBroadcastShape(std::vector<std::ve
                ss << ConvertShapeToString(shape[i]);
                if (n > 2 && i < n - 2) {
                   ss << ", ";
-               } else if ( n >=2 && i == n - 2) {
+               } else if (n >= 2 && i == n - 2) {
                   ss << " and ";
                }
             }
             ss << " to the same shape.";
-            throw
-               std::runtime_error(ss.str());
+            throw std::runtime_error(ss.str());
          }
       } // end sameShape
    } // end sameSize
@@ -351,28 +365,27 @@ std::vector<size_t>  UTILITY::MultidirectionalBroadcastShape(std::vector<std::ve
          ss << ConvertShapeToString(shape[i]);
          if (n > 2 && i < n - 2) {
             ss << ", ";
-         } else if ( n >=2 && i == n - 2) {
+         } else if (n >= 2 && i == n - 2) {
             ss << " and ";
          }
       }
       ss << " to the same shape.";
-      throw
-         std::runtime_error(ss.str());
+      throw std::runtime_error(ss.str());
    }
 }
 
-// check multi-directional broadcasting of two shapes (need to pass inputs by non const ref. since we might prepends with one's
-// return a pair of integer flag and new broadcasted shape
-// if flag = 0: shape are identical
+// check multi-directional broadcasting of two shapes (need to pass inputs by non const ref. since we might prepends
+// with one's return a pair of integer flag and new broadcasted shape if flag = 0: shape are identical
 //    flag = 1: return shape is equal to A, we broadcast B
 //    flag = 2: return shape is equal to B we broadcast A
 //    flag = 3: return shape is common of two we broadcast A and B to output
-std::pair<int, std::vector<size_t>>  UTILITY::MultidirectionalBroadcastShape(std::vector<size_t> & shapeA, std::vector<size_t> & shapeB)
+std::pair<int, std::vector<size_t>>
+UTILITY::MultidirectionalBroadcastShape(std::vector<size_t> &shapeA, std::vector<size_t> &shapeB)
 {
    size_t sizeA = shapeA.size();
    size_t sizeB = shapeB.size();
    // Check if A and B have the same shape
-   if (UTILITY::AreSameShape(shapeA, shapeB)){
+   if (UTILITY::AreSameShape(shapeA, shapeB)) {
       return std::make_pair(0, shapeA);
    }
    // Find the common shape of A and B
@@ -403,26 +416,26 @@ std::pair<int, std::vector<size_t>>  UTILITY::MultidirectionalBroadcastShape(std
       std::vector<size_t> targetShape(size, 1);
       for (size_t i = 0; i < size; i++) {
          targetShape[i] = std::max(shapeA[i], shapeB[i]);
-         if (shapeB[i] < targetShape[i]) broadcastFlag |= 1;
-         if (shapeA[i] < targetShape[i]) broadcastFlag |= 2;
+         if (shapeB[i] < targetShape[i])
+            broadcastFlag |= 1;
+         if (shapeA[i] < targetShape[i])
+            broadcastFlag |= 2;
       }
       return std::make_pair(broadcastFlag, targetShape);
    } else {
-      throw
-         std::runtime_error("TMVA::SOFIE - Error multidirectional broadcasting tensors of shape "
-            + ConvertShapeToString(shapeA) + " and " + ConvertShapeToString(shapeB)
-            + " to a common shape.");
+      throw std::runtime_error("TMVA::SOFIE - Error multidirectional broadcasting tensors of shape " +
+                               ConvertShapeToString(shapeA) + " and " + ConvertShapeToString(shapeB) +
+                               " to a common shape.");
    }
 }
 // unidirectional broadcast- of shape A to target B
-std::vector<size_t>  UTILITY::UnidirectionalBroadcastShape(std::vector<size_t> & shapeA, std::vector<size_t> & shapeB)
+std::vector<size_t> UTILITY::UnidirectionalBroadcastShape(std::vector<size_t> &shapeA, std::vector<size_t> &shapeB)
 {
    auto ret = UTILITY::MultidirectionalBroadcastShape(shapeB, shapeA);
    if (ret.first > 1) {
-      throw
-         std::runtime_error("TMVA::SOFIE - Error unidirectional broadcasting tensors of shape "
-            + ConvertShapeToString(shapeA) + " to  " + ConvertShapeToString(shapeB)
-            + " in a common shape.");
+      throw std::runtime_error("TMVA::SOFIE - Error unidirectional broadcasting tensors of shape " +
+                               ConvertShapeToString(shapeA) + " to  " + ConvertShapeToString(shapeB) +
+                               " in a common shape.");
    }
    return ret.second;
 }
@@ -432,11 +445,13 @@ std::vector<size_t>  UTILITY::UnidirectionalBroadcastShape(std::vector<size_t> &
 //    flag & 1 == 1 : broadcast B -> A
 //    flag & 2 == 2 : broadcast A -> B
 //    flag & 4 == 4 a run time check is needed on shapes with values
-std::pair<int, std::vector<Dim>> UTILITY::MultidirectionalBroadcastShape(std::vector<Dim> & shapeA, std::vector<Dim> & shapeB) {
+std::pair<int, std::vector<Dim>>
+UTILITY::MultidirectionalBroadcastShape(std::vector<Dim> &shapeA, std::vector<Dim> &shapeB)
+{
    size_t sizeA = shapeA.size();
    size_t sizeB = shapeB.size();
    // Check if A and B have the same shape
-   if (UTILITY::AreSameShape(shapeA, shapeB)){
+   if (UTILITY::AreSameShape(shapeA, shapeB)) {
       return std::make_pair(0, shapeA);
    }
    // Find the common shape of A and B
@@ -462,7 +477,7 @@ std::pair<int, std::vector<Dim>> UTILITY::MultidirectionalBroadcastShape(std::ve
       // assume we broadcast to the parametric value
       if (shapeA[i] == shapeB[i]) {
          targetShape[i] = shapeA[i];
-      } else if (shapeA[i].isParam && shapeB[i].GetVal() == "1" ) {
+      } else if (shapeA[i].isParam && shapeB[i].GetVal() == "1") {
          // broadcast B to A (case A is parametric with )
          targetShape[i] = shapeA[i];
          broadcastFlag |= 1;
@@ -484,9 +499,9 @@ std::pair<int, std::vector<Dim>> UTILITY::MultidirectionalBroadcastShape(std::ve
       } else if (shapeA[i].isParam && shapeB[i].isParam) {
          // full dynamic case - we will decided at run time
          std::stringstream s;
-         s <<  "std::max(" << shapeA[i] << "," << shapeB[i] << ")";
+         s << "std::max(" << shapeA[i] << "," << shapeB[i] << ")";
          // use -1 for dim to indicate is an expression
-         targetShape[i] = Dim { s.str() , static_cast<size_t>(-1)};
+         targetShape[i] = Dim{s.str(), static_cast<size_t>(-1)};
          broadcastFlag |= 4;
       } else if (shapeA[i].isParam && !shapeB[i].isParam) {
          // A -> B need to check at run time if consistent
@@ -503,47 +518,52 @@ std::pair<int, std::vector<Dim>> UTILITY::MultidirectionalBroadcastShape(std::ve
    }
    if (broadcastFlag == -1) {
       throw std::runtime_error("TMVA::SOFIE - Error multidirectional broadcasting tensors of shape " +
-                                 ConvertDimShapeToString(shapeA) + " and " + ConvertDimShapeToString(shapeB) +
-                                 " to a common shape.");
+                               ConvertDimShapeToString(shapeA) + " and " + ConvertDimShapeToString(shapeB) +
+                               " to a common shape.");
    }
 
    return std::make_pair(broadcastFlag, targetShape);
 }
 
-std::string UTILITY::Clean_name(std::string input_tensor_name){
-   std::string s (input_tensor_name);
-   std::replace( s.begin(), s.end(), '-', '_');
+std::string UTILITY::Clean_name(std::string input_tensor_name)
+{
+   std::string s(input_tensor_name);
+   std::replace(s.begin(), s.end(), '-', '_');
+   std::replace(s.begin(), s.end(), '.', '_');
    // replace all non-alpohanumeric character except for "_"
-   s.erase(std::remove_if(s.begin(), s.end(), []( char const& c ) -> bool { return !std::isalnum(c) && c != '_'; } ), s.end());
+   s.erase(std::remove_if(s.begin(), s.end(), [](char const &c) -> bool { return !std::isalnum(c) && c != '_'; }),
+           s.end());
    return s;
 }
 
-std::vector<size_t> UTILITY::ComputeStrideFromShape(const std::vector<size_t> & shape) {
+std::vector<size_t> UTILITY::ComputeStrideFromShape(const std::vector<size_t> &shape)
+{
    // assume row major layout
    const auto size = shape.size();
-   std::vector<size_t> strides(size,1);
+   std::vector<size_t> strides(size, 1);
    for (std::size_t i = 1; i < size; i++) {
-      strides[size - 1 - i] = strides[size - i ] * shape[size - i];
+      strides[size - 1 - i] = strides[size - i] * shape[size - i];
    }
    return strides;
 }
 
-std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> & shape) {
+std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> &shape)
+{
    // assume row major layout
    const auto size = shape.size();
    std::vector<Dim> strides(size);
    if (size > 0) {
-      strides[size-1] = Dim{1};
+      strides[size - 1] = Dim{1};
       for (std::size_t i = 1; i < size; i++) {
-         if (!shape[size-i].isParam && !strides[size-i].isParam)
-            strides[size - 1 - i] = Dim{strides[size-i].dim * shape[size-i].dim};
+         if (!shape[size - i].isParam && !strides[size - i].isParam)
+            strides[size - 1 - i] = Dim{strides[size - i].dim * shape[size - i].dim};
          else {
-            if (strides[size-i].GetVal() == "1")
-               strides[size - 1 - i] = shape[size-i];
-            else if (shape[size-i].GetVal() == "1")
-               strides[size - 1 - i] = strides[size-i];
+            if (strides[size - i].GetVal() == "1")
+               strides[size - 1 - i] = shape[size - i];
+            else if (shape[size - i].GetVal() == "1")
+               strides[size - 1 - i] = strides[size - i];
             else
-              strides[size - 1 - i] = Dim{std::string(strides[size-i].GetVal() + "*" + shape[size-i].GetVal())};
+               strides[size - 1 - i] = Dim{std::string(strides[size - i].GetVal() + "*" + shape[size - i].GetVal())};
          }
       }
    }
@@ -551,26 +571,29 @@ std::vector<Dim> UTILITY::ComputeStrideFromShape(const std::vector<Dim> & shape)
 }
 
 struct FreeBlock {
-  std::size_t offset;
-  std::size_t size;
-  bool operator<(const FreeBlock& other) const {
-    // order by offset for deterministic coalescing
-    return offset < other.offset;
-  }
+   std::size_t offset;
+   std::size_t size;
+   bool operator<(const FreeBlock &other) const
+   {
+      // order by offset for deterministic coalescing
+      return offset < other.offset;
+   }
 };
 
 struct MemoryEvent {
-  int t;      // time (i.e. operator index)
-  int type;   // 0 = END first, 1 = START
-  int idx;    // tensor index
-  bool operator<(const MemoryEvent& o) const {
-    if (t != o.t) return t < o.t;
-    return type < o.type; // END before START at the same time
-  }
+   int t;    // time (i.e. operator index)
+   int type; // 0 = END first, 1 = START
+   int idx;  // tensor index
+   bool operator<(const MemoryEvent &o) const
+   {
+      if (t != o.t)
+         return t < o.t;
+      return type < o.type; // END before START at the same time
+   }
 };
 
 /// Greedy best-fit planner with coalescing free list.
-MemoryResult OrganizeMemory(const std::vector<TensorLifeInfo> & tensorsInfo )
+MemoryResult OrganizeMemory(const std::vector<TensorLifeInfo> &tensorsInfo)
 {
    // Basic validation
    for (const auto &t : tensorsInfo) {


### PR DESCRIPTION
Dots were being erased instead of replaced in `UTILITY::Clean_name()`,
causing tensor name collisions when parsing models with dotted intermediate
names. TorchScript generates names like `input.1` and `input1` which both
mapped to `input1` after `Clean_name()`, producing duplicate declarations
in the generated inference code.

The fix adds `std::replace( s.begin(), s.end(), '.', '_')` before the
erase step, consistent with the existing `-` → `_` treatment.

Fixes #21527

# This Pull Request:
## Changes or fixes:
Added `std::replace( s.begin(), s.end(), '.', '_')` in
`UTILITY::Clean_name()` in `tmva/sofie/src/SOFIE_common.cxx`.
This makes `input.1` → `input_1` (distinct from `input1`),
eliminating the collision across all parsers (ONNX, PyTorch).

## Checklist:
- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #21527