### PR TITLE
[Python][RF] Set correct Python-side ownership to function return values

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsdata.py
@@ -56,9 +56,12 @@ class RooAbsData(object):
         r"""The RooAbsData::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsData.createHistogram` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createHistogram(*args, **kwargs)
+        out = self._createHistogram(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooAbsData *RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2={},"
@@ -70,9 +73,12 @@ class RooAbsData(object):
         r"""The RooAbsData::reduce() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsData.reduce` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._reduce(*args, **kwargs)
+        out = self._reduce(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooPlot *RooAbsData::statOn(RooPlot* frame,"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabspdf.py
@@ -66,8 +66,11 @@ class RooAbsPdf(RooAbsReal):
         r"""The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsPdf.fitTo` for keyword arguments.
-        return self._fitTo["RooLinkedList const&"](args[0], _pack_cmd_args(*args[1:], **kwargs))
+        import ROOT
+
+        out = self._fitTo["RooLinkedList const&"](args[0], _pack_cmd_args(*args[1:], **kwargs))
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooPlot *RooAbsPdf::plotOn(RooPlot* frame,"
@@ -120,8 +123,11 @@ class RooAbsPdf(RooAbsReal):
         r"""The RooAbsPdf::createNLL() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsPdf.createNLL` for keyword arguments.
-        return self._createNLL["RooLinkedList const&"](args[0], _pack_cmd_args(*args[1:], **kwargs))
+        import ROOT
+
+        out = self._createNLL["RooLinkedList const&"](args[0], _pack_cmd_args(*args[1:], **kwargs))
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooAbsReal *RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
@@ -133,9 +139,12 @@ class RooAbsPdf(RooAbsReal):
         r"""The RooAbsPdf::createCdf() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsPdf.createCdf` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createCdf(*args, **kwargs)
+        out = self._createCdf(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooDataHist *RooAbsPdf::generateBinned(const RooArgSet &whatVars,"
@@ -147,9 +156,12 @@ class RooAbsPdf(RooAbsReal):
         r"""The RooAbsPdf::generateBinned() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsPdf.generateBinned` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._generateBinned(*args, **kwargs)
+        out = self._generateBinned(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "GenSpec *RooAbsPdf::prepareMultiGen(const RooArgSet &whatVars,"

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
@@ -58,9 +58,12 @@ class RooAbsReal(object):
         r"""The RooAbsReal::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsReal.createHistogram` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createHistogram(*args, **kwargs)
+        out = self._createHistogram(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
@@ -72,9 +75,12 @@ class RooAbsReal(object):
         r"""The RooAbsReal::createIntegral() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsReal.createIntegral` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createIntegral(*args, **kwargs)
+        out = self._createIntegral(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCmdArg& arg1, const RooCmdArg& arg2={},"
@@ -86,9 +92,12 @@ class RooAbsReal(object):
         r"""The RooAbsReal::createRunningIntegral() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsReal.createRunningIntegral` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createRunningIntegral(*args, **kwargs)
+        out = self._createRunningIntegral(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooAbsReal* RooAbsReal::createChi2(RooDataHist& data, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},"
@@ -99,9 +108,12 @@ class RooAbsReal(object):
         r"""The RooAbsReal::createChi2() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsReal.createChi2` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createChi2(*args, **kwargs)
+        out = self._createChi2(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooFitResult *RooAbsReal::chi2FitTo(RooDataSet& xydata, const RooCmdArg& arg1={},  const RooCmdArg& arg2={},"
@@ -112,9 +124,12 @@ class RooAbsReal(object):
         r"""The RooAbsReal::chi2FitTo() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsReal.chi2FitTo` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._chi2FitTo(*args, **kwargs)
+        out = self._chi2FitTo(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     def setEvalErrorLoggingMode(m):
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
@@ -40,9 +40,12 @@ class RooAbsRealLValue(object):
         r"""The RooAbsRealLValue::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
-        # Redefinition of `RooAbsRealLValue.createHistogram` for keyword arguments.
+        import ROOT
+
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._createHistogram(*args, **kwargs)
+        out = self._createHistogram(*args, **kwargs)
+        ROOT.SetOwnership(out, True)
+        return out
 
     @cpp_signature(
         "RooPlot *RooAbsRealLValue::frame(const RooCmdArg& arg1, const RooCmdArg& arg2={},"

--- a/tutorials/roofit/roofit/rf617_simulation_based_inference_multidimensional.py
+++ b/tutorials/roofit/roofit/rf617_simulation_based_inference_multidimensional.py
@@ -78,6 +78,7 @@ def morphing(setting, n_dimensions):
             hist.add(hist.get(i_bin), 1.0)
 
         templates[nd_idx] = ROOT.RooHistPdf(f"histpdf{idx}", f"histpdf{idx}", ROOT.RooArgSet(*x_vars), hist, 1)
+        templates[nd_idx]._data_hist = hist  # To keep the underlying RooDataHist alive
 
         # Add the PDF to the grid
         grid.addPdf(templates[nd_idx], *nd_idx)


### PR DESCRIPTION
We still have no mechanism to annotate C++ signatures to flag to cppyy that the returned value needs to be manually deleted. Thils should be prioritized after the current upgrade to the new compiler toolchain.

Until then, RooFit methods need to be manually Pythonized for clear ownership to avoid memory leaks, such as the one reported on the forum:

https://root-forum.cern.ch/t/how-to-clean-delete-properly-roodataset-in-pyroot/64749