### PR TITLE
[geom] Support quad facets in TGeoTessellatedBVH

### DIFF
--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -773,6 +773,28 @@ double rayTriangle(const Vertex_t &orig, const Vertex_t &dir, const Vertex_t &v0
    return (t > rayEPS) ? t : INF;
 }
 
+inline double rayFacet(const Vertex_t &orig, const Vertex_t &dir, const TGeoFacet &facet,
+                       const std::vector<Vertex_t> &vertices, double rayEPS = 1e-8)
+{
+   // Keep the stored facet topology intact and triangulate quads only for geometric queries.
+   const auto &v0 = vertices[facet[0]];
+   const auto &v1 = vertices[facet[1]];
+   const auto &v2 = vertices[facet[2]];
+   auto t = rayTriangle(orig, dir, v0, v1, v2, rayEPS);
+   if (facet.GetNvert() == 3)
+      return t;
+   const auto &v3 = vertices[facet[3]];
+   auto t2 = rayTriangle(orig, dir, v0, v2, v3, rayEPS);
+   return std::min(t, t2);
+}
+
+inline bool rayFacetHit(const Vertex_t &orig, const Vertex_t &dir, const TGeoFacet &facet,
+                        const std::vector<Vertex_t> &vertices, double rayEPS = 1e-8)
+{
+   // Contains/parity checks only need a boolean hit, so keep the finite-distance test in one place.
+   return rayFacet(orig, dir, facet, vertices, rayEPS) != std::numeric_limits<double>::infinity();
+}
+
 template <typename T = float>
 struct Vec3f {
    T x, y, z;
@@ -866,24 +888,21 @@ T pointTriangleDistSq(const Vec3f<T> &p, const Vec3f<T> &a, const Vec3f<T> &b, c
    return dot(d, d);
 }
 
-template <typename T>
-inline Vec3f<T> normalize(const Vec3f<T> &v)
+template <typename T = float>
+T pointFacetDistSq(const Vec3f<T> &p, const TGeoFacet &facet, const std::vector<Vertex_t> &vertices)
 {
-   T len2 = dot(v, v);
-   if (len2 == T(0.0f)) {
-      std::cerr << "Degnerate triangle. Cannot determine normal";
-      return {0, 0, 0};
-   }
-   T invLen = T(1.0f) / std::sqrt(len2);
-   return {v.x * invLen, v.y * invLen, v.z * invLen};
-}
-
-template <typename T>
-inline Vec3f<T> triangleNormal(const Vec3f<T> &a, const Vec3f<T> &b, const Vec3f<T> &c)
-{
-   const Vec3f<T> e1 = b - a;
-   const Vec3f<T> e2 = c - a;
-   return normalize(cross(e1, e2));
+   // Safety uses the same on-the-fly split as ray queries so triangles and quads stay consistent.
+   const auto &v0 = vertices[facet[0]];
+   const auto &v1 = vertices[facet[1]];
+   const auto &v2 = vertices[facet[2]];
+   auto d = pointTriangleDistSq(p, Vec3f<T>(v0[0], v0[1], v0[2]), Vec3f<T>(v1[0], v1[1], v1[2]),
+                                Vec3f<T>(v2[0], v2[1], v2[2]));
+   if (facet.GetNvert() == 3)
+      return d;
+   const auto &v3 = vertices[facet[3]];
+   auto d2 = pointTriangleDistSq(p, Vec3f<T>(v0[0], v0[1], v0[2]), Vec3f<T>(v2[0], v2[1], v2[2]),
+                                 Vec3f<T>(v3[0], v3[1], v3[2]));
+   return std::min(d, d2);
 }
 
 } // end anonymous namespace
@@ -959,8 +978,7 @@ Double_t TGeoTessellated::DistFromOutside(const Double_t *point, const Double_t 
             continue;
          }
 
