### PR TITLE
[Python] Remove `TCollection.count()` pythonization

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -370,6 +370,17 @@ json_str = json.dumps(h, default=uhi.io.json.default)
 h_from_uhi = ROOT.TH1D(json.loads(json_str, , object_hook=uhi.io.json.object_hook))
 ```
 
+### Removed `TCollection.count()` Pythonization
+
+The Python-only `TCollection.count()` method has been removed. The meaning of the underlying comparison was ambiguous for C++ objects: depending on the element class, it might have counted by matching by value equality or pointer equality. This behavior can vary silently between classes and lead to inconsistent or misleading results, so it was safer to remove the `count()` method.
+
+Users who need to count occurrences in a **TCollection** can explicitly implement the desired comparison logic in Python, for example:
+
+```Python
+sum(1 for x in collection if x is obj)   # pointer comparison
+sum(1 for x in collection if x == obj)   # value comparison (if defined for the element C++ class)
+```
+
 ## ROOT executable
 
 - Removed stray linebreak when running `root -q` with input files or commands passed with `-e`.

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcollection.py
@@ -29,20 +29,6 @@ def _extend_pyz(self, c):
     for _ in range(len(c)):
         self.Add(next(it))
 
-def _count_pyz(self, o):
-    # Parameters:
-    # - self: collection
-    # - o: object to be counted in the collection
-    # Returns:
-    # - Number of occurrences of the object in the collection
-    n = 0
-
-    for elem in self:
-        if elem == o:
-            n += 1
-
-    return n
-
 # Python operators
 
 def _add_pyz(self, c):
@@ -117,7 +103,6 @@ def pythonize_tcollection(klass):
     klass.append = klass.Add
     klass.remove = _remove_pyz
     klass.extend = _extend_pyz
-    klass.count = _count_pyz
 
     # Define Python operators
     klass.__add__ = _add_pyz

--- a/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
+++ b/bindings/pyroot/pythonizations/test/tcollection_listmethods.py
@@ -100,21 +100,6 @@ class TCollectionListMethods(unittest.TestCase):
         for _ in range(len2):
             self.assertIs(itc1.Next(), itc2.Next())
 
-    def test_count(self):
-        c = ROOT.TList()
-
-        o1 = ROOT.TObject()
-        o2 = ROOT.TObject()
-
-        c.Add(o1)
-        c.Add(o2)
-        c.Add(o1)
-
-        self.assertEqual(c.count(o1), 2)
-        self.assertEqual(c.count(o2), 1)
-
-        c.Clear()
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/roottest/python/basic/PyROOT_basictests.py
+++ b/roottest/python/basic/PyROOT_basictests.py
@@ -332,9 +332,9 @@ class Basic5PythonizationTestCase( MyTestCase ):
 
       l.extend( [ make_obj_str('5'), make_obj_str('j') ] )
       self.assertEqual( list(l), ['a', 'b', '1', '2', 'i', 'j', '3', '4', '5', 'j'] )
-      self.assertEqual( l.count( 'b' ), 1 )
-      self.assertEqual( l.count( 'j' ), 2 )
-      self.assertEqual( l.count( 'x' ), 0 )
+      self.assertEqual( sum(1 for x in l if x == 'b'), 1 )
+      self.assertEqual( sum(1 for x in l if x == 'j'), 2 )
+      self.assertEqual( sum(1 for x in l if x == 'x'), 0 )
 
       self.assertEqual( l.index( make_obj_str( 'i' ) ), 4 )
       self.assertRaises( ValueError, l.index, make_obj_str( 'x' ) )


### PR DESCRIPTION
The `TCollection.count()` pythonization is not clear in its docstring how the objects are compared for counting: by pointer or by value? In its implementation, it uses the `==` comparison operator, but this might do one or the other depending on whether `operator==` is implemented on the C++ side or not
(see discussion in https://github.com/root-project/root/issues/21347). So it's not clear what the intend of the Pythonization was.

The `TCollection` pythonizations introduced in
https://github.com/root-project/root/pull/3298 are undocumented, so I think the best solution to avoid this implementation ambiguity is just to remove the `TCollection.count()` Pythonization, which is also mentioned in the release notes.

As this extra-function in the Python interface was also never publictly advertised in release notes and tutorials, it is very likeliy unused and can be removed without deprecation period. And the faster this is removed, the smaller the likelihood that unclear comparisons in the counting negatively impacts users.