### PR TITLE
Record alignment of class in dictionary and use in TStreamerInfo

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1987,7 +1987,7 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
    if (HasCustomStreamerMemberFunction(cl, decl, interp, normCtxt)) {
       rootflag = rootflag | TClassTable__kHasCustomStreamerMember;
    }
-   finalString << "isa_proxy, " << rootflag << "," << "\n" << "                  sizeof(" << csymbol << ") );" << "\n";
+   finalString << "isa_proxy, " << rootflag << "," << "\n" << "                  sizeof(" << csymbol << "), alignof(" << csymbol << ") );" << "\n";
    if (HasIOConstructor(decl, args, ctorTypes, interp)) {
       finalString << "      instance.SetNew(&new_" << mappedname.c_str() << ");" << "\n";
       if (args.size()==0 && NeedDestructor(decl, interp))

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -1987,7 +1987,8 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
    if (HasCustomStreamerMemberFunction(cl, decl, interp, normCtxt)) {
       rootflag = rootflag | TClassTable__kHasCustomStreamerMember;
    }
-   finalString << "isa_proxy, " << rootflag << "," << "\n" << "                  sizeof(" << csymbol << "), alignof(" << csymbol << ") );" << "\n";
+   finalString << "isa_proxy, " << rootflag << "," << "\n"
+               << "                  sizeof(" << csymbol << "), alignof(" << csymbol << ") );" << "\n";
    if (HasIOConstructor(decl, args, ctorTypes, interp)) {
       finalString << "      instance.SetNew(&new_" << mappedname.c_str() << ");" << "\n";
       if (args.size()==0 && NeedDestructor(decl, interp))
@@ -2051,7 +2052,8 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
       auto classNameForIO = TClassEdit::GetNameForIO(classname);
 
       finalString << "      static_assert(alignof(" << csymbol << "::value_type) <= 4096,\n";
-      finalString << "          \"Class with alignment strictly greater than 4096 are currently not supported in CollectionProxy. \"\n";
+      finalString << "          \"Class with alignment strictly greater than 4096 are currently not supported in "
+                     "CollectionProxy. \"\n";
       finalString << "          \"Please report this case to the developers\");\n";
       finalString << "      instance.AdoptCollectionProxyInfo(TCollectionProxyInfo::Generate(TCollectionProxyInfo::" << methodTCP << "< " << classNameForIO.c_str() << " >()));" << "\n";
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -2049,6 +2049,10 @@ void ROOT::TMetaUtils::WriteClassInit(std::ostream& finalString,
       // FIXME Workaround: for the moment we do not generate coll proxies with unique ptrs since
       // they imply copies and therefore do not compile.
       auto classNameForIO = TClassEdit::GetNameForIO(classname);
+
+      finalString << "      static_assert(alignof(" << csymbol << "::value_type) <= 4096,\n";
+      finalString << "          \"Class with alignment strictly greater than 4096 are currently not supported in CollectionProxy. \"\n";
+      finalString << "          \"Please report this case to the developers\");\n";
       finalString << "      instance.AdoptCollectionProxyInfo(TCollectionProxyInfo::Generate(TCollectionProxyInfo::" << methodTCP << "< " << classNameForIO.c_str() << " >()));" << "\n";
 
       needCollectionProxy = true;

--- a/core/foundation/CMakeLists.txt
+++ b/core/foundation/CMakeLists.txt
@@ -14,6 +14,7 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TClassEdit.h
   TError.h
   ThreadLocalStorage.h
+  ROOT/RAlignmentUtils.hxx
   ROOT/RError.hxx
   ROOT/RLogger.hxx
   ROOT/RNotFn.hxx

--- a/core/foundation/inc/ROOT/RAlignmentUtils.hxx
+++ b/core/foundation/inc/ROOT/RAlignmentUtils.hxx
@@ -1,0 +1,32 @@
+// @(#)root/foundation:
+// Author: Philippe Canal, April 2026
+
+/*************************************************************************
+ * Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RAlignmentUtils
+#define ROOT_RAlignmentUtils
+
+#include <cassert>
+#include <cstddef>
+
+namespace ROOT {
+namespace Internal {
+
+/// Return true if \p align is a valid C++ alignment value: strictly positive
+/// and a power of two.  This is the set of values accepted by
+/// `::operator new[](n, std::align_val_t(align))`.
+inline constexpr bool IsValidAlignment(std::size_t align) noexcept
+{
+   return align > 0 && (align & (align - 1)) == 0;
+}
+
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_RAlignmentUtils

--- a/core/foundation/inc/ROOT/RAlignmentUtils.hxx
+++ b/core/foundation/inc/ROOT/RAlignmentUtils.hxx
@@ -26,6 +26,15 @@ inline constexpr bool IsValidAlignment(std::size_t align) noexcept
    return align > 0 && (align & (align - 1)) == 0;
 }
 
+/// Round \p value up to the next multiple of \p align.
+/// \p align must be a power of two (asserted at runtime in debug builds).
+template <typename T>
+inline constexpr T AlignUp(T value, T align) noexcept
+{
+   assert(IsValidAlignment(static_cast<std::size_t>(align))); // must be a power of two
+   return (value + align - 1) & ~(align - 1);
+}
+
 } // namespace Internal
 } // namespace ROOT
 

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -248,6 +248,7 @@ private:
    //Wrapper around this class custom conversion Streamer member function.
    ClassConvStreamerFunc_t fConvStreamerFunc = nullptr;
    Int_t               fSizeof = -1;            //Sizeof the class.
+   std::size_t         fAlignment = 0;          //Alignment of the class (0 for unknown alignment)
 
    std::atomic<Char_t> fCanSplit = -1; ///<!Indicates whether this class can be split or not. Values are -1, 0, 1, 2
 
@@ -313,6 +314,7 @@ private:
 
    void               SetClassVersion(Version_t version);
    void               SetClassSize(Int_t sizof) { fSizeof = sizof; }
+   void               SetClassAlignment(std::size_t align) { fAlignment = align; }
    TVirtualStreamerInfo* DetermineCurrentStreamerInfo();
 
    void SetStreamerImpl(Int_t streamerType);
@@ -435,6 +437,7 @@ public:
       return fClassVersion;
    }
    Int_t              GetClassSize() const { return Size(); }
+   size_t             GetClassAlignment() const;
    TDataMember       *GetDataMember(const char *datamember) const;
    Longptr_t          GetDataMemberOffset(const char *membername) const;
    const char        *GetDeclFileName() const;

--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -25,7 +25,6 @@
 #include "TDictionary.h"
 #include <cstddef>
 
-
 enum EDataType {
    kChar_t   = 1,  kUChar_t  = 11, kShort_t    = 2,  kUShort_t = 12,
    kInt_t    = 3,  kUInt_t   = 13, kLong_t     = 4,  kULong_t  = 14,
@@ -46,8 +45,8 @@ class TDataType : public TDictionary {
 
 private:
    TypedefInfo_t    *fInfo;     ///<!pointer to CINT typedef info
-   Int_t             fSize;        //size of type
-   std::size_t       fAlignOf;     //alignment of type (0 if unknown)
+   Int_t             fSize;     // size of type
+   std::size_t       fAlignOf;  // alignment of type (0 if unknown)
    EDataType         fType;     //type id
    Long_t            fProperty; //The property information for the (potential) underlying class
    TString           fTrueName; //Qualified name of the (potential) underlying class, e.g. "MyClass*const*"

--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -23,6 +23,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "TDictionary.h"
+#include <cstddef>
 
 
 enum EDataType {
@@ -45,7 +46,8 @@ class TDataType : public TDictionary {
 
 private:
    TypedefInfo_t    *fInfo;     ///<!pointer to CINT typedef info
-   Int_t             fSize;     //size of type
+   Int_t             fSize;        //size of type
+   std::size_t       fAlignOf;     //alignment of type (0 if unknown)
    EDataType         fType;     //type id
    Long_t            fProperty; //The property information for the (potential) underlying class
    TString           fTrueName; //Qualified name of the (potential) underlying class, e.g. "MyClass*const*"
@@ -65,6 +67,8 @@ public:
    TDataType(const char *typenam);
    virtual       ~TDataType();
    Int_t          Size() const;
+   /// Return the alignment of the type in bytes, or 0 if unknown.
+   std::size_t    GetAlignOf() const { return fAlignOf; }
    Int_t          GetType() const { return (Int_t)fType; }
    TString        GetTypeName();
    const char    *GetFullTypeName() const;

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -67,6 +67,7 @@ namespace ROOT {
       ClassConvStreamerFunc_t     fConvStreamerFunc;
       TVirtualCollectionProxy    *fCollectionProxy;
       Int_t                       fSizeof;
+      std::size_t                 fAlignment;
       Int_t                       fPragmaBits;
       std::string                 fRNTupleSoARecord;
       Detail::TCollectionProxyInfo *fCollectionProxyInfo;
@@ -81,13 +82,13 @@ namespace ROOT {
                        const char *declFileName, Int_t declFileLine,
                        const std::type_info &info, const Internal::TInitBehavior *action,
                        DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof);
+                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
 
       TGenericClassInfo(const char *fullClassname, Int_t version,
                        const char *declFileName, Int_t declFileLine,
                        const std::type_info &info, const Internal::TInitBehavior *action,
                        DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof);
+                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
 
       TGenericClassInfo(const char *fullClassname, Int_t version,
                         const char *declFileName, Int_t declFileLine,

--- a/core/meta/inc/TGenericClassInfo.h
+++ b/core/meta/inc/TGenericClassInfo.h
@@ -78,17 +78,13 @@ namespace ROOT {
       std::unordered_map<std::string, TMemberStreamer *> fAdoptedMemberStreamers;
 
    public:
-      TGenericClassInfo(const char *fullClassname,
-                       const char *declFileName, Int_t declFileLine,
-                       const std::type_info &info, const Internal::TInitBehavior *action,
-                       DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
+      TGenericClassInfo(const char *fullClassname, const char *declFileName, Int_t declFileLine,
+                        const std::type_info &info, const Internal::TInitBehavior *action, DictFuncPtr_t dictionary,
+                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
 
-      TGenericClassInfo(const char *fullClassname, Int_t version,
-                       const char *declFileName, Int_t declFileLine,
-                       const std::type_info &info, const Internal::TInitBehavior *action,
-                       DictFuncPtr_t dictionary,
-                       TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
+      TGenericClassInfo(const char *fullClassname, Int_t version, const char *declFileName, Int_t declFileLine,
+                        const std::type_info &info, const Internal::TInitBehavior *action, DictFuncPtr_t dictionary,
+                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_ = 0);
 
       TGenericClassInfo(const char *fullClassname, Int_t version,
                         const char *declFileName, Int_t declFileLine,

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -430,6 +430,7 @@ public:
    virtual void  *ClassInfo_New(ClassInfo_t * /* info */, void * /* arena */) const {return nullptr;}
    virtual Long_t ClassInfo_Property(ClassInfo_t * /* info */) const {return 0;}
    virtual int    ClassInfo_Size(ClassInfo_t * /* info */) const {return 0;}
+   virtual size_t ClassInfo_AlignOf(ClassInfo_t * /* info */) const {return 0;}
    virtual Longptr_t ClassInfo_Tagnum(ClassInfo_t * /* info */) const {return 0;}
    virtual const char *ClassInfo_FileName(ClassInfo_t * /* info */) const {return nullptr;}
    virtual const char *ClassInfo_FullName(ClassInfo_t * /* info */) const {return nullptr;}

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -101,6 +101,7 @@ public:
    Int_t            GetArrayLength() const {return fArrayLength;}
    virtual TClass  *GetClassPointer() const;
            TClass  *GetClass()        const {return GetClassPointer();}
+   virtual std::size_t GetAlignment() const;
    virtual Int_t    GetExecID() const;
    virtual const char *GetFullName() const;
    virtual const char *GetInclude() const {return "";}
@@ -172,6 +173,7 @@ public:
    const char      *GetInclude() const override;
    TClass          *GetNewBaseClass() { return fNewBaseClass; }
    ULongptr_t       GetMethod() const override {return 0;}
+   std::size_t      GetAlignment() const override;
    Int_t            GetSize() const override;
    TVirtualStreamerInfo *GetBaseStreamerInfo() const { return fStreamerInfo; }
    void             Init(TVirtualStreamerInfo *obj = nullptr) override;
@@ -213,6 +215,7 @@ public:
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
    ULongptr_t     GetMethod() const override;
+   std::size_t    GetAlignment() const override { return alignof(void *); }
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
    Bool_t         HasCounter() const override { return fCounter != nullptr; }
@@ -249,6 +252,7 @@ public:
    Int_t          GetCountVersion() const {return fCountVersion;}
    const char    *GetInclude() const override;
    ULongptr_t     GetMethod() const override;
+   std::size_t    GetAlignment() const override;
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
    Bool_t         IsaPointer() const override {return kTRUE; }
@@ -297,6 +301,7 @@ public:
    TStreamerObject(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObject();
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override;
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
 
@@ -316,6 +321,7 @@ public:
    TStreamerObjectAny(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectAny();
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override;
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
 
@@ -335,6 +341,7 @@ public:
    TStreamerObjectPointer(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectPointer();
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override { return alignof(void *); }
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
    Bool_t         IsaPointer() const override {return kTRUE;}
@@ -356,6 +363,7 @@ public:
    TStreamerObjectAnyPointer(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectAnyPointer();
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override { return alignof(void *); }
    Int_t          GetSize() const override;
    void           Init(TVirtualStreamerInfo *obj = nullptr) override;
    Bool_t         IsaPointer() const override { return kTRUE; }
@@ -377,6 +385,7 @@ public:
    TStreamerString(const char *name, const char *title, Int_t offset);
    virtual       ~TStreamerString();
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override { return alignof(TString); }
    Int_t          GetSize() const override;
 
    ClassDefOverride(TStreamerString,2)  //Streamer element of type TString
@@ -408,6 +417,7 @@ public:
    Int_t          GetSTLtype() const {return fSTLtype;}
    Int_t          GetCtype()   const {return fCtype;}
    const char    *GetInclude() const override;
+   std::size_t    GetAlignment() const override;
    Int_t          GetSize() const override;
    void           ls(Option_t *option="") const override;
    void           SetSTLtype(Int_t t) {fSTLtype = t;}

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -177,6 +177,7 @@ public:
    TVirtualStreamerInfo();
    TVirtualStreamerInfo(TClass * /*cl*/);
    virtual            ~TVirtualStreamerInfo();
+   virtual size_t      GetClassAlignment() const = 0;
    virtual void        Build(Bool_t isTransient = kFALSE) = 0;
    virtual void        BuildCheck(TFile *file = nullptr, Bool_t load = kTRUE) = 0;
    virtual void        BuildEmulated(TFile *file) = 0;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2736,6 +2736,13 @@ Int_t TClass::GetBaseClassOffsetRecurse(const TClass *cl)
                   if (!baseclass) return -1;
                   Int_t subOffset = baseclass->GetBaseClassOffsetRecurse(cl);
                   if (subOffset == -2) return -2;
+                  auto align = baseclass->GetClassAlignment();
+                  if (ROOT::Internal::IsValidAlignment(align)) {
+                     offset = ROOT::Internal::AlignUp((size_t)offset, align);
+                  } else {
+                     Error("GetBaseClassOffsetRecurse", "Can not determine alignment for base class %s (got %zu)\n",
+                           baseclass->GetName(), align);
+                  }
                   if (subOffset != -1) return offset+subOffset;
                   offset += baseclass->Size();
                } else if (element->IsA() == TStreamerSTL::Class()) {
@@ -2744,6 +2751,13 @@ Int_t TClass::GetBaseClassOffsetRecurse(const TClass *cl)
                   if (!baseclass) return -1;
                   Int_t subOffset = baseclass->GetBaseClassOffsetRecurse(cl);
                   if (subOffset == -2) return -2;
+                  auto align = baseclass->GetClassAlignment();
+                  if (ROOT::Internal::IsValidAlignment(align)) {
+                     offset = ROOT::Internal::AlignUp((size_t)offset, align);
+                  } else {
+                     Error("GetBaseClassOffsetRecurse", "Can not determine alignment for base class %s (got %zu)\n",
+                           baseclass->GetName(), align);
+                  }
                   if (subOffset != -1) return offset+subOffset;
                   offset += baseclass->Size();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5782,7 +5782,7 @@ size_t TClass::GetClassAlignment() const
 {
    if (fAlignment != 0)
       return fAlignment;
-   if ((fState < kEmulated && !fCollectionProxy) || Property() & (kIsNamespace|kIsEnum))
+   if ((fState < kEmulated && !fCollectionProxy) || Property() & (kIsNamespace | kIsEnum))
       return 0;
    if (HasInterpreterInfo()) {
       return gCling->ClassInfo_AlignOf(GetClassInfo());

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5783,6 +5783,7 @@ size_t TClass::GetClassAlignment() const
       }
       return alignof(std::vector<char>);
    }
+   assert(GetStreamerInfo() && GetStreamerInfo()->GetClassAlignment() != 0);
    return GetStreamerInfo()->GetClassAlignment();
 }
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5777,8 +5777,7 @@ size_t TClass::GetClassAlignment() const
       // If the collection proxy has a dictionary, it will have return earlier,
       // so we know that the collection proxy is emulated.
       if (!(fCollectionProxy->GetProperties() & TVirtualCollectionProxy::kIsEmulated)) {
-         Fatal("TClass::GetClassAlignment", "Cannot determine alignment for collection proxy of class %s, returning 0",
-               GetName());
+         Fatal("TClass::GetClassAlignment", "Cannot determine alignment for collection proxy of class %s.", GetName());
          return 0;
       }
       return alignof(std::vector<char>);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5754,6 +5754,31 @@ void TClass::SetCurrentStreamerInfo(TVirtualStreamerInfo *info)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the alignment requirement (in bytes) for objects of this class.
+///
+/// Returns (size_t)-1 if the class info is invalid, 0 for a forward-declared
+/// class, an enum, a namespace or or a class with no definition. For all other
+/// cases the actual alignment obtained from the dictionary or the clang ASTRecordLayout,
+/// or the StreamerInfo (in that order of priority) is returned.
+///
+/// Returns `0` when the alignment cannot be determined.
+
+size_t TClass::GetClassAlignment() const
+{
+   if (fAlignment != 0)
+      return fAlignment;
+   if ((fState < kEmulated && !fCollectionProxy) || Property() & (kIsNamespace|kIsEnum))
+      return 0;
+   // FIX-ALIGN: do we need to have something special for collection proxy?
+   //if (fCollectionProxy)
+   //   return fCollectionProxy->AlignOf();
+   if (HasInterpreterInfo()) {
+      return gCling->ClassInfo_AlignOf(GetClassInfo());
+   }
+   return GetStreamerInfo()->GetClassAlignment();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return size of object of this class.
 
 Int_t TClass::Size() const

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -124,6 +124,7 @@ In order to access the name of a class within the ROOT type system, the method T
 #include "TClonesArray.h"
 #include "TRef.h"
 #include "TRefArray.h"
+#include "ROOT/RAlignmentUtils.hxx"
 
 using std::multimap, std::make_pair, std::string;
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5769,11 +5769,18 @@ size_t TClass::GetClassAlignment() const
       return fAlignment;
    if ((fState < kEmulated && !fCollectionProxy) || Property() & (kIsNamespace|kIsEnum))
       return 0;
-   // FIX-ALIGN: do we need to have something special for collection proxy?
-   //if (fCollectionProxy)
-   //   return fCollectionProxy->AlignOf();
    if (HasInterpreterInfo()) {
       return gCling->ClassInfo_AlignOf(GetClassInfo());
+   }
+   if (fCollectionProxy) {
+      // If the collection proxy has a dictionary, it will have return earlier,
+      // so we know that the collection proxy is emulated.
+      if (!(fCollectionProxy->GetProperties() & TVirtualCollectionProxy::kIsEmulated)) {
+         Fatal("TClass::GetClassAlignment", "Cannot determine alignment for collection proxy of class %s, returning 0",
+               GetName());
+         return 0;
+      }
+      return alignof(std::vector<char>);
    }
    return GetStreamerInfo()->GetClassAlignment();
 }

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -48,6 +48,7 @@ TDataType::TDataType(TypedefInfo_t *info) : TDictionary(),
       SetTitle("Builtin basic type");
       fProperty = 0;
       fSize = 0;
+      fAlignOf = 0;
       fType = kNoType_t;
    }
 }
@@ -72,6 +73,7 @@ TDataType::TDataType(const TDataType& dt) :
   TDictionary(dt),
   fInfo(gCling->TypedefInfo_FactoryCopy(dt.fInfo)),
   fSize(dt.fSize),
+  fAlignOf(dt.fAlignOf),
   fType(dt.fType),
   fProperty(dt.fProperty),
   fTrueName(dt.fTrueName),
@@ -89,6 +91,7 @@ TDataType& TDataType::operator=(const TDataType& dt)
       gCling->TypedefInfo_Delete(fInfo);
       fInfo=gCling->TypedefInfo_FactoryCopy(dt.fInfo);
       fSize=dt.fSize;
+      fAlignOf=dt.fAlignOf;
       fType=dt.fType;
       fProperty=dt.fProperty;
       fTrueName=dt.fTrueName;
@@ -301,69 +304,89 @@ void TDataType::SetType(const char *name)
    fTrueName = name;
    fType = kOther_t;
    fSize = 0;
+   fAlignOf = 0;
 
    if (name==nullptr) {
       return;
    } else if (!strcmp("unsigned int", name)) {
       fType = kUInt_t;
       fSize = sizeof(UInt_t);
+      fAlignOf = alignof(UInt_t);
    } else if (!strcmp("unsigned", name)) {
       fType = kUInt_t;
       fSize = sizeof(UInt_t);
+      fAlignOf = alignof(UInt_t);
    } else if (!strcmp("int", name)) {
       fType = kInt_t;
       fSize = sizeof(Int_t);
+      fAlignOf = alignof(Int_t);
    } else if (!strcmp("unsigned long", name)) {
       fType = kULong_t;
       fSize = sizeof(ULong_t);
+      fAlignOf = alignof(ULong_t);
    } else if (!strcmp("long", name)) {
       fType = kLong_t;
       fSize = sizeof(Long_t);
+      fAlignOf = alignof(Long_t);
    } else if (!strcmp("unsigned long long", name) || !strcmp("ULong64_t",name)) {
       fType = kULong64_t;
       fSize = sizeof(ULong64_t);
+      fAlignOf = alignof(ULong64_t);
    } else if (!strcmp("long long", name) || !strcmp("Long64_t",name)) {
       fType = kLong64_t;
       fSize = sizeof(Long64_t);
+      fAlignOf = alignof(Long64_t);
    } else if (!strcmp("unsigned short", name)) {
       fType = kUShort_t;
       fSize = sizeof(UShort_t);
+      fAlignOf = alignof(UShort_t);
    } else if (!strcmp("short", name)) {
       fType = kShort_t;
       fSize = sizeof(Short_t);
+      fAlignOf = alignof(Short_t);
    } else if (!strcmp("unsigned char", name)) {
       fType = kUChar_t;
       fSize = sizeof(UChar_t);
+      fAlignOf = alignof(UChar_t);
    } else if (!strcmp("char", name)) {
       fType = kChar_t;
       fSize = sizeof(Char_t);
+      fAlignOf = alignof(Char_t);
    } else if (!strcmp("bool", name)) {
       fType = kBool_t;
       fSize = sizeof(Bool_t);
+      fAlignOf = alignof(Bool_t);
    } else if (!strcmp("float", name)) {
       fType = kFloat_t;
       fSize = sizeof(Float_t);
+      fAlignOf = alignof(Float_t);
    } else if (!strcmp("double", name)) {
       fType = kDouble_t;
       fSize = sizeof(Double_t);
+      fAlignOf = alignof(Double_t);
    } else if (!strcmp("signed char", name)) {
       fType = kChar_t; // kDataTypeAliasSignedChar_t;
       fSize = sizeof(Char_t);
+      fAlignOf = alignof(Char_t);
    } else if (!strcmp("void", name)) {
       fType = kVoid_t;
       fSize = 0;
+      fAlignOf = 0;
    }
 
    if (!strcmp("Float16_t", fName.Data())) {
       fSize = sizeof(Float16_t);
+      fAlignOf = alignof(Float16_t);
       fType = kFloat16_t;
    }
    if (!strcmp("Double32_t", fName.Data())) {
       fSize = sizeof(Double32_t);
+      fAlignOf = alignof(Double32_t);
       fType = kDouble32_t;
    }
    if (!strcmp("char*",fName.Data())) {
       fType = kCharStar;
+      fAlignOf = alignof(char*);
    }
    // kCounter =  6, kBits     = 15
 }

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -41,6 +41,7 @@ TDataType::TDataType(TypedefInfo_t *info) : TDictionary(),
       R__LOCKGUARD(gInterpreterMutex);
       SetName(gCling->TypedefInfo_Name(fInfo));
       SetTitle(gCling->TypedefInfo_Title(fInfo));
+      // SetType sets fTrueName, fType , fSize and fAlignOf.
       SetType(gCling->TypedefInfo_TrueName(fInfo));
       fProperty = gCling->TypedefInfo_Property(fInfo);
       fSize = gCling->TypedefInfo_Size(fInfo);

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -70,15 +70,16 @@ TDataType::TDataType(const char *typenam) : fInfo(nullptr), fProperty(kIsFundame
 ////////////////////////////////////////////////////////////////////////////////
 ///copy constructor
 
-TDataType::TDataType(const TDataType& dt) :
-  TDictionary(dt),
-  fInfo(gCling->TypedefInfo_FactoryCopy(dt.fInfo)),
-  fSize(dt.fSize),
-  fAlignOf(dt.fAlignOf),
-  fType(dt.fType),
-  fProperty(dt.fProperty),
-  fTrueName(dt.fTrueName),
-  fTypeNameIdx(dt.fTypeNameIdx), fTypeNameLen(dt.fTypeNameLen)
+TDataType::TDataType(const TDataType &dt)
+   : TDictionary(dt),
+     fInfo(gCling->TypedefInfo_FactoryCopy(dt.fInfo)),
+     fSize(dt.fSize),
+     fAlignOf(dt.fAlignOf),
+     fType(dt.fType),
+     fProperty(dt.fProperty),
+     fTrueName(dt.fTrueName),
+     fTypeNameIdx(dt.fTypeNameIdx),
+     fTypeNameLen(dt.fTypeNameLen)
 {
 }
 
@@ -387,7 +388,7 @@ void TDataType::SetType(const char *name)
    }
    if (!strcmp("char*",fName.Data())) {
       fType = kCharStar;
-      fAlignOf = alignof(char*);
+      fAlignOf = alignof(char *);
    }
    // kCounter =  6, kBits     = 15
 }

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -82,63 +82,116 @@ namespace Internal {
    }
 } // Internal
 
