### PR TITLE
[webcanv] use fill/line/text attributes from TWebPS instance

### DIFF
--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "TWebPainting.h"
+#include "TWebPS.h"
 
 class TWebCanvas;
 
@@ -29,7 +30,8 @@ friend class TWebCanvas;
 
 protected:
 
-   TWebPainting *fPainting{nullptr};      ///!< object to store all painting, owned by TWebPS object
+   TWebPainting *fPainting{nullptr};      ///<! object to store all painting, owned by TWebPS object
+   TWebPS *fPS{nullptr};                  ///<! current TWebPS instance
 
    enum { attrLine = 0x1, attrFill = 0x2, attrMarker = 0x4, attrText = 0x8, attrAll = 0xf };
 
@@ -39,42 +41,42 @@ public:
 
    TWebPadPainter() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
 
-   void SetPainting(TWebPainting *p) { fPainting = p; }
+   void SetPainting(TWebPainting *p, TWebPS *ps) { fPainting = p; fPS = ps; }
 
    //Final overrides for TVirtualPadPainter pure virtual functions.
    //1. Part, which simply catch attributes.
    //Line attributes.
-   Color_t  GetLineColor() const override { return TAttLine::GetLineColor(); }
-   Style_t  GetLineStyle() const override { return TAttLine::GetLineStyle(); }
-   Width_t  GetLineWidth() const override { return TAttLine::GetLineWidth(); }
+   Color_t  GetLineColor() const override { return fPS ? fPS->GetLineColor() : TAttLine::GetLineColor(); }
+   Style_t  GetLineStyle() const override { return fPS ? fPS->GetLineStyle() : TAttLine::GetLineStyle(); }
+   Width_t  GetLineWidth() const override { return fPS ? fPS->GetLineWidth() : TAttLine::GetLineWidth(); }
 
-   void     SetLineColor(Color_t lcolor) override { TAttLine::SetLineColor(lcolor); }
-   void     SetLineStyle(Style_t lstyle) override { TAttLine::SetLineStyle(lstyle); }
-   void     SetLineWidth(Width_t lwidth) override { TAttLine::SetLineWidth(lwidth); }
+   void     SetLineColor(Color_t lcolor) override { if (fPS) fPS->SetLineColor(lcolor); else TAttLine::SetLineColor(lcolor); }
+   void     SetLineStyle(Style_t lstyle) override { if (fPS) fPS->SetLineStyle(lstyle); else TAttLine::SetLineStyle(lstyle); }
+   void     SetLineWidth(Width_t lwidth) override { if (fPS) fPS->SetLineWidth(lwidth); else TAttLine::SetLineWidth(lwidth); }
 
    //Fill attributes.
-   Color_t  GetFillColor() const override { return TAttFill::GetFillColor(); }
-   Style_t  GetFillStyle() const override { return TAttFill::GetFillStyle(); }
-   Bool_t   IsTransparent() const override { return TAttFill::IsTransparent(); }
+   Color_t  GetFillColor() const override { return fPS ? fPS->GetFillColor() : TAttFill::GetFillColor(); }
+   Style_t  GetFillStyle() const override { return fPS ? fPS->GetFillStyle() : TAttFill::GetFillStyle(); }
+   Bool_t   IsTransparent() const override { return fPS ? fPS->IsTransparent() : TAttFill::IsTransparent(); }
 
-   void     SetFillColor(Color_t fcolor) override { TAttFill::SetFillColor(fcolor); }
-   void     SetFillStyle(Style_t fstyle) override { TAttFill::SetFillStyle(fstyle); }
-   void     SetOpacity(Int_t percent) override { TAttFill::SetFillStyle(4000 + percent); }
+   void     SetFillColor(Color_t fcolor) override { if (fPS) fPS->SetFillColor(fcolor); else TAttFill::SetFillColor(fcolor); }
+   void     SetFillStyle(Style_t fstyle) override { if (fPS) fPS->SetFillStyle(fstyle); else TAttFill::SetFillStyle(fstyle); }
+   void     SetOpacity(Int_t percent) override { if (fPS) fPS->SetFillStyle(4000 + percent); else TAttFill::SetFillStyle(4000 + percent); }
 
    //Text attributes.
-   Short_t  GetTextAlign() const override { return TAttText::GetTextAlign(); }
-   Float_t  GetTextAngle() const override { return TAttText::GetTextAngle(); }
-   Color_t  GetTextColor() const override { return TAttText::GetTextColor(); }
-   Font_t   GetTextFont()  const override { return TAttText::GetTextFont(); }
-   Float_t  GetTextSize()  const override { return TAttText::GetTextSize(); }
+   Short_t  GetTextAlign() const override { return fPS ? fPS->GetTextAlign() : TAttText::GetTextAlign(); }
+   Float_t  GetTextAngle() const override { return fPS ? fPS->GetTextAngle() : TAttText::GetTextAngle(); }
+   Color_t  GetTextColor() const override { return fPS ? fPS->GetTextColor() : TAttText::GetTextColor(); }
+   Font_t   GetTextFont()  const override { return fPS ? fPS->GetTextFont() : TAttText::GetTextFont(); }
+   Float_t  GetTextSize()  const override { return fPS ? fPS->GetTextSize() : TAttText::GetTextSize(); }
    Float_t  GetTextMagnitude() const override { return  0; }
 
