### PR TITLE
[6.32][ci] Update doxy build container config on alma10

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
 
     container:
-      image: registry.cern.ch/root-ci/alma9:buildready # ALSO UPDATE BELOW!
+      image: registry.cern.ch/root-ci/alma10:buildready # ALSO UPDATE BELOW!
       options: '--security-opt label=disable --rm --name rootdoc' # ALSO UPDATE BELOW!
       env:
         OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
@@ -91,7 +91,7 @@ jobs:
     - name: Apply option overrides
       env:
         OVERRIDES: "testing=Off roottest=Off minimal=On"
-        CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma9.txt'
+        CONFIGFILE: '.github/workflows/root-ci-config/buildconfig/alma10.txt'
       shell: bash
       run: |
         set -x


### PR DESCRIPTION
Commit 0a9d051fdb90b55f198500d6ae2d3a4b8d38860e Updated `PLATFORM: alma10` downloading build artifacts from the `alma10` S3 bucket, but the doxy build still ran on `alma9`.

The build now fails with the error:
```
2026-03-11T01:39:37.0012392Z /github/home/ROOT-CI/src/interpreter/llvm-project/llvm/lib/Support/Unix/Process.inc: In static member function ‘static unsigned int llvm::sys::Process::GetRandomNumber()’:
2026-03-11T01:39:37.0015851Z /github/home/ROOT-CI/src/interpreter/llvm-project/llvm/lib/Support/Unix/Process.inc:452:10: error: ‘arc4random’ was not declared in this scope; did you mean ‘srandom’?
2026-03-11T01:39:37.0016462Z   452 |   return arc4random();
2026-03-11T01:39:37.0016645Z       |          ^~~~~~~~~~
2026-03-11T01:39:37.0016807Z       |          srandom
```

[`arc4random`](https://man7.org/linux/man-pages/man3/arc4random.3.html) was added in `glibc 2.36`, `alma9` ships [`glibc 2.34`](https://wiki.almalinux.org/release-notes/9.0.html#changelog).

 here i also update `image` and `CONFIGFILE` to `alma10`.