### PR TITLE
[math] Remove the pasted ERotation3DMatrixIndex

### DIFF
--- a/math/experimental/genvectorx/src/3DConversions.cxx
+++ b/math/experimental/genvectorx/src/3DConversions.cxx
@@ -42,6 +42,9 @@ namespace ROOT {
 namespace ROOT_MATH_ARCH {
 namespace gv_detail {
 
+#if __cplusplus >= 202002L
+using enum Rotation3D::ERotation3DMatrixIndex;
+#else
 enum ERotation3DMatrixIndex {
    kXX = Rotation3D::kXX,
    kXY = Rotation3D::kXY,
@@ -53,6 +56,7 @@ enum ERotation3DMatrixIndex {
    kZY = Rotation3D::kZY,
    kZZ = Rotation3D::kZZ
 };
+#endif
 
 // ----------------------------------------------------------------------
 void convert(Rotation3D const &from, AxisAngle &to)

--- a/math/experimental/genvectorx/src/3DDistances.cxx
+++ b/math/experimental/genvectorx/src/3DDistances.cxx
@@ -36,18 +36,6 @@ namespace ROOT {
 namespace ROOT_MATH_ARCH {
 namespace gv_detail {
 
-enum ERotation3DMatrixIndex {
-   kXX = 0,
-   kXY = 1,
-   kXZ = 2,
-   kYX = 3,
-   kYY = 4,
-   kYZ = 5,
-   kZX = 6,
-   kZY = 7,
-   kZZ = 8
-};
-
 // ----------------------------------------------------------------------
 // distance from Rotation3D
 

--- a/math/experimental/genvectorx/src/AxisAngle.cxx
+++ b/math/experimental/genvectorx/src/AxisAngle.cxx
@@ -65,20 +65,6 @@ void AxisAngle::Rectify()
    RectifyAngle();
 } // Rectify()
 
-// ======== Transformation to other Rotation Forms ==================
-
-enum ERotation3DMatrixIndex {
-   kXX = 0,
-   kXY = 1,
-   kXZ = 2,
-   kYX = 3,
-   kYY = 4,
-   kYZ = 5,
-   kZX = 6,
-   kZY = 7,
-   kZZ = 8
-};
-
 // ========== Operations =====================
 
 DisplacementVector3D<Cartesian3D<double>> AxisAngle::operator()(const XYZVector &v) const

--- a/math/genvector/src/3DConversions.cxx
+++ b/math/genvector/src/3DConversions.cxx
@@ -39,12 +39,15 @@ namespace ROOT {
 namespace Math {
 namespace gv_detail {
 
+#if __cplusplus >= 202002L
+using enum Rotation3D::ERotation3DMatrixIndex;
+#else
 enum ERotation3DMatrixIndex
 { kXX = Rotation3D::kXX, kXY = Rotation3D::kXY, kXZ = Rotation3D::kXZ
 , kYX = Rotation3D::kYX, kYY = Rotation3D::kYY, kYZ = Rotation3D::kYZ
 , kZX = Rotation3D::kZX, kZY = Rotation3D::kZY, kZZ = Rotation3D::kZZ
 };
-
+#endif
 
 // ----------------------------------------------------------------------
 void convert( Rotation3D const & from, AxisAngle   & to)

--- a/math/genvector/src/3DDistances.cxx
+++ b/math/genvector/src/3DDistances.cxx
@@ -34,14 +34,6 @@ namespace ROOT {
 namespace Math {
 namespace gv_detail {
 
-
-enum ERotation3DMatrixIndex
-{ kXX = 0, kXY = 1, kXZ = 2
-, kYX = 3, kYY = 4, kYZ = 5
-, kZX = 6, kZY = 7, kZZ = 8
-};
-
-
 // ----------------------------------------------------------------------
 // distance from Rotation3D
 

--- a/math/genvector/src/AxisAngle.cxx
+++ b/math/genvector/src/AxisAngle.cxx
@@ -59,16 +59,6 @@ void AxisAngle::Rectify()
    RectifyAngle();
 } // Rectify()
 
-// ======== Transformation to other Rotation Forms ==================
-
-enum ERotation3DMatrixIndex {
-   kXX = 0, kXY = 1, kXZ = 2
-   , kYX = 3, kYY = 4, kYZ = 5
-   , kZX = 6, kZY = 7, kZZ = 8
-};
-
-
-
 // ========== Operations =====================
 
 DisplacementVector3D< Cartesian3D<double> >


### PR DESCRIPTION
Use a single source for it when needed; more precisely, remove it in files where it's not used. Also prepare for using C++20 where `using enum` is allowed and is basically what is being done.