### PR TITLE
[x11] Fixes in Rotated.cxx

### DIFF
--- a/graf2d/x11/src/Rotated.cxx
+++ b/graf2d/x11/src/Rotated.cxx
@@ -813,6 +813,8 @@ static RotatedTextItem_t *XRotCreateTextItem(Display *dpy, XFontStruct *font, fl
    RotatedTextItem_t *item = (RotatedTextItem_t *)malloc((unsigned)sizeof(RotatedTextItem_t));
    if(!item) return nullptr;
 
+   memset(item, 0, sizeof(RotatedTextItem_t));
+
    /* count number of sections in string */
    item->fNl=1;
    if(align!=NONE)
@@ -868,7 +870,7 @@ static RotatedTextItem_t *XRotCreateTextItem(Display *dpy, XFontStruct *font, fl
 
    /* bitmap for drawing on */
    canvas=XCreatePixmap(dpy, DefaultRootWindow(dpy),
-                         item->fColsIn, item->fRowsIn, 1);
+                         item->fColsIn > 0 ? item->fColsIn : 1, item->fRowsIn, 1);
 
    /* create a GC for the bitmap */
    font_gc = XCreateGC(dpy, canvas, 0, nullptr);


### PR DESCRIPTION
1. Clear all members in RotatedTextItem_t via memset(item, 0). Otherwise some values like fXimage can stay uninitialized.

2. When create pixmap, provide at least size 1 x 1 - otherwise X11 server may complain

Failure appears with plain TX11 text drawing.
Just add to .rootrc line:
```
 Gui.Backend: x11
```

And in the begin of script add:
 ```
gVirtualX->SetTextMagnitude(1.1)
```

Then X11 made a lot of errors like:
```
Error in <RootX11ErrorHandler>: BadDrawable (invalid Pixmap or Window parameter) (XID: 44040631, XREQ: 55)
```
And either ROOT crashes or graphics will not work