### PR TITLE
[AI SLOP] docs: secure and modernize HTTP external reference links in tutorials

### DIFF
--- a/tutorials/analysis/dataframe/df014_CSVDataSource.C
+++ b/tutorials/analysis/dataframe/df014_CSVDataSource.C
@@ -11,7 +11,7 @@
 /// Dataset Reference:
 /// McCauley, T. (2014). Dimuon event information derived from the Run2010B
 /// public Mu dataset. CERN Open Data Portal.
-/// DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](http://opendata.cern.ch/record/700).
+/// DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](https://opendata.cern.ch/record/700).
 ///
 /// \macro_code
 /// \macro_image

--- a/tutorials/analysis/dataframe/df014_CSVDataSource.py
+++ b/tutorials/analysis/dataframe/df014_CSVDataSource.py
@@ -11,7 +11,7 @@
 ## Dataset Reference:
 ## McCauley, T. (2014). Dimuon event information derived from the Run2010B
 ## public Mu dataset. CERN Open Data Portal.
-## DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](http://opendata.cern.ch/record/700).
+## DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](https://opendata.cern.ch/record/700).
 ##
 ## \macro_code
 ## \macro_image

--- a/tutorials/analysis/dataframe/df015_LazyDataSource.C
+++ b/tutorials/analysis/dataframe/df015_LazyDataSource.C
@@ -10,7 +10,7 @@
 /// Dataset Reference:
 /// McCauley, T. (2014). Dimuon event information derived from the Run2010B
 /// public Mu dataset. CERN Open Data Portal.
-/// DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](http://opendata.cern.ch/record/700).
+/// DOI: [10.7483/OPENDATA.CMS.CB8H.MFFA](https://opendata.cern.ch/record/700).
 /// From the ROOT website: https://root.cern/files/tutorials/tdf014_CsvDataSource_MuRun2010B.csv
 ///
 /// \macro_code

--- a/tutorials/analysis/dataframe/df028_SQliteIPLocation.C
+++ b/tutorials/analysis/dataframe/df028_SQliteIPLocation.C
@@ -11,7 +11,7 @@
 /// The data related to the latitude and the longitude has been provided from the
 /// log files storing the users IP.
 /// This product includes GeoLite2 data created by MaxMind, available from
-/// <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+/// <a href="https://www.maxmind.com">https://www.maxmind.com</a>.
 ///
 /// \macro_code
 /// \macro_image

--- a/tutorials/analysis/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/analysis/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -6,8 +6,8 @@
 /// This tutorial illustrates how NanoAOD files can be processed with ROOT
 /// dataframes. The NanoAOD-like input files are filled with 66 mio. events
 /// from CMS OpenData containing muon candidates part of 2012 dataset
-/// ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](http://opendata.cern.ch/record/6004)
-/// and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](http://opendata.cern.ch/record/6030)).
+/// ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](https://opendata.cern.ch/record/6004)
+/// and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](https://opendata.cern.ch/record/6030)).
 /// The macro matches muon pairs and produces an histogram of the dimuon mass
 /// spectrum showing resonances up to the Z mass.
 /// Note that the bump at 30 GeV is not a resonance but a trigger effect.

--- a/tutorials/analysis/dataframe/df102_NanoAODDimuonAnalysis.py
+++ b/tutorials/analysis/dataframe/df102_NanoAODDimuonAnalysis.py
@@ -6,8 +6,8 @@
 ## This tutorial illustrates how NanoAOD files can be processed with ROOT
 ## dataframes. The NanoAOD-like input files are filled with 66 mio. events
 ## from CMS OpenData containing muon candidates part of 2012 dataset
-## ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](http://opendata.cern.ch/record/6004)
-## and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](http://opendata.cern.ch/record/6030)).
+## ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](https://opendata.cern.ch/record/6004)
+## and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](https://opendata.cern.ch/record/6030)).
 ## The macro matches muon pairs and produces an histogram of the dimuon mass
 ## spectrum showing resonances up to the Z mass.
 ## Note that the bump at 30 GeV is not a resonance but a trigger effect.

--- a/tutorials/analysis/dataframe/df103_NanoAODHiggsAnalysis.C
+++ b/tutorials/analysis/dataframe/df103_NanoAODHiggsAnalysis.C
@@ -8,7 +8,7 @@
 /// and simulated events are taken from CERN OpenData representing a subset of the data
 /// recorded in 2012 with the CMS detector at the LHC. The tutorials follows the Higgs
 /// to four leptons analysis published on CERN Open Data portal
-/// ([10.7483/OPENDATA.CMS.JKB8.RR42](http://opendata.cern.ch/record/5500)).
+/// ([10.7483/OPENDATA.CMS.JKB8.RR42](https://opendata.cern.ch/record/5500)).
 /// The resulting plots show the invariant mass of the selected four lepton systems
 /// in different decay modes (four muons, four electrons and two of each kind)
 /// and in a combined plot indicating the decay of the Higgs boson with a mass

