### PR TITLE
[v636][df] Mark initialization method of DistRDF Base as `staticmethod`

### DIFF
--- a/bindings/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/distrdf/python/DistRDF/Backends/Base.py
@@ -201,7 +201,7 @@ class BaseBackend(ABC):
 
             **kwargs (dict): Keyword arguments used to execute the function.
         """
-        cls.initialization = partial(fun, *args, **kwargs)    
+        cls.initialization = staticmethod(partial(fun, *args, **kwargs))
         fun(*args, **kwargs) 
 
     @classmethod


### PR DESCRIPTION
This is necessary with Python 3.14 so the function returned by `partial` doesn't won't be passed the `self` when called as a member of the DistRDF base class.

Fixes failures like these:
```txt
=================================== FAILURES ===================================
_________________ TestInitialization.test_initialization[dask] _________________

self = <check_backend.TestInitialization object at 0x7f0248aea5d0>
payload = (<Client: 'tcp://127.0.0.1:45111' processes=2 threads=2, memory=4.00 GiB>, 'dask')

    def test_initialization(self, payload):
        """
        Check that the user initialization method is assigned to the current
        backend.
        """
        connection, _ = payload

        def returnNumber(n):
            return n

        DistRDF.initialize(returnNumber, 123)

        df = ROOT.RDataFrame(10, executor=connection)

        # Dummy df just to retrieve the initialization function
        f = df._headnode.backend.initialization

>       assert f() == 123
               ^^^
E       TypeError: TestInitialization.test_initialization.<locals>.returnNumber() takes 1 positional argument but 2 were given

../../../../../src/roottest/python/distrdf/backends/check_backend.py:81: TypeError
```

(cherry picked from commit 8a8f621cba92fb7f4a189eee30b3df56c5812c04)