+TGenericClassInfo::TGenericClassInfo(const char *fullClassname, const char *declFileName, Int_t declFileLine,
+                                     const std::type_info &info, const Internal::TInitBehavior *action,
+                                     DictFuncPtr_t dictionary, TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof,
+                                     std::size_t alignof_)
+   : fAction(action),
+     fClass(nullptr),
+     fClassName(fullClassname),
+     fDeclFileName(declFileName),
+     fDeclFileLine(declFileLine),
+     fDictionary(dictionary),
+     fInfo(info),
+     fImplFileName(nullptr),
+     fImplFileLine(0),
+     fIsA(isa),
+     fVersion(1),
+     fMerge(nullptr),
+     fResetAfterMerge(nullptr),
+     fNew(nullptr),
+     fNewArray(nullptr),
+     fDelete(nullptr),
+     fDeleteArray(nullptr),
+     fDestructor(nullptr),
+     fDirAutoAdd(nullptr),
+     fStreamer(nullptr),
+     fStreamerFunc(nullptr),
+     fConvStreamerFunc(nullptr),
+     fCollectionProxy(nullptr),
+     fSizeof(sizof),
+     fAlignment(alignof_),
+     fPragmaBits(pragmabits),
+     fCollectionProxyInfo(nullptr),
+     fCollectionStreamerInfo(nullptr)
+{
+   // Constructor.
 
-   TGenericClassInfo::TGenericClassInfo(const char *fullClassname,
-                                        const char *declFileName, Int_t declFileLine,
-                                        const std::type_info &info, const Internal::TInitBehavior  *action,
-                                        DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_)
-      : fAction(action), fClass(nullptr), fClassName(fullClassname),
-        fDeclFileName(declFileName), fDeclFileLine(declFileLine),
-        fDictionary(dictionary), fInfo(info),
-        fImplFileName(nullptr), fImplFileLine(0),
-        fIsA(isa),
-        fVersion(1),
-        fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fAlignment(alignof_), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
-   {
-      // Constructor.
+   Init(pragmabits);
+}
 
-      Init(pragmabits);
-   }
+TGenericClassInfo::TGenericClassInfo(const char *fullClassname, Int_t version, const char *declFileName,
+                                     Int_t declFileLine, const std::type_info &info,
+                                     const Internal::TInitBehavior *action, DictFuncPtr_t dictionary,
+                                     TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_)
+   : fAction(action),
+     fClass(nullptr),
+     fClassName(fullClassname),
+     fDeclFileName(declFileName),
+     fDeclFileLine(declFileLine),
+     fDictionary(dictionary),
+     fInfo(info),
+     fImplFileName(nullptr),
+     fImplFileLine(0),
+     fIsA(isa),
+     fVersion(version),
+     fMerge(nullptr),
+     fResetAfterMerge(nullptr),
+     fNew(nullptr),
+     fNewArray(nullptr),
+     fDelete(nullptr),
+     fDeleteArray(nullptr),
+     fDestructor(nullptr),
+     fDirAutoAdd(nullptr),
+     fStreamer(nullptr),
+     fStreamerFunc(nullptr),
+     fConvStreamerFunc(nullptr),
+     fCollectionProxy(nullptr),
+     fSizeof(sizof),
+     fAlignment(alignof_),
+     fPragmaBits(pragmabits),
+     fCollectionProxyInfo(nullptr),
+     fCollectionStreamerInfo(nullptr)
 
-   TGenericClassInfo::TGenericClassInfo(const char *fullClassname, Int_t version,
-                                        const char *declFileName, Int_t declFileLine,
-                                        const std::type_info &info, const Internal::TInitBehavior  *action,
-                                        DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_)
-      : fAction(action), fClass(nullptr), fClassName(fullClassname),
-        fDeclFileName(declFileName), fDeclFileLine(declFileLine),
-        fDictionary(dictionary), fInfo(info),
-        fImplFileName(nullptr), fImplFileLine(0),
-        fIsA(isa),
-        fVersion(version),
-        fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fAlignment(alignof_), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
+{
+   // Constructor with version number and no showmembers.
 
-   {
-      // Constructor with version number and no showmembers.
-
-      Init(pragmabits);
-   }
+   Init(pragmabits);
+}
 
    class TForNamespace {}; // Dummy class to give a typeid to namespace (See also TClassTable.cc)
 
