### PR TITLE
[CPyCppyy] Fix improper warning handling and support `-W error`

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -439,7 +439,8 @@ static PyObject* SetCppLazyLookup(PyObject*, PyObject* args)
 #else
 // As of py3.11, there is no longer a lookup function pointer in the dict object
 // to replace. Since this feature is not widely advertised, it's simply dropped
-    PyErr_Warn(PyExc_RuntimeWarning, (char*)"lazy lookup is no longer supported");
+    if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)"lazy lookup is no longer supported", 1) < 0)
+        return nullptr;
     (void)args; // avoid warning about unused parameter
 #endif
 

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -1304,7 +1304,8 @@ bool CPyCppyy::CStringConverter::SetArg(
 
 // verify (too long string will cause truncation, no crash)
     if (fMaxSize != std::string::npos && fMaxSize < fBuffer.size())
-        PyErr_Warn(PyExc_RuntimeWarning, (char*)"string too long for char array (truncated)");
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)"string too long for char array (truncated)", 1) < 0)
+            return false;
 
     if (!ctxt->fPyContext) {
     // use internal buffer as workaround
@@ -1349,7 +1350,8 @@ bool CPyCppyy::CStringConverter::ToMemory(PyObject* value, void* address, PyObje
 
 // verify (too long string will cause truncation, no crash)
     if (fMaxSize != std::string::npos && fMaxSize < (std::string::size_type)len)
-        PyErr_Warn(PyExc_RuntimeWarning, (char*)"string too long for char array (truncated)");
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)"string too long for char array (truncated)", 1) < 0)
+            return false;
 
 // if address is available, and it wasn't set by this converter, assume a byte-wise copy;
 // otherwise assume a pointer copy (this relies on the converter to be used for properties,
@@ -1426,7 +1428,8 @@ bool CPyCppyy::WCStringConverter::ToMemory(PyObject* value, void* address, PyObj
 
 // verify (too long string will cause truncation, no crash)
     if (fMaxSize != std::wstring::npos && fMaxSize < (std::wstring::size_type)len)
-        PyErr_Warn(PyExc_RuntimeWarning, (char*)"string too long for wchar_t array (truncated)");
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)"string too long for wchar_t array (truncated)", 1) < 0)
+            return false;
 
     Py_ssize_t res = -1;
     if (fMaxSize != std::wstring::npos)
@@ -1485,7 +1488,10 @@ bool CPyCppyy::name##Converter::ToMemory(PyObject* value, void* address, PyObjec
                                                                              \
 /* verify (too long string will cause truncation, no crash) */               \
     if (fMaxSize != std::wstring::npos && maxbytes < len) {                  \
-        PyErr_Warn(PyExc_RuntimeWarning, (char*)"string too long for "#type" array (truncated)");\
+        if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)"string too long for "#type" array (truncated)", 1) < 0) { \
+            Py_DECREF(bstr);                                                 \
+            return false;                                                    \
+        }                                                                    \
         len = maxbytes;                                                      \
     }                                                                        \
                                                                              \

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Dispatcher.cxx
@@ -203,7 +203,8 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
 
         if (!Cppyy::HasVirtualDestructor(basetype)) {
             const std::string& bname = Cppyy::GetScopedFinalName(basetype);
-            PyErr_Warn(PyExc_RuntimeWarning, (char*)("class \""+bname+"\" has no virtual destructor").c_str());
+            if (PyErr_WarnEx(PyExc_RuntimeWarning, (char*)("class \""+bname+"\" has no virtual destructor").c_str(), 1) < 0)
+                return false;
         }
 
         base_infos.emplace_back(

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -1703,7 +1703,7 @@ ptrdiff_t Cppyy::GetBaseOffset(TCppType_t derived, TCppType_t base,
             std::ostringstream msg;
             msg << "failed offset calculation between " << cb->GetName() << " and " << cd->GetName();
             // TODO: propagate this warning to caller w/o use of Python C-API
-            // PyErr_Warn(PyExc_RuntimeWarning, const_cast<char*>(msg.str().c_str()));
+            // PyErr_WarnEx(PyExc_RuntimeWarning, const_cast<char*>(msg.str().c_str()), 1);
             std::cerr << "Warning: " << msg.str() << '\n';
         }
 

--- a/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
@@ -448,6 +448,12 @@ class TestCROSSINHERITANCE:
       # as the C++ side now carries the type of the dispatcher, not the type of
       # the direct base class
         with warnings.catch_warnings(record=True) as w:
+            # ensure warnings are not turned into errors, even if we run python -W error
+            # The reason why we don't turn warnings into errors instead and just
+            # catch the exception is that the error would be changed into a
+            # more uninformative "TypeError: no python-side overrides supported ()"
+            warnings.simplefilter("default")
+
             class MyPyDerived1(VD.MyClass1):
                 pass        # TODO: verify warning is given
             assert len(w) == 1
@@ -1139,7 +1145,7 @@ class TestCROSSINHERITANCE:
     def test26_no_default_ctor(self):
         """Make sure no default ctor is created if not viable"""
 
-        import cppyy, warnings
+        import cppyy
 
         cppyy.cppdef("""namespace no_default_ctor {
         struct NoDefCtor1 {
@@ -1158,7 +1164,11 @@ class TestCROSSINHERITANCE:
           virtual ~NoDefCtor3() {}
         };
 
-        class Simple {}; }""")
+        class Simple {
+        public:
+          virtual ~Simple() {}
+        };
+        }""")
 
         ns = cppyy.gbl.no_default_ctor
 
@@ -1170,18 +1180,16 @@ class TestCROSSINHERITANCE:
             with raises(TypeError):
                 PyDerived()
 
-            with warnings.catch_warnings(record=True) as w:
-                class PyDerived(cppyy.multi(kls, ns.Simple)):
-                    def __init__(self):
-                        super(PyDerived, self).__init__()
+            class PyDerived(cppyy.multi(kls, ns.Simple)):
+                def __init__(self):
+                    super(PyDerived, self).__init__()
 
             with raises(TypeError):
                 PyDerived()
 
-            with warnings.catch_warnings(record=True) as w:
-                class PyDerived(cppyy.multi(ns.Simple, kls)):
-                    def __init__(self):
-                        super(PyDerived, self).__init__()
+            class PyDerived(cppyy.multi(ns.Simple, kls)):
+                def __init__(self):
+                    super(PyDerived, self).__init__()
 
             with raises(TypeError):
                 PyDerived()

--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -604,16 +604,18 @@ class TestFRAGILE:
                 int add42(int i) { return i + 42; }
             }""")
 
