### PR TITLE
[cppyy] Disallow calling functions with non-const pointer references

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -369,6 +369,29 @@ after importing ROOT.
 
 This option is intended **for debugging only and will be removed in ROOT 6.44**.
 
+### Drop support for calling C++ functions with non-const pointer references
+
+From now on, we disallow calling C++ functions with non-const pointer references (`T*&`) from Python.
+These allow pointer rebinding, which cannot be represented safely in Python and could previously lead to confusing behavior.
+A `TypeError` is now raised. Typical ROOT usage is unaffected.
+
+In the rare case where you want to call such a function, please change the C++ interface or - if the interface is outside your control - write a wrapper function that avoids non-const pointer references as arguments.
+
+For example, a function with the signature `bool setPtr(MyClass *&)` could be wrapped by a function that augments the return value with the updated pointer:
+```
+ROOT.gInterpreter.Declare("""
+    std::pair<bool, MyClass*> setPtrWrapper(MyClass *ptr) {
+       bool out = setPtr(ptr);
+       return {out, ptr};
+    }
+""")
+```
+Then, call it from Python as follows:
+```Python
+# Use tuple unpacking for convenience
+_, ptr = cppyy.gbl.setPtrWrapper(ptr)
+```
+
 ### UHI
 #### Backwards incompatible changes
 - `TH1.values()` now returns a **read-only** NumPy array by default. Previously it returned a writable array that allowed modifying histogram contents implicitly.

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -3262,11 +3262,25 @@ bool CPyCppyy::InitializerListConverter::SetArg(
 #endif
 }
 
+namespace CPyCppyy {
+
+// raising converter to take out overloads
+class NotImplementedConverter : public Converter {
+public:
+    NotImplementedConverter(PyObject *errorType, std::string const &message) : fErrorType{errorType}, fMessage{message} {}
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+private:
+    PyObject *fErrorType;
+    std::string fMessage;
+};
+
+} // namespace CPyCppyy
+
 //----------------------------------------------------------------------------
 bool CPyCppyy::NotImplementedConverter::SetArg(PyObject*, Parameter&, CallContext*)
 {
 // raise a NotImplemented exception to take a method out of overload resolution
-    PyErr_SetString(PyExc_NotImplementedError, "this method cannot (yet) be called");
+    PyErr_SetString(fErrorType, fMessage.c_str());
     return false;
 }
 
@@ -3331,6 +3345,14 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
     bool isConst = strncmp(resolvedType.c_str(), "const", 5) == 0;
     const std::string& cpd = TypeManip::compound(resolvedType);
     std::string realType   = TypeManip::clean_type(resolvedType, false, true);
+
+// mutable pointer references (T*&) are incompatible with Python's object model
+   if (cpd == "*&") {
+       return new NotImplementedConverter{PyExc_TypeError,
+           "argument type '" + resolvedType + "' is not supported: non-const references to pointers (T*&) allow a"
+           " function to replace the pointer itself. Python cannot represent this safely. Consider changing the"
+           " C++ API to return the new pointer or use a wrapper"};
+   }
 
 // accept unqualified type (as python does not know about qualifiers)
     h = gConvFactories.find((isConst ? "const " : "") + realType + cpd);
@@ -3481,7 +3503,7 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
         if (h != gConvFactories.end())
             return (h->second)(dims);
     // else, unhandled moves
-        result = new NotImplementedConverter();
+        result = new NotImplementedConverter{PyExc_NotImplementedError, "this method cannot (yet) be called"};
     }
 
     if (!result && h != gConvFactories.end())
@@ -3494,7 +3516,8 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
         else if (!cpd.empty())
             result = new VoidArrayConverter();        // "user knows best"
         else
-            result = new NotImplementedConverter();   // fails on use
+            // fails on use
+            result = new NotImplementedConverter{PyExc_NotImplementedError, "this method cannot (yet) be called"};
     }
 
     return result;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/DeclareConverters.h
@@ -481,13 +481,6 @@ protected:
     size_t            fValueSize;
 };
 
-
-// raising converter to take out overloads
-class NotImplementedConverter : public Converter {
-public:
-    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
-};
-
 } // unnamed namespace
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -1871,7 +1871,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
 
             std::ostringstream initdef;
             initdef << "namespace __cppyy_internal {\n"
