### PR TITLE
[builtins] Add -fPIC to the flags to build libgif

### DIFF
--- a/builtins/libgif/libgif_add_cmakelists.patch
+++ b/builtins/libgif/libgif_add_cmakelists.patch
@@ -20,7 +20,7 @@
 +)
 +
 +if(NOT MSVC)
-+    target_compile_options(gif-static PRIVATE -std=gnu99 -Wall -Wno-format-truncation)
++    target_compile_options(gif-static PRIVATE -std=gnu99 -fPIC -Wall -Wno-format-truncation)
 +endif()
 +
 +target_include_directories(gif-static PUBLIC ./)


### PR DESCRIPTION
-fPIC is in the source code flags (both in 5.2.2 and the latest version, 6.1.2) and is causing errors when building in the LCG stacks. The errors look like 

```
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: ..<path-to-libgif-static>: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
/cvmfs/sft.cern.ch/lcg/releases/binutils/2.40-acaab/x86_64-el9/bin/ld: failed to set dynamic section sizes: bad value
```

I have built on Alma 9 with GCC 14 and that doesn't appear with this change anymore. I think you didn't see it in your CI because there isn't a Linux version with this enabled.