### PR TITLE
[clad] Bump clad to version 2.3

### DIFF
--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -74,7 +74,7 @@ if (DEFINED CLAD_SOURCE_DIR)
   list(APPEND _clad_extra_settings SOURCE_DIR ${CLAD_SOURCE_DIR})
 else()
   list(APPEND _clad_extra_settings GIT_REPOSITORY https://github.com/vgvassilev/clad.git)
-  list(APPEND _clad_extra_settings GIT_TAG v2.2)
+  list(APPEND _clad_extra_settings GIT_TAG v2.3)
 endif()
 
 ## list(APPEND _clad_patches_list "patch1.patch" "patch2.patch")


### PR DESCRIPTION
This release  brings substantial improvements across both forward and reverse modes, including expanded custom derivative support, new derivatives for standard library functions like std::beta, std::expint, and std::comp_ellint, and better handling of lambdas and nested differentiation. Reverse mode gains basic OpenMP support, reduced overhead by skipping unnecessary reverse_forw passes when custom pullbacks are available, and important correctness fixes for nested Hessian computations and complex record adjoints. A major highlight is the new dual-mode tape memory system, offering an in-memory RAM-disk backend via mmap with automatic disk offloading, plus hooks for user-defined tape implementations. Error estimation has been unified with reverse mode behind a cleaner function-based interface, CUDA support is stronger thanks to compute-sanitizer integration, and nearly 40 tracked issues have been resolved.