### PR TITLE
[CMake][tmva] Fix SOFIE tests exclusion with builtin GSL

### DIFF
--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -46,7 +46,7 @@ ROOTTEST_ADD_TEST(SofieCompileModels_ONNX
 )
 
 # Creating a Google Test
-if (BLAS_FOUND OR use_gsl_cblas)  # we need BLAS for compiling the models
+if (TARGET ROOT::BLAS)  # we need BLAS for compiling the models
   ROOT_EXECUTABLE(TestCustomModelsFromONNX TestCustomModelsFromONNX.cxx
     LIBRARIES
       Core
@@ -74,7 +74,7 @@ ROOTTEST_ADD_TEST(SofieCompileModels_ROOT
   FIXTURES_SETUP sofie-compile-models-root
 )
 
-if (BLAS_FOUND OR use_gsl_cblas)
+if (TARGET ROOT::BLAS)
   # Creating a Google Test for Serialisation of RModel
   ROOT_EXECUTABLE(TestCustomModelsFromROOT TestCustomModelsFromROOT.cxx
     LIBRARIES
@@ -119,7 +119,7 @@ if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND NOT broken_onnx)
   configure_file(LinearModelGenerator.py  LinearModelGenerator.py COPYONLY)
   configure_file(RecurrentModelGenerator.py  RecurrentModelGenerator.py COPYONLY)
 
-  if (BLAS_FOUND OR use_gsl_cblas)
+  if (TARGET ROOT::BLAS)
     ROOT_ADD_GTEST(TestSofieModels TestSofieModels.cxx
       LIBRARIES
         ROOTTMVASofie
@@ -132,7 +132,7 @@ if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND NOT broken_onnx)
 endif()
 
 # Any features that link against libpython are disabled if built with tpython=OFF
-if (tpython AND ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND (BLAS_FOUND OR use_gsl_cblas) AND NOT broken_onnx)
+if (tpython AND ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND AND (TARGET ROOT::BLAS) AND NOT broken_onnx)
   configure_file(generatePyTorchModels.py generatePyTorchModels.py COPYONLY)
 
   # Test RModelParser_PyTorch
@@ -151,7 +151,7 @@ endif()
 
 
 # Any features that link against libpython are disabled if built with tpython=OFF
-if (tpython AND ROOT_KERAS_FOUND AND (BLAS_FOUND OR use_gsl_cblas))
+if (tpython AND ROOT_KERAS_FOUND AND (TARGET ROOT::BLAS))
 
    configure_file(generateKerasModels.py generateKerasModels.py COPYONLY)
    configure_file(scale_by_2_op.hxx scale_by_2_op.hxx COPYONLY)


### PR DESCRIPTION
# This Pull request:

The TMVA-SOFIE test configurations in `tmva/sofie/test/CMakeLists.txt` currently gate the GTest targets strictly on `if(BLAS_FOUND)`. 

However, when ROOT is configured to fall back to the builtin GSL library to fulfill its BLAS interface requirement (`-Dbuiltin_gsl=ON`), the `use_gsl_cblas` CMake flag is correctly set to `ON`, but `BLAS_FOUND` remains `OFF`. 

Consequently, TMVA successfully links against the internal `ROOT::BLAS` interface, but the SOFIE execution tests (e.g., `TestRModelParserKeras`, `TestRModelParserPyTorch`) are silently excluded from the build manifest.

This patch updates the capability checks to account for both standalone BLAS discovery and GSL CBLAS fallback by verifying `if (BLAS_FOUND OR use_gsl_cblas)`.

### Reproducer
```bash
cmake -Dbuiltin_gsl=ON -Dtpython=ON -DROOT_TEST_KERAS=ON ../src
cmake --build . --target TestRModelParserKeras
```
(Fails: Target does not exist prior to this patch).

## Changes or fixes:

The capability checks in `tmva/sofie/test/CMakeLists.txt` need to account for both standalone BLAS discovery and GSL CBLAS fallback.

For instance, surrounding the GTest targets, the conditional logic:
```CMake
if (BLAS_FOUND)
```
And
```CMake
if (tpython AND ROOT_KERAS_FOUND AND BLAS_FOUND)
```
Should be updated to:
```CMake
if (BLAS_FOUND OR use_gsl_cblas)
```
And
```CMake
if (tpython AND ROOT_KERAS_FOUND AND (BLAS_FOUND OR use_gsl_cblas))
```

(I have tested this patch locally and it successfully re-enables the test suite compilation while correctly linking TestRModelParserKeras against the GSL CBLAS interface).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

@bellenot @lmoneta @sanjibansg @guitargeek 