-        with warnings.catch_warnings(record=True) as w:
-          # missing return statement
-            cppyy.cppdef("""\
-            namespace fragile {
-                double add42d(double d) { d + 42.; return d; }
-            }""")
+      # isolate the warning configuration
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # turn warnings into errors
 
-        assert len(w) == 1
-        assert issubclass(w[-1].category, SyntaxWarning)
-        assert "return" in str(w[-1].message)
+          # missing return statement
+            with pytest.raises(SyntaxWarning) as exc:
+                cppyy.cppdef("""\
+                namespace fragile {
+                    double add42d(double d) { d + 42.; return d; }
+                }""")
+
+            assert "return" in str(exc.value)
 
       # mix of error and warning
         with raises(SyntaxError):

--- a/bindings/pyroot/cppyy/cppyy/test/test_regression.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_regression.py
@@ -1114,9 +1114,13 @@ class TestREGRESSION:
             len(ai.name) == 6
             assert ai.name[:len(s)] == s
 
-        with warnings.catch_warnings(record=True) as w:
-            ai.name = u'hellowd'
-            assert 'too long' in str(w[-1].message)
+      # isolate the warning configuration
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # turn warnings into errors
+
+            with pytest.raises(RuntimeWarning) as exc:
+                ai.name = u'hellowd'
+            assert 'too long' in str(exc.value)
 
         # vector of objects
         va = cppyy.gbl.std.vector[ns.AxisInformation](N)


### PR DESCRIPTION
Replace deprecated [1] `PyErr_Warn()` with `PyErr_WarnEx()` and correctly handle its return value throughout the CPyCppyy codebase.

Previously, warnings were emitted without checking for failure. When Python is run with `"-W error"` (or equivalent filters), warnings are promoted to exceptions, causing `PyErr_Warn*()` to return an error while leaving an exception set. The code would then continue execution and return a valid value, triggering errors such as:

```
    SystemError: <blah ...> returned a result with an exception set
```

This change ensures that all warning calls:
  - use the non-deprecated `PyErr_WarnEx()`
  - properly propagate errors when warnings are turned into exceptions

Additional fixes:
  - Update tests to explicitly control warning behavior using `warnings.catch_warnings()`, avoiding unintended interaction with global `"-W error"` settings
  - Adjust tests to expect exceptions when warnings are promoted to errors

This makes CPyCppyy more compliant with CPython C API requirements and robust under strict warning configurations.

[1] https://www.cs.auckland.ac.nz/references/python/2.7.3-docs/c-api/exceptions.html?utm_source=chatgpt.com#PyErr_Warn