-   void     SetTextAlign(Short_t align) override { TAttText::SetTextAlign(align); }
-   void     SetTextAngle(Float_t tangle) override { TAttText::SetTextAngle(tangle); }
-   void     SetTextColor(Color_t tcolor) override { TAttText::SetTextColor(tcolor); }
-   void     SetTextFont(Font_t tfont) override { TAttText::SetTextFont(tfont); }
-   void     SetTextSize(Float_t tsize) override { TAttText::SetTextSize(tsize); }
-   void     SetTextSizePixels(Int_t npixels) override { TAttText::SetTextSizePixels(npixels); }
+   void     SetTextAlign(Short_t align) override { if (fPS) fPS->SetTextAlign(align); else TAttText::SetTextAlign(align); }
+   void     SetTextAngle(Float_t tangle) override { if (fPS) fPS->SetTextAngle(tangle); else TAttText::SetTextAngle(tangle); }
+   void     SetTextColor(Color_t tcolor) override { if (fPS) fPS->SetTextColor(tcolor); else TAttText::SetTextColor(tcolor); }
+   void     SetTextFont(Font_t tfont) override { if (fPS) fPS->SetTextFont(tfont); else TAttText::SetTextFont(tfont); }
+   void     SetTextSize(Float_t tsize) override { if (fPS) fPS->SetTextSize(tsize); else TAttText::SetTextSize(tsize); }
+   void     SetTextSizePixels(Int_t npixels) override { if (fPS) fPS->SetTextSizePixels(npixels); else TAttText::SetTextSizePixels(npixels); }
 
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t, UInt_t) override { return -1; }

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -538,12 +538,15 @@ void TWebCanvas::CreateObjectSnapshot(TPadWebSnapshot &master, TPad *pad, TObjec
 
    TVirtualPS *saveps = gVirtualPS;
 
-   TWebPS ps;
-   ps.GetPainting()->SetClassName(obj->ClassName());
-   ps.GetPainting()->SetObjectName(obj->GetName());
-   gVirtualPS = masterps ? masterps : &ps;
+   TWebPS *webps = masterps;
+   if (!masterps) {
+      webps = new TWebPS;
+      webps->GetPainting()->SetClassName(obj->ClassName());
+      webps->GetPainting()->SetObjectName(obj->GetName());
+   }
+   gVirtualPS = webps;
    if (painter)
-      painter->SetPainting(ps.GetPainting());
+      painter->SetPainting(webps->GetPainting(), webps);
 
    // calling Paint function for the object
    obj->Paint(opt);
@@ -556,15 +559,18 @@ void TWebCanvas::CreateObjectSnapshot(TPadWebSnapshot &master, TPad *pad, TObjec
    }
 
    if (painter)
-      painter->SetPainting(nullptr);
+      painter->SetPainting(nullptr, nullptr);
 
    gVirtualPS = saveps;
 
    fPadsStatus[pad]._has_specials = true;
 
    // if there are master PS, do not create separate entries
-   if (!masterps && !ps.IsEmptyPainting())
-      master.NewPrimitive(obj, opt).SetSnapshot(TWebSnapshot::kSVG, ps.TakePainting(), kTRUE);
+   if (!masterps) {
+      if (!webps->IsEmptyPainting())
+         master.NewPrimitive(obj, opt).SetSnapshot(TWebSnapshot::kSVG, webps->TakePainting(), kTRUE);
+      delete webps;
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/gui/webgui6/src/TWebPadPainter.cxx
+++ b/gui/webgui6/src/TWebPadPainter.cxx
@@ -30,19 +30,20 @@ Main classes (like histograms or graphs) should be painted on JavaScript side
 
 Float_t *TWebPadPainter::StoreOperation(const std::string &oper, unsigned attrkind, int opersize)
 {
-   if (!fPainting) return nullptr;
+   if (!fPainting)
+      return nullptr;
 
    if (attrkind & attrLine)
-      fPainting->AddLineAttr(*this);
+      fPainting->AddLineAttr(fPS ? *((TAttLine *) fPS) : *((TAttLine *)this));
 
    if (attrkind & attrFill)
-      fPainting->AddFillAttr(*this);
+      fPainting->AddFillAttr(fPS ? *((TAttFill *) fPS) : *((TAttFill *)this));
 
    if (attrkind & attrMarker)
-      fPainting->AddMarkerAttr(*this);
+      fPainting->AddMarkerAttr(fPS ? *((TAttMarker *) fPS) : *((TAttMarker *)this));
 
    if (attrkind & attrText)
-      fPainting->AddTextAttr(*this);
+      fPainting->AddTextAttr(fPS ? *((TAttText *)fPS) : *((TAttText *)this));
 
    fPainting->AddOper(oper);
 


### PR DESCRIPTION
When plain obj->Paint() method is invoked from web canvas, attributes are set to gVirtualPS instance.
So use this attributes in web canvas.

Also properly use TWebPainting when master TWebPS is used
