### PR TITLE
[tmva][sofie] Fix ReduceMean kFirst loop variable typo causing infinite…

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Reduce.hxx
@@ -218,7 +218,7 @@ public:
          out << SP << SP << "}\n"; // end j loop
          out << SP  << "}\n"; // end i loop
          if(fReduceOpMode == ReduceMean) {
-            out << SP  << "for (size_t j = 0; j < " << outputLength << "; j++) {\n";
+            out << SP << "for (size_t j = 0; j < " << outputLength << "; j++) {\n";
             out << SP << SP << "tensor_" << fNY << "[j] /= static_cast<float>(" << reducedLength << ");\n";
             out << SP << "}\n"; // end j loop
          }


### PR DESCRIPTION
One-character typo in the kFirst reduction path of `ROperator_Reduce.hxx`. The division loop after the accumulation was using `i` in its condition instead of `j`:
```
// before
for (size_t j = 0; i < outputLength; j++)

// after
for (size_t j = 0; j < outputLength; j++)
```
## Checklist

- [x] tested changes locally

This PR fixes #21682

