### PR TITLE
[Python] Don't rely on `__eq__` fallback to pointer comparison in tests

### DIFF
--- a/bindings/pyroot/pythonizations/test/tcollection_iterable.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_iterable.py
@@ -31,7 +31,7 @@ class TCollectionIterable(unittest.TestCase):
 
         itc = ROOT.TIter(c)
         for elem in c:
-            self.assertEqual(elem, itc.Next())
+            self.assertIs(elem, itc.Next())
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
@@ -44,7 +44,7 @@ class TCollectionListMethods(unittest.TestCase):
             itc.Next()
 
         # Check that `o` is indeed the last element
-        self.assertEqual(o, itc.Next())
+        self.assertIs(o, itc.Next())
 
         # Clear before the added element might be garbage collected,
         # to avoid dangling pointer access.
@@ -98,7 +98,7 @@ class TCollectionListMethods(unittest.TestCase):
         # Compare with elements of second collection
         itc2 = ROOT.TIter(c2)
         for _ in range(len2):
-            self.assertEqual(itc1.Next(), itc2.Next())
+            self.assertIs(itc1.Next(), itc2.Next())
 
     def test_count(self):
         c = ROOT.TList()

--- a/bindings/pyroot/pythonizations/test/tcollection_operators.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_operators.py
@@ -34,7 +34,7 @@ class TCollectionOperators(unittest.TestCase):
             for _ in range(lenc):
                 oc = itc.Next()
                 omul = itmul.Next()
-                self.assertEqual(oc, omul)
+                self.assertIs(oc, omul)
 
     # Tests
     def test_add(self):
@@ -56,14 +56,14 @@ class TCollectionOperators(unittest.TestCase):
         for _ in range(len1):
             oc1 = itc1.Next()
             oadd = itadd.Next()
-            self.assertEqual(oc1, oadd)
+            self.assertIs(oc1, oadd)
 
         # Compare with elements of second collection
         itc2 = ROOT.TIter(c2)
         for _ in range(len2):
             oc2 = itc2.Next()
             oadd = itadd.Next()
-            self.assertEqual(oc2, oadd)
+            self.assertIs(oc2, oadd)
 
     def test_mul(self):
         c = self.create_tcollection()
@@ -94,7 +94,7 @@ class TCollectionOperators(unittest.TestCase):
 
         for _ in range(self.factor - 1):
             for o in subc:
-                self.assertEqual(o, it.Next())
+                self.assertIs(o, it.Next())
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
+++ b/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
@@ -16,15 +16,15 @@ class TContextContextManager(unittest.TestCase):
         Check status of gDirectory with default constructor.
         """
         filename = "TContextContextManager_test_default_constructor.root"
-        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
+        self.assertIs(ROOT.gDirectory, ROOT.gROOT)
 
         with TDirectory.TContext():
             # Create a file to change gDirectory
             testfile = ROOT.TFile(filename, "recreate")
-            self.assertEqual(ROOT.gDirectory, testfile)
+            self.assertIs(ROOT.gDirectory, testfile)
             testfile.Close()
 
-        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
+        self.assertIs(ROOT.gDirectory, ROOT.gROOT)
         os.remove(filename)
 
     def constructor_onearg(self):
@@ -35,12 +35,12 @@ class TContextContextManager(unittest.TestCase):
 
         file0 = ROOT.TFile(filenames[0], "recreate")
         file1 = ROOT.TFile(filenames[1], "recreate")
-        self.assertEqual(ROOT.gDirectory, file1)
+        self.assertIs(ROOT.gDirectory, file1)
 
         with TDirectory.TContext(file0):
-            self.assertEqual(ROOT.gDirectory, file0)
+            self.assertIs(ROOT.gDirectory, file0)
 
-        self.assertEqual(ROOT.gDirectory, file1)
+        self.assertIs(ROOT.gDirectory, file1)
         file0.Close()
         file1.Close()
         for filename in filenames:
@@ -55,12 +55,12 @@ class TContextContextManager(unittest.TestCase):
         file0 = ROOT.TFile(filenames[0], "recreate")
         file1 = ROOT.TFile(filenames[1], "recreate")
         file2 = ROOT.TFile(filenames[2], "recreate")
-        self.assertEqual(ROOT.gDirectory, file2)
+        self.assertIs(ROOT.gDirectory, file2)
 
         with TDirectory.TContext(file0, file1):
-            self.assertEqual(ROOT.gDirectory, file1)
+            self.assertIs(ROOT.gDirectory, file1)
 
-        self.assertEqual(ROOT.gDirectory, file0)
+        self.assertIs(ROOT.gDirectory, file0)
         file0.Close()
         file1.Close()
         file2.Close()

--- a/bindings/pyroot/pythonizations/test/titer_iterator.py
+++ b/bindings/pyroot/pythonizations/test/titer_iterator.py
@@ -38,7 +38,7 @@ class TIterIterator(unittest.TestCase):
         itc1 = ROOT.TIter(c)
         itc2 = ROOT.TIter(c)
         for _ in range(c.GetEntries()):
-            self.assertEqual(next(itc1), itc2.Next())
+            self.assertIs(next(itc1), itc2.Next())
 
     def test_for_loop_syntax(self):
         # Somehow redundant, but good to test with real syntax
@@ -47,7 +47,7 @@ class TIterIterator(unittest.TestCase):
         itc1 = ROOT.TIter(c)
         itc2 = ROOT.TIter(c)
         for elem1, elem2 in zip(itc1, itc2):
-            self.assertEqual(elem1, elem2)
+            self.assertIs(elem1, elem2)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tobject_comparisonops.py
+++ b/bindings/pyroot/pythonizations/test/tobject_comparisonops.py
@@ -109,12 +109,14 @@ class TObjectComparisonOps(unittest.TestCase):
         l1 = [ ROOT.TUrl(str(i)) for i in range(self.num_elems) ]
         l2 = list(reversed(l1))
 
-        self.assertNotEqual(l1, l2)
+        for i in range(self.num_elems):
+            self.assertIs(l1[i], l2[self.num_elems - 1 - i])
 
         # Test that comparison operators enable list sorting
         l2.sort()
 
-        self.assertEqual(l1, l2)
+        for e1, e2 in zip(l1, l2):
+            self.assertIs(e1, e2)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_itemaccess.py
@@ -32,13 +32,13 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         # Get items
         it = ROOT.TIter(sc)
         for i in range(self.num_elems):
-            self.assertEqual(it.Next(), sc[i])
+            self.assertIs(it.Next(), sc[i])
 
         # Get items, negative indices
         it2 = ROOT.TIter(sc)
         neg_idcs = [ -i-1 for i in reversed(range(self.num_elems)) ]
         for i in neg_idcs:
-            self.assertEqual(it2.Next(), sc[i])
+            self.assertIs(it2.Next(), sc[i])
 
         # Check invalid index cases
         with self.assertRaises(IndexError):
@@ -56,32 +56,32 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         # All items
         slice1 = sc[:]
         for i in range(slice1.GetEntries()):
-            self.assertEqual(sc[i], slice1[i])
+            self.assertIs(sc[i], slice1[i])
 
         # First two items
         slice2 = sc[0:2]
-        self.assertEqual(sc[0], slice2[0])
-        self.assertEqual(sc[1], slice2[1])
+        self.assertIs(sc[0], slice2[0])
+        self.assertIs(sc[1], slice2[1])
 
         # Last two items
         slice3 = sc[-2:]
-        self.assertEqual(sc[1], slice3[0])
-        self.assertEqual(sc[2], slice3[1])
+        self.assertIs(sc[1], slice3[0])
+        self.assertIs(sc[2], slice3[1])
 
         # First and third items
         slice4 = sc[0::2]
-        self.assertEqual(sc[0], slice4[0])
-        self.assertEqual(sc[2], slice4[1])
+        self.assertIs(sc[0], slice4[0])
+        self.assertIs(sc[2], slice4[1])
 
         # All items, reverse order
         slice5 = sc[::-1]
         for i in range(slice5.GetEntries()):
-            self.assertEqual(sc[i], slice5[self.num_elems - 1 - i])
+            self.assertIs(sc[i], slice5[self.num_elems - 1 - i])
 
         # First and third items, reverse order
         slice6 = sc[::-2]
-        self.assertEqual(sc[0], slice6[1])
-        self.assertEqual(sc[2], slice6[0])
+        self.assertIs(sc[0], slice6[1])
+        self.assertIs(sc[2], slice6[0])
 
         # Step cannot be zero
         with self.assertRaises(ValueError):
@@ -100,7 +100,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         # Check previously set items
         it = ROOT.TIter(sc)
         for i in range(self.num_elems):
-            self.assertEqual(it.Next(), l1[i])
+            self.assertIs(it.Next(), l1[i])
 
         # Set items, negative indices
         l2 = []
@@ -113,7 +113,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         # Check previously set items
         it2 = ROOT.TIter(sc)
         for i in range(self.num_elems):
-            self.assertEqual(it2.Next(), l2[i])
+            self.assertIs(it2.Next(), l2[i])
 
         # Check invalid index cases
         with self.assertRaises(IndexError):
@@ -137,7 +137,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         sc1[:] = sc2
         self.assertEqual(sc1.GetEntries(), self.num_elems)
         for i in range(self.num_elems):
-            self.assertEqual(sc1[i], sc2[i])
+            self.assertIs(sc1[i], sc2[i])
 
         # Append items
         sc1 = self.create_tseqcollection()
@@ -148,10 +148,10 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         self.assertEqual(sc1.GetEntries(), 2 * self.num_elems)
         i = 0
         for elem in l1:  # first half
-            self.assertEqual(sc1[i], elem)
+            self.assertIs(sc1[i], elem)
             i += 1
         for elem in sc2:  # second half
-            self.assertEqual(sc1[i], elem)
+            self.assertIs(sc1[i], elem)
             i += 1
 
         # Assign second item.
@@ -163,9 +163,9 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         sc3[1:2] = l2
 
         self.assertEqual(sc3.GetEntries(), self.num_elems)
-        self.assertEqual(sc3[0], l3[0])
-        self.assertEqual(sc3[1], l2[0])
-        self.assertEqual(sc3[2], l3[2])
+        self.assertIs(sc3[0], l3[0])
+        self.assertIs(sc3[1], l2[0])
+        self.assertIs(sc3[2], l3[2])
 
         # Assign second and third items to just one item.
         # This tests that the third item is removed
@@ -176,8 +176,8 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         sc4[1:3] = l4
 
         self.assertEqual(sc4.GetEntries(), self.num_elems - 1)
-        self.assertEqual(sc4[0], l5[0])
-        self.assertEqual(sc4[1], l4[0])
+        self.assertIs(sc4[0], l5[0])
+        self.assertIs(sc4[1], l4[0])
 
         # Assign with step
         sc5 = self.create_tseqcollection()
@@ -188,17 +188,17 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         sc5[::2] = l6
 
         self.assertEqual(sc5.GetEntries(), self.num_elems)
-        self.assertEqual(sc5[0], l6[0])
-        self.assertEqual(sc5[1], o)
-        self.assertEqual(sc5[2], l6[1])
+        self.assertIs(sc5[0], l6[0])
+        self.assertIs(sc5[1], o)
+        self.assertIs(sc5[2], l6[1])
 
         # Assign with step (start from end)
         sc5[::-2] = l6
 
         self.assertEqual(sc5.GetEntries(), self.num_elems)
-        self.assertEqual(sc5[0], l6[1])
-        self.assertEqual(sc5[1], o)
-        self.assertEqual(sc5[2], l6[0])
+        self.assertIs(sc5[0], l6[1])
+        self.assertIs(sc5[1], o)
+        self.assertIs(sc5[2], l6[0])
 
         # Step cannot be zero
         sc6 = self.create_tseqcollection()
@@ -231,7 +231,7 @@ class TSeqCollectionItemAccess(unittest.TestCase):
 
         it = ROOT.TIter(sc)
         for _ in range(2):
-            self.assertEqual(it.Next(), o1)
+            self.assertIs(it.Next(), o1)
 
         # Check invalid index cases
         with self.assertRaises(IndexError):
@@ -257,28 +257,28 @@ class TSeqCollectionItemAccess(unittest.TestCase):
         del sc2[self.num_elems:]
         self.assertEqual(sc2.GetEntries(), self.num_elems)
         for el1, el2 in zip(sc2, l2):
-            self.assertEqual(el1, el2)
+            self.assertIs(el1, el2)
 
         # Delete first two items
         sc3 = self.create_tseqcollection()
         o = sc3[2]
         del sc3[0:2]
         self.assertEqual(sc3.GetEntries(), 1)
-        self.assertEqual(sc3[0], o)
+        self.assertIs(sc3[0], o)
 
         # Delete first and third items
         sc4 = self.create_tseqcollection()
         o = sc4[1]
         del sc4[::2]
         self.assertEqual(sc4.GetEntries(), 1)
-        self.assertEqual(sc4[0], o)
+        self.assertIs(sc4[0], o)
 
         # Delete first and third items (start from end)
         sc5 = self.create_tseqcollection()
         o = sc5[1]
         del sc5[::-2]
         self.assertEqual(sc5.GetEntries(), 1)
-        self.assertEqual(sc5[0], o)
+        self.assertIs(sc5[0], o)
 
         # Step cannot be zero
         sc6 = self.create_tseqcollection()

--- a/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tseqcollection_listmethods.py
@@ -32,27 +32,27 @@ class TSeqCollectionListMethods(unittest.TestCase):
         o1 = ROOT.TObject()
         sc.insert(1, o1)
         self.assertEqual(sc.GetEntries(), self.num_elems + 1)
-        self.assertEqual(sc.At(1), o1)
+        self.assertIs(sc.At(1), o1)
 
         # Insert with negative index (starts from end)
         o2 = ROOT.TObject()
         sc.insert(-1, o2)
         self.assertEqual(sc.GetEntries(), self.num_elems + 2)
-        self.assertEqual(sc.At(self.num_elems), o2)
+        self.assertIs(sc.At(self.num_elems), o2)
 
         # Insert with index beyond lower boundary.
         # Inserts at the beginning
         o3 = ROOT.TObject()
         sc.insert(-(self.num_elems + 3), o3)
         self.assertEqual(sc.GetEntries(), self.num_elems + 3)
-        self.assertEqual(sc.At(0), o3)
+        self.assertIs(sc.At(0), o3)
 
         # Insert with index beyond upper boundary.
         # Inserts at the end
         o4 = ROOT.TObject()
         sc.insert(self.num_elems + 4, o4)
         self.assertEqual(sc.GetEntries(), self.num_elems + 4)
-        self.assertEqual(sc.At(self.num_elems + 3), o4)
+        self.assertIs(sc.At(self.num_elems + 3), o4)
 
         # Clear before the added element might be garbage collected,
         # to avoid dangling pointer access.


### PR DESCRIPTION
Don't rely on the fallback of equality comparisons to pointer comparisons. Use object identity comparisons with `is` instead.

This change ensures that the tests will still work if we were to remove this fallback for type safety (see discussion in
https://github.com/root-project/root/issues/21347).