-   TGenericClassInfo::TGenericClassInfo(const char *fullClassname, Int_t version,
-                                        const char *declFileName, Int_t declFileLine,
-                                        const Internal::TInitBehavior  *action,
+   TGenericClassInfo::TGenericClassInfo(const char *fullClassname, Int_t version, const char *declFileName,
+                                        Int_t declFileLine, const Internal::TInitBehavior *action,
                                         DictFuncPtr_t dictionary, Int_t pragmabits)
-      : fAction(action), fClass(nullptr), fClassName(fullClassname),
-        fDeclFileName(declFileName), fDeclFileLine(declFileLine),
-        fDictionary(dictionary), fInfo(typeid(TForNamespace)),
-        fImplFileName(nullptr), fImplFileLine(0),
+      : fAction(action),
+        fClass(nullptr),
+        fClassName(fullClassname),
+        fDeclFileName(declFileName),
+        fDeclFileLine(declFileLine),
+        fDictionary(dictionary),
+        fInfo(typeid(TForNamespace)),
+        fImplFileName(nullptr),
+        fImplFileLine(0),
         fIsA(nullptr),
         fVersion(version),
-        fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(0), fAlignment(0), fPragmaBits(pragmabits),
-        fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
+        fMerge(nullptr),
+        fResetAfterMerge(nullptr),
+        fNew(nullptr),
+        fNewArray(nullptr),
+        fDelete(nullptr),
+        fDeleteArray(nullptr),
+        fDestructor(nullptr),
+        fDirAutoAdd(nullptr),
+        fStreamer(nullptr),
+        fStreamerFunc(nullptr),
+        fConvStreamerFunc(nullptr),
+        fCollectionProxy(nullptr),
+        fSizeof(0),
+        fAlignment(0),
+        fPragmaBits(pragmabits),
+        fCollectionProxyInfo(nullptr),
+        fCollectionStreamerInfo(nullptr)
 
    {
       // Constructor for namespace

--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -87,7 +87,7 @@ namespace Internal {
                                         const char *declFileName, Int_t declFileLine,
                                         const std::type_info &info, const Internal::TInitBehavior  *action,
                                         DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof)
+                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_)
       : fAction(action), fClass(nullptr), fClassName(fullClassname),
         fDeclFileName(declFileName), fDeclFileLine(declFileLine),
         fDictionary(dictionary), fInfo(info),
@@ -95,7 +95,7 @@ namespace Internal {
         fIsA(isa),
         fVersion(1),
         fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fPragmaBits(pragmabits),
+        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fAlignment(alignof_), fPragmaBits(pragmabits),
         fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
    {
       // Constructor.
@@ -107,7 +107,7 @@ namespace Internal {
                                         const char *declFileName, Int_t declFileLine,
                                         const std::type_info &info, const Internal::TInitBehavior  *action,
                                         DictFuncPtr_t dictionary,
-                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof)
+                                        TVirtualIsAProxy *isa, Int_t pragmabits, Int_t sizof, std::size_t alignof_)
       : fAction(action), fClass(nullptr), fClassName(fullClassname),
         fDeclFileName(declFileName), fDeclFileLine(declFileLine),
         fDictionary(dictionary), fInfo(info),
@@ -115,7 +115,7 @@ namespace Internal {
         fIsA(isa),
         fVersion(version),
         fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fPragmaBits(pragmabits),
+        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(sizof), fAlignment(alignof_), fPragmaBits(pragmabits),
         fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
 
    {
@@ -137,7 +137,7 @@ namespace Internal {
         fIsA(nullptr),
         fVersion(version),
         fMerge(nullptr),fResetAfterMerge(nullptr),fNew(nullptr),fNewArray(nullptr),fDelete(nullptr),fDeleteArray(nullptr),fDestructor(nullptr), fDirAutoAdd(nullptr), fStreamer(nullptr),
-        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(0), fPragmaBits(pragmabits),
+        fStreamerFunc(nullptr), fConvStreamerFunc(nullptr), fCollectionProxy(nullptr), fSizeof(0), fAlignment(0), fPragmaBits(pragmabits),
         fCollectionProxyInfo(nullptr), fCollectionStreamerInfo(nullptr)
 
    {
@@ -295,6 +295,7 @@ namespace Internal {
             }
          }
          fClass->SetClassSize(fSizeof);
+         fClass->SetClassAlignment(fAlignment);
 
          //---------------------------------------------------------------------
          // Attach the schema evolution information

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -403,7 +403,8 @@ std::size_t TStreamerElement::GetAlignment() const
       return sizeof(UInt_t);
    if (auto *dt = TDataType::GetDataType(bareType); dt && dt->GetAlignOf())
       return dt->GetAlignOf();
-   Fatal("TStreamerElement::GetAlignment", "Cannot determine alignment for type %d (bare type %d)", fType, bareType);
+   Error("TStreamerElement::GetAlignment", "Cannot determine alignment for type %d (bare type %d) for element %s",
+         fType, bareType, GetName());
    return alignof(std::max_align_t);
 }
 
@@ -721,8 +722,9 @@ std::size_t TStreamerBase::GetAlignment() const
       cl = GetClassPointer();
    if (cl && cl->GetClassAlignment())
       return cl->GetClassAlignment();
-   Fatal("TStreamerBase::GetAlignment", "Cannot determine alignment for base class %s", GetName());
-   return alignof(std::max_align_t);
+   // The caller will complains if the missing alignment information
+   // causes a problem.
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1100,7 +1102,8 @@ std::size_t TStreamerLoop::GetAlignment() const
       return sizeof(UInt_t);
    if (auto *dt = TDataType::GetDataType(bareType); dt && dt->GetAlignOf())
       return dt->GetAlignOf();
-   Fatal("TStreamerLoop::GetAlignment", "Cannot determine alignment for type %d (bare type %d)", fType, bareType);
+   Error("TStreamerLoop::GetAlignment", "Cannot determine alignment for type %d (bare type %d) for element %s", fType,
+         bareType, GetName());
    return alignof(std::max_align_t);
 }
 
@@ -1359,8 +1362,9 @@ std::size_t TStreamerObject::GetAlignment() const
       cl = GetClassPointer();
    if (cl && cl->GetClassAlignment())
       return cl->GetClassAlignment();
-   Fatal("TStreamerObject::GetAlignment", "Cannot determine alignment for class %s", GetName());
-   return alignof(std::max_align_t);
+   // The caller will complains if the missing alignment information
+   // causes a problem.
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1469,8 +1473,9 @@ std::size_t TStreamerObjectAny::GetAlignment() const
       cl = GetClassPointer();
    if (cl && cl->GetClassAlignment())
       return cl->GetClassAlignment();
-   Fatal("TStreamerObjectAny::GetAlignment", "Cannot determine alignment for class %s", GetName());
-   return alignof(std::max_align_t);
+   // The caller will complains if the missing alignment information
+   // causes a problem.
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2020,8 +2025,9 @@ std::size_t TStreamerSTL::GetAlignment() const
       cl = GetClassPointer();
    if (cl && cl->GetClassAlignment())
       return cl->GetClassAlignment();
-   Fatal("TStreamerSTL::GetAlignment", "Cannot determine alignment for class %s", GetName());
-   return alignof(std::max_align_t);
+   // The caller will complains if the missing alignment information
+   // causes a problem.
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -20,6 +20,7 @@
 #include "TBaseClass.h"
 #include "TDataMember.h"
 #include "TDataType.h"
+#include "ROOT/RAlignmentUtils.hxx"
 #include "TEnum.h"
 #include "TRealData.h"
 #include "ThreadLocalStorage.h"
@@ -390,6 +391,23 @@ Int_t TStreamerElement::GetSize() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of this element in bytes.
+/// The bare underlying type (stripping kOffsetL / kOffsetP array/pointer markers)
+/// is used to determine the alignment from TDataType.
+
+std::size_t TStreamerElement::GetAlignment() const
+{
+   // Strip kOffsetL / kOffsetP markers to recover the bare type id.
+   const EDataType bareType = (EDataType)(fType % TVirtualStreamerInfo::kOffsetL);
+   if (bareType == kCounter || bareType == kBits)
+      return sizeof(UInt_t);
+   if (auto *dt = TDataType::GetDataType(bareType); dt && dt->GetAlignOf())
+      return dt->GetAlignOf();
+   Fatal("TStreamerElement::GetAlignment", "Cannot determine alignment for type %d (bare type %d)", fType, bareType);
+   return alignof(std::max_align_t);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the local streamer object.
 
 TMemberStreamer *TStreamerElement::GetStreamer() const
@@ -691,6 +709,20 @@ Int_t TStreamerBase::GetSize() const
    if (cl)
       return cl->Size();
    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of the base class in bytes.
+
+std::size_t TStreamerBase::GetAlignment() const
+{
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
+   if (cl && cl->GetClassAlignment())
+      return cl->GetClassAlignment();
+   Fatal("TStreamerBase::GetAlignment", "Cannot determine alignment for base class %s", GetName());
+   return alignof(std::max_align_t);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1056,6 +1088,23 @@ TStreamerLoop::~TStreamerLoop()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of this element in bytes.
+/// The bare underlying type (stripping kOffsetL / kOffsetP array/pointer markers)
+/// is used to determine the alignment from TDataType.
+
+std::size_t TStreamerLoop::GetAlignment() const
+{
+   // Strip kOffsetL / kOffsetP markers to recover the bare type id.
+   const EDataType bareType = (EDataType)(fType % TVirtualStreamerInfo::kOffsetL);
+   if (bareType == kCounter || bareType == kBits)
+      return sizeof(UInt_t);
+   if (auto *dt = TDataType::GetDataType(bareType); dt && dt->GetAlignOf())
+      return dt->GetAlignOf();
+   Fatal("TStreamerLoop::GetAlignment", "Cannot determine alignment for type %d (bare type %d)", fType, bareType);
+   return alignof(std::max_align_t);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// return address of counter
 
 ULongptr_t TStreamerLoop::GetMethod() const
@@ -1301,6 +1350,20 @@ Int_t TStreamerObject::GetSize() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of the object class in bytes.
+
+std::size_t TStreamerObject::GetAlignment() const
+{
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
+   if (cl && cl->GetClassAlignment())
+      return cl->GetClassAlignment();
+   Fatal("TStreamerObject::GetAlignment", "Cannot determine alignment for class %s", GetName());
+   return alignof(std::max_align_t);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Stream an object of class TStreamerObject.
 
 void TStreamerObject::Streamer(TBuffer &R__b)
@@ -1394,6 +1457,20 @@ Int_t TStreamerObjectAny::GetSize() const
    if (fArrayLength)
       return fArrayLength * classSize;
    return classSize;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of the object (non-TObject) class in bytes.
+
+std::size_t TStreamerObjectAny::GetAlignment() const
+{
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
+   if (cl && cl->GetClassAlignment())
+      return cl->GetClassAlignment();
+   Fatal("TStreamerObjectAny::GetAlignment", "Cannot determine alignment for class %s", GetName());
+   return alignof(std::max_align_t);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1931,6 +2008,20 @@ Int_t TStreamerSTL::GetSize() const
 
    if (fArrayLength) return fArrayLength*size;
    return size;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the alignment of the STL container in bytes.
+
+std::size_t TStreamerSTL::GetAlignment() const
+{
+   TClass *cl = GetNewClass();
+   if (!cl)
+      cl = GetClassPointer();
+   if (cl && cl->GetClassAlignment())
+      return cl->GetClassAlignment();
+   Fatal("TStreamerSTL::GetAlignment", "Cannot determine alignment for class %s", GetName());
+   return alignof(std::max_align_t);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8262,9 +8262,9 @@ std::string TCling::CallFunc_GetWrapperCode(CallFunc_t *func) const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-size_t TCling::ClassInfo_AlignOf(ClassInfo_t* cinfo) const
+size_t TCling::ClassInfo_AlignOf(ClassInfo_t *cinfo) const
 {
-   TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
+   TClingClassInfo *TClinginfo = (TClingClassInfo *)cinfo;
    return TClinginfo->GetAlignOf();
 }
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -8261,6 +8261,14 @@ std::string TCling::CallFunc_GetWrapperCode(CallFunc_t *func) const
 //
 
 ////////////////////////////////////////////////////////////////////////////////
+
+size_t TCling::ClassInfo_AlignOf(ClassInfo_t* cinfo) const
+{
+   TClingClassInfo* TClinginfo = (TClingClassInfo*) cinfo;
+   return TClinginfo->GetAlignOf();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return true if the entity pointed to by 'declid' is declared in
 /// the context described by 'info'.  If info is null, look into the
 /// global scope (translation unit scope).

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -447,6 +447,7 @@ public: // Public Interface
    void*  ClassInfo_New(ClassInfo_t* info, void* arena) const final;
    Long_t ClassInfo_Property(ClassInfo_t* info) const final;
    int    ClassInfo_Size(ClassInfo_t* info) const final;
+   size_t ClassInfo_AlignOf(ClassInfo_t* info) const final;
    Longptr_t ClassInfo_Tagnum(ClassInfo_t* info) const final;
    const char* ClassInfo_FileName(ClassInfo_t* info) const final;
    const char* ClassInfo_FullName(ClassInfo_t* info) const final;

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1384,8 +1384,7 @@ size_t TClingClassInfo::GetAlignOf() const
    Decl::Kind DK = GetDecl()->getKind();
    if (DK == Decl::Namespace) {
       return 0;
-   }
-   else if (DK == Decl::Enum) {
+   } else if (DK == Decl::Enum) {
       return 0;
    }
    const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(GetDecl());

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -1317,6 +1317,12 @@ int TClingClassInfo::RootFlag() const
    return 0;
 }
 
+/// Return the size of the class in bytes as reported by clang.
+///
+/// Returns -1 if the class info is invalid, 0 for a forward-declared class,
+/// an enum, or a class with no definition, and 1 for a namespace (a special
+/// value inherited from CINT).  For all other cases the actual byte size
+/// obtained from the clang ASTRecordLayout is returned.
 int TClingClassInfo::Size() const
 {
    if (!IsValid()) {
@@ -1353,6 +1359,47 @@ int TClingClassInfo::Size() const
    int64_t size = Layout.getSize().getQuantity();
    int clang_size = static_cast<int>(size);
    return clang_size;
+}
+
+/// Return the alignment of the class in bytes as reported by clang.
+///
+/// Returns (size_t)-1 if the class info is invalid, 0 for a forward-declared
+/// class, an enum, a namespace or or a class with no definition. For all other
+/// cases the actual alignment obtained from the clang ASTRecordLayout is
+/// returned.
+size_t TClingClassInfo::GetAlignOf() const
+{
+   if (!IsValid()) {
+      return -1;
+   }
+   if (!GetDecl()) {
+      // A forward declared class.
+      return 0;
+   }
+
+   R__LOCKGUARD(gInterpreterMutex);
+
+   Decl::Kind DK = GetDecl()->getKind();
+   if (DK == Decl::Namespace) {
+      return 0;
+   }
+   else if (DK == Decl::Enum) {
+      return 0;
+   }
+   const RecordDecl *RD = llvm::dyn_cast<RecordDecl>(GetDecl());
+   if (!RD) {
+      return -1;
+   }
+   if (!RD->getDefinition()) {
+      // Forward-declared class.
+      return 0;
+   }
+   ASTContext &Context = GetDecl()->getASTContext();
+   cling::Interpreter::PushTransactionRAII RAII(fInterp);
+   const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
+   auto align = Layout.getAlignment().getQuantity();
+   assert(align > 0);
+   return align;
 }
 
 Longptr_t TClingClassInfo::Tagnum() const

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -51,6 +51,8 @@ but the class metadata comes from the Clang C++ compiler, not CINT.
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "ROOT/RAlignmentUtils.hxx"
+
 #include <sstream>
 #include <string>
 
@@ -1398,7 +1400,7 @@ size_t TClingClassInfo::GetAlignOf() const
    cling::Interpreter::PushTransactionRAII RAII(fInterp);
    const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
    auto align = Layout.getAlignment().getQuantity();
-   assert(align > 0);
+   assert(ROOT::Internal::IsValidAlignment(align));
    return align;
 }
 

--- a/core/metacling/src/TClingClassInfo.h
+++ b/core/metacling/src/TClingClassInfo.h
@@ -181,6 +181,7 @@ public:
    long                 Property() const;
    int                  RootFlag() const;
    int                  Size() const;
+   size_t               GetAlignOf() const;
    Longptr_t            Tagnum() const;
    const char          *FileName();
    void                 FullName(std::string &output, const ROOT::TMetaUtils::TNormalizedCtxt &normCtxt) const;

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -63,6 +63,7 @@ public:
          // If the collection contains pointers, we need to use the alignment of a pointer, not of the value class.
          align = alignof(void*);
       } else if (vcl) {
+         assert(ROOT::Internal::IsValidAlignment(vcl->GetClassAlignment()));
          align = vcl->GetClassAlignment();
       } else {
          switch( int(fVal->fKind) ) {
@@ -76,8 +77,13 @@ public:
             case kULong_t:  align = alignof(long); break;
             case kLong64_t:
             case kULong64_t:align = alignof(long long); break;
+            case kFloat16_t:
             case kFloat_t:  align = alignof(float); break;
+            case kDouble32_t:
             case kDouble_t: align = alignof(double); break;
+            default:
+               Fatal("TEmulatedCollectionProxy::WithCont", "Unsupported value type %s for value class %s",
+                     EDataTypeName(fVal->fKind), vcl ? vcl->GetName() : "<unknown>");
          }
       }
       switch (align) {

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -82,8 +82,8 @@ public:
             case kDouble32_t:
             case kDouble_t: align = alignof(double); break;
             default:
-               Fatal("TEmulatedCollectionProxy::WithCont", "Unsupported value type %s for value class %s",
-                     EDataTypeName(fVal->fKind), vcl ? vcl->GetName() : "<unknown>");
+               Fatal("TEmulatedCollectionProxy::WithCont", "Unsupported value type %d for value class %s", fVal->fKind,
+                     vcl ? vcl->GetName() : "<unknown>");
          }
       }
       switch (align) {

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -12,6 +12,7 @@
 #define ROOT_TEmulatedCollectionProxy
 
 #include "TGenCollectionProxy.h"
+#include "ROOT/RAlignmentUtils.hxx"
 
 #include <type_traits>
 #include <vector>

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -13,6 +13,7 @@
 
 #include "TGenCollectionProxy.h"
 
+#include <type_traits>
 #include <vector>
 
 class TEmulatedCollectionProxy : public TGenCollectionProxy  {
@@ -21,10 +22,58 @@ class TEmulatedCollectionProxy : public TGenCollectionProxy  {
    friend class TCollectionProxy;
 
 public:
-   // Container type definition
-   typedef std::vector<char>  Cont_t;
-   // Pointer to container type
-   typedef Cont_t            *PCont_t;
+   /// Storage type whose alignment matches \a Align bytes.
+   /// Used to instantiate std::vector specializations with guaranteed buffer alignment.
+   template <std::size_t Align>
+   struct alignas(Align) AlignedStorage {
+      char data[Align] = {};
+   };
+
+   // Convenience vector aliases for each supported alignment.
+   using Cont1_t    = std::vector<AlignedStorage<   1>>;
+   using Cont2_t    = std::vector<AlignedStorage<   2>>;
+   using Cont4_t    = std::vector<AlignedStorage<   4>>;
+   using Cont8_t    = std::vector<AlignedStorage<   8>>;
+   using Cont16_t   = std::vector<AlignedStorage<  16>>;
+   using Cont32_t   = std::vector<AlignedStorage<  32>>;
+   using Cont64_t   = std::vector<AlignedStorage<  64>>;
+   using Cont128_t  = std::vector<AlignedStorage< 128>>;
+   using Cont256_t  = std::vector<AlignedStorage< 256>>;
+   using Cont512_t  = std::vector<AlignedStorage< 512>>;
+   using Cont1024_t = std::vector<AlignedStorage<1024>>;
+   using Cont2048_t = std::vector<AlignedStorage<2048>>;
+   using Cont4096_t = std::vector<AlignedStorage<4096>>;
+
+   // Canonical container type (used for sizeof/typeid; actual alignment is
+   // selected at runtime via the alignment switch in each method).
+   using Cont_t  = std::vector<char>;
+   using PCont_t = Cont_t *;
+
+   /// Invoke \a fn(typed_ptr, elemSize) where typed_ptr is the container
+   /// pointer cast to the correct AlignedStorage<N>* for the value class
+   /// alignment.  \a fn receives the element size (N) as a second argument
+   /// so it can convert byte counts to element counts.
+   template <typename F>
+   void WithCont(void *obj, F &&fn) const
+   {
+      auto *vcl = GetValueClass();
+      std::size_t align = vcl ? vcl->GetClassAlignment() : alignof(std::max_align_t);
+      switch (align) {
+         case 4096: fn(reinterpret_cast<Cont4096_t*>(obj), std::size_t(4096)); break;
+         case 2048: fn(reinterpret_cast<Cont2048_t*>(obj), std::size_t(2048)); break;
+         case 1024: fn(reinterpret_cast<Cont1024_t*>(obj), std::size_t(1024)); break;
+         case  512: fn(reinterpret_cast<Cont512_t *>(obj), std::size_t( 512)); break;
+         case  256: fn(reinterpret_cast<Cont256_t *>(obj), std::size_t( 256)); break;
+         case  128: fn(reinterpret_cast<Cont128_t *>(obj), std::size_t( 128)); break;
+         case   64: fn(reinterpret_cast<Cont64_t  *>(obj), std::size_t(  64)); break;
+         case   32: fn(reinterpret_cast<Cont32_t  *>(obj), std::size_t(  32)); break;
+         case   16: fn(reinterpret_cast<Cont16_t  *>(obj), std::size_t(  16)); break;
+         case    8: fn(reinterpret_cast<Cont8_t   *>(obj), std::size_t(   8)); break;
+         case    4: fn(reinterpret_cast<Cont4_t   *>(obj), std::size_t(   4)); break;
+         case    2: fn(reinterpret_cast<Cont2_t   *>(obj), std::size_t(   2)); break;
+         default:   fn(reinterpret_cast<Cont1_t   *>(obj), std::size_t(   1)); break;
+      }
+   }
 protected:
 
    // Some hack to avoid const-ness
@@ -59,28 +108,62 @@ public:
    ~TEmulatedCollectionProxy() override;
 
    // Virtual constructor
-   void* New() const override             {  return new Cont_t;         }
+   void* New() const override
+   {
+      void *mem = ::operator new(sizeof(Cont_t));
+      WithCont(mem, [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
+      return mem;
+   }
 
    // Virtual in-place constructor
-   void* New(void* memory) const override {  return new(memory) Cont_t; }
+   void* New(void* memory) const override
+   {
+      WithCont(memory, [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
+      return memory;
+   }
 
    // Virtual constructor
-   TClass::ObjectPtr NewObject() const override             {  return {new Cont_t, nullptr};         }
+   TClass::ObjectPtr NewObject() const override
+   {
+      return {New(), nullptr};
+   }
 
    // Virtual in-place constructor
-   TClass::ObjectPtr NewObject(void* memory) const override {  return {new(memory) Cont_t, nullptr}; }
+   TClass::ObjectPtr NewObject(void* memory) const override
+   {
+      return {New(memory), nullptr};
+   }
 
    // Virtual array constructor
-   void* NewArray(Int_t nElements) const override             {  return new Cont_t[nElements]; }
+   void* NewArray(Int_t nElements) const override
+   {
+      void *arr = ::operator new(nElements * sizeof(Cont_t));
+      for (Int_t i = 0; i < nElements; ++i)
+         WithCont(static_cast<char*>(arr) + i * sizeof(Cont_t),
+                  [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
+      return arr;
+   }
 
-   // Virtual in-place constructor
-   void* NewArray(Int_t nElements, void* memory) const override {  return new(memory) Cont_t[nElements]; }
+   // Virtual in-place array constructor
+   void* NewArray(Int_t nElements, void* memory) const override
+   {
+      for (Int_t i = 0; i < nElements; ++i)
+         WithCont(static_cast<char*>(memory) + i * sizeof(Cont_t),
+                  [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
+      return memory;
+   }
 
    // Virtual array constructor
-   TClass::ObjectPtr NewObjectArray(Int_t nElements) const override  {  return {new Cont_t[nElements], nullptr}; }
+   TClass::ObjectPtr NewObjectArray(Int_t nElements) const override
+   {
+      return {NewArray(nElements), nullptr};
+   }
 
-   // Virtual in-place constructor
-   TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory) const override {  return {new(memory) Cont_t[nElements], nullptr}; }
+   // Virtual in-place array constructor
+   TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory) const override
+   {
+      return {NewArray(nElements, memory), nullptr};
+   }
 
    // Virtual destructor
    void  Destructor(void* p, Bool_t dtorOnly = kFALSE) const override;

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -141,7 +141,7 @@ public:
    ~TEmulatedCollectionProxy() override;
 
    // Virtual constructor
-   void* New() const override
+   void *New() const override
    {
       void *mem = ::operator new(sizeof(Cont_t));
       WithCont(mem, [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
@@ -149,51 +149,42 @@ public:
    }
 
    // Virtual in-place constructor
-   void* New(void* memory) const override
+   void *New(void *memory) const override
    {
       WithCont(memory, [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
       return memory;
    }
 
    // Virtual constructor
-   TClass::ObjectPtr NewObject() const override
-   {
-      return {New(), nullptr};
-   }
+   TClass::ObjectPtr NewObject() const override { return {New(), nullptr}; }
 
    // Virtual in-place constructor
-   TClass::ObjectPtr NewObject(void* memory) const override
-   {
-      return {New(memory), nullptr};
-   }
+   TClass::ObjectPtr NewObject(void *memory) const override { return {New(memory), nullptr}; }
 
    // Virtual array constructor
-   void* NewArray(Int_t nElements) const override
+   void *NewArray(Int_t nElements) const override
    {
       void *arr = ::operator new(nElements * sizeof(Cont_t));
       for (Int_t i = 0; i < nElements; ++i)
-         WithCont(static_cast<char*>(arr) + i * sizeof(Cont_t),
+         WithCont(static_cast<char *>(arr) + i * sizeof(Cont_t),
                   [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
       return arr;
    }
 
    // Virtual in-place array constructor
-   void* NewArray(Int_t nElements, void* memory) const override
+   void *NewArray(Int_t nElements, void *memory) const override
    {
       for (Int_t i = 0; i < nElements; ++i)
-         WithCont(static_cast<char*>(memory) + i * sizeof(Cont_t),
+         WithCont(static_cast<char *>(memory) + i * sizeof(Cont_t),
                   [](auto *c, std::size_t) { new (c) std::decay_t<decltype(*c)>(); });
       return memory;
    }
 
    // Virtual array constructor
-   TClass::ObjectPtr NewObjectArray(Int_t nElements) const override
-   {
-      return {NewArray(nElements), nullptr};
-   }
+   TClass::ObjectPtr NewObjectArray(Int_t nElements) const override { return {NewArray(nElements), nullptr}; }
 
    // Virtual in-place array constructor
-   TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory) const override
+   TClass::ObjectPtr NewObjectArray(Int_t nElements, void *memory) const override
    {
       return {NewArray(nElements, memory), nullptr};
    }

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -57,7 +57,28 @@ public:
    void WithCont(void *obj, F &&fn) const
    {
       auto *vcl = GetValueClass();
-      std::size_t align = vcl ? vcl->GetClassAlignment() : alignof(std::max_align_t);
+      std::size_t align = alignof(std::max_align_t);
+      if (!fKey && (fVal->fCase & kIsPointer)) {
+         // If the collection contains pointers, we need to use the alignment of a pointer, not of the value class.
+         align = alignof(void*);
+      } else if (vcl) {
+         align = vcl->GetClassAlignment();
+      } else {
+         switch( int(fVal->fKind) ) {
+            case kChar_t:
+            case kUChar_t:  align = alignof(char); break;
+            case kShort_t:
+            case kUShort_t: align = alignof(short); break;
+            case kInt_t:
+            case kUInt_t:   align = alignof(int); break;
+            case kLong_t:
+            case kULong_t:  align = alignof(long); break;
+            case kLong64_t:
+            case kULong64_t:align = alignof(long long); break;
+            case kFloat_t:  align = alignof(float); break;
+            case kDouble_t: align = alignof(double); break;
+         }
+      }
       switch (align) {
          case 4096: fn(reinterpret_cast<Cont4096_t*>(obj), std::size_t(4096)); break;
          case 2048: fn(reinterpret_cast<Cont2048_t*>(obj), std::size_t(2048)); break;

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -80,6 +80,8 @@ public:
          }
       }
       switch (align) {
+         // When adding new cases here, also update the static_assert in TClingUtils.cxx
+         // to explicitly allow the new alignment and to update the error message accordingly.
          case 4096: fn(reinterpret_cast<Cont4096_t*>(obj), std::size_t(4096)); break;
          case 2048: fn(reinterpret_cast<Cont2048_t*>(obj), std::size_t(2048)); break;
          case 1024: fn(reinterpret_cast<Cont1024_t*>(obj), std::size_t(1024)); break;
@@ -92,7 +94,10 @@ public:
          case    8: fn(reinterpret_cast<Cont8_t   *>(obj), std::size_t(   8)); break;
          case    4: fn(reinterpret_cast<Cont4_t   *>(obj), std::size_t(   4)); break;
          case    2: fn(reinterpret_cast<Cont2_t   *>(obj), std::size_t(   2)); break;
-         default:   fn(reinterpret_cast<Cont1_t   *>(obj), std::size_t(   1)); break;
+         case    1: fn(reinterpret_cast<Cont1_t   *>(obj), std::size_t(   1)); break;
+         default:
+            Fatal("TEmulatedCollectionProxy::WithCont", "Unsupported alignment %zu for value class %s",
+                  align, vcl ? vcl->GetName() : "<unknown>");
       }
    }
 protected:

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -287,39 +287,6 @@ public:
       }
    };
 
-   /// Allocator that allocates memory aligned to at least \a Align bytes.
-   /// The alignment is chosen at construction time and must be a power of two.
-   template <typename T>
-   struct AlignedAllocator {
-      using value_type = T;
-
-      std::size_t alignment;
-
-      explicit AlignedAllocator(std::size_t align = alignof(std::max_align_t)) : alignment(align) {}
-
-      template <typename U>
-      AlignedAllocator(const AlignedAllocator<U> &other) noexcept : alignment(other.alignment) {}
-
-      T *allocate(std::size_t n)
-      {
-         std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         std::size_t bytes = ROOT::Internal::AlignUp(n * sizeof(T), effectiveAlign);
-         return static_cast<T *>(::operator new(bytes, std::align_val_t{effectiveAlign}));
-      }
-
-      void deallocate(T *p, std::size_t n) noexcept
-      {
-         std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         std::size_t bytes = ROOT::Internal::AlignUp(n * sizeof(T), effectiveAlign);
-         ::operator delete(p, bytes, std::align_val_t{effectiveAlign});
-      }
-
-      template <typename U>
-      bool operator==(const AlignedAllocator<U> &other) const noexcept { return alignment == other.alignment; }
-      template <typename U>
-      bool operator!=(const AlignedAllocator<U> &other) const noexcept { return !(*this == other); }
-   };
-
 protected:
    typedef ROOT::Detail::TCollectionProxyInfo::Environ<char[64]> Env_t;
    typedef ROOT::Detail::TCollectionProxyInfo::EnvironBase EnvironBase_t;

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -283,6 +283,42 @@ public:
       }
    };
 
+   /// Allocator that allocates memory aligned to at least \a Align bytes.
+   /// The alignment is chosen at construction time and must be a power of two.
+   template <typename T>
+   struct AlignedAllocator {
+      using value_type = T;
+
+      std::size_t alignment;
+
+      explicit AlignedAllocator(std::size_t align = alignof(std::max_align_t)) : alignment(align) {}
+
+      template <typename U>
+      AlignedAllocator(const AlignedAllocator<U> &other) noexcept : alignment(other.alignment) {}
+
+      T *allocate(std::size_t n)
+      {
+         std::size_t bytes = n * sizeof(T);
+         std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
+         // Round up to a multiple of effectiveAlign (required by aligned operator new)
+         bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+         return static_cast<T *>(::operator new(bytes, std::align_val_t{effectiveAlign}));
+      }
+
+      void deallocate(T *p, std::size_t n) noexcept
+      {
+         std::size_t bytes = n * sizeof(T);
+         std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
+         bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+         ::operator delete(p, bytes, std::align_val_t{effectiveAlign});
+      }
+
+      template <typename U>
+      bool operator==(const AlignedAllocator<U> &other) const noexcept { return alignment == other.alignment; }
+      template <typename U>
+      bool operator!=(const AlignedAllocator<U> &other) const noexcept { return !(*this == other); }
+   };
+
 protected:
    typedef ROOT::Detail::TCollectionProxyInfo::Environ<char[64]> Env_t;
    typedef ROOT::Detail::TCollectionProxyInfo::EnvironBase EnvironBase_t;

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -21,7 +21,9 @@
 #include <string>
 #include <map>
 #include <cstdlib>
+#include <cstddef>
 #include <vector>
+#include <new>
 
 class TObjArray;
 class TCollectionProxyFactory;
@@ -298,18 +300,15 @@ public:
 
       T *allocate(std::size_t n)
       {
-         std::size_t bytes = n * sizeof(T);
          std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         // Round up to a multiple of effectiveAlign (required by aligned operator new)
-         bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+         std::size_t bytes = AlignUp(n * sizeof(T), effectiveAlign);
          return static_cast<T *>(::operator new(bytes, std::align_val_t{effectiveAlign}));
       }
 
       void deallocate(T *p, std::size_t n) noexcept
       {
-         std::size_t bytes = n * sizeof(T);
          std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+         std::size_t bytes = AlignUp(n * sizeof(T), effectiveAlign);
          ::operator delete(p, bytes, std::align_val_t{effectiveAlign});
       }
 
@@ -317,6 +316,13 @@ public:
       bool operator==(const AlignedAllocator<U> &other) const noexcept { return alignment == other.alignment; }
       template <typename U>
       bool operator!=(const AlignedAllocator<U> &other) const noexcept { return !(*this == other); }
+
+   private:
+      /// Round \p value up to the next multiple of \p align. \p align must be a power of two.
+      static std::size_t AlignUp(std::size_t value, std::size_t align)
+      {
+         return (value + align - 1) & ~(align - 1);
+      }
    };
 
 protected:

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -17,6 +17,8 @@
 
 #include "TCollectionProxyInfo.h"
 
+#include "ROOT/RAlignmentUtils.hxx"
+
 #include <atomic>
 #include <string>
 #include <map>
@@ -301,14 +303,14 @@ public:
       T *allocate(std::size_t n)
       {
          std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         std::size_t bytes = AlignUp(n * sizeof(T), effectiveAlign);
+         std::size_t bytes = ROOT::Internal::AlignUp(n * sizeof(T), effectiveAlign);
          return static_cast<T *>(::operator new(bytes, std::align_val_t{effectiveAlign}));
       }
 
       void deallocate(T *p, std::size_t n) noexcept
       {
          std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
-         std::size_t bytes = AlignUp(n * sizeof(T), effectiveAlign);
+         std::size_t bytes = ROOT::Internal::AlignUp(n * sizeof(T), effectiveAlign);
          ::operator delete(p, bytes, std::align_val_t{effectiveAlign});
       }
 
@@ -316,13 +318,6 @@ public:
       bool operator==(const AlignedAllocator<U> &other) const noexcept { return alignment == other.alignment; }
       template <typename U>
       bool operator!=(const AlignedAllocator<U> &other) const noexcept { return !(*this == other); }
-
-   private:
-      /// Round \p value up to the next multiple of \p align. \p align must be a power of two.
-      static std::size_t AlignUp(std::size_t value, std::size_t align)
-      {
-         return (value + align - 1) & ~(align - 1);
-      }
    };
 
 protected:

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -90,6 +90,7 @@ private:
    Int_t             fOnFileClassVersion;///<!Class version identifier as stored on file.
    Int_t             fNumber;            ///<!Unique identifier
    Int_t             fSize;              ///<!size of the persistent class
+   size_t            fAlignment;         ///<!alignment of the memory representation of the class
    Int_t             fNdata;             ///<!number of optimized elements
    Int_t             fNfulldata;         ///<!number of elements
    Int_t             fNslots;            ///<!total number of slots in fComp.
@@ -155,6 +156,7 @@ public:
    void                ForceWriteInfo(TFile *file, Bool_t force = kFALSE) override;
    Int_t               GenerateHeaderFile(const char *dirname, const TList *subClasses = nullptr, const TList *extrainfos = nullptr) override;
    TClass             *GetActualClass(const void *obj) const override;
+   size_t              GetClassAlignment() const override { return fAlignment; }
    TClass             *GetClass() const override { return fClass; }
    UInt_t              GetCheckSum() const override { return fCheckSum; }
    UInt_t              GetCheckSum(TClass::ECheckSum code) const;

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -47,7 +47,7 @@ TEmulatedCollectionProxy::TEmulatedCollectionProxy(const TEmulatedCollectionProx
    fProperties |= kIsEmulated;
 }
 
-TEmulatedCollectionProxy::TEmulatedCollectionProxy(const char* cl_name, Bool_t silent)
+TEmulatedCollectionProxy::TEmulatedCollectionProxy(const char *cl_name, Bool_t silent)
    : TGenCollectionProxy(typeid(Cont_t), sizeof(Cont_t::iterator))
 {
    // Build a Streamer for a collection whose type is described by 'collectionClass'.
@@ -88,7 +88,10 @@ void TEmulatedCollectionProxy::Destructor(void* p, Bool_t dtorOnly) const
       const_cast<TEmulatedCollectionProxy*>(this)->Clear("force");
    }
    if (dtorOnly) {
-      WithCont(p, [](auto *c, std::size_t) { using Vec_t = std::decay_t<decltype(*c)>; c->~Vec_t(); });
+      WithCont(p, [](auto *c, std::size_t) {
+         using Vec_t = std::decay_t<decltype(*c)>;
+         c->~Vec_t();
+      });
    } else {
       WithCont(p, [](auto *c, std::size_t) { delete c; });
    }
@@ -265,7 +268,7 @@ void TEmulatedCollectionProxy::Shrink(UInt_t nCurr, UInt_t left, Bool_t force )
 {
    // Shrink the container
 
-   typedef std::string  String_t;
+   typedef std::string String_t;
    char* addr  = ((char*)fEnv->fStart) + fValDiff*left;
    size_t i;
 
@@ -361,7 +364,7 @@ void TEmulatedCollectionProxy::Shrink(UInt_t nCurr, UInt_t left, Bool_t force )
          }
    }
    WithCont(fEnv->fObject, [&](auto *c, std::size_t alignmentElemSize) {
-      assert( fValDiff % alignmentElemSize == 0 );
+      assert(fValDiff % alignmentElemSize == 0);
       c->resize(left * fValDiff / alignmentElemSize);
       fEnv->fStart = left > 0 ? c->data() : nullptr;
    });
@@ -374,7 +377,7 @@ void TEmulatedCollectionProxy::Expand(UInt_t nCurr, UInt_t left)
    size_t i;
    void *oldstart = fEnv->fStart;
    WithCont(fEnv->fObject, [&](auto *c, std::size_t alignmentElemSize) {
-      assert( fValDiff % alignmentElemSize == 0 );
+      assert(fValDiff % alignmentElemSize == 0);
       c->resize(left * fValDiff / alignmentElemSize);
       fEnv->fStart = left > 0 ? c->data() : nullptr;
    });

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -134,12 +134,10 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
          // since under-neath is actually an array.
 
          auto alignedSize = [](size_t in, TClass *align_cl) {
-            constexpr size_t kSizeOfPtr = sizeof(void*);
-            size_t align = align_cl ? align_cl->GetClassAlignment() : kSizeOfPtr;
-            return in + (align - in%align)%align;
+            size_t align = align_cl ? align_cl->GetClassAlignment() : alignof(std::max_align_t);
+            return in + (align - in % align) % align;
          };
-         struct GenerateTemporaryTEnum
-         {
+         struct GenerateTemporaryTEnum {
             TEnum *fTemporaryTEnum = nullptr;
 
             GenerateTemporaryTEnum(UInt_t typecase, const std::string &enumname)

--- a/io/io/src/TEmulatedCollectionProxy.cxx
+++ b/io/io/src/TEmulatedCollectionProxy.cxx
@@ -48,7 +48,7 @@ TEmulatedCollectionProxy::TEmulatedCollectionProxy(const TEmulatedCollectionProx
 }
 
 TEmulatedCollectionProxy::TEmulatedCollectionProxy(const char* cl_name, Bool_t silent)
-   : TGenCollectionProxy(typeid(std::vector<char>), sizeof(std::vector<char>::iterator))
+   : TGenCollectionProxy(typeid(Cont_t), sizeof(Cont_t::iterator))
 {
    // Build a Streamer for a collection whose type is described by 'collectionClass'.
 
@@ -88,9 +88,9 @@ void TEmulatedCollectionProxy::Destructor(void* p, Bool_t dtorOnly) const
       const_cast<TEmulatedCollectionProxy*>(this)->Clear("force");
    }
    if (dtorOnly) {
-      ((Cont_t*)p)->~Cont_t();
+      WithCont(p, [](auto *c, std::size_t) { using Vec_t = std::decay_t<decltype(*c)>; c->~Vec_t(); });
    } else {
-      delete (Cont_t*) p;
+      WithCont(p, [](auto *c, std::size_t) { delete c; });
    }
 }
 
@@ -102,7 +102,7 @@ void TEmulatedCollectionProxy::DeleteArray(void* p, Bool_t dtorOnly) const
    // how many elements are in the array.
    Warning("DeleteArray", "Cannot properly delete emulated array of %s at %p, I don't know how many elements it has!", fClass->GetName(), p);
    if (!dtorOnly) {
-      delete[] (Cont_t*) p;
+      ::operator delete(p);
    }
 }
 
@@ -133,10 +133,10 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
          // Note: an emulated collection proxy is never really associative
          // since under-neath is actually an array.
 
-         // std::cout << "Initialized " << typeid(*this).name() << ":" << fName << std::endl;
-         auto alignedSize = [](size_t in) {
+         auto alignedSize = [](size_t in, TClass *align_cl) {
             constexpr size_t kSizeOfPtr = sizeof(void*);
-            return in + (kSizeOfPtr - in%kSizeOfPtr)%kSizeOfPtr;
+            size_t align = align_cl ? align_cl->GetClassAlignment() : kSizeOfPtr;
+            return in + (align - in%align)%align;
          };
          struct GenerateTemporaryTEnum
          {
@@ -195,10 +195,10 @@ TGenCollectionProxy *TEmulatedCollectionProxy::InitializeEx(Bool_t silent)
                   fProperties |= kNeedDelete;
                }
                if ( 0 == fValOffset )  {
-                  fValOffset = alignedSize(fKey->fSize);
+                  fValOffset = alignedSize(fKey->fSize, (*fValue).fType.GetClass());
                }
                if ( 0 == fValDiff )  {
-                  fValDiff = alignedSize(fValOffset + fVal->fSize);
+                  fValDiff = alignedSize(fValOffset + fVal->fSize, (*fValue).fType.GetClass());
                }
                if (num > 3 && !inside[3].empty()) {
                   if (! TClassEdit::IsDefAlloc(inside[3].c_str(),inside[0].c_str())) {
@@ -268,7 +268,6 @@ void TEmulatedCollectionProxy::Shrink(UInt_t nCurr, UInt_t left, Bool_t force )
    // Shrink the container
 
    typedef std::string  String_t;
-   PCont_t c   = PCont_t(fEnv->fObject);
    char* addr  = ((char*)fEnv->fStart) + fValDiff*left;
    size_t i;
 
@@ -363,8 +362,11 @@ void TEmulatedCollectionProxy::Shrink(UInt_t nCurr, UInt_t left, Bool_t force )
                break;
          }
    }
-   c->resize(left*fValDiff,0);
-   fEnv->fStart = left > 0 ? c->data() : 0;
+   WithCont(fEnv->fObject, [&](auto *c, std::size_t alignmentElemSize) {
+      assert( fValDiff % alignmentElemSize == 0 );
+      c->resize(left * fValDiff / alignmentElemSize);
+      fEnv->fStart = left > 0 ? c->data() : nullptr;
+   });
    return;
 }
 
@@ -372,10 +374,12 @@ void TEmulatedCollectionProxy::Expand(UInt_t nCurr, UInt_t left)
 {
    // Expand the container
    size_t i;
-   PCont_t c   = PCont_t(fEnv->fObject);
-   c->resize(left*fValDiff,0);
    void *oldstart = fEnv->fStart;
-   fEnv->fStart = left > 0 ? c->data() : 0;
+   WithCont(fEnv->fObject, [&](auto *c, std::size_t alignmentElemSize) {
+      assert( fValDiff % alignmentElemSize == 0 );
+      c->resize(left * fValDiff / alignmentElemSize);
+      fEnv->fStart = left > 0 ? c->data() : nullptr;
+   });
 
    char* addr = ((char*)fEnv->fStart) + fValDiff*nCurr;
    switch ( fSTL_type )  {

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -1520,7 +1520,6 @@ void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, v
    }
    *begin_arena = vec->data();
    *end_arena = vec->data() + vec->size();
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1624,7 +1623,9 @@ TVirtualCollectionProxy::CreateIterators_t TGenCollectionProxy::GetFunctionCreat
 //      fprintf(stderr,"a generic iterator\n");
 
    // TODO could we do better than SlowCreateIterators for RVec?
-   if (fSTL_type==ROOT::kSTLvector || (fProperties & kIsEmulated))
+   if (fProperties & kIsEmulated)
+      return fFunctionCreateIterators = TGenCollectionProxy__VectorCreateIterators;
+   else if (fSTL_type==ROOT::kSTLvector)
       return fFunctionCreateIterators = TGenCollectionProxy__VectorCreateIterators;
    else if ( (fProperties & kIsAssociative) && read)
       return TGenCollectionProxy__StagingCreateIterators;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -1519,7 +1519,7 @@ void TGenCollectionProxy__VectorCreateIterators(void *obj, void **begin_arena, v
       return;
    }
    *begin_arena = vec->data();
-   *end_arena = vec->data() + vec->size();
+   *end_arena   = vec->data() + vec->size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1625,7 +1625,7 @@ TVirtualCollectionProxy::CreateIterators_t TGenCollectionProxy::GetFunctionCreat
    // TODO could we do better than SlowCreateIterators for RVec?
    if (fProperties & kIsEmulated)
       return fFunctionCreateIterators = TGenCollectionProxy__VectorCreateIterators;
-   else if (fSTL_type==ROOT::kSTLvector)
+   else if (fSTL_type == ROOT::kSTLvector)
       return fFunctionCreateIterators = TGenCollectionProxy__VectorCreateIterators;
    else if ( (fProperties & kIsAssociative) && read)
       return TGenCollectionProxy__StagingCreateIterators;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2345,7 +2345,7 @@ void TStreamerInfo::BuildOld()
       if (fClass->GetState() > TClass::kEmulated && !fClass->IsSyntheticPair()) {
          if (TClass *elCl = element->GetClass())
             fAlignment = std::max(fAlignment, elCl->GetClassAlignment());
-         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+         else if (auto *eldt = TDataType::GetDataType((EDataType)(element->GetType() % kOffsetL)); eldt && eldt->GetAlignOf())
             fAlignment = std::max(fAlignment, eldt->GetAlignOf());
       }
 
@@ -2681,10 +2681,12 @@ void TStreamerInfo::BuildOld()
          // Use the precise alignment of the element type, falling back to
          // max_align_t for types whose alignment is not known.
          // (e.g. forward declared classes, or classes with incomplete types info, etc..)
+         // Strip kOffsetL / kOffsetP markers to get the bare underlying type id.
+         const EDataType bareType = (EDataType)(element->GetType() % kOffsetL);
          std::size_t align = alignof(std::max_align_t);
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();
-         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+         else if (auto *eldt = TDataType::GetDataType(bareType); eldt && eldt->GetAlignOf())
             align = eldt->GetAlignOf();
          else
             Fatal("BuildOld",
@@ -2697,7 +2699,7 @@ void TStreamerInfo::BuildOld()
          offset += asize;
          if (element->GetClass())
             fAlignment = std::max(fAlignment, element->GetClass()->GetClassAlignment());
-         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+         else if (auto *eldt = TDataType::GetDataType(bareType); eldt && eldt->GetAlignOf())
             fAlignment = std::max(fAlignment, eldt->GetAlignOf());
       }
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3347,10 +3347,8 @@ void TStreamerInfo::ComputeSize()
       fSize = fVirtualInfoLoc[0] + sizeof(TStreamerInfo*);
    }
 
-   // On some platform and in some case of layout non-basic data types needs
-   // to be aligned.  So let's be on the safe side and align on the alignment
-   // of `std::max_align_t`.
-   if (fAlignment < alignof(std::max_align_t)) {
+   // If we have no information use the default alignment.
+   if (!fAlignment) {
       fAlignment = alignof(std::max_align_t);
    }
    if ((fSize % fAlignment) != 0) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2650,9 +2650,7 @@ void TStreamerInfo::BuildOld()
          Int_t align = kSizeOfPtr;
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();
-         if ((offset % align) != 0) {
-            offset = offset - (offset % align) + align;
-         }
+         offset = (offset + align - 1) & ~(align - 1);
          element->SetOffset(offset);
          offset += asize;
          if (element->GetClass())
@@ -3345,7 +3343,7 @@ void TStreamerInfo::ComputeSize()
       fAlignment = kSizeOfPtr;
    }
    if ((fSize % fAlignment) != 0) {
-      fSize = fSize - (fSize % fAlignment) + fAlignment;
+      fSize = (fSize + fAlignment - 1) & ~(fAlignment - 1);
    }
 }
 
@@ -5963,7 +5961,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
    //align the non-basic data types (required on alpha and IRIX!!)
    size_t align = sizeof(void *);
    if (needAlign && offset % align != 0)
-      offset = offset - offset % align + align;
+      offset = (offset + align - 1) & ~(align - 1);
 
    TDataType *dt = gROOT->GetType(dmType);
    if (dt && dt->GetType() > 0 ) {  // found a basic type
@@ -6017,7 +6015,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       // a class
       align = std::max(align, clm->GetClassAlignment());
       if (needAlign && align != sizeof(void *) && offset % align != 0)
-         offset = offset - offset % align + align;
+         offset = (offset + align - 1) & ~(align - 1);
       if (clm->IsTObject()) {
          return new TStreamerObject(dmName,dmTitle,offset,dmFull.c_str());
       } else if(clm == TString::Class() && !dmIsPtr) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2053,6 +2053,7 @@ void TStreamerInfo::BuildOld()
 
             // Calculate the offset using the 'real' base class name (as opposed to the
             // '@@emulated' in the case of the emulation of an abstract base class.
+            // baseOffset already take alignment in consideration.
             Int_t baseOffset = fClass->GetBaseClassOffset(baseclass);
 
             // Deal with potential schema evolution (renaming) of the base class.
@@ -2117,15 +2118,24 @@ void TStreamerInfo::BuildOld()
                fNVirtualInfoLoc += infobase->fNVirtualInfoLoc;
             }
 
-
-            {
-               if (baseOffset < 0) {
-                  element->SetNewType(TVirtualStreamerInfo::kNoType);
+            if (baseOffset < 0) {
+               element->SetNewType(TVirtualStreamerInfo::kNoType);
+            } else {
+               auto align = baseclass->GetClassAlignment();
+               if (!ROOT::Internal::IsValidAlignment(align)) {
+                  // Print error only if this is meant to be the 'current'
+                  // class layout description.
+                  if (fClass->GetClassVersion() == fClassVersion) {
+                     Error("TStreamerInfo::BuildOld", "Cannot determine alignment for base class %s for element %s",
+                           baseclass->GetName(), GetName());
+                  }
+                  align = alignof(std::max_align_t);
                }
+               fAlignment = std::max(fAlignment, align);
             }
             element->SetOffset(baseOffset);
-            offset += baseclass->Size();
-            fAlignment = std::max(fAlignment, baseclass->GetClassAlignment());
+            // We might be treating the base classes out of memory order.
+            offset = std::max(offset, baseOffset + baseclass->Size());
 
             continue;
          } else {
@@ -2210,10 +2220,22 @@ void TStreamerInfo::BuildOld()
                element->SetNewType(TVirtualStreamerInfo::kNoType);
                continue;
             }
+
+            auto align = element->GetAlignment();
+            if (!ROOT::Internal::IsValidAlignment(align)) {
+               // Print error only if this is meant to be the 'current'
+               // class layout description.
+               if (fClass->GetClassVersion() == fClassVersion) {
+                  Error("TStreamerInfo::BuildOld", "Cannot determine alignment for base class %s for element %s",
+                        element->GetClassPointer()->GetName(), GetName());
+               }
+               align = alignof(std::max_align_t);
+            }
+            fAlignment = std::max(fAlignment, align);
+
             element->SetOffset(baseOffset);
-            offset += asize;
-            if (TClass *bcPtr = element->GetClassPointer())
-               fAlignment = std::max(fAlignment, bcPtr->GetClassAlignment());
+            // We might be treating the base classes out of memory order.
+            offset = std::max(offset, baseOffset + asize);
             element->Init(this);
             continue;
          } // if element is of type TStreamerBase or not.

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -530,6 +530,10 @@ void TStreamerInfo::Build(Bool_t isTransient)
          }
          if (element) {
             fElements->Add(element);
+            // We are building the TStreamerInfo for the in-memory representation
+            // of a loaded class, so we don't need to cross check the element's
+            // alignment (fAlignment will eventually be set to the one provided
+            // to the dictionary).
             fAlignment = std::max(fAlignment, element->GetAlignment());
          }
       } // end of base class loop
@@ -828,6 +832,10 @@ void TStreamerInfo::Build(Bool_t isTransient)
       }
 
       fElements->Add(element);
+      // We are building the TStreamerInfo for the in-memory representation
+      // of a loaded class, so we don't need to cross check the element's
+      // alignment (fAlignment will eventually be set to the one provided
+      // to the dictionary).
       fAlignment = std::max(fAlignment, element->GetAlignment());
    } // end of member loop
 
@@ -2247,7 +2255,7 @@ void TStreamerInfo::BuildOld()
          fVirtualInfoLoc = new ULong_t[1]; // To allow for a single delete statement.
          fVirtualInfoLoc[0] = offset;
          offset += sizeof(TStreamerInfo*);
-         fAlignment = std::max(fAlignment, sizeof(TStreamerInfo*));
+         fAlignment          = std::max(fAlignment, alignof(TStreamerInfo *));
       }
 
       TDataMember* dm = 0;
@@ -2364,7 +2372,19 @@ void TStreamerInfo::BuildOld()
          }
       } // Class corresponding to StreamerInfo is emulated or not.
 
-      fAlignment = std::max(fAlignment, element->GetAlignment());
+      {
+         auto align = element->GetAlignment();
+         if (!ROOT::Internal::IsValidAlignment(align)) {
+            // Print error only if this is meant to be the 'current'
+            // class layout description.
+            if (fClass->GetClassVersion() == fClassVersion) {
+               Error("TStreamerInfo::BuildOld", "Cannot determine alignment for type %s for element %s",
+                     element->GetTypeName(), GetName());
+            }
+            align = alignof(std::max_align_t);
+         }
+         fAlignment = std::max(fAlignment, align);
+      }
 
       // Now let's deal with Schema evolution
       Int_t newType = -1;
@@ -2802,6 +2822,7 @@ void TStreamerInfo::BuildOld()
    // If we get here, this means that there no data member after the last base class
    // (or no base class at all).
    if (shouldHaveInfoLoc && fNVirtualInfoLoc==0) {
+      offset = (Int_t)AlignUp((size_t)offset, alignof(TStreamerInfo *));
       fNVirtualInfoLoc = 1;
       fVirtualInfoLoc = new ULong_t[1]; // To allow for a single delete statement.
       fVirtualInfoLoc[0] = offset;
@@ -3403,9 +3424,7 @@ void TStreamerInfo::ComputeSize()
 
    // If we have no information use the default alignment.
    if (!fAlignment) {
-      // FIXME-ALIGN: this currently happens when the TStreamerInfo is not
-      // the current one.
-      Fatal("ComputeSize", "No information on the alignment of class %s, using default alignment of %d bytes",
+      Error("ComputeSize", "No information on the alignment of class %s, using default alignment of %d bytes",
             GetName(), (Int_t)alignof(std::max_align_t));
       fAlignment = alignof(std::max_align_t);
    }
@@ -6078,7 +6097,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       // a class
       assert(ROOT::Internal::IsValidAlignment(clm->GetClassAlignment()));
       align = std::max(align, clm->GetClassAlignment());
-      if (needAlign && align != alignof(std::max_align_t) && ((offset % align) != 0))
+      if (needAlign && ((offset % align) != 0))
          offset = (Int_t)AlignUp((size_t)offset, align);
       if (clm->IsTObject()) {
          return new TStreamerObject(dmName,dmTitle,offset,dmFull.c_str());

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -245,14 +245,7 @@ TStreamerInfo::~TStreamerInfo()
 /// Makes sure kBuildRunning reset once Build finishes.
 
 namespace {
-   /// Round \p value up to the next multiple of \p align.
-   /// \p align must be a power of two.
-   template <typename T>
-   inline T AlignUp(T value, T align)
-   {
-      assert(ROOT::Internal::IsValidAlignment(align)); // must be a power of two
-      return (value + align - 1) & ~(align - 1);
-   }
+   using ROOT::Internal::AlignUp;
 
    struct TPreventRecursiveBuildGuard {
       TPreventRecursiveBuildGuard(TStreamerInfo* info): fInfo(info) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5095,7 +5095,7 @@ void* TStreamerInfo::New(void *obj)
       // Use aligned new (C++17). This will return memory aligned to
       // 'align' and can be freed with the matching delete[].
       assert(ROOT::Internal::IsValidAlignment(align)); // align must be a power of 2
-      p = static_cast<char*>(::operator new[](fSize, std::align_val_t(align)));
+      p = static_cast<char *>(::operator new[](fSize, std::align_val_t(align)));
       memset(p, 0, fSize);
    }
 
@@ -5258,17 +5258,17 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
       // Allocate and initialize the memory block.  Request alignment so
       // that the raw block starts on an 'align'-boundary; combined with
       // the rounded-up header this guarantees dataBegin is also aligned.
-      p = static_cast<char*>(::operator new[](len, std::align_val_t(layout.align)));
+      p = static_cast<char *>(::operator new[](len, std::align_val_t(layout.align)));
       memset(p, 0, len);
    }
 
    Long_t* r = (Long_t*)(p + layout.headerSize - layout.cookieSize);
    r[0] = size;
    r[1] = nElements;
-   char* dataBegin = p + layout.headerSize;
+   char *dataBegin = p + layout.headerSize;
 
    // Do a placement new for each element.
-   char* q = dataBegin;
+   char *q = dataBegin;
    for (Long_t cnt = 0; cnt < nElements; ++cnt) {
       New(q);
       q += size;
@@ -5472,10 +5472,10 @@ void TStreamerInfo::DeleteArray(void* ary, Bool_t dtorOnly)
    // headerSize that NewArray used.
    const ArrayCookieLayout layout(fClass);
 
-   Long_t* r = (Long_t*)((char*)ary - layout.cookieSize);
-   Long_t arrayLen = r[1];
-   Long_t size     = r[0];
-   char* memBegin  = (char*)ary - layout.headerSize;
+   Long_t *r        = (Long_t *)((char *)ary - layout.cookieSize);
+   Long_t  arrayLen = r[1];
+   Long_t  size     = r[0];
+   char   *memBegin = (char *)ary - layout.headerSize;
 
    char* p = ((char*) ary) + ((arrayLen - 1) * size);
    for (Long_t cnt = 0; cnt < arrayLen; ++cnt, p -= size) {
@@ -6032,7 +6032,8 @@ TStreamerInfo::GenExplicitClassStreamer( const ::ROOT::TCollectionProxyInfo &inf
 //
 // Utility functions
 //
-static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset, bool silent, bool needAlign)
+static TStreamerElement *
+R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset, bool silent, bool needAlign)
 {
    // Create a TStreamerElement for the type 'dmFull' and whose data member name is 'dmName'.
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -530,6 +530,7 @@ void TStreamerInfo::Build(Bool_t isTransient)
          }
          if (element) {
             fElements->Add(element);
+            fAlignment = std::max(fAlignment, element->GetAlignment());
          }
       } // end of base class loop
    }
@@ -827,6 +828,7 @@ void TStreamerInfo::Build(Bool_t isTransient)
       }
 
       fElements->Add(element);
+      fAlignment = std::max(fAlignment, element->GetAlignment());
    } // end of member loop
 
    // Now add artificial TStreamerElement (i.e. rules that creates new members or set transient members).
@@ -2340,14 +2342,7 @@ void TStreamerInfo::BuildOld()
          }
       } // Class corresponding to StreamerInfo is emulated or not.
 
-      // For non-emulated (loaded) classes, propagate the member's alignment into
-      // fAlignment so that ComputeSize() has a valid value for older StreamerInfos.
-      if (fClass->GetState() > TClass::kEmulated && !fClass->IsSyntheticPair()) {
-         if (TClass *elCl = element->GetClass())
-            fAlignment = std::max(fAlignment, elCl->GetClassAlignment());
-         else if (auto *eldt = TDataType::GetDataType((EDataType)(element->GetType() % kOffsetL)); eldt && eldt->GetAlignOf())
-            fAlignment = std::max(fAlignment, eldt->GetAlignOf());
-      }
+      fAlignment = std::max(fAlignment, element->GetAlignment());
 
       // Now let's deal with Schema evolution
       Int_t newType = -1;
@@ -2681,26 +2676,12 @@ void TStreamerInfo::BuildOld()
          // Use the precise alignment of the element type, falling back to
          // max_align_t for types whose alignment is not known.
          // (e.g. forward declared classes, or classes with incomplete types info, etc..)
-         // Strip kOffsetL / kOffsetP markers to get the bare underlying type id.
-         const EDataType bareType = (EDataType)(element->GetType() % kOffsetL);
-         std::size_t align = alignof(std::max_align_t);
-         if (element->GetClass() && element->GetClass()->GetClassAlignment())
-            align = element->GetClass()->GetClassAlignment();
-         else if (auto *eldt = TDataType::GetDataType(bareType); eldt && eldt->GetAlignOf())
-            align = eldt->GetAlignOf();
-         else
-            Fatal("BuildOld",
-                  "Cannot determine the alignment of the element %s::%s of type %s, unable to build the StreamerInfo "
-                  "for version %d of %s",
-                  GetName(), element->GetName(), element->GetTypeName(), GetClassVersion(), GetName());
+         const std::size_t align = element->GetAlignment();
          assert(ROOT::Internal::IsValidAlignment(align));
          offset = (Int_t)AlignUp((std::size_t)offset, align);
          element->SetOffset(offset);
          offset += asize;
-         if (element->GetClass())
-            fAlignment = std::max(fAlignment, element->GetClass()->GetClassAlignment());
-         else if (auto *eldt = TDataType::GetDataType(bareType); eldt && eldt->GetAlignOf())
-            fAlignment = std::max(fAlignment, eldt->GetAlignOf());
+         fAlignment = std::max(fAlignment, align);
       }
 
       if (!wasCompiled && rules) {
@@ -3369,6 +3350,7 @@ void TStreamerInfo::ComputeSize()
    if (this == fClass->GetCurrentStreamerInfo()) {
       if (fClass->GetState() >= TClass::kInterpreted || fClass->fIsSyntheticPair) {
          fSize = fClass->GetClassSize();
+         fAlignment = fClass->GetClassAlignment();
          return;
       }
    }
@@ -6121,15 +6103,9 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    i->GetElements()->Delete();
    TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0, silent, /*needAlign=*/false);
    Int_t size = 0;
-   size_t align = alignof(std::max_align_t);
    if (fel) {
       i->GetElements()->Add(fel);
-
-      if (fel->GetClass() && fel->GetClass()->GetClassAlignment()) {
-         assert(ROOT::Internal::IsValidAlignment(fel->GetClass()->GetClassAlignment()));
-         i->fAlignment = std::max(align, fel->GetClass()->GetClassAlignment());
-      } else if (auto *dt = TDataType::GetDataType((EDataType)fel->GetType()); dt && dt->GetAlignOf())
-         i->fAlignment = std::max(align, dt->GetAlignOf());
+      i->fAlignment = std::max(i->fAlignment, fel->GetAlignment());
    } else {
       delete i;
       return 0;
@@ -6140,11 +6116,7 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
       R__CreateEmulatedElement("second", secondname, size, silent, /*needAlign=*/!hint_pair_offset);
    if (second) {
       i->GetElements()->Add(second);
-      if (second->GetClass() && second->GetClass()->GetClassAlignment()){
-         assert(ROOT::Internal::IsValidAlignment(second->GetClass()->GetClassAlignment()));
-         i->fAlignment = std::max(align, second->GetClass()->GetClassAlignment());
-      } else if (auto *dt = TDataType::GetDataType((EDataType)second->GetType()); dt && dt->GetAlignOf())
-         i->fAlignment = std::max(align, dt->GetAlignOf());
+      i->fAlignment = std::max(i->fAlignment, second->GetAlignment());
    } else {
       delete i;
       return 0;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2686,6 +2686,11 @@ void TStreamerInfo::BuildOld()
             align = element->GetClass()->GetClassAlignment();
          else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
             align = eldt->GetAlignOf();
+         else
+            Fatal("BuildOld",
+                  "Cannot determine the alignment of the element %s::%s of type %s, unable to build the StreamerInfo "
+                  "for version %d of %s",
+                  GetName(), element->GetName(), element->GetTypeName(), GetClassVersion(), GetName());
          assert(ROOT::Internal::IsValidAlignment(align));
          offset = (Int_t)AlignUp((std::size_t)offset, align);
          element->SetOffset(offset);
@@ -3376,6 +3381,10 @@ void TStreamerInfo::ComputeSize()
 
    // If we have no information use the default alignment.
    if (!fAlignment) {
+      // FIXME-ALIGN: this currently happens when the TStreamerInfo is not
+      // the current one.
+      Fatal("ComputeSize", "No information on the alignment of class %s, using default alignment of %d bytes",
+            GetName(), (Int_t)alignof(std::max_align_t));
       fAlignment = alignof(std::max_align_t);
    }
    if ((fSize % fAlignment) != 0) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2210,6 +2210,8 @@ void TStreamerInfo::BuildOld()
             }
             element->SetOffset(baseOffset);
             offset += asize;
+            if (TClass *bcPtr = element->GetClassPointer())
+               fAlignment = std::max(fAlignment, bcPtr->GetClassAlignment());
             element->Init(this);
             continue;
          } // if element is of type TStreamerBase or not.
@@ -2337,6 +2339,15 @@ void TStreamerInfo::BuildOld()
             }
          }
       } // Class corresponding to StreamerInfo is emulated or not.
+
+      // For non-emulated (loaded) classes, propagate the member's alignment into
+      // fAlignment so that ComputeSize() has a valid value for older StreamerInfos.
+      if (fClass->GetState() > TClass::kEmulated && !fClass->IsSyntheticPair()) {
+         if (TClass *elCl = element->GetClass())
+            fAlignment = std::max(fAlignment, elCl->GetClassAlignment());
+         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+            fAlignment = std::max(fAlignment, eldt->GetAlignOf());
+      }
 
       // Now let's deal with Schema evolution
       Int_t newType = -1;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5173,7 +5173,7 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
 
    if (!p) {
       // Determine the alignment requirement for the class.
-      const std::size_t align = fClass->GetClassAlignment();
+      const std::size_t align = std::max(fClass->GetClassAlignment(), alignof(Long_t));
       // The header holds two Long_t cookie values (size and nElements).
       // Round the header size up to the next multiple of 'align' so that
       // dataBegin (= p + headerSize) is itself aligned to 'align'.
@@ -5191,7 +5191,7 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
 
    // Store the array cookie in the two Long_t slots immediately before dataBegin.
    // Recompute headerSize from the class alignment so the layout matches DeleteArray.
-   const std::size_t align      = fClass->GetClassAlignment();
+   const std::size_t align = std::max(fClass->GetClassAlignment(), alignof(Long_t));
    const std::size_t cookieSize = sizeof(Long_t) * 2;
    const std::size_t headerSize = AlignUp(cookieSize, align);
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -1925,8 +1925,6 @@ void TStreamerInfo::BuildOld()
    Int_t offset = 0;
    TMemberStreamer* streamer = 0;
 
-   constexpr size_t kSizeOfPtr = sizeof(void*);
-
    int nBaze = 0;
 
    if ((fElements->GetEntriesFast() == 1) && !strcmp(fElements->At(0)->GetName(), "This")) {
@@ -2655,8 +2653,8 @@ void TStreamerInfo::BuildOld()
             // Regular case
             asize = element->GetSize();
          }
-         // align the non-basic data types (required on alpha and IRIX!!)
-         Int_t align = kSizeOfPtr;
+         // Over align the basic data types.
+         Int_t align = alignof(std::max_align_t);
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();
          offset = AlignUp(offset, align);
@@ -3345,11 +3343,10 @@ void TStreamerInfo::ComputeSize()
    }
 
    // On some platform and in some case of layout non-basic data types needs
-   // to be aligned.  So let's be on the safe side and align on the size of
-   // the pointers.  (Question: is that the right thing on x32 ABI ?)
-   constexpr size_t kSizeOfPtr = sizeof(void*);
-   if (fAlignment < kSizeOfPtr) {
-      fAlignment = kSizeOfPtr;
+   // to be aligned.  So let's be on the safe side and align on the alignment
+   // of `std::max_align_t`.
+   if (fAlignment < alignof(std::max_align_t)) {
+      fAlignment = alignof(std::max_align_t);
    }
    if ((fSize % fAlignment) != 0) {
       fSize = (Int_t)AlignUp((size_t)fSize, fAlignment);
@@ -5967,8 +5964,8 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
    TString dmType( TClassEdit::ShortType(dmFull.c_str(),1) );
    Bool_t dmIsPtr = (s1 != dmType);
    const char *dmTitle = "Emulation";
-   //align the non-basic data types (required on alpha and IRIX!!)
-   size_t align = sizeof(void *);
+   // Over align the basic data types.
+   size_t align = alignof(std::max_align_t);
    if (needAlign && offset % align != 0)
       offset = (Int_t)AlignUp((size_t)offset, align);
 
@@ -6023,7 +6020,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       }
       // a class
       align = std::max(align, clm->GetClassAlignment());
-      if (needAlign && align != sizeof(void *) && ((offset % align) != 0))
+      if (needAlign && align != alignof(std::max_align_t) && ((offset % align) != 0))
          offset = (Int_t)AlignUp((size_t)offset, align);
       if (clm->IsTObject()) {
          return new TStreamerObject(dmName,dmTitle,offset,dmFull.c_str());
@@ -6070,7 +6067,7 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    i->GetElements()->Delete();
    TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0, silent, /*needAlign=*/false);
    Int_t size = 0;
-   size_t align = sizeof(void *);
+   size_t align = alignof(std::max_align_t);
    if (fel) {
       i->GetElements()->Add(fel);
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -74,6 +74,7 @@ element type.
 #include "TVirtualMutex.h"
 
 #include "TStreamerInfoActions.h"
+#include "ROOT/RAlignmentUtils.hxx"
 
 #include <memory>
 #include <algorithm>
@@ -249,7 +250,7 @@ namespace {
    template <typename T>
    inline T AlignUp(T value, T align)
    {
-      assert((align & (align - 1)) == 0); // must be a power of two
+      assert(ROOT::Internal::IsValidAlignment(align)); // must be a power of two
       return (value + align - 1) & ~(align - 1);
    }
 
@@ -5018,6 +5019,7 @@ void* TStreamerInfo::New(void *obj)
       auto align = fClass->GetClassAlignment();
       // Use aligned new (C++17). This will return memory aligned to
       // 'align' and can be freed with the matching delete[].
+      assert(ROOT::Internal::IsValidAlignment(align)); // align must be a power of 2
       p = static_cast<char*>(::operator new[](fSize, std::align_val_t(align)));
       memset(p, 0, fSize);
    }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2655,6 +2655,7 @@ void TStreamerInfo::BuildOld()
             align = element->GetClass()->GetClassAlignment();
          else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
             align = eldt->GetAlignOf();
+         assert(ROOT::Internal::IsValidAlignment(align));
          offset = (Int_t)AlignUp((std::size_t)offset, align);
          element->SetOffset(offset);
          offset += asize;
@@ -5187,6 +5188,7 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
    // Store the array cookie in the two Long_t slots immediately before dataBegin.
    // Recompute headerSize from the class alignment so the layout matches DeleteArray.
    const std::size_t align = std::max(fClass->GetClassAlignment(), alignof(Long_t));
+   assert(ROOT::Internal::IsValidAlignment(align));
    const std::size_t cookieSize = sizeof(Long_t) * 2;
    const std::size_t headerSize = AlignUp(cookieSize, align);
 
@@ -5344,6 +5346,7 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
    } // iter over elements
 
    if (!dtorOnly) {
+      assert(ROOT::Internal::IsValidAlignment(fClass->GetClassAlignment()));
       ::operator delete[](p, std::align_val_t(fClass->GetClassAlignment()));
    }
 }
@@ -6024,6 +6027,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
          }
       }
       // a class