-         auto thisdist = rayTriangle(Vertex_t(point[0], point[1], point[2]), dir_v, fVertices[facet[0]],
-                                     fVertices[facet[1]], fVertices[facet[2]], 0.);
+         auto thisdist = rayFacet(Vertex_t(point[0], point[1], point[2]), dir_v, facet, fVertices, 0.);
 
          if (thisdist < local_step) {
             local_step = thisdist;
@@ -1022,11 +1040,7 @@ Double_t TGeoTessellated::DistFromInside(const Double_t *point, const Double_t *
             continue;
          }
 
-         const auto &v0 = fVertices[facet[0]];
-         const auto &v1 = fVertices[facet[1]];
-         const auto &v2 = fVertices[facet[2]];
-
-         const double t = rayTriangle(Vertex_t{point[0], point[1], point[2]}, dir_v, v0, v1, v2, 0.);
+         const double t = rayFacet(Vertex_t{point[0], point[1], point[2]}, dir_v, facet, fVertices, 0.);
          if (t < local_step) {
             local_step = t;
          }
@@ -1071,20 +1085,21 @@ void TGeoTessellated::BuildBVH()
 
    // helper determining axis aligned bounding box from a facet;
    auto GetBoundingBox = [this](TGeoFacet const &facet) {
-#ifndef NDEBUG
       const auto nvertices = facet.GetNvert();
-      assert(nvertices == 3); // for now only triangles
-#endif
+      if (nvertices != 3 && nvertices != 4)
+         Fatal("BuildBVH", "only facets with 3 or 4 vertices supported");
       const auto &v1 = fVertices[facet[0]];
       const auto &v2 = fVertices[facet[1]];
       const auto &v3 = fVertices[facet[2]];
+      const auto &v4 = (nvertices == 4) ? fVertices[facet[3]] : v3;
       BBox bbox;
-      bbox.min[0] = std::min(std::min(v1[0], v2[0]), v3[0]) - 0.001f;
-      bbox.min[1] = std::min(std::min(v1[1], v2[1]), v3[1]) - 0.001f;
-      bbox.min[2] = std::min(std::min(v1[2], v2[2]), v3[2]) - 0.001f;
-      bbox.max[0] = std::max(std::max(v1[0], v2[0]), v3[0]) + 0.001f;
-      bbox.max[1] = std::max(std::max(v1[1], v2[1]), v3[1]) + 0.001f;
-      bbox.max[2] = std::max(std::max(v1[2], v2[2]), v3[2]) + 0.001f;
+      // A quad needs all four vertices in the BVH bounds even though traversal tests two triangles later on.
+      bbox.min[0] = std::min(std::min(std::min(v1[0], v2[0]), v3[0]), v4[0]) - 0.001f;
+      bbox.min[1] = std::min(std::min(std::min(v1[1], v2[1]), v3[1]), v4[1]) - 0.001f;
+      bbox.min[2] = std::min(std::min(std::min(v1[2], v2[2]), v3[2]), v4[2]) - 0.001f;
+      bbox.max[0] = std::max(std::max(std::max(v1[0], v2[0]), v3[0]), v4[0]) + 0.001f;
+      bbox.max[1] = std::max(std::max(std::max(v1[1], v2[1]), v3[1]), v4[1]) + 0.001f;
+      bbox.max[2] = std::max(std::max(std::max(v1[2], v2[2]), v3[2]), v4[2]) + 0.001f;
       return bbox;
    };
 
@@ -1173,13 +1188,7 @@ bool TGeoTessellated::Contains(Double_t const *point) const
          auto &facet = fFacets[objectid];
 
          // for the parity test, we probe all crossing surfaces
-         const auto &v0 = fVertices[facet[0]];
-         const auto &v1 = fVertices[facet[1]];
-         const auto &v2 = fVertices[facet[2]];
-
-         const double t = rayTriangle(Vertex_t(point[0], point[1], point[2]), test_dir, v0, v1, v2, 0.);
-
-         if (t != std::numeric_limits<double>::infinity()) {
+         if (rayFacetHit(Vertex_t(point[0], point[1], point[2]), test_dir, facet, fVertices, 0.)) {
             ++crossings;
          }
       }
@@ -1260,7 +1269,7 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
 
    do {
       if (currnode.is_leaf()) {
-         // we are in a leaf node and actually talk to a face/triangular primitive
+         // we are in a leaf node and actually talk to a face primitive
          const auto begin_prim_id = currnode.index.first_id();
          const auto end_prim_id = begin_prim_id + currnode.index.prim_count();
 
@@ -1268,13 +1277,8 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
             const auto object_id = mybvh->prim_ids[p_id];
 
             const auto &facet = fFacets[object_id];
-            const auto &v1 = fVertices[facet[0]];
-            const auto &v2 = fVertices[facet[1]];
-            const auto &v3 = fVertices[facet[2]];
-
             auto thissafetySQ =
-               pointTriangleDistSq(Vec3f<float>(point[0], point[1], point[2]), Vec3f<float>(v1[0], v1[1], v1[2]),
-                                   Vec3f<float>(v2[0], v2[1], v2[2]), Vec3f<float>(v3[0], v3[1], v3[2]));
+               pointFacetDistSq(Vec3f<float>(point[0], point[1], point[2]), facet, fVertices);
 
             if (thissafetySQ < smallest_safety_sq) {
                smallest_safety_sq = thissafetySQ;
@@ -1390,12 +1394,11 @@ void TGeoTessellated::Streamer(TBuffer &b)
 void TGeoTessellated::CalculateNormals()
 {
    fOutwardNormals.clear();
-   for (auto &facet : fFacets) {
-      auto &v1 = fVertices[facet[0]];
-      auto &v2 = fVertices[facet[1]];
-      auto &v3 = fVertices[facet[2]];
-      using Vec3d = Vec3f<double>;
-      auto norm = triangleNormal(Vec3d{v1[0], v1[1], v1[2]}, Vec3d{v2[0], v2[1], v2[2]}, Vec3d{v3[0], v3[1], v3[2]});
-      fOutwardNormals.emplace_back(Vertex_t{norm.x, norm.y, norm.z});
+   fOutwardNormals.reserve(fFacets.size());
+   for (size_t i = 0; i < fFacets.size(); ++i) {
+      // Reuse the generic facet normal code so triangles and quads follow the same path.
+      bool degenerated = false;
+      auto norm = FacetComputeNormal(static_cast<int>(i), degenerated);
+      fOutwardNormals.emplace_back(norm);
    }
 }


### PR DESCRIPTION
Extend the TGeoTessellated BVH-based navigation code to handle quadrilateral facets in addition to triangles.

# This Pull request:

The implementation keeps the stored tessellated topology unchanged and triangulates quads only at query time:
- ray queries test a quad as two triangles
- safety queries compute the minimum distance to the same two-triangle split
- BVH node bounds now include the 4th vertex of quad facets
- normal computation is routed through FacetComputeNormal() so triangles and quads follow the same path

This keeps the existing face representation, closure logic and drawing code intact while allowing BVH traversal, contains, distance and safety queries to work consistently on tessellations containing quads.

## Changes or fixes:
Fixes missing quadrilateral support for tessellated BVH traversal

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/AIDASoft/DD4hep/issues/1594

