### PR TITLE
[cppyy] Fix typo in CPPInstance richcompare for `operator<=`

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -624,7 +624,7 @@ static PyObject* op_richcompare(CPPInstance* self, PyObject* other, int op)
             CPYCPPYY_ORDERED_OPERATOR_STUB(<,  klass->fOperators->fLt, __lt__)
             break;
         case Py_LE:
-            CPYCPPYY_ORDERED_OPERATOR_STUB(<=, klass->fOperators->fLe, __ge__)
+            CPYCPPYY_ORDERED_OPERATOR_STUB(<=, klass->fOperators->fLe, __le__)
             break;
         case Py_GT:
             CPYCPPYY_ORDERED_OPERATOR_STUB(>,  klass->fOperators->fGt, __gt__)


### PR DESCRIPTION
Fix the label of the created CPPOverload for `operator<=` when used in `tp_richcompare` for CPPInstance comparison.

This copy-paste typo has no effect in practice because it's just for a label to an internal CPPOverload instance, but it's still cleaner if it's consistent and then it doesn't trip up future readers of the code.