### PR TITLE
[do not merge] Test mock RDF Define pythonization

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -188,3 +188,6 @@ if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 8 OR win_broken_tests)
     # https://github.com/root-project/root/issues/9809
     ROOT_ADD_PYUNITTEST(pyroot_array_numpy_views array_conversions.py PYTHON_DEPS numpy)
 endif()
+
+file(COPY mock_rdf_define_header.hxx DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ROOT_ADD_PYUNITTEST(mock_rdf_define_pyz mock_rdf_define_pyz.py)

--- a/bindings/pyroot/pythonizations/test/mock_rdf_define_header.hxx
+++ b/bindings/pyroot/pythonizations/test/mock_rdf_define_header.hxx
@@ -1,0 +1,25 @@
+#ifndef MOCK_RDF_DEFINE_HEADER
+#define MOCK_RDF_DEFINE_HEADER
+
+#include <iostream>
+#include <string_view>
+#include <string>
+#include <vector>
+
+float foo()
+{
+   return 42;
+}
+
+using ColumnNames_t = std::vector<std::string>;
+
+struct MockRDF {
+   template <typename F, typename std::enable_if_t<!std::is_convertible<F, std::string>::value, int> = 0>
+   void mock_define(std::string_view name, F fun, const ColumnNames_t &columns = {})
+   {
+      auto val = fun();
+      std::cout << "Class method with name " << name << " got value " << val << "\n";
+   }
+};
+
+#endif // MOCK_RDF_DEFINE_HEADER

--- a/bindings/pyroot/pythonizations/test/mock_rdf_define_pyz.py
+++ b/bindings/pyroot/pythonizations/test/mock_rdf_define_pyz.py
@@ -1,0 +1,29 @@
+import unittest
+
+import ROOT
+
+
+class MockRDFTest(unittest.TestCase):
+
+    def test_mock_define(self):
+
+        ROOT.gInterpreter.Declare('#include "mock_rdf_define_header.hxx"')
+
+        ROOT.MockRDF._original_define = ROOT.MockRDF.mock_define
+        ROOT.MockRDF.mock_define = None
+
+        # On Linux and MacOS this should work, on Windows it triggers an error like
+        # Traceback (most recent call last):
+        #   File "C:\root-dev\build\x64\relwithdebinfo\runtutorials\test_header.py", line 4, in <module>
+        #     val = df._OriginalDefine("x", ROOT.foo).Sum("x").GetValue()
+        #                                   ^^^^^^^^
+        #   File "C:\root-dev\build\x64\relwithdebinfo\bin\ROOT\_facade.py", line 120, in _fallback_getattr
+        #     raise AttributeError("Failed to get attribute {} from ROOT".format(name))
+        # AttributeError: Failed to get attribute foo from ROOT
+        signature_of_foo = "float()"
+        std_fn = ROOT.std.function(signature_of_foo)
+        ROOT.MockRDF()._original_define[type(std_fn)]("myname", ROOT.foo)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
While working on https://github.com/root-project/root/pull/20898 I discovered that the Python version of the tutorial fails only on Windows for what looks to be a problem with the RDF Define Pythonization. This may or may not be related to https://github.com/root-project/root/issues/21405. I wanted to test it on all platforms to make sure my hypothesis is correct.
