### PR TITLE
[Python] Start switching ROOT pythonizations to Python Limited C API

### DIFF
--- a/bindings/pyroot/pythonizations/src/CPPInstancePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/CPPInstancePyz.cxx
@@ -12,9 +12,7 @@
 // Bindings
 #include "CPyCppyy/API.h"
 
-#include "../../cppyy/CPyCppyy/src/CPyCppyy.h"
 #include "../../cppyy/CPyCppyy/src/CPPInstance.h"
-#include "../../cppyy/CPyCppyy/src/CustomPyTypes.h"
 
 #include "PyROOTPythonize.h"
 #include "TBufferFile.h"
@@ -40,18 +38,18 @@ PyObject *PyROOT::CPPInstanceExpand(PyObject * /*self*/, PyObject *args)
    PyObject *pybuf = 0, *pyname = 0;
    if (!PyArg_ParseTuple(args, "O!O!:__expand__", &PyBytes_Type, &pybuf, &PyBytes_Type, &pyname))
       return 0;
-   const char *clname = PyBytes_AS_STRING(pyname);
+   const char *clname = PyBytes_AsString(pyname);
    // TBuffer and its derived classes can't write themselves, but can be created
    // directly from the buffer, so handle them in a special case
    void *newObj = 0;
    if (strcmp(clname, "TBufferFile") == 0) {
       TBufferFile *buf = new TBufferFile(TBuffer::kWrite);
-      buf->WriteFastArray(PyBytes_AS_STRING(pybuf), PyBytes_GET_SIZE(pybuf));
+      buf->WriteFastArray(PyBytes_AsString(pybuf), PyBytes_Size(pybuf));
       newObj = buf;
    } else {
       // use the PyString macro's to by-pass error checking; do not adopt the buffer,
       // as the local TBufferFile can go out of scope (there is no copying)
-      TBufferFile buf(TBuffer::kRead, PyBytes_GET_SIZE(pybuf), PyBytes_AS_STRING(pybuf), kFALSE);
+      TBufferFile buf(TBuffer::kRead, PyBytes_Size(pybuf), PyBytes_AsString(pybuf), kFALSE);
       newObj = buf.ReadObjectAny(0);
    }
    PyObject *result = CPyCppyy::Instance_FromVoidPtr(newObj, clname, /*python_owns=*/true);
@@ -101,13 +99,13 @@ PyObject *op_reduce(PyObject *self)
    // the buffer contents; use a string for the class name, used when casting
    // on reading back in (see CPPInstanceExpand defined above)
    PyObject *res2 = PyTuple_New(2);
-   PyTuple_SET_ITEM(res2, 0, PyBytes_FromStringAndSize(buff->Buffer(), buff->Length()));
-   PyTuple_SET_ITEM(res2, 1, PyBytes_FromString(Cppyy::GetScopedFinalName(selfClass).c_str()));
+   PyTuple_SetItem(res2, 0, PyBytes_FromStringAndSize(buff->Buffer(), buff->Length()));
+   PyTuple_SetItem(res2, 1, PyBytes_FromString(Cppyy::GetScopedFinalName(selfClass).c_str()));
 
    PyObject *result = PyTuple_New(2);
    Py_INCREF(s_expand);
-   PyTuple_SET_ITEM(result, 0, s_expand);
-   PyTuple_SET_ITEM(result, 1, res2);
+   PyTuple_SetItem(result, 0, s_expand);
+   PyTuple_SetItem(result, 1, res2);
 
    return result;
 }

--- a/bindings/pyroot/pythonizations/src/IOHandler.cxx
+++ b/bindings/pyroot/pythonizations/src/IOHandler.cxx
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <Python.h>
+#include "PythonLimitedAPI.h"
 
 #include <fcntl.h>
 #ifdef _MSC_VER // Visual Studio

--- a/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
+++ b/bindings/pyroot/pythonizations/src/PyROOTModule.cxx
@@ -42,9 +42,21 @@ PyObject *RegisterConverterAlias(PyObject * /*self*/, PyObject *args)
    PyObject *name = nullptr;
    PyObject *target = nullptr;
 
-   PyArg_ParseTuple(args, "UU:RegisterConverterAlias", &name, &target);
+   if (!PyArg_ParseTuple(args, "UU:RegisterConverterAlias", &name, &target)) {
+      return nullptr;
+   }
 
