### PR TITLE
[RF] Refactor coefficient updating for RooAddPdf and RooAddModel

### DIFF
--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -57,9 +57,8 @@ private:
 
 class RooAddHelpers {
 public:
-   static void updateCoefficients(RooAbsPdf const &addPdf, std::vector<double> &coefCache, RooArgList const &pdfList,
-                                  bool haveLastCoef, AddCacheElem &cache, const RooArgSet *nset,
-                                  RooArgSet const &refCoefNormSet, bool allExtendable, int &coefErrCount);
+   static void updateCoefficients(RooAbsPdf const &addPdf, std::size_t nPdfs, std::vector<double> &coefCache,
+                                  bool haveLastCoef, AddCacheElem &cache, int &coefErrCount);
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -329,14 +329,21 @@ AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* 
 /// multiply the various range and dimensional corrections needed in the
 /// current use context.
 
-void RooAddModel::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const
+void RooAddModel::updateCoefficients(AddCacheElem &cache, const RooArgSet *nset) const
 {
-  _coefCache.resize(_pdfList.size());
-  for(std::size_t i = 0; i < _coefList.size(); ++i) {
-    _coefCache[i] = static_cast<RooAbsReal const&>(_coefList[i]).getVal(nset);
-  }
-  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset,
-                                    _refCoefNorm, _allExtendable, _coefErrCount);
+   _coefCache.resize(_pdfList.size());
+   for (std::size_t i = 0; i < _coefList.size(); ++i) {
+      _coefCache[i] = static_cast<RooAbsReal const &>(_coefList[i]).getVal(nset);
+   }
+   if (_allExtendable) {
+      for (std::size_t i = 0; i < _pdfList.size(); ++i) {
+         auto &pdf = static_cast<RooAbsPdf &>(_pdfList[i]);
+         _coefCache[i] = pdf.expectedEvents(!_refCoefNorm.empty() ? &_refCoefNorm : nset);
+      }
+   }
+
+   RooAddHelpers::updateCoefficients(*this, _pdfList.size(), _coefCache, _haveLastCoef || _allExtendable, cache,
+                                     _coefErrCount);
 }
 
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -439,16 +439,23 @@ AddCacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* is
 ///                          need to be copied from the `_coefList` elements to
 ///                          the `_coefCache`. True by default.
 
-void RooAddPdf::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset, bool syncCoefValues) const
+void RooAddPdf::updateCoefficients(AddCacheElem &cache, const RooArgSet *nset, bool syncCoefValues) const
 {
-  _coefCache.resize(_pdfList.size());
-  if(syncCoefValues) {
-    for(std::size_t i = 0; i < _coefList.size(); ++i) {
-      _coefCache[i] = static_cast<RooAbsReal const&>(_coefList[i]).getVal(nset);
-    }
-  }
-  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset,
-                                    _refCoefNorm, _allExtendable, _coefErrCount);
+   _coefCache.resize(_pdfList.size());
+   if (syncCoefValues) {
+      for (std::size_t i = 0; i < _coefList.size(); ++i) {
+         _coefCache[i] = static_cast<RooAbsReal const &>(_coefList[i]).getVal(nset);
+      }
+   }
+   if (_allExtendable) {
+      for (std::size_t i = 0; i < _pdfList.size(); ++i) {
+         auto &pdf = static_cast<RooAbsPdf &>(_pdfList[i]);
+         _coefCache[i] = pdf.expectedEvents(!_refCoefNorm.empty() ? &_refCoefNorm : nset);
+      }
+   }
+
+   RooAddHelpers::updateCoefficients(*this, _pdfList.size(), _coefCache, _haveLastCoef || _allExtendable, cache,
+                                     _coefErrCount);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is to avoid relying too much on the RooAddPdf/Model implementation details in the RooAddHelpers. That will make it easier to port the RooAddHelpers to a free function for RooFit `codegen` in the future.

Spinoff from https://github.com/root-project/root/pull/21343, where this a prerequisite to refactor RooAddPdf further to avoid requiring the legacy dirty flag propagation.