### PR TITLE
[ruff] Try to run all range checks before exiting.

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -90,8 +90,8 @@ jobs:
       run: |
         files=$(grep '\.py$' changed_files.txt || echo "")
         if [ -n "$files" ]; then
-          diff_command=""
           apply_command=""
+          failure=false
           for file in $files; do
             while IFS=- read -r start length; do
               [ -z "$start" ] && continue
@@ -101,20 +101,14 @@ jobs:
                 continue
               fi
               end=$((start + length))
-              diff_command+="ruff format --diff --range $start-$end $file && "
+              ruff format --diff --preview --range ${start}-${end} ${file} || failure=true
               apply_command+="ruff format --range $start-$end $file && "
             done < <(git diff --unified=0 HEAD~1 -- "$file" | grep '^@@' | sed -E 's/^@@ -[0-9]+(,[0-9]+)? \+([0-9]+)(,([0-9]+))? @@.*/\2-\4/')
           done
 
-          if [ -n "$diff_command" ]; then
-            diff_command=${diff_command% && }
-            if ! eval "$diff_command"; then
-              apply_command=${apply_command% && }
-              echo -e "::error::Formatting failed. To apply the changes locally, run the following command:\n$apply_command"
-              exit 123
-            fi
-          else
-            echo "No ranges detected to format."
+          if ${failure}; then
+            echo -e "::error::Formatting failed. To apply the changes locally, run the following command:\n$apply_command"
+            exit 123;
           fi
         else
           echo "No python files to format"


### PR DESCRIPTION
The current ruff script exits at the first formatting failure in a file. Here, it is updated to run all range checks to get the full picture in the CI.
Furthermore, `--preview` is added, so ruff doesn't warn about output being formatted for github.

Note: Effectively, we are removing the short-circuit due to the `&&` in the command that's generated:
`ruff --range xxx && ruff --range yyy && ...`

See this CI run for seeing it in action:
https://github.com/root-project/root/actions/runs/23500132581/job/68392500589?pr=18083