### PR TITLE
[ci] Enable `tmva-pymva` on openSUSE march native platform

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/opensuse15-march_native.txt
+++ b/.github/workflows/root-ci-config/buildconfig/opensuse15-march_native.txt
@@ -8,6 +8,7 @@ builtin_unuran=ON
 builtin_nlohmannjson=ON
 test_distrdf_dask=OFF
 test_distrdf_pyspark=OFF
+tmva-pymva=ON
 tmva-sofie=ON
 pythia8=OFF
 r=OFF


### PR DESCRIPTION
Replay of 0f76e0aaab3, because we should have at least one platform that tests PyMVA. This flag was lost in the transition from Alma 9 to openSUSE in commit 6e8d66409161.