### PR TITLE
[6.38] [HS3] PiecwiseInterpolationFactory: Allow for functions as vars

### DIFF
--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -574,7 +574,7 @@ public:
    {
       std::string name(RooJSONFactoryWSTool::name(p));
 
-      RooArgList vars{tool->requestArgList<RooRealVar>(p, "vars")};
+      RooArgList vars{tool->requestArgList<RooAbsReal>(p, "vars")};
 
       auto &pip = tool->wsEmplace<PiecewiseInterpolation>(name, *tool->requestArg<RooAbsReal>(p, "nom"),
                                                           tool->requestArgList<RooAbsReal>(p, "low"),


### PR DESCRIPTION
Backport of #21630, requested by @guitargeek. For your information @Phmonski