-   CPyCppyy::RegisterConverterAlias(PyUnicode_AsUTF8(name), PyUnicode_AsUTF8(target));
+   const char *nameStr = PyUnicode_AsUTF8AndSize(name, nullptr);
+   if (!nameStr) {
+      return nullptr;
+   }
+
+   const char *targetStr = PyUnicode_AsUTF8AndSize(target, nullptr);
+   if (!targetStr) {
+      return nullptr;
+   }
+
+   CPyCppyy::RegisterConverterAlias(nameStr, targetStr);
 
    Py_RETURN_NONE;
 }
@@ -54,9 +66,21 @@ PyObject *RegisterExecutorAlias(PyObject * /*self*/, PyObject *args)
    PyObject *name = nullptr;
    PyObject *target = nullptr;
 
-   PyArg_ParseTuple(args, "UU:RegisterExecutorAlias", &name, &target);
+   if (!PyArg_ParseTuple(args, "UU:RegisterExecutorAlias", &name, &target)) {
+      return nullptr;
+   }
 
-   CPyCppyy::RegisterExecutorAlias(PyUnicode_AsUTF8(name), PyUnicode_AsUTF8(target));
+   const char *nameStr = PyUnicode_AsUTF8AndSize(name, nullptr);
+   if (!nameStr) {
+      return nullptr;
+   }
+
+   const char *targetStr = PyUnicode_AsUTF8AndSize(target, nullptr);
+   if (!targetStr) {
+      return nullptr;
+   }
+
+   CPyCppyy::RegisterExecutorAlias(nameStr, targetStr);
 
    Py_RETURN_NONE;
 }