--- a/tutorials/analysis/dataframe/df103_NanoAODHiggsAnalysis.py
+++ b/tutorials/analysis/dataframe/df103_NanoAODHiggsAnalysis.py
@@ -6,7 +6,7 @@
 ## This tutorial is a simplified but yet complex example of an analysis reconstructing the Higgs boson decaying to two Z
 ## bosons from events with four leptons. The data and simulated events are taken from CERN OpenData representing a
 ## subset of the data recorded in 2012 with the CMS detector at the LHC. The tutorials follows the Higgs to four leptons
-## analysis published on CERN Open Data portal ([10.7483/OPENDATA.CMS.JKB8.RR42](http://opendata.cern.ch/record/5500)).
+## analysis published on CERN Open Data portal ([10.7483/OPENDATA.CMS.JKB8.RR42](https://opendata.cern.ch/record/5500)).
 ## The resulting plots show the invariant mass of the selected four lepton systems in different decay modes (four muons,
 ## four electrons and two of each kind) and in a combined plot indicating the decay of the Higgs boson with a mass of
 ## about 125 GeV.

--- a/tutorials/hist/histv7/hist102_NanoAODDimuonAnalysis.C
+++ b/tutorials/hist/histv7/hist102_NanoAODDimuonAnalysis.C
@@ -7,8 +7,8 @@
 /// It illustrates how NanoAOD files can be processed with ROOT
 /// dataframes. The NanoAOD-like input files are filled with 66 mio. events
 /// from CMS OpenData containing muon candidates part of 2012 dataset
-/// ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](http://opendata.cern.ch/record/6004)
-/// and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](http://opendata.cern.ch/record/6030)).
+/// ([DOI: 10.7483/OPENDATA.CMS.YLIC.86ZZ](https://opendata.cern.ch/record/6004)
+/// and [DOI: 10.7483/OPENDATA.CMS.M5AD.Y3V3](https://opendata.cern.ch/record/6030)).
 /// The macro matches muon pairs and produces an histogram of the dimuon mass
 /// spectrum showing resonances up to the Z mass.
 /// Note that the bump at 30 GeV is not a resonance but a trigger effect.

--- a/tutorials/hist/histv7/hist103_NanoAODHiggsAnalysis.C
+++ b/tutorials/hist/histv7/hist103_NanoAODHiggsAnalysis.C
@@ -9,7 +9,7 @@
 /// and simulated events are taken from CERN OpenData representing a subset of the data
 /// recorded in 2012 with the CMS detector at the LHC. The tutorials follows the Higgs
 /// to four leptons analysis published on CERN Open Data portal
-/// ([10.7483/OPENDATA.CMS.JKB8.RR42](http://opendata.cern.ch/record/5500)).
+/// ([10.7483/OPENDATA.CMS.JKB8.RR42](https://opendata.cern.ch/record/5500)).
 /// The resulting plots show the invariant mass of the selected four lepton systems
 /// in different decay modes (four muons, four electrons and two of each kind)
 /// and in a combined plot indicating the decay of the Higgs boson with a mass

--- a/tutorials/io/sql/SQLiteIPLocation.C
+++ b/tutorials/io/sql/SQLiteIPLocation.C
@@ -12,7 +12,7 @@
 /// The data related to the latitude and the longitude has been provided from the
 /// log files storing the users IP.
 /// This product includes GeoLite2 data created by MaxMind, available from
-/// <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+/// <a href="https://www.maxmind.com">https://www.maxmind.com</a>.
 ///
 /// \macro_code
 ///

--- a/tutorials/io/sql/SQLitePlatformDistribution.C
+++ b/tutorials/io/sql/SQLitePlatformDistribution.C
@@ -10,7 +10,7 @@
 /// database. At the end, the histograms are filled
 /// with their specific demand regarding the platform's type.
 /// This product includes GeoLite2 data created by MaxMind, available from
-/// <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+/// <a href="https://www.maxmind.com">https://www.maxmind.com</a>.
 ///
 /// \macro_code
 ///

--- a/tutorials/io/sql/SQLiteTimeVersionOfRoot.C
+++ b/tutorials/io/sql/SQLiteTimeVersionOfRoot.C
@@ -9,7 +9,7 @@
 /// The next step is to create a TH1F Histogram, which will be filled with the values stored in
 /// two different columns from the database, the "Time" and "Version" columns.
 /// This product includes GeoLite2 data created by MaxMind, available from
-/// <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+/// <a href="https://www.maxmind.com">https://www.maxmind.com</a>.
 ///
 /// \macro_code
 ///

--- a/tutorials/io/sql/SQLiteVersionsOfRoot.C
+++ b/tutorials/io/sql/SQLiteVersionsOfRoot.C
@@ -9,7 +9,7 @@
 /// values in the "version" column of the sqlite3 database.
 /// The histogram shows the usage of the ROOT development version.
 /// This product includes GeoLite2 data created by MaxMind, available from
-/// <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+/// <a href="https://www.maxmind.com">https://www.maxmind.com</a>.
 ///
 /// \macro_code
 ///


### PR DESCRIPTION
### Description
Modernizes the tutorial scripts by converting outdated `http://` references to secure `https://` endpoints.

### Changes
- Updated reference URL links in the `tutorials/` directory (`*.C`, `*.py`, `*.cpp`) to use modern HTTPS without altering runtime execution parameters.