+      assert(ROOT::Internal::IsValidAlignment(clm->GetClassAlignment()));
       align = std::max(align, clm->GetClassAlignment());
       if (needAlign && align != alignof(std::max_align_t) && ((offset % align) != 0))
          offset = (Int_t)AlignUp((size_t)offset, align);
@@ -6076,9 +6080,10 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    if (fel) {
       i->GetElements()->Add(fel);
 
-      if (fel->GetClass() && fel->GetClass()->GetClassAlignment())
+      if (fel->GetClass() && fel->GetClass()->GetClassAlignment()) {
+         assert(ROOT::Internal::IsValidAlignment(fel->GetClass()->GetClassAlignment()));
          i->fAlignment = std::max(align, fel->GetClass()->GetClassAlignment());
-      else if (auto *dt = TDataType::GetDataType((EDataType)fel->GetType()); dt && dt->GetAlignOf())
+      } else if (auto *dt = TDataType::GetDataType((EDataType)fel->GetType()); dt && dt->GetAlignOf())
          i->fAlignment = std::max(align, dt->GetAlignOf());
    } else {
       delete i;
@@ -6090,9 +6095,10 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
       R__CreateEmulatedElement("second", secondname, size, silent, /*needAlign=*/!hint_pair_offset);
    if (second) {
       i->GetElements()->Add(second);
-      if (second->GetClass() && second->GetClass()->GetClassAlignment())
+      if (second->GetClass() && second->GetClass()->GetClassAlignment()){
+         assert(ROOT::Internal::IsValidAlignment(second->GetClass()->GetClassAlignment()));
          i->fAlignment = std::max(align, second->GetClass()->GetClassAlignment());
-      else if (auto *dt = TDataType::GetDataType((EDataType)second->GetType()); dt && dt->GetAlignOf())
+      } else if (auto *dt = TDataType::GetDataType((EDataType)second->GetType()); dt && dt->GetAlignOf())
          i->fAlignment = std::max(align, dt->GetAlignOf());
    } else {
       delete i;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -247,6 +247,26 @@ TStreamerInfo::~TStreamerInfo()
 namespace {
    using ROOT::Internal::AlignUp;
 
+   /// Layout of the cookie header that NewArray writes before the data and
+   /// DeleteArray reads back.  Both functions must use exactly this struct to
+   /// stay in sync;
+   /// The header holds two Long_t cookie values (size and nElements).
+   /// Round the header size up to the next multiple of 'align' so that
+   /// dataBegin (= p + headerSize) is itself aligned to 'align'.
+   struct ArrayCookieLayout {
+      std::size_t align;       ///< Alignment of the class (and of the whole block).
+      std::size_t cookieSize;  ///< Raw size of the two Long_t cookie fields.
+      std::size_t headerSize;  ///< Padded header size (cookieSize rounded up to align).
+
+      explicit ArrayCookieLayout(const TClass *cl)
+         : align(std::max(cl->GetClassAlignment(), alignof(Long_t))),
+           cookieSize(sizeof(Long_t) * 2),
+           headerSize(AlignUp(cookieSize, align))
+      {
+         assert(ROOT::Internal::IsValidAlignment(align));
+      }
+   };
+
    struct TPreventRecursiveBuildGuard {
       TPreventRecursiveBuildGuard(TStreamerInfo* info): fInfo(info) {
          fInfo->SetBit(TStreamerInfo::kBuildRunning);
@@ -5167,35 +5187,24 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
 
    char* p = (char*) ary;
 
-   if (!p) {
-      // Determine the alignment requirement for the class.
-      const std::size_t align = std::max(fClass->GetClassAlignment(), alignof(Long_t));
-      // The header holds two Long_t cookie values (size and nElements).
-      // Round the header size up to the next multiple of 'align' so that
-      // dataBegin (= p + headerSize) is itself aligned to 'align'.
-      const std::size_t cookieSize = sizeof(Long_t) * 2;
-      const std::size_t headerSize = AlignUp(cookieSize, align);
+   // Determine the alignment requirement for the class.
+   const ArrayCookieLayout layout(fClass);
 
-      Long_t len = nElements * size + headerSize;
+   if (!p) {
+
+      Long_t len = nElements * size + layout.headerSize;
 
       // Allocate and initialize the memory block.  Request alignment so
       // that the raw block starts on an 'align'-boundary; combined with
       // the rounded-up header this guarantees dataBegin is also aligned.
-      p = static_cast<char*>(::operator new[](len, std::align_val_t(align)));
+      p = static_cast<char*>(::operator new[](len, std::align_val_t(layout.align)));
       memset(p, 0, len);
    }
 
-   // Store the array cookie in the two Long_t slots immediately before dataBegin.
-   // Recompute headerSize from the class alignment so the layout matches DeleteArray.
-   const std::size_t align = std::max(fClass->GetClassAlignment(), alignof(Long_t));
-   assert(ROOT::Internal::IsValidAlignment(align));
-   const std::size_t cookieSize = sizeof(Long_t) * 2;
-   const std::size_t headerSize = AlignUp(cookieSize, align);
-
-   Long_t* r = (Long_t*)(p + headerSize - cookieSize);
+   Long_t* r = (Long_t*)(p + layout.headerSize - layout.cookieSize);
    r[0] = size;
    r[1] = nElements;
-   char* dataBegin = p + headerSize;
+   char* dataBegin = p + layout.headerSize;
 
    // Do a placement new for each element.
    char* q = dataBegin;
@@ -5394,14 +5403,12 @@ void TStreamerInfo::DeleteArray(void* ary, Bool_t dtorOnly)
    // Recover the cookie layout: the two Long_t values sit in the header
    // block immediately before dataBegin, with the same alignment-based
    // headerSize that NewArray used.
-   const std::size_t align      = fClass->GetClassAlignment();
-   const std::size_t cookieSize = sizeof(Long_t) * 2;
-   const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+   const ArrayCookieLayout layout(fClass);
 
-   Long_t* r = (Long_t*)((char*)ary - cookieSize);
+   Long_t* r = (Long_t*)((char*)ary - layout.cookieSize);
    Long_t arrayLen = r[1];
    Long_t size     = r[0];
-   char* memBegin  = (char*)ary - headerSize;
+   char* memBegin  = (char*)ary - layout.headerSize;
 
    char* p = ((char*) ary) + ((arrayLen - 1) * size);
    for (Long_t cnt = 0; cnt < arrayLen; ++cnt, p -= size) {
@@ -5410,7 +5417,7 @@ void TStreamerInfo::DeleteArray(void* ary, Bool_t dtorOnly)
    } // for arrayItemSize
 
    if (!dtorOnly) {
-      ::operator delete[](memBegin, std::align_val_t(align));
+      ::operator delete[](memBegin, std::align_val_t(layout.align));
    }
 }
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3388,6 +3388,15 @@ void TStreamerInfo::ComputeSize()
       fSize = fVirtualInfoLoc[0] + sizeof(TStreamerInfo*);
    }
 
+   if (fClass->GetCollectionProxy()) {
+      fAlignment = fClass->GetClassAlignment();
+   }
+
+   if (!fAlignment && fElements->IsEmpty()) {
+      // Empty class alignment is 1.
+      fAlignment = 1;
+   }
+
    // If we have no information use the default alignment.
    if (!fAlignment) {
       // FIXME-ALIGN: this currently happens when the TStreamerInfo is not

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2653,15 +2653,20 @@ void TStreamerInfo::BuildOld()
             // Regular case
             asize = element->GetSize();
          }
-         // Over align the basic data types.
-         Int_t align = alignof(std::max_align_t);
+         // Use the precise alignment of the element type, falling back to
+         // max_align_t for types whose alignment is not known.
+         std::size_t align = alignof(std::max_align_t);
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();
-         offset = AlignUp(offset, align);
+         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+            align = eldt->GetAlignOf();
+         offset = (Int_t)AlignUp((std::size_t)offset, align);
          element->SetOffset(offset);
          offset += asize;
          if (element->GetClass())
             fAlignment = std::max(fAlignment, element->GetClass()->GetClassAlignment());
+         else if (auto *eldt = TDataType::GetDataType((EDataType)element->GetType()); eldt && eldt->GetAlignOf())
+            fAlignment = std::max(fAlignment, eldt->GetAlignOf());
       }
 
       if (!wasCompiled && rules) {
@@ -5974,6 +5979,12 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       Int_t dsize,dtype;
       dtype = dt->GetType();
       dsize = dt->Size();
+      // Use the precise alignment for the basic type if available.
+      if (needAlign && dt->GetAlignOf()) {
+         align = dt->GetAlignOf();
+         if (offset % align != 0)
+            offset = (Int_t)AlignUp((size_t)offset, align);
+      }
       if (dmIsPtr && dtype != kCharStar) {
          if (!silent)
             Error("Pair Emulation Building","%s is not yet supported in pair emulation",
@@ -6073,6 +6084,8 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
 
       if (fel->GetClass() && fel->GetClass()->GetClassAlignment())
          i->fAlignment = std::max(align, fel->GetClass()->GetClassAlignment());
+      else if (auto *dt = TDataType::GetDataType((EDataType)fel->GetType()); dt && dt->GetAlignOf())
+         i->fAlignment = std::max(align, dt->GetAlignOf());
    } else {
       delete i;
       return 0;
@@ -6085,6 +6098,8 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
       i->GetElements()->Add(second);
       if (second->GetClass() && second->GetClass()->GetClassAlignment())
          i->fAlignment = std::max(align, second->GetClass()->GetClassAlignment());
+      else if (auto *dt = TDataType::GetDataType((EDataType)second->GetType()); dt && dt->GetAlignOf())
+         i->fAlignment = std::max(align, dt->GetAlignOf());
    } else {
       delete i;
       return 0;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -5416,6 +5416,12 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
    } // iter over elements
 
    if (!dtorOnly) {
+      // Note: We rely on fClass->GetClassAlignment() being the same than we had
+      // on construction time.
+      // However it technically can change but there is no much we can sensibly do to detect it. eg. "allocate object,
+      // unload library, reload library, destruct object" (but in this case the 'unload' library is meant to/should also
+      // destruct the object (unload transaction) but this is not always possible) or "allocate emulated object, load
+      // library, destruct object".
       assert(ROOT::Internal::IsValidAlignment(fClass->GetClassAlignment()));
       ::operator delete[](p, std::align_val_t(fClass->GetClassAlignment()));
    }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -244,6 +244,15 @@ TStreamerInfo::~TStreamerInfo()
 /// Makes sure kBuildRunning reset once Build finishes.
 
 namespace {
+   /// Round \p value up to the next multiple of \p align.
+   /// \p align must be a power of two.
+   template <typename T>
+   inline T AlignUp(T value, T align)
+   {
+      assert((align & (align - 1)) == 0); // must be a power of two
+      return (value + align - 1) & ~(align - 1);
+   }
+
    struct TPreventRecursiveBuildGuard {
       TPreventRecursiveBuildGuard(TStreamerInfo* info): fInfo(info) {
          fInfo->SetBit(TStreamerInfo::kBuildRunning);
@@ -2650,7 +2659,7 @@ void TStreamerInfo::BuildOld()
          Int_t align = kSizeOfPtr;
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();
-         offset = (offset + align - 1) & ~(align - 1);
+         offset = AlignUp(offset, align);
          element->SetOffset(offset);
          offset += asize;
          if (element->GetClass())
@@ -3343,7 +3352,7 @@ void TStreamerInfo::ComputeSize()
       fAlignment = kSizeOfPtr;
    }
    if ((fSize % fAlignment) != 0) {
-      fSize = (fSize + fAlignment - 1) & ~(fAlignment - 1);
+      fSize = (Int_t)AlignUp((size_t)fSize, fAlignment);
    }
 }
 
@@ -5168,7 +5177,7 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
       // Round the header size up to the next multiple of 'align' so that
       // dataBegin (= p + headerSize) is itself aligned to 'align'.
       const std::size_t cookieSize = sizeof(Long_t) * 2;
-      const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+      const std::size_t headerSize = AlignUp(cookieSize, align);
 
       Long_t len = nElements * size + headerSize;
 
@@ -5183,7 +5192,7 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
    // Recompute headerSize from the class alignment so the layout matches DeleteArray.
    const std::size_t align      = fClass->GetClassAlignment();
    const std::size_t cookieSize = sizeof(Long_t) * 2;
-   const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+   const std::size_t headerSize = AlignUp(cookieSize, align);
 
    Long_t* r = (Long_t*)(p + headerSize - cookieSize);
    r[0] = size;
@@ -5961,7 +5970,7 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
    //align the non-basic data types (required on alpha and IRIX!!)
    size_t align = sizeof(void *);
    if (needAlign && offset % align != 0)
-      offset = (offset + align - 1) & ~(align - 1);
+      offset = (Int_t)AlignUp((size_t)offset, align);
 
    TDataType *dt = gROOT->GetType(dmType);
    if (dt && dt->GetType() > 0 ) {  // found a basic type
@@ -6014,8 +6023,8 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
       }
       // a class
       align = std::max(align, clm->GetClassAlignment());
-      if (needAlign && align != sizeof(void *) && offset % align != 0)
-         offset = (offset + align - 1) & ~(align - 1);
+      if (needAlign && align != sizeof(void *) && ((offset % align) != 0))
+         offset = (Int_t)AlignUp((size_t)offset, align);
       if (clm->IsTObject()) {
          return new TStreamerObject(dmName,dmTitle,offset,dmFull.c_str());
       } else if(clm == TString::Class() && !dmIsPtr) {

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -76,7 +76,9 @@ element type.
 #include "TStreamerInfoActions.h"
 
 #include <memory>
+#include <algorithm>
 #include <array>
+#include <new>
 
 std::atomic<Int_t> TStreamerInfo::fgCount{0};
 
@@ -154,6 +156,7 @@ TStreamerInfo::TStreamerInfo()
    fNfulldata= 0;
    fNslots   = 0;
    fSize     = 0;
+   fAlignment= 0;
    fClassVersion = 0;
    fOnFileClassVersion = 0;
    fOldVersion = Class()->GetClassVersion();
@@ -188,6 +191,7 @@ TStreamerInfo::TStreamerInfo(TClass *cl)
    fNfulldata= 0;
    fNslots   = 0;
    fSize     = 0;
+   fAlignment= 0;
    fClassVersion = fClass->GetClassVersion();
    fOnFileClassVersion = 0;
    fOldVersion = Class()->GetClassVersion();
@@ -2098,6 +2102,7 @@ void TStreamerInfo::BuildOld()
             }
             element->SetOffset(baseOffset);
             offset += baseclass->Size();
+            fAlignment = std::max(fAlignment, baseclass->GetClassAlignment());
 
             continue;
          } else {
@@ -2195,6 +2200,7 @@ void TStreamerInfo::BuildOld()
          fVirtualInfoLoc = new ULong_t[1]; // To allow for a single delete statement.
          fVirtualInfoLoc[0] = offset;
          offset += sizeof(TStreamerInfo*);
+         fAlignment = std::max(fAlignment, sizeof(TStreamerInfo*));
       }
 
       TDataMember* dm = 0;
@@ -2641,11 +2647,16 @@ void TStreamerInfo::BuildOld()
             asize = element->GetSize();
          }
          // align the non-basic data types (required on alpha and IRIX!!)
-         if ((offset % kSizeOfPtr) != 0) {
-            offset = offset - (offset % kSizeOfPtr) + kSizeOfPtr;
+         Int_t align = kSizeOfPtr;
+         if (element->GetClass() && element->GetClass()->GetClassAlignment())
+            align = element->GetClass()->GetClassAlignment();
+         if ((offset % align) != 0) {
+            offset = offset - (offset % align) + align;
          }
          element->SetOffset(offset);
          offset += asize;
+         if (element->GetClass())
+            fAlignment = std::max(fAlignment, element->GetClass()->GetClassAlignment());
       }
 
       if (!wasCompiled && rules) {
@@ -3330,8 +3341,11 @@ void TStreamerInfo::ComputeSize()
    // to be aligned.  So let's be on the safe side and align on the size of
    // the pointers.  (Question: is that the right thing on x32 ABI ?)
    constexpr size_t kSizeOfPtr = sizeof(void*);
-   if ((fSize % kSizeOfPtr) != 0 && !fClass->IsSyntheticPair()) {
-      fSize = fSize - (fSize % kSizeOfPtr) + kSizeOfPtr;
+   if (fAlignment < kSizeOfPtr) {
+      fAlignment = kSizeOfPtr;
+   }
+   if ((fSize % fAlignment) != 0) {
+      fSize = fSize - (fSize % fAlignment) + fAlignment;
    }
 }
 
@@ -4991,8 +5005,12 @@ void* TStreamerInfo::New(void *obj)
    TIter next(fElements);
 
    if (!p) {
-      // Allocate and initialize the memory block.
-      p = new char[fSize];
+      // Allocate and initialize the memory block. Ensure the returned
+      // storage is aligned to the class alignment requirement.
+      auto align = fClass->GetClassAlignment();
+      // Use aligned new (C++17). This will return memory aligned to
+      // 'align' and can be freed with the matching delete[].
+      p = static_cast<char*>(::operator new[](fSize, std::align_val_t(align)));
       memset(p, 0, fSize);
    }
 
@@ -5146,22 +5164,39 @@ void* TStreamerInfo::NewArray(Long_t nElements, void *ary)
    char* p = (char*) ary;
 
    if (!p) {
-      Long_t len = nElements * size + sizeof(Long_t)*2;
-      p = new char[len];
+      // Determine the alignment requirement for the class.
+      const std::size_t align = fClass->GetClassAlignment();
+      // The header holds two Long_t cookie values (size and nElements).
+      // Round the header size up to the next multiple of 'align' so that
+      // dataBegin (= p + headerSize) is itself aligned to 'align'.
+      const std::size_t cookieSize = sizeof(Long_t) * 2;
+      const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+
+      Long_t len = nElements * size + headerSize;
+
+      // Allocate and initialize the memory block.  Request alignment so
+      // that the raw block starts on an 'align'-boundary; combined with
+      // the rounded-up header this guarantees dataBegin is also aligned.
+      p = static_cast<char*>(::operator new[](len, std::align_val_t(align)));
       memset(p, 0, len);
    }
 
-   // Store the array cookie
-   Long_t* r = (Long_t*) p;
+   // Store the array cookie in the two Long_t slots immediately before dataBegin.
+   // Recompute headerSize from the class alignment so the layout matches DeleteArray.
+   const std::size_t align      = fClass->GetClassAlignment();
+   const std::size_t cookieSize = sizeof(Long_t) * 2;
+   const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+
+   Long_t* r = (Long_t*)(p + headerSize - cookieSize);
    r[0] = size;
    r[1] = nElements;
-   char* dataBegin = (char*) &r[2];
+   char* dataBegin = p + headerSize;
 
    // Do a placement new for each element.
-   p = dataBegin;
+   char* q = dataBegin;
    for (Long_t cnt = 0; cnt < nElements; ++cnt) {
-      New(p);
-      p += size;
+      New(q);
+      q += size;
    } // for nElements
 
    return dataBegin;
@@ -5306,7 +5341,7 @@ void TStreamerInfo::DestructorImpl(void* obj, Bool_t dtorOnly)
    } // iter over elements
 
    if (!dtorOnly) {
-      delete[] p;
+      ::operator delete[](p, std::align_val_t(fClass->GetClassAlignment()));
    }
 }
 
@@ -5350,10 +5385,17 @@ void TStreamerInfo::DeleteArray(void* ary, Bool_t dtorOnly)
 
    //???FIX ME: What about varying length arrays?
 
-   Long_t* r = (Long_t*) ary;
-   Long_t arrayLen = r[-1];
-   Long_t size = r[-2];
-   char* memBegin = (char*) &r[-2];
+   // Recover the cookie layout: the two Long_t values sit in the header
+   // block immediately before dataBegin, with the same alignment-based
+   // headerSize that NewArray used.
+   const std::size_t align      = fClass->GetClassAlignment();
+   const std::size_t cookieSize = sizeof(Long_t) * 2;
+   const std::size_t headerSize = ((cookieSize + align - 1) / align) * align;
+
+   Long_t* r = (Long_t*)((char*)ary - cookieSize);
+   Long_t arrayLen = r[1];
+   Long_t size     = r[0];
+   char* memBegin  = (char*)ary - headerSize;
 
    char* p = ((char*) ary) + ((arrayLen - 1) * size);
    for (Long_t cnt = 0; cnt < arrayLen; ++cnt, p -= size) {
@@ -5362,7 +5404,7 @@ void TStreamerInfo::DeleteArray(void* ary, Bool_t dtorOnly)
    } // for arrayItemSize
 
    if (!dtorOnly) {
-      delete[] memBegin;
+      ::operator delete[](memBegin, std::align_val_t(align));
    }
 }
 
@@ -5910,7 +5952,7 @@ TStreamerInfo::GenExplicitClassStreamer( const ::ROOT::TCollectionProxyInfo &inf
 //
 // Utility functions
 //
-static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset, bool silent)
+static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std::string &dmFull, Int_t offset, bool silent, bool needAlign)
 {
    // Create a TStreamerElement for the type 'dmFull' and whose data member name is 'dmName'.
 
@@ -5918,6 +5960,10 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
    TString dmType( TClassEdit::ShortType(dmFull.c_str(),1) );
    Bool_t dmIsPtr = (s1 != dmType);
    const char *dmTitle = "Emulation";
+   //align the non-basic data types (required on alpha and IRIX!!)
+   size_t align = sizeof(void *);
+   if (needAlign && offset % align != 0)
+      offset = offset - offset % align + align;
 
    TDataType *dt = gROOT->GetType(dmType);
    if (dt && dt->GetType() > 0 ) {  // found a basic type
@@ -5969,6 +6015,9 @@ static TStreamerElement* R__CreateEmulatedElement(const char *dmName, const std:
          }
       }
       // a class
+      align = std::max(align, clm->GetClassAlignment());
+      if (needAlign && align != sizeof(void *) && offset % align != 0)
+         offset = offset - offset % align + align;
       if (clm->IsTObject()) {
          return new TStreamerObject(dmName,dmTitle,offset,dmFull.c_str());
       } else if(clm == TString::Class() && !dmIsPtr) {
@@ -6012,24 +6061,26 @@ TVirtualStreamerInfo *TStreamerInfo::GenerateInfoForPair(const std::string &firs
    i->SetName(pname.c_str());
    i->SetClass(nullptr);
    i->GetElements()->Delete();
-   TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0, silent);
+   TStreamerElement *fel = R__CreateEmulatedElement("first", firstname, 0, silent, /*needAlign=*/false);
    Int_t size = 0;
+   size_t align = sizeof(void *);
    if (fel) {
-      i->GetElements()->Add( fel );
+      i->GetElements()->Add(fel);
 
-      size = fel->GetSize();
-      Int_t sp = sizeof(void *);
-      //align the non-basic data types (required on alpha and IRIX!!)
-      if (size%sp != 0) size = size - size%sp + sp;
+      if (fel->GetClass() && fel->GetClass()->GetClassAlignment())
+         i->fAlignment = std::max(align, fel->GetClass()->GetClassAlignment());
    } else {
       delete i;
       return 0;
    }
    if (hint_pair_offset)
       size = hint_pair_offset;
-   TStreamerElement *second = R__CreateEmulatedElement("second", secondname, size, silent);
+   TStreamerElement *second =
+      R__CreateEmulatedElement("second", secondname, size, silent, /*needAlign=*/!hint_pair_offset);
    if (second) {
-      i->GetElements()->Add( second );
+      i->GetElements()->Add(second);
+      if (second->GetClass() && second->GetClass()->GetClassAlignment())
+         i->fAlignment = std::max(align, second->GetClass()->GetClassAlignment());
    } else {
       delete i;
       return 0;

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2655,6 +2655,7 @@ void TStreamerInfo::BuildOld()
          }
          // Use the precise alignment of the element type, falling back to
          // max_align_t for types whose alignment is not known.
+         // (e.g. forward declared classes, or classes with incomplete types info, etc..)
          std::size_t align = alignof(std::max_align_t);
          if (element->GetClass() && element->GetClass()->GetClassAlignment())
             align = element->GetClass()->GetClassAlignment();

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3373,6 +3373,13 @@ void TStreamerInfo::ComputeSize()
       }
    }
 
+   // Note for TStreamerInfo that do not represent the current in memory
+   // layout of the class (whether that layout is the compiled, interpreted
+   // or emulated), the size calculated below is fantasy since the last element
+   // of this StreamerInfo may or may not be the last one in the in-memory layout.
+   // However this is per se a non issue as this size will not be used for
+   // anything.
+
    TStreamerElement *element = (TStreamerElement*)fElements->Last();
    //faster and more precise to use last element offset +size
    //on 64 bit machines, offset may be forced to be a multiple of 8 bytes

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -4198,6 +4198,7 @@ void TStreamerInfo::Compile()
       fCompFull = new TCompInfo*[1];
       fCompOpt  = new TCompInfo*[1];
       fCompOpt[0] = fCompFull[0] = &(fComp[0]);
+      fAlignment = 1;
       SetIsCompiled();
       return;
    }

