### PR TITLE
Revert "[format] Use AlignFunctionDeclarations from clang-format 20.1.0"

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,20 +1,9 @@
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments:
-  Enabled: true
-  AcrossEmptyLines: false
-  AcrossComments: true
-  AlignCompound: true
-  PadOperators: true
-AlignConsecutiveBitFields:
-  Enabled: true
-  AcrossEmptyLines: false
-  AcrossComments: false
-AlignConsecutiveDeclarations:
-  Enabled: true
-  # Part of clang-format 20.1.0
-  AlignFunctionDeclarations: true
+AlignConsecutiveAssignments: None
+# This would be nice to have but seems to also (mis)align function parameters
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true


### PR DESCRIPTION
This reverts commit ffe6e248fffb2131e75e35236c781451b86f10e7 from PR https://github.com/root-project/root/pull/19753.