### PR TITLE
[RF] Deprecate `removeRange()` method

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -41,6 +41,7 @@ The following people have contributed to this new version:
 * `TDirectory::AddDirectoryStatus()` and `TDirectory::AddDirectory()` have been deprecated. These functions were meant to replace TH1::AddDirectoryStatus(), but
   never had any effect on ROOT. The associated bit TDirectory::fgAddDirectory was deprecated as well. Although users can set and read the bit, its usage should be
   stopped completely to avoid any confusion. The bit and functions will be removed in ROOT 7.
+* The method `RooRealVar::removeRange()` and the corresponding method in `RooErrorVar` have been deprecated because the name was misleading, and they will be removed in ROOT 6.42. Despite the name, the function did not actually remove a range, but only cleared its limits by setting them to  `−inf,+inf` leaving the named range itself defined (so `hasRange()` would still return `true`). Users should now explicitly call `removeMin()` and `removeMax()` to remove the lower and upper limits of a range.
 
 ## Removals
 

--- a/roofit/roofitcore/inc/RooErrorVar.h
+++ b/roofit/roofitcore/inc/RooErrorVar.h
@@ -84,7 +84,10 @@ public:
   // Set infinite fit range limits
   void removeMin(const char* name=nullptr);
   void removeMax(const char* name=nullptr);
-  void removeRange(const char* name=nullptr);
+  void removeRange(const char *name = nullptr)
+     R__DEPRECATED(6, 42,
+                   "\"removeRange\" was a misleading name."
+                   " Please use \"removeMin()\" and \"removeMax()\" instead, for the same effect.");
 
   using RooAbsRealLValue::operator= ;
   using RooAbsRealLValue::setVal ;

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -97,7 +97,10 @@ public:
   /// Remove upper range limit for binning with given name. Empty name means default range.
   void removeMax(const char* name=nullptr);
   /// Remove range limits for binning with given name. Empty name means default range.