--- a/roottest/root/meta/alignment/CMakeLists.txt
+++ b/roottest/root/meta/alignment/CMakeLists.txt
@@ -1,0 +1,10 @@
+ROOTTEST_ADD_TEST(evolution
+                  MACRO evolution.C+
+                  FIXTURES_SETUP root-meta-alignment-evolution-fixture)
+
+ROOTTEST_ADD_TEST(emulation
+                  MACRO emulation.C+
+                  FIXTURES_REQUIRED root-meta-alignment-evolution-fixture)
+
+ROOTTEST_ADD_TEST(vecalloc
+                  MACRO vecalloc.C+)

--- a/roottest/root/meta/alignment/emulation.C
+++ b/roottest/root/meta/alignment/emulation.C
@@ -1,0 +1,110 @@
+// File: emulation.C
+
+#include <iostream>
+#include <cstdint> // uintptr_t
+#include <cassert>
+#include "TError.h"
+#include "TFile.h"
+#include "TBuffer.h"
+#include "TObjArray.h"
+
+// Containee type with a custom alignment (over-aligned)
+struct alignas(256) Containee {
+   int id;
+   // some payload to make sizeof non-trivial
+   double payload[7];
+
+   Containee(int i = -1) : id(i) {}
+   ~Containee() = default;
+
+   void Streamer(TBuffer &b)
+   {
+      if (b.IsReading()) {
+         std::cout << "Streaming Containee\n";
+         // Guess the effective alignment of c's address: largest power-of-two
+         // that divides the address.
+         uintptr_t addr = reinterpret_cast<uintptr_t>(this);
+         uintptr_t guessed = 1;
+         if (addr != 0) {
+            guessed = addr & (~addr + 1); // isolate lowest set bit
+         }
+         std::cout << "  address: " << static_cast<const void *>(this) << "  (guessed alignment: " << guessed
+                   << " bytes)\n";
+         if (reinterpret_cast<uintptr_t>(this) % alignof(Containee) != 0) {
+            Fatal("copyContainer", "Containee object at %p does not satisfy alignment requirement of %zu\n", this,
+                  alignof(Containee));
+         }
+
+         b.ReadClassBuffer(TClass::GetClass("Containee"), this);
+      } else {
+         b.WriteClassBuffer(TClass::GetClass("Containee"), this);
+      }
+   }
+};
+
+static_assert(alignof(Containee) == 256, "Containee must be 256-byte aligned");
+
+#ifdef __ROOTCLING__
+#pragma link C++ class Containee - ;
+#endif
+
+/// Check that the emulated TClass for \a className reports the expected
+/// \a expectedAlignment and \a expectedSize.  Returns 0 on success or a
+/// non-zero error code on failure.
+int checkEmulatedClass(const char *className, std::size_t expectedAlignment, Int_t expectedSize)
+{
+   auto cl = TClass::GetClass(className);
+   if (!cl) {
+      Error("checkEmulatedClass", "Could not get TClass for %s", className);
+      return 1;
+   }
+   if (cl->GetClassAlignment() != expectedAlignment) {
+      Error("checkEmulatedClass", "TClass for %s has alignment %zu, expected %zu", className, cl->GetClassAlignment(),
+            expectedAlignment);
+      return 2;
+   }
+   if (cl->GetClassSize() != expectedSize) {
+      Error("checkEmulatedClass", "TClass for %s has size %d, expected %d", className, cl->GetClassSize(),
+            expectedSize);
+      return 3;
+   }
+   return 0;
+}
+
+int readfile(const char *filename)
+{
+   TFile file(filename, "READ");
+   if (file.IsZombie())
+      return 1;
+   auto c = file.Get("origContainer");
+   TClass::GetClass("Container")->GetStreamerInfos()->ls();
+   if (!c) {
+      Error("readfile", "Could not read object from file");
+      return 2;
+   }
+
+   size_t align = alignof(Containee);
+   std::vector<char> vec;
+   vec.resize(20);
+
+   // Container: char(1) + padding(255) + Containee(256) + ... = 768 bytes, align=256
+   if (int rc = checkEmulatedClass("Container", alignof(Containee), 768))
+      return 10 + rc;
+
+   // std::pair<int,Containee>: int(4) + padding(252) + Containee(256) = 512 bytes, align=256
+   if (int rc = checkEmulatedClass("pair<int,Containee>", alignof(Containee), 512))
+      return 20 + rc;
+
+   // When emulating the Wrapper class, we start with some metadata and thus
+   // the Containee members starts at offset 256, which means the total size
+   // of the pair becomes 768 bytes.
+   if (int rc = checkEmulatedClass("pair<int,Wrapper>", alignof(Containee), 768))
+      return 30 + rc;
+
+   return 0;
+}
+
+int emulation()
+{
+   return readfile("alignment_evolution.root");
+}

