### PR TITLE
[RF] Error out of dataset constructors if data imports are not valid

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -204,6 +204,8 @@ As part of this migration, the following build options are deprecated. From ROOT
   looking up the static variables with the epsilon values incurred significant
   overhead in `RooAbsRealLValue::inRange()`, which is visible in many-parameter
   fits. Therefore, these functions are removed.
+- The constructors of **RooDataSet** and **RooDataHist** that combine datasets via `Index()` and `Import()` now validate that the import names correspond to existing states of the index category. If an imported data slice refers to a category label that is not defined in the index category, the constructor now throws an error.
+  Previously, such labels were silently added as new category states, which could lead to inconsistent datasets when the state names were not synchronized with the model definition. This change prevents the creation of invalid combined datasets and surfaces configuration problems earlier.
 
 ### New implementation of `RooHistError::getPoissonInterval`
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -327,6 +327,17 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
       std::map<std::string,TH1*> hmap ;
       auto hiter = impSliceHistos.begin() ;
       for (const auto& token : ROOT::Split(impSliceNames, ",", /*skipEmpty=*/true)) {
+
+        if (!indexCat->hasLabel(token)) {
+           std::stringstream errorMsgStream;
+           errorMsgStream << "RooDataHist::RooDataHist(\"" << GetName() << "\") "
+                          << "you are providing import data for the category state \"" << token
+                          << "\", but the index category \"" << indexCat->GetName() << "\" has no such state!";
+           const std::string errorMsg = errorMsgStream.str();
+           coutE(InputArguments) << errorMsg << std::endl;
+           throw std::invalid_argument(errorMsg);
+        }
+
         if(auto dHist = dynamic_cast<RooDataHist*>(*hiter)) {
            dmap[token] = dHist;
         }

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -427,6 +427,17 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
     if (indexCat) {
       auto hiter = impSliceData.begin() ;
       for (const auto& token : ROOT::Split(impSliceNames, ",")) {
+
+        if (!indexCat->hasLabel(token)) {
+           std::stringstream errorMsgStream;
+           errorMsgStream << "RooDataSet::RooDataSet(\"" << GetName() << "\") "
+                          << "you are providing import data for the category state \"" << token
+                          << "\", but the index category \"" << indexCat->GetName() << "\" has no such state!";
+           const std::string errorMsg = errorMsgStream.str();
+           coutE(InputArguments) << errorMsg << std::endl;
+           throw std::invalid_argument(errorMsg);
+        }
+
         hmap[token] = static_cast<RooDataSet*>(*hiter);
         ++hiter;
       }

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -323,6 +323,8 @@ TEST(RooDataHist, BatchDataAccessWithCategories)
 
    RooRealVar x("x", "x", 0, -10, 10);
    RooCategory cat("cat", "category");
+   cat.defineType("catX");
+   cat.defineType("catY");
 
    auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
    auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);
@@ -367,8 +369,11 @@ TEST(RooDataHist, BatchDataAccessWithCategoriesAndFitRange)
    RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
 
    RooRealVar x("x", "x", 0, -10, 10);
-   RooCategory cat("cat", "category");
    x.setRange(-8., 5);
+
+   RooCategory cat("cat", "category");
+   cat.defineType("catX");
+   cat.defineType("catY");
 
    auto histoX = std::make_unique<TH1D>("xHist", "xHist", 20, -10., 10.);
    auto histoY = std::make_unique<TH1D>("yHist", "yHist", 20, -10., 10.);


### PR DESCRIPTION
If the data slices imported to a `RooDataHist` or `RooDataSet` correspond category labels that are invalid for the index category of the combined category, it's better to error out so the user doesn't end up with an invalid dataset that causes problems down the line, like in the reproducer in GitHub issue #20087. Before, category states that correspond to the data import names were implicitly added without a warning, which could easily lead to problems if the state names were not synced with the model.

Since this is a behavioral change, it's mentioned in the ROOT release notes.

Closes #20087, which was actually not a problem with RooFFTConvPdf inside RooSimultaneous, but just a problem with the combined dataset.