@@ -75,7 +99,7 @@ class PyObjRefCounter final {
    void Reset(PyObject *object)
    {
       if (fObject) {
-         Py_DECREF(fObject);
+         Py_DecRef(fObject);
          fObject = nullptr;
       }
       if (object) {

--- a/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
+++ b/bindings/pyroot/pythonizations/src/PyROOTPythonize.h
@@ -12,7 +12,7 @@
 #ifndef PYROOT_PYTHONIZE_H
 #define PYROOT_PYTHONIZE_H
 
-#include "Python.h"
+#include "PythonLimitedAPI.h"
 
 namespace PyROOT {
 

--- a/bindings/pyroot/pythonizations/src/PythonLimitedAPI.h
+++ b/bindings/pyroot/pythonizations/src/PythonLimitedAPI.h
@@ -1,0 +1,9 @@
+#ifndef ROOT_PythonLimitedAPI_h
+#define ROOT_PythonLimitedAPI_h
+
+// Use what is in the limited API since Python 3.10
+#define Py_LIMITED_API 0x030A0000
+
+#include <Python.h>
+
+#endif

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -10,7 +10,7 @@
  *************************************************************************/
 
 // Bindings
-#include "Python.h"
+#include "PythonLimitedAPI.h"
 #include "RPyROOTApplication.h"
 
 // ROOT
@@ -51,18 +51,24 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
          // Retrieve sys.argv list from Python
          PyObject *argl = PySys_GetObject("argv");
 
-         if (argl && 0 < PyList_Size(argl))
-            argc = (int)PyList_GET_SIZE(argl);
+         if (argl) {
+            Py_ssize_t size = PyList_Size(argl);
+            if (size > 0)
+               argc = static_cast<int>(size);
+         }
 
          argv = new char *[argc];
+
          for (int i = 1; i < argc; ++i) {
-            char *argi = const_cast<char *>(PyUnicode_AsUTF8(PyList_GET_ITEM(argl, i)));
+            PyObject *item = PyList_GetItem(argl, i);
+            const char *argi = PyUnicode_AsUTF8AndSize(item, nullptr);
+
             if (strcmp(argi, "-") == 0 || strcmp(argi, "--") == 0) {
                // Stop collecting options, the remaining are for the Python script
                argc = i; // includes program name
                break;
             }
-            argv[i] = argi;
+            argv[i] = const_cast<char *>(argi);
          }
       }
 
@@ -139,7 +145,7 @@ void PyROOT::RPyROOTApplication::InitROOTMessageCallback()
 /// \param[in] args [0] Boolean that tells whether to ignore the command line options.
 PyObject *PyROOT::RPyROOTApplication::InitApplication(PyObject * /*self*/, PyObject *args)
 {
-   int argc = PyTuple_GET_SIZE(args);
+   int argc = PyTuple_Size(args);
    if (argc == 1) {
       PyObject *ignoreCmdLineOpts = PyTuple_GetItem(args, 0);
 

--- a/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
+++ b/bindings/pyroot/pythonizations/src/TPyDispatcher.cxx
@@ -54,7 +54,7 @@ TPyDispatcher &TPyDispatcher::operator=(const TPyDispatcher &other)
    if (this != &other) {
       this->TObject::operator=(other);
 
-      Py_XDECREF(fCallable);
+      Py_DecRef(fCallable);
       Py_XINCREF(other.fCallable);
       fCallable = other.fCallable;
    }
@@ -67,7 +67,7 @@ TPyDispatcher &TPyDispatcher::operator=(const TPyDispatcher &other)
 
 TPyDispatcher::~TPyDispatcher()
 {
-   Py_XDECREF(fCallable);
+   Py_DecRef(fCallable);
 }
 
 //- public members -----------------------------------------------------------
@@ -93,13 +93,13 @@ PyObject *TPyDispatcher::DispatchVA(const char *format, ...)
 
       if (!PyTuple_Check(args)) { // if only one arg ...
          PyObject *t = PyTuple_New(1);
-         PyTuple_SET_ITEM(t, 0, args);
+         PyTuple_SetItem(t, 0, args);
          args = t;
       }
    }
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -136,27 +136,27 @@ PyObject *TPyDispatcher::DispatchVA1(const char *clname, void *obj, const char *
 
       if (!PyTuple_Check(args)) { // if only one arg ...
          PyObject *t = PyTuple_New(2);
-         PyTuple_SET_ITEM(t, 0, pyobj);
-         PyTuple_SET_ITEM(t, 1, args);
+         PyTuple_SetItem(t, 0, pyobj);
+         PyTuple_SetItem(t, 1, args);
          args = t;
       } else {
-         PyObject *t = PyTuple_New(PyTuple_GET_SIZE(args) + 1);
-         PyTuple_SET_ITEM(t, 0, pyobj);
-         for (int i = 0; i < PyTuple_GET_SIZE(args); i++) {
-            PyObject *item = PyTuple_GET_ITEM(args, i);
-            Py_INCREF(item);
-            PyTuple_SET_ITEM(t, i + 1, item);
+         PyObject *t = PyTuple_New(PyTuple_Size(args) + 1);
+         PyTuple_SetItem(t, 0, pyobj);
+         for (int i = 0; i < PyTuple_Size(args); i++) {
+            PyObject *item = PyTuple_GetItem(args, i);
+            Py_IncRef(item);
+            PyTuple_SetItem(t, i + 1, item);
          }
-         Py_DECREF(args);
+         Py_DecRef(args);
          args = t;
       }
    } else {
       args = PyTuple_New(1);
-      PyTuple_SET_ITEM(args, 0, pyobj);
+      PyTuple_SetItem(args, 0, pyobj);
    }
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -171,12 +171,12 @@ PyObject *TPyDispatcher::DispatchVA1(const char *clname, void *obj, const char *
 PyObject *TPyDispatcher::Dispatch(TPad *selpad, TObject *selected, Int_t event)
 {
    PyObject *args = PyTuple_New(3);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(selpad, "TPad"));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
-   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(event));
+   PyTuple_SetItem(args, 0, CPyCppyy::Instance_FromVoidPtr(selpad, "TPad"));
+   PyTuple_SetItem(args, 1, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
+   PyTuple_SetItem(args, 2, PyLong_FromLong(event));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -191,13 +191,13 @@ PyObject *TPyDispatcher::Dispatch(TPad *selpad, TObject *selected, Int_t event)
 PyObject *TPyDispatcher::Dispatch(Int_t event, Int_t x, Int_t y, TObject *selected)
 {
    PyObject *args = PyTuple_New(4);
-   PyTuple_SET_ITEM(args, 0, PyLong_FromLong(event));
-   PyTuple_SET_ITEM(args, 1, PyLong_FromLong(x));
-   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(y));
-   PyTuple_SET_ITEM(args, 3, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
+   PyTuple_SetItem(args, 0, PyLong_FromLong(event));
+   PyTuple_SetItem(args, 1, PyLong_FromLong(x));
+   PyTuple_SetItem(args, 2, PyLong_FromLong(y));
+   PyTuple_SetItem(args, 3, CPyCppyy::Instance_FromVoidPtr(selected, "TObject"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -212,12 +212,12 @@ PyObject *TPyDispatcher::Dispatch(Int_t event, Int_t x, Int_t y, TObject *select
 PyObject *TPyDispatcher::Dispatch(TVirtualPad *pad, TObject *obj, Int_t event)
 {
    PyObject *args = PyTuple_New(3);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(pad, "TVirtualPad"));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(obj, "TObject"));
-   PyTuple_SET_ITEM(args, 2, PyLong_FromLong(event));
+   PyTuple_SetItem(args, 0, CPyCppyy::Instance_FromVoidPtr(pad, "TVirtualPad"));
+   PyTuple_SetItem(args, 1, CPyCppyy::Instance_FromVoidPtr(obj, "TObject"));
+   PyTuple_SetItem(args, 2, PyLong_FromLong(event));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -232,11 +232,11 @@ PyObject *TPyDispatcher::Dispatch(TVirtualPad *pad, TObject *obj, Int_t event)
 PyObject *TPyDispatcher::Dispatch(TGListTreeItem *item, TDNDData *data)
 {
    PyObject *args = PyTuple_New(2);
-   PyTuple_SET_ITEM(args, 0, CPyCppyy::Instance_FromVoidPtr(item, "TGListTreeItem"));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr(data, "TDNDData"));
+   PyTuple_SetItem(args, 0, CPyCppyy::Instance_FromVoidPtr(item, "TGListTreeItem"));
+   PyTuple_SetItem(args, 1, CPyCppyy::Instance_FromVoidPtr(data, "TDNDData"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();
@@ -251,11 +251,11 @@ PyObject *TPyDispatcher::Dispatch(TGListTreeItem *item, TDNDData *data)
 PyObject *TPyDispatcher::Dispatch(const char *name, const TList *attr)
 {
    PyObject *args = PyTuple_New(2);
-   PyTuple_SET_ITEM(args, 0, PyBytes_FromString(name));
-   PyTuple_SET_ITEM(args, 1, CPyCppyy::Instance_FromVoidPtr((void *)attr, "TList"));
+   PyTuple_SetItem(args, 0, PyBytes_FromString(name));
+   PyTuple_SetItem(args, 1, CPyCppyy::Instance_FromVoidPtr((void *)attr, "TList"));
 
    PyObject *result = PyObject_CallObject(fCallable, args);
-   Py_XDECREF(args);
+   Py_DecRef(args);
 
    if (!result) {
       PyErr_Print();

--- a/bindings/pyroot/pythonizations/src/TTreePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TTreePyz.cxx
@@ -180,9 +180,9 @@ PyObject *PyROOT::GetBranchAttr(PyObject * /*self*/, PyObject *args)
 
    PyArg_ParseTuple(args, "OU:GetBranchAttr", &self, &pyname);
 
-   const char *name_possibly_alias = PyUnicode_AsUTF8(pyname);
+   const char *name_possibly_alias = PyUnicode_AsUTF8AndSize(pyname, nullptr);
    if (!name_possibly_alias)
-      return 0;
+      return nullptr;
 
    // get hold of actual tree
    auto tree = (TTree *)GetTClass(self)->DynamicCast(TTree::Class(), CPyCppyy::Instance_AsVoidPtr(self));
@@ -205,8 +205,8 @@ PyObject *PyROOT::GetBranchAttr(PyObject * /*self*/, PyObject *args)
       const auto [finalAddressVoidPtr, finalTypeName] = ResolveBranch(tree, name, branch);
       if (!finalTypeName.empty()) {
          PyObject *outTuple = PyTuple_New(2);
-         PyTuple_SET_ITEM(outTuple, 0, PyLong_FromLongLong((intptr_t)finalAddressVoidPtr));
-         PyTuple_SET_ITEM(outTuple, 1, CPyCppyy_PyText_FromString((finalTypeName + "*").c_str()));
+         PyTuple_SetItem(outTuple, 0, PyLong_FromLongLong((intptr_t)finalAddressVoidPtr));
+         PyTuple_SetItem(outTuple, 1, CPyCppyy_PyText_FromString((finalTypeName + "*").c_str()));
          return outTuple;
       }
    }
@@ -217,8 +217,8 @@ PyObject *PyROOT::GetBranchAttr(PyObject * /*self*/, PyObject *args)
       auto wrapper = WrapLeaf(leaf);
       if (wrapper != nullptr) {
          PyObject *outTuple = PyTuple_New(2);
-         PyTuple_SET_ITEM(outTuple, 0, wrapper);
-         PyTuple_SET_ITEM(outTuple, 1, CPyCppyy_PyText_FromString(""));
+         PyTuple_SetItem(outTuple, 0, wrapper);
+         PyTuple_SetItem(outTuple, 1, CPyCppyy_PyText_FromString(""));
          return outTuple;
       }
    }
@@ -255,10 +255,18 @@ PyObject *TryBranchLeafListOverload(int argc, PyObject *args)
 
       if (buf) {
          TBranch *branch = nullptr;
+         const char *nameString = PyUnicode_AsUTF8AndSize(name, nullptr);
+         if (!nameString) {
+            return nullptr;
+         }
+         const char *leaflistString = PyUnicode_AsUTF8AndSize(leaflist, nullptr);
+         if (!leaflistString) {
+            return nullptr;
+         }
          if (argc == 5) {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), buf, PyUnicode_AsUTF8(leaflist), PyInt_AS_LONG(bufsize));
+            branch = tree->Branch(nameString, buf, leaflistString, PyInt_AsLong(bufsize));
          } else {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), buf, PyUnicode_AsUTF8(leaflist));
+            branch = tree->Branch(nameString, buf, leaflistString);
          }
 
          return BindCppObject(branch, Cppyy::GetScope("TBranch"));
@@ -302,7 +310,14 @@ PyObject *TryBranchPtrToPtrOverloads(int argc, PyObject *args)
          return nullptr;
       }
 
-      std::string klName = clName ? PyUnicode_AsUTF8(clName) : "";
+      std::string klName;
+      if (clName) {
+         const char *clNameString = PyUnicode_AsUTF8AndSize(clName, nullptr);
+         if (!clNameString) {
+            return nullptr;
+         }
+         klName = clNameString;
+      }
       void *buf = nullptr;
 
       if (CPPInstance_Check(address)) {
@@ -321,13 +336,20 @@ PyObject *TryBranchPtrToPtrOverloads(int argc, PyObject *args)
 
       if (buf && !klName.empty()) {
          TBranch *branch = nullptr;
+         const char *nameString = nullptr;
+         if (argc == 4 || argc == 5 || argc == 6) {
+             nameString = PyUnicode_AsUTF8AndSize(name, nullptr);
+             if (!nameString) {
+                return nullptr;
+             }
+         }
          if (argc == 4) {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), klName.c_str(), buf);
+            branch = tree->Branch(nameString, klName.c_str(), buf);
          } else if (argc == 5) {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), klName.c_str(), buf, PyInt_AS_LONG(bufsize));
+            branch = tree->Branch(nameString, klName.c_str(), buf, PyInt_AsLong(bufsize));
          } else if (argc == 6) {
-            branch = tree->Branch(PyUnicode_AsUTF8(name), klName.c_str(), buf, PyInt_AS_LONG(bufsize),
-                                  PyInt_AS_LONG(splitlevel));
+            branch = tree->Branch(nameString, klName.c_str(), buf, PyInt_AsLong(bufsize),
+                                  PyInt_AsLong(splitlevel));
          }
 
          return BindCppObject(branch, Cppyy::GetScope("TBranch"));
@@ -359,7 +381,7 @@ PyObject *TryBranchPtrToPtrOverloads(int argc, PyObject *args)
 /// - ( const char*, T**, Int_t = 32000, Int_t = 99 )
 PyObject *PyROOT::BranchPyz(PyObject * /* self */, PyObject *args)
 {
-   int argc = PyTuple_GET_SIZE(args);
+   int argc = PyTuple_Size(args);
 
    if (argc >= 3) { // We count the TTree proxy object too
       auto branch = TryBranchLeafListOverload(argc, args);


### PR DESCRIPTION
This patch replaces usage of CPython macros and non-stable APIs with functions compatible with the Python Limited C API (stable ABI).

Replace direct macros with API functions:

  * `PyBytes_AS_STRING`   : `PyBytes_AsString`
  * `PyBytes_GET_SIZE`    : `PyBytes_Size`
  * `PyTuple_GET_SIZE`    : `PyTuple_Size`
  * `PyTuple_SET_ITEM`    : `PyTuple_SetItem`
  * `PyList_GET_ITEM`     : `PyList_GetItem`
  * `PyList_GET_SIZE`     : `PyList_Size`
  * `PyInt_AS_LONG`       : `PyInt_AsLong`
  * `Py_DECREF`           : `Py_DecRef`
  * `Py_XDECREF`          : `Py_DecRef`

Furthermore, replace `PyUnicode_AsUTF8` with a helper based on the stable `PyUnicode_AsUTF8AndSize`. Also, replace `<Python.h>` with `"PythonLimitedAPI.h"`, where the `Py_LIMITED_API` macro is set.

This change is part of enabling PyROOT to build against the Python stable ABI.