--- a/roottest/root/meta/alignment/evolution.C
+++ b/roottest/root/meta/alignment/evolution.C
@@ -1,0 +1,167 @@
+// File: evolution.C
+// Demonstrates a containee with custom alignment embedded directly inside a
+// container (no heap allocation).  The compiler is responsible for satisfying
+// the alignment requirement of the embedded object, inserting padding before it
+// if necessary.
+
+#include <iostream>
+#include <cstdint> // uintptr_t
+#include <cassert>
+#include "TError.h"
+#include "TFile.h"
+
+// Containee type with a custom alignment (over-aligned)
+struct alignas(256) Containee {
+   int id;
+   // some payload to make sizeof non-trivial
+   double payload[7];
+
+   Containee(int i = -1) : id(i) {}
+   ~Containee() = default;
+};
+
+struct Wrapper {
+   Containee c;
+   Wrapper(int i = -1) : c(i) {}
+   ~Wrapper() = default;
+};
+
+static_assert(alignof(Containee) == 256, "Containee must be 256-byte aligned");
+
+// Container that embeds a single Containee object directly as a data member.
+// The compiler guarantees the member satisfies alignof(Containee) because the
+// member type carries the alignas specifier; it inserts padding before m_data
+// as needed.
+class Container {
+private:
+   using pair_t = std::pair<int, Containee>;
+   using coll_t = std::map<int, Containee>;
+   using nested_coll_t = std::map<int, Wrapper>;
+
+   char m_misalign;  // dummy member to show the compiler inserts padding
+   Containee m_data; // embedded – no manual aligned allocation
+   // pair_t       m_pair_data; // check on the run-time dictionary generated for pairs
+   coll_t m_collection; // check on the run-time dictionary generated for collections
+   nested_coll_t m_nested_collection;
+
+public:
+   Container() = default;
+   explicit Container(int id) : m_misalign(0), m_data(id)
+   {
+      m_collection.emplace(id, Containee(id + 1));
+      m_nested_collection.emplace(id, Wrapper(id + 2));
+   }
+   ~Container() = default; // embedded object is destroyed automatically
+
+   // Demonstrate and verify alignment of the embedded element
+   void showAlignment() const
+   {
+      const void *addr = static_cast<const void *>(&m_data);
+      uintptr_t v = reinterpret_cast<uintptr_t>(addr);
+      std::cout << "Containee alignment requirement: " << alignof(Containee) << '\n';
+      std::cout << "m_data at " << addr << "  (addr % align = " << (v % alignof(Containee)) << ")\n";
+      // runtime check
+      assert((v % alignof(Containee)) == 0 && "m_data not correctly aligned");
+   }
+
+   Containee &get() { return m_data; }
+   const Containee &get() const { return m_data; }
+
+   ClassDef(Container, 2) // Container with embedded Containee
+};
+
+// AlternateContainer: same layout and behaviour as Container.
+class AlternateContainer {
+private:
+   double padding;       // dummy member to show the compiler inserts padding
+   char m_misalign;      // dummy member to show the compiler inserts padding
+   Containee m_alt_data; // embedded – no manual aligned allocation
+
+public:
+   AlternateContainer() = default;
+   explicit AlternateContainer(int id) : m_misalign(0), m_alt_data(id) {}
+   ~AlternateContainer() = default; // embedded object is destroyed automatically
+
+   // Demonstrate and verify alignment of the embedded element
+   void showAlignment() const
+   {
+      const void *addr = static_cast<const void *>(&m_alt_data);
+      uintptr_t v = reinterpret_cast<uintptr_t>(addr);
+      std::cout << "Containee alignment requirement: " << alignof(Containee) << '\n';
+      std::cout << "m_alt_data at " << addr << "  (addr % align = " << (v % alignof(Containee)) << ")\n";
+      // runtime check
+      assert((v % alignof(Containee)) == 0 && "m_data not correctly aligned");
+   }
+
+   void copyContainee(const Containee &c)
+   {
+      std::cout << "Copying Containee with id = " << c.id << " into AlternateContainer\n";
+      // Guess the effective alignment of c's address: largest power-of-two
+      // that divides the address.
+      uintptr_t addr = reinterpret_cast<uintptr_t>(&c);
+      uintptr_t guessed = 1;
+      if (addr != 0) {
+         guessed = addr & (~addr + 1); // isolate lowest set bit
+      }
+      std::cout << "  address of c: " << static_cast<const void *>(&c) << "  (guessed alignment: " << guessed
+                << " bytes)\n";
+      if (reinterpret_cast<uintptr_t>(&c) % alignof(Containee) != 0) {
+         Error("copyContainer", "Containee object at %p does not satisfy alignment requirement of %zu\n", &c,
+               alignof(Containee));
+      }
+      m_alt_data = c;
+   }
+
+   Containee &get() { return m_alt_data; }
+   const Containee &get() const { return m_alt_data; }
+
+   ClassDef(AlternateContainer, 2) // Alternate container with embedded Containee
+};
+
+#ifdef __ROOTCLING__
+#pragma link C++ class Container + ;
+#pragma link C++ class Containee + ;
+#pragma link C++ class Wrapper + ;
+#pragma link C++ class AlternateContainer + ;
+#pragma read sourceClass = "Container" source = "char m_misalign" targetClass = "AlternateContainer" target = \
+   "m_misalign" code = "{ m_misalign = onfile.m_misalign; }";
+#pragma read sourceClass = "Container" source = "Containee m_data" targetClass = "AlternateContainer" target = \
+   "m_alt_data" code = "{ newObj->copyContainee(onfile.m_data); }";
+#endif
+
+void writefile(const char *filename)
+{
+   Container c(42);
+   c.showAlignment();
+   std::cout << "c.get().id = " << c.get().id << '\n';
+
+   TFile file(filename, "RECREATE");
+   file.WriteObject(&c, "origContainer");
+   file.Write();
+};
+
+void readfile(const char *filename)
+{
+   TFile file(filename, "READ");
+   AlternateContainer *alt = file.Get<AlternateContainer>("origContainer");
+   if (alt) {
+      std::cout << "Successfully read AlternateContainer from file:\n";
+      alt->showAlignment();
+      std::cout << "Containee id = " << alt->get().id << '\n';
+   } else {
+      Fatal("readfile", "Failed to read AlternateContainer from file");
+   }
+};
+
+int evolution()
+{
+   const char *filename = "alignment_evolution.root";
+   writefile(filename);
+   readfile(filename);
+   return 0;
+}
+
+int main()
+{
+   return evolution();
+}

