### PR TITLE
[tmva] Retire TH1::AddDirectory use in TMVA.

### DIFF
--- a/tmva/tmva/src/MethodBase.cxx
+++ b/tmva/tmva/src/MethodBase.cxx
@@ -1458,12 +1458,9 @@ void TMVA::MethodBase::WriteStateToXML( void* parent ) const
 
 void TMVA::MethodBase::ReadStateFromStream( TFile& rf )
 {
-   Bool_t addDirStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory( 0 ); // this avoids the binding of the hists in PDF to the current ROOT file
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
    fMVAPdfS = (TMVA::PDF*)rf.Get( "MVA_PDF_Signal" );
    fMVAPdfB = (TMVA::PDF*)rf.Get( "MVA_PDF_Background" );
-
-   TH1::AddDirectory( addDirStatus );
 
    ReadWeightsFromStream( rf );
 

--- a/tmva/tmva/src/MethodLikelihood.cxx
+++ b/tmva/tmva/src/MethodLikelihood.cxx
@@ -668,8 +668,7 @@ void  TMVA::MethodLikelihood::WriteWeightsToStream( TFile& ) const
 void  TMVA::MethodLikelihood::ReadWeightsFromXML(void* wghtnode)
 {
    TString pname = "PDF_";
-   Bool_t addDirStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
    UInt_t nvars=0;
    gTools().ReadAttr(wghtnode, "NVariables",nvars);
    void* descnode = gTools().GetChild(wghtnode);
@@ -688,7 +687,6 @@ void  TMVA::MethodLikelihood::ReadWeightsFromXML(void* wghtnode)
       (*(*fPDFBgd)[ivar]).ReadXML(pdfnode);
       descnode = gTools().GetNextChild(descnode);
    }
-   TH1::AddDirectory(addDirStatus);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -698,8 +696,7 @@ void  TMVA::MethodLikelihood::ReadWeightsFromXML(void* wghtnode)
 void  TMVA::MethodLikelihood::ReadWeightsFromStream( std::istream & istr )
 {
    TString pname = "PDF_";
-   Bool_t addDirStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
       Log() << kDEBUG << "Reading signal and background PDF for variable: " << GetInputVar( ivar ) << Endl;
       if ((*fPDFSig)[ivar] !=0) delete (*fPDFSig)[ivar];
@@ -711,7 +708,6 @@ void  TMVA::MethodLikelihood::ReadWeightsFromStream( std::istream & istr )
       istr >> *(*fPDFSig)[ivar];
       istr >> *(*fPDFBgd)[ivar];
    }
-   TH1::AddDirectory(addDirStatus);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -720,13 +716,11 @@ void  TMVA::MethodLikelihood::ReadWeightsFromStream( std::istream & istr )
 void  TMVA::MethodLikelihood::ReadWeightsFromStream( TFile& rf )
 {
    TString pname = "PDF_";
-   Bool_t addDirStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
    for (UInt_t ivar=0; ivar<GetNvar(); ivar++){
       (*fPDFSig)[ivar] = (TMVA::PDF*)rf.Get( TString::Format( "PDF_%s_S", GetInputVar( ivar ).Data() ) );
       (*fPDFBgd)[ivar] = (TMVA::PDF*)rf.Get( TString::Format( "PDF_%s_B", GetInputVar( ivar ).Data() ) );
    }
-   TH1::AddDirectory(addDirStatus);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tmva/tmva/src/PDEFoam.cxx
+++ b/tmva/tmva/src/PDEFoam.cxx
@@ -288,8 +288,7 @@ void TMVA::PDEFoam::SetXmax(Int_t idim, Double_t wmax)
 
 void TMVA::PDEFoam::Create()
 {
-   Bool_t addStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory(kFALSE);
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
 
    if(fPseRan==0) Log() << kFATAL << "Random number generator not set" << Endl;
    if(fDistr==0)  Log() << kFATAL << "Distribution function not set" << Endl;
@@ -339,8 +338,6 @@ void TMVA::PDEFoam::Create()
    // Define and explore root cell(s)
    InitCells();
    Grow();
-
-   TH1::AddDirectory(addStatus);
 
    // prepare PDEFoam for the filling with events
    ResetCellElements(); // reset all cell elements

--- a/tmva/tmva/src/VariableGaussTransform.cxx
+++ b/tmva/tmva/src/VariableGaussTransform.cxx
@@ -549,8 +549,7 @@ void TMVA::VariableGaussTransform::ReadFromXML( void* trfnode ) {
 
 void TMVA::VariableGaussTransform::ReadTransformationFromStream( std::istream& istr, const TString& classname)
 {
-   Bool_t addDirStatus = TH1::AddDirectoryStatus();
-   TH1::AddDirectory(0); // this avoids the binding of the hists in TMVA::PDF to the current ROOT file
+   TDirectory::TContext dirCtx{nullptr}; // Don't register histograms to current directory
    char buf[512];
    istr.getline(buf,512);
 
@@ -615,7 +614,6 @@ void TMVA::VariableGaussTransform::ReadTransformationFromStream( std::istream& i
 
       istr.getline(buf,512); // reading the next line
    }
-   TH1::AddDirectory(addDirStatus);
 
    UInt_t classIdx=(classname=="signal")?0:1;
    for(UInt_t ivar=0; ivar<fCumulativePDF.size(); ++ivar) {


### PR DESCRIPTION
Replace uses of `TH1::AddDirectory()` by `TDirectory::TContext`. It is thread-local and uses the RAII idiom, so state changes cannot inadvertently leak out of TMVA functions.