### PR TITLE
[6.32][skip-ci] Fix qhelpgenerator-qt5 check on alma10

### DIFF
--- a/.github/workflows/root-docs-ci.yml
+++ b/.github/workflows/root-docs-ci.yml
@@ -86,7 +86,7 @@ jobs:
         dnf update -y
         dnf upgrade -y
         dnf install -y qt5-doctools
-        which qhelpgenerator-qt5
+        command -v qhelpgenerator-qt5
 
     - name: Apply option overrides
       env:


### PR DESCRIPTION
The build fails with `which: command not found` on the `alma10:buildready` image, here we replace it with `command -v`.