--- a/roottest/root/meta/alignment/vecalloc.C
+++ b/roottest/root/meta/alignment/vecalloc.C
@@ -1,0 +1,141 @@
+// vecalloc.C
+// Tests round-trip TFile I/O for a Container whose data member is a
+// std::vector that uses a custom over-aligned allocator.
+
+#include <vector>
+#include <cassert>
+#include <iostream>
+#include "TError.h"
+#include "TFile.h"
+
+template <typename T>
+struct MyAlignedAllocator {
+   using value_type = T;
+
+   std::size_t alignment;
+
+   explicit MyAlignedAllocator(std::size_t align = alignof(std::max_align_t)) : alignment(align) {}
+
+   template <typename U>
+   MyAlignedAllocator(const MyAlignedAllocator<U> &other) noexcept : alignment(other.alignment)
+   {
+   }
+
+   T *allocate(std::size_t n)
+   {
+      std::size_t bytes = n * sizeof(T);
+      std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
+      // Round up to a multiple of effectiveAlign (required by aligned operator new)
+      bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+      return static_cast<T *>(::operator new(bytes, std::align_val_t{effectiveAlign}));
+   }
+
+   void deallocate(T *p, std::size_t n) noexcept
+   {
+      std::size_t bytes = n * sizeof(T);
+      std::size_t effectiveAlign = alignment < alignof(T) ? alignof(T) : alignment;
+      bytes = (bytes + effectiveAlign - 1) & ~(effectiveAlign - 1);
+      ::operator delete(p, bytes, std::align_val_t{effectiveAlign});
+   }
+
+   template <typename U>
+   bool operator==(const MyAlignedAllocator<U> &other) const noexcept
+   {
+      return alignment == other.alignment;
+   }
+   template <typename U>
+   bool operator!=(const MyAlignedAllocator<U> &other) const noexcept
+   {
+      return !(*this == other);
+   }
+};
+
+struct Container {
+   std::vector<int, MyAlignedAllocator<int>> data;
+
+   Container() = default;
+   Container(std::initializer_list<int> vals) : data(vals) {}
+   template <typename Iter>
+   Container(Iter first, Iter last) : data(first, last)
+   {
+   }
+
+   ClassDefNV(Container, 1)
+};
+
+#ifdef __ROOTCLING__
+#pragma link C++ class Container + ;
+#endif
+
+static const char *kFileName = "vecalloc_test.root";
+static const char *kObjName = "cont";
+
+// Known values written into the Container
+static const std::vector<int> kExpected = {10, 20, 30, 42, 99};
+
+int writefile()
+{
+   Container c(kExpected.begin(), kExpected.end());
+   std::cout << "Writing Container with data:";
+   for (int v : c.data)
+      std::cout << ' ' << v;
+   std::cout << '\n';
+
+   TFile f(kFileName, "RECREATE");
+   if (f.IsZombie()) {
+      Error("writefile", "Cannot open %s for writing", kFileName);
+      return 1;
+   }
+   f.WriteObject(&c, kObjName);
+   f.Write();
+   return 0;
+}
+
+int readfile()
+{
+   TFile f(kFileName, "READ");
+   if (f.IsZombie()) {
+      Error("readfile", "Cannot open %s for reading", kFileName);
+      return 1;
+   }
+
+   Container *c = f.Get<Container>(kObjName);
+   if (!c) {
+      Error("readfile", "Failed to read Container '%s' from file", kObjName);
+      return 1;
+   }
+
+   std::cout << "Read back Container with data:";
+   for (int v : c->data)
+      std::cout << ' ' << v;
+   std::cout << '\n';
+
+   // Verify size
+   if (c->data.size() != kExpected.size()) {
+      Error("readfile", "Size mismatch: expected %zu, got %zu", kExpected.size(), c->data.size());
+      return 1;
+   }
+
+   // Verify values
+   for (std::size_t i = 0; i < kExpected.size(); ++i) {
+      if (c->data[i] != kExpected[i]) {
+         Error("readfile", "Value mismatch at index %zu: expected %d, got %d", i, kExpected[i], c->data[i]);
+         return 1;
+      }
+   }
+
+   std::cout << "All values verified successfully.\n";
+   return 0;
+}
+
+int vecalloc()
+{
+   if (int ret = writefile())
+      return ret;
+   return readfile();
+}
+
+int main()
+{
+   return vecalloc();
+}

