### PR TITLE
[ci][skip-ci] Remove the VS update job

### DIFF
--- a/.github/workflows/visual-studio-latest.yml
+++ b/.github/workflows/visual-studio-latest.yml
@@ -2,46 +2,12 @@ name: 'Visual Studio - Latest'
 
 on:
   workflow_dispatch:
-    inputs:
-      selected-job:
-        description: 'Select which job to run'
-        required: true
-        default: 'Build'
-        type: choice
-        options:
-        - Update
-        - Build
   schedule:
-    - cron: '0  6 * * 3'
     - cron: '0  7 * * 3'
 
 jobs:
-  update-visualstudio-latest:
-    if: ${{ github.event.schedule == '0  6 * * 3' || (github.event_name == 'workflow_dispatch' && inputs.selected-job == 'Update') }}
-
-    name: Update Visual Studio - Latest
-
-    runs-on:
-      - self-hosted
-      - windows
-      - x64
-      - latest
-
-    steps:
-    - name: Update Visual Studio Latest
-      shell: cmd
-      run: "C:\\bin\\vs_update.bat"
-
-    - name: Display Update Log - Visual Studio Latest
-      shell: cmd
-      run: "timeout 30 > NUL & type C:\\ROOT-CI\\VS-Update.log"
-
-    - name: Reboot after update - Visual Studio Latest
-      shell: cmd
-      run: "timeout 30 > NUL & shutdown /r"
-
   build-windows:
-    if: ${{ github.event.schedule == '0  7 * * 3' || (github.event_name == 'workflow_dispatch' && inputs.selected-job == 'Build') }}
+    if: ${{ github.event.schedule == '0  7 * * 3' || github.event_name == 'workflow_dispatch' }}
 
     permissions:
       contents: read
@@ -58,6 +24,10 @@ jobs:
       - latest
 
     steps:
+      - name: Display Update Log - Visual Studio Latest
+        shell: cmd
+        run: "type C:\\ROOT-CI\\VS-Update.log"
+
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/visual-studio-preview.yml
+++ b/.github/workflows/visual-studio-preview.yml
@@ -2,46 +2,12 @@ name: 'Visual Studio - Preview'
 
 on:
   workflow_dispatch:
-    inputs:
-      selected-job:
-        description: 'Select which job to run'
-        required: true
-        default: 'Build'
-        type: choice
-        options:
-        - Update
-        - Build
   schedule:
-    - cron: '0  6 * * 3'
     - cron: '0  7 * * 3'
 
 jobs:
-  update-visualstudio-preview:
-    if: ${{ github.event.schedule == '0  6 * * 3' || (github.event_name == 'workflow_dispatch' && inputs.selected-job == 'Update') }}
-
-    name: Update Visual Studio - Preview (Insiders)
-
-    runs-on:
-      - self-hosted
-      - windows
-      - x64
-      - preview
-
-    steps:
-    - name: Update Visual Studio Preview
-      shell: cmd
-      run: "C:\\bin\\vs_update.bat"
-
-    - name: Display Update Log - Visual Studio Preview
-      shell: cmd
-      run: "timeout 30 > NUL & type C:\\ROOT-CI\\VS-Update.log"
-
-    - name: Reboot after update - Visual Studio Preview
-      shell: cmd
-      run: "timeout 30 > NUL & shutdown /r"
-
   build-windows:
-    if: ${{ github.event.schedule == '0  7 * * 3' || (github.event_name == 'workflow_dispatch' && inputs.selected-job == 'Build') }}
+    if: ${{ github.event.schedule == '0  7 * * 3' || github.event_name == 'workflow_dispatch' }}
 
     permissions:
       contents: read
@@ -58,6 +24,10 @@ jobs:
       - preview
 
     steps:
+      - name: Display Update Log - Visual Studio Preview
+        shell: cmd
+        run: "type C:\\ROOT-CI\\VS-Update.log"
+
       - name: Checkout
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Updating Visual Studio requires elevated privileges
So delegate the update process to the task scheduler
