### PR TITLE
[roottest] Refactor custom_diff.py

### DIFF
--- a/roottest/scripts/custom_diff.py
+++ b/roottest/scripts/custom_diff.py
@@ -1,11 +1,11 @@
-""" Clever (with filters) compare command using difflib.py providing diffs in four formats:
+"""Clever (with filters) compare command using difflib.py providing diffs in four formats:
 
-  * ndiff:    lists every line and highlights interline changes.
-  * context:  highlights clusters of changes in a before/after format.
-  * unified:  highlights clusters of changes in an inline format.
-  * html:     generates side by side comparison with change highlights.
+* ndiff:    lists every line and highlights interline changes.
+* context:  highlights clusters of changes in a before/after format.
+* unified:  highlights clusters of changes in an inline format.
+* html:     generates side by side comparison with change highlights.
 
-  """
+"""
 import difflib
 import optparse
 import os
@@ -13,55 +13,73 @@ import re
 import sys
 import time
 
+
 #---------------------------------------------------------------------------------------------------------------------------
 #---Filter and substitutions------------------------------------------------------------------------------------------------
+class LineFilter:
+    """A line filter to suppress lines in the diff.
+    self.skip_regexes contains patterns to skip entirely.
+    self.substitutions contains patterns to replace with the given strings.
+    These patterns only need to be compiled once for all the incoming lines.
+    """
 
-def filter(lines, ignoreWhiteSpace = False):
-  outlines = []
-  for line in lines:
-    if sys.platform == 'win32':
-      if 'Creating library ' in line:
-        continue
-      if '_ACLiC_dict' in line:
-        continue
-      if 'Warning in <TInterpreter::ReadRootmapFile>:' in line:
-        continue
-      if 'Warning in <TClassTable::Add>:' in line:
-        continue
-      if 'Error: Removing ' in line:
-        continue
-      if ' -nologo -TP -c -nologo -I' in line:
-        continue
-      if 'rootcling -v1 -f ' in line:
-        continue
-      if 'No precompiled header available' in line:
-        continue
-      #if line in ['\n', '\r\n']:
-      #  continue
-    #---Processing line from interpreter (root.exe)------------------------------
-    if re.match(r'^Processing ', line):
-      continue
-    #---ACLiC info---------------------------------------------------------------
-    if re.match(r'^Info in <\w+::ACLiC>: creating shared library', line):
-      continue
-    #---Compilation error--------------------------------------------------------
-    elif re.search(r': error:', line):
-      nline = re.sub(r'\S+/', '', line)
-      nline = re.sub(r'(:|_)[0-9]+(?=:)', ':--', nline)
-    #---Wrapper input line-------------------------------------------------------
-    elif re.match(r'^In file included from input_line', line):
-      continue
-    else:
-      nline = line
-    #---Remove Addresses in cling/cint-------------------------------------------
-    nline = re.sub(r'[ ]@0x[a-fA-F0-9]+', '', nline)
-    #---Remove versioning in std-------------------------------------------------
-    nline = re.sub(r'std::__[0-9]::', 'std::', nline)
-    #---Remove white spaces------------------------------------------------------
-    if (ignoreWhiteSpace):
-      nline = re.sub(r'[ ]', '', nline)
-    outlines.append(nline)
-  return outlines
+    def __init__(self):
+        # Skip these lines
+        self.skip_regexes = [
+            re.compile(pattern)
+            for pattern in [
+                r"^Processing ",  # Interpreted macros
+                r"^Info in <\w+::ACLiC>: creating shared library",  # Compiled macros
+                r"^In file included from input_line",  # Wrapper input line
+                r"^[:space:]*$",  # Lines which are empty apart from spaces
+            ]
+        ]
+
+        # Replace these patterns in all lines
+        self.substitutions = [
+            (re.compile(r"[ ]@0x[a-fA-F0-9]+"), ""),  # Remove pointers from output
+            (re.compile(r"std::__[0-9]+::"), "std::"),  # Canonicalise standard namespaces
+            (
+                re.compile(r"^(\S*/|)([^:/]+)[-:0-9]*(?=: error:)"),
+                r"\2",
+            ),  # Trim file paths and line numbers from lines with ": error:"
+            (re.compile(r"(input_line_|ROOT_prompt_)[0-9]+"), r"\1--"),  # Canonicalise input_line_123, ROOT_prompt_345
+        ]
+
+    def filter(self, lines, ignoreWhiteSpace=False):
+        outlines = []
+        for line in lines:
+            if sys.platform == "win32":
+                if "Creating library " in line:
+                    continue
+                if "_ACLiC_dict" in line:
+                    continue
+                if "Warning in <TInterpreter::ReadRootmapFile>:" in line:
+                    continue
+                if "Warning in <TClassTable::Add>:" in line:
+                    continue
+                if "Error: Removing " in line:
+                    continue
+                if " -nologo -TP -c -nologo -I" in line:
+                    continue
+                if "rootcling -v1 -f " in line:
+                    continue
+                if "No precompiled header available" in line:
+                    continue
+
+            # ---Skip all lines matching predefined expressions---------------------------
+            if any(pattern.match(line) is not None for pattern in self.skip_regexes):
+                continue
+
+            # ---Apply predefined replacements--------------------------------------------
+            for pattern, replacement in self.substitutions:
+                line = pattern.sub(replacement, line)
+
+            # ---Remove white spaces------------------------------------------------------
+            if ignoreWhiteSpace:
+                line = re.sub(r"[ ]", "", line)
+            outlines.append(line)
+        return outlines
 
 #-----------------------------------------------------------------------------------------------------------------------------
 def main():
@@ -92,8 +110,9 @@ def main():
     fromlines = open(fromfile, 'r' if sys.version_info >= (3, 4) else 'U').readlines()
     tolines = open(tofile, 'r' if sys.version_info >= (3, 4) else 'U').readlines()
 
-  nows_fromlines = filter(fromlines, True)
-  nows_tolines = filter(tolines, True)
+  lineFilter = LineFilter()
+  nows_fromlines = lineFilter.filter(fromlines, True)
+  nows_tolines = lineFilter.filter(tolines, True)
 
   check = difflib.context_diff(nows_fromlines, nows_tolines)
   try:
@@ -101,8 +120,8 @@ def main():
   except StopIteration:
     sys.exit(0)
 
-  fromlines = filter(fromlines, False)
-  tolines = filter(tolines, False)
+  fromlines = lineFilter.filter(fromlines, False)
+  tolines = lineFilter.filter(tolines, False)
 
   if options.u:
     diff = difflib.unified_diff(fromlines, tolines, fromfile, tofile, fromdate, todate, n=n)


### PR DESCRIPTION
For #18083, I wanted to add a regex to the custom_diff script. I thought it would be nice to collect all suppressions and replacements in one single place, and precompile the regexes before starting to apply the filter.
The speed gains are small, since the script only runs < 1s typically, but now one can add further filters/replacements by adding one single line instead of having to deal with if/else/continue.

This also was a good opportunity to "ruff" it up a little bit.