-                    << "void init_" << rname << "(" << name << "*& self";
+                    << "void init_" << rname << "(" << name << "** self";
             bool codegen_ok = true;
             std::vector<std::string> arg_types, arg_names, arg_defaults;
             arg_types.reserve(ndata); arg_names.reserve(ndata); arg_defaults.reserve(ndata);
@@ -1909,7 +1909,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
                     initdef << ", " << arg_types[i] << " " << arg_names[i];
                     if (defaults_ok) initdef << " = " << arg_defaults[i];
                 }
-                initdef << ") {\n  self = new " << name << "{";
+                initdef << ") {\n  *self = new " << name << "{";
                 for (std::vector<std::string>::size_type i = 0; i < arg_names.size(); ++i) {
                     if (i != 0) initdef << ", ";
                     initdef << arg_names[i];

--- a/bindings/pyroot/cppyy/cppyy/test/templates.h
+++ b/bindings/pyroot/cppyy/cppyy/test/templates.h
@@ -528,7 +528,7 @@ struct Test {};
 using testptr = Test *;
 
 template <typename T>
-bool testfun(T const &x)
+bool testfun(T x)
 {
    return !(bool)x;
 }

--- a/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_overloads.py
@@ -448,5 +448,24 @@ class TestOVERLOADS:
         assert cppyy.gbl.test14_baz(functor) == 2 # should resolve to baz(std::function)
 
 
+    def test15_disallow_mutable_pointer_references(self):
+        """Verify that mutable pointer references (T*&) are not allowed as arguments.
+        """
+
+        import cppyy
+
+        cppyy.cppdef("""
+        struct MyClass {
+           int val = 0;
+        };
+
+        void changePtr(MyClass *& ptr) {}
+        """)
+
+        ptr = cppyy.gbl.MyClass()
+
+        raises(TypeError, cppyy.gbl.changePtr, ptr)
+
+
 if __name__ == "__main__":
     exit(pytest.main(args=['-sv', '-ra', __file__]))

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1133,9 +1133,7 @@ class TestTEMPLATES:
 
         assert ns.testfun["testptr"](cppyy.bind_object(cppyy.nullptr, ns.Test))
 
-        # TODO: raises TypeError; the problem is that the type is resolved
-        # from UsingPtr::Test*const& to UsingPtr::Test*& (ie. `const` is lost)
-        # assert ns.testfun["UsingPtr::testptr"](cppyy.nullptr)
+        assert ns.testfun["UsingPtr::testptr"](cppyy.nullptr)
 
         assert ns.testptr.__name__     == "Test"
         assert ns.testptr.__cpp_name__ == "UsingPtr::Test*"

--- a/roottest/python/cpp/PyROOT_cpptests.py
+++ b/roottest/python/cpp/PyROOT_cpptests.py
@@ -228,8 +228,7 @@ class Cpp1LanguageFeatureTestCase( MyTestCase ):
       self.assertEqual( oaddr, Z.GimeAddressPtr( o ) )
       self.assertEqual( oaddr, Z.GimeAddressPtrRef( o ) )
       
-      pZ = Z.getZ(0)
-      self.assertEqual( Z.checkAddressOfZ( pZ ), True )
+      pZ = Z.getZ(1)
       self.assertEqual( pZ , Z.getZ(1) )
 
       import array


### PR DESCRIPTION
Functions taking non-const references to pointers `(T*&)` allow rebinding the pointer inside the callee. This behavior does not map cleanly to Python, which has no equivalent concept of pointer rebinding.

In cppyy, this can lead to confusing and unintended side effects due to pointer deduplication and proxy identity semantics.

This change explicitly rejects such argument types and raises a `TypeError` with a clear explanation and suggested alternatives.

Here is an example of previously confusing behavior:

```Python
import cppyy

cppyy.cppdef("""

struct MyClass {
   int val = 0;
};

MyClass *staticPtr() {
   static MyClass x;
   x.val = 1;
   return &x;
}

void changePtr(std::string ptr) {
}

void changePtr(MyClass *& ptr) {
   static MyClass y;
   y.val = 2;
   ptr = &y;
}

""")

p1 = cppyy.gbl.staticPtr()
p2 = cppyy.gbl.staticPtr()

cppyy.gbl.changePtr(p2)

print(p1.val)
print(p2.val)
```

Output:
```txt
2
2
```

Here, it was completely not obvious that changing `p2` is changing the `p1` pointer.