### PR TITLE
[RF] Fix unused variable warning in RooFormula.cxx

### DIFF
--- a/roofit/roofitcore/src/RooFormula.cxx
+++ b/roofit/roofitcore/src/RooFormula.cxx
@@ -135,12 +135,12 @@ bool isNumericNameValid(RooAbsArg &_rooAbsArg)
    try {
       nameValue = std::stod(_rooAbsArg.GetName());
       actualValue = std::stod(ss.str());
-   } catch (const std::invalid_argument &e) {
+   } catch (const std::invalid_argument &) {
       std::stringstream ssExc;
       ssExc << "RooConstVar named " << _rooAbsArg.GetName() << " has name or value that "
             << "cannot be converted to number";
       throw std::invalid_argument(ssExc.str());
-   } catch (const std::out_of_range &e) {
+   } catch (const std::out_of_range &) {
       std::stringstream ssExc;
       ssExc << "RooConstVar named " << _rooAbsArg.GetName() << " has numeric name or value that "
             << "gets out of a double range";


### PR DESCRIPTION
This follows up on 24bc34ebce, fixing a warning that we're seeing in the Windows CI:
```txt
2026-03-09T19:50:35.9844446Z C:\ROOT-CI\src\roofit\roofitcore\src\RooFormula.cxx(138,42): warning C4101: 'e': unreferenced local variable [C:\ROOT-CI\build\roofit\roofitcore\RooFitCore.vcxproj]
2026-03-09T19:50:35.9845269Z C:\ROOT-CI\src\roofit\roofitcore\src\RooFormula.cxx(143,38): warning C4101: 'e': unreferenced local variable [C:\ROOT-CI\build\roofit\roofitcore\RooFitCore.vcxproj]
2026-03-09T19:50:36.6940378Z   RooFormulaVar.cxx
```