--- a/roottest/root/tree/cloning/references/exectrimZLIB.ref
+++ b/roottest/root/tree/cloning/references/exectrimZLIB.ref
@@ -46,7 +46,7 @@ Warning in <TClass::Init>: no dictionary for class Belle2::CalcMeanCov<2,double>
 *............................................................................*
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =           22683 bytes  File  Size =       5407 *
+*Entries :       10 : Total =           22683 bytes  File  Size =       5389 *
 *        :          : Tree compression factor =   1.18                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *

--- a/roottest/root/tree/cloning/references/exectrimZLIB_ng.ref
+++ b/roottest/root/tree/cloning/references/exectrimZLIB_ng.ref
@@ -46,7 +46,7 @@ Warning in <TClass::Init>: no dictionary for class Belle2::CalcMeanCov<2,double>
 *............................................................................*
 ******************************************************************************
 *Tree    :tree      : tree                                                   *
-*Entries :       10 : Total =           22683 bytes  File  Size =       4912 *
+*Entries :       10 : Total =           22683 bytes  File  Size =       4905 *
 *        :          : Tree compression factor =   1.17                       *
 ******************************************************************************
 *Br    0 :StrSimHits : Int_t StrSimHits_                                     *


### PR DESCRIPTION
This fixes #21667 and thus addresses CMS issue seen at  github.com/cms-sw/cmssw/pull/49969

With the current version storage of collection whose content needs to be aligned with more than 4096 is not supported.  Extending it to higher number is trivial but require specific handling for each value so we had to stop at an arbitrary value.  The error is seen at dictionary compilation time:
```
..../root/meta/alignment/evolution_C_ACLiC_dict.cxx:483:21: error: static assertion failed due to requirement 'alignof(std::pair<const int, Wrapper>) <= 4096': Class with
      alignment strictly greater than 4096 are currently not supported in CollectionProxy. Please report this case to the developers
  483 |       static_assert(alignof(map<int,Wrapper>::value_type) <= 64,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Alignment information has also been added to `TDataType`, hence improving (tightening) the alignment of numerical type data member in emulated classes and requiring updates some test reference files.