### PR TITLE
[HS3] PiecwiseInterpolationFactory: Allow for functions as vars

### DIFF
--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -574,7 +574,7 @@ public:
    {
       std::string name(RooJSONFactoryWSTool::name(p));
 
-      RooArgList vars{tool->requestArgList<RooRealVar>(p, "vars")};
+      RooArgList vars{tool->requestArgList<RooAbsReal>(p, "vars")};
 
       auto &pip = tool->wsEmplace<PiecewiseInterpolation>(name, *tool->requestArg<RooAbsReal>(p, "nom"),
                                                           tool->requestArgList<RooAbsReal>(p, "low"),


### PR DESCRIPTION
# Changes or fixes:
Changed casting for PiecewiseInterpolationFactory to allow for functions in dependencies.

# Checklist:
- tested changes locally