-  void removeRange(const char* name=nullptr);
+  void removeRange(const char* name=nullptr)
+     R__DEPRECATED(6, 42,
+                   "\"removeRange\" was a misleading name."
+                   " Please use \"removeMin()\" and \"removeMax()\" instead, for the same effect.");
 
   // I/O streaming interface (machine readable)
   bool readFromStream(std::istream& is, bool compact, bool verbose=false) override ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3116,7 +3116,8 @@ void RooAbsReal::setTreeBranchStatus(TTree& t, bool active)
 RooFit::OwningPtr<RooAbsArg> RooAbsReal::createFundamental(const char* newname) const
 {
   auto fund = std::make_unique<RooRealVar>(newname?newname:GetName(),GetTitle(),_value,getUnit());
-  fund->removeRange();
+  fund->removeMin();
+  fund->removeMax();
   fund->setPlotLabel(getPlotLabel());
   fund->setAttribute("fundamentalCopy");
   return RooFit::makeOwningPtr<RooAbsArg>(std::move(fund));

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -75,7 +75,8 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
   if (!convV) {
     throw std::runtime_error("RooConvGenContext only works with convolution variables of type RooRealVar.");
   }
-  convV->removeRange();
+  convV->removeMin();
+  convV->removeMax();
 
   // Create generator for physics X truth model
   _pdfVars = std::unique_ptr<RooArgSet>{pdfClone->getObservables(&vars)};
@@ -94,7 +95,8 @@ RooConvGenContext::RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArg
   if (!convV) {
     throw std::runtime_error("RooConvGenContext only works with convolution variables of type RooRealVar.");
   }
-  convV->removeRange();
+  convV->removeMin();
+  convV->removeMax();
 
   // Create generator for resolution model as PDF
   _modelVars = std::unique_ptr<RooArgSet>{modelClone->getObservables(&vars)};
@@ -193,7 +195,8 @@ RooConvGenContext::RooConvGenContext(const RooFFTConvPdf &model, const RooArgSet
   RooArgSet(model._pdf1.arg()).snapshot(*_pdfCloneSet, true);
   RooAbsPdf* pdfClone = static_cast<RooAbsPdf*>(_pdfCloneSet->find(model._pdf1.arg().GetName())) ;
   RooRealVar* cvPdf = static_cast<RooRealVar*>(_pdfCloneSet->find(model._x.arg().GetName())) ;
-  cvPdf->removeRange() ;
+  cvPdf->removeMin() ;
+  cvPdf->removeMax() ;
   RooArgSet tmp1;
   pdfClone->getObservables(&vars, tmp1) ;
   _pdfVarsOwned = std::make_unique<RooArgSet>();
@@ -206,7 +209,8 @@ RooConvGenContext::RooConvGenContext(const RooFFTConvPdf &model, const RooArgSet
   RooArgSet(model._pdf2.arg()).snapshot(*_modelCloneSet, true);
   RooAbsPdf* modelClone = static_cast<RooAbsPdf*>(_modelCloneSet->find(model._pdf2.arg().GetName())) ;
   RooRealVar* cvModel = static_cast<RooRealVar*>(_modelCloneSet->find(model._x.arg().GetName())) ;
-  cvModel->removeRange() ;
+  cvModel->removeMin() ;
+  cvModel->removeMax() ;
   RooArgSet tmp2;
   modelClone->getObservables(&vars, tmp2) ;
   _modelVarsOwned = std::make_unique<RooArgSet>();

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -108,7 +108,8 @@ RooRealVar::RooRealVar(const char *name, const char *title,
 {
   _value = value ;
   _fast = true ;
-  removeRange();
+  removeMin();
+  removeMax();
   setConstant(true) ;
   TRACE_CREATE;
 }

--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -687,7 +687,8 @@ RooArgList xRooNLLVar::xRooFitResult::ranknp(const char *poi, bool up, bool pref
       auto vv = static_cast<RooRealVar *>(out.at(out.size() - 1));
       vv->setVal(v);
       vv->removeError();
-      vv->removeRange();
+      vv->removeMin();
+      vv->removeMax();
    }
    return out;
 }
@@ -3052,8 +3053,10 @@ xRooNLLVar::xRooHypoSpace xRooNLLVar::hypoSpace(const char *parName, int nPoints
          if (tsType == xRooFit::TestStatistic::qmutilde) {
             dynamic_cast<RooRealVar *>(p)->setRange("physical", 0, std::numeric_limits<double>::infinity());
             Info("xRooNLLVar::hypoSpace", "Setting physical range of %s to [0,inf]", p->GetName());
-         } else if (dynamic_cast<RooRealVar *>(p)->hasRange("physical")) {
-            dynamic_cast<RooRealVar *>(p)->removeRange("physical");
+         } else if (dynamic_cast<RooRealVar *>(p) && static_cast<RooRealVar *>(p)->hasRange("physical")) {
+            auto *var = static_cast<RooRealVar *>(p);
+            var->removeMin("physical");
+            var->removeMax("physical");
             Info("xRooNLLVar::hypoSpace", "Removing physical range of %s", p->GetName());
          }
       }

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -8817,13 +8817,15 @@ TH1 *xRooNode::BuildHistogram(RooAbsLValue *v, bool empty, bool errors, int binS
 
    for (auto o : _obs) {
       if (auto rr = o->get<RooRealVar>(); rr && rr->hasRange("coordRange")) {
-         rr->removeRange("coordRange");                 // doesn't actually remove, just sets to -inf->+inf
+         rr->removeMin("coordRange");
+         rr->removeMax("coordRange");
          rr->setStringAttribute("coordRange", nullptr); // removes the attribute
       }
    }
    // probably should also remove any range on the x-axis variable too, if there is one
    if (auto rr = dynamic_cast<RooRealVar *>(v); rr && rr->hasRange("coordRange")) {
-      rr->removeRange("coordRange");                 // doesn't actually remove, just sets to -inf->+inf
+      rr->removeMin("coordRange");
+      rr->removeMax("coordRange");
       rr->setStringAttribute("coordRange", nullptr); // removes the attribute
    }
    coords(); // loads current coordinates and populates coordRange, if any


### PR DESCRIPTION
The method `RooRealVar::removeRange()` and the corresponding method in `RooErrorVar` have been deprecated because the name was misleading, and they will be removed in ROOT 6.42. Despite the name, the function did not actually remove a range, but only cleared its limits by setting them to  `−inf,+inf` leaving the named range itself defined (so `hasRange()` would still return `true`). Users should now explicitly call `removeMin()` and `removeMax()` to remove the lower and upper limits of a range.

Internal RooFit code has been updated accordingly.

I deliberately didn't introduce an alternative function with a more descriptive name (like `removeMinMax()`), because using that would result in backwards incompatible code, and also removing the range limits it a niche feature. Even our own code doesn't do it much. So I think it's fair to suggest to replace usage with `removeMin()` and `removeMax()`, even if slightly more verbose.

Closes #21542