### PR TITLE
[tmva][sofie] Account for dilation in Conv2D same padding calculation

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/layers/conv.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/layers/conv.py
@@ -56,8 +56,10 @@ def MakeKerasConv(layer):
             inputWidth = fInputShape[3]
         outputHeight = math.ceil(float(inputHeight) / float(fAttrStrides[0]))
         outputWidth = math.ceil(float(inputWidth) / float(fAttrStrides[1]))
-        padding_height = max((outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight, 0)
-        padding_width = max((outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth, 0)
+        effective_kH = fAttrDilations[0] * (fAttrKernelShape[0] - 1) + 1
+        effective_kW = fAttrDilations[1] * (fAttrKernelShape[1] - 1) + 1
+        padding_height = max((outputHeight - 1) * fAttrStrides[0] + effective_kH - inputHeight, 0)
+        padding_width = max((outputWidth - 1) * fAttrStrides[1] + effective_kW - inputWidth, 0)
         padding_top = math.floor(padding_height / 2)
         padding_bottom = padding_height - padding_top
         padding_left = math.floor(padding_width / 2)

--- a/bindings/pyroot/pythonizations/test/generate_keras_functional.py
+++ b/bindings/pyroot/pythonizations/test/generate_keras_functional.py
@@ -98,6 +98,12 @@ def generate_keras_functional(dst_dir):
     model = models.Model(inp, out)
     train_and_save(model, "Conv2D_padding_same")
 
+    # Conv2D padding_same with dilation_rate=2
+    inp = layers.Input(shape=(8, 8, 3))
+    out = layers.Conv2D(4, (3, 3), padding='same', dilation_rate=2, data_format='channels_last', activation='relu')(inp)
+    model = models.Model(inp, out)
+    train_and_save(model, "Conv2D_padding_same_dilation")
+
     # Conv2D padding_valid
     inp = layers.Input(shape=(8, 8, 3))
     out = layers.Conv2D(4, (3, 3), padding='valid', data_format='channels_last', activation='elu')(inp)

--- a/bindings/pyroot/pythonizations/test/generate_keras_sequential.py
+++ b/bindings/pyroot/pythonizations/test/generate_keras_sequential.py
@@ -88,6 +88,13 @@ def generate_keras_sequential(dst_dir):
     ])
     train_and_save(model, "Conv2D_padding_same")
 
+    # Conv2D padding_same with dilation_rate=2
+    model = models.Sequential([
+        layers.Input(shape=(8, 8, 3)),
+        layers.Conv2D(4, (3, 3), padding='same', dilation_rate=2, data_format='channels_last', activation='relu')
+    ])
+    train_and_save(model, "Conv2D_padding_same_dilation")
+
     # Conv2D padding_valid
     model = models.Sequential([
         layers.Input(shape=(8, 8, 3)),

--- a/bindings/pyroot/pythonizations/test/sofie_keras_parser.py
+++ b/bindings/pyroot/pythonizations/test/sofie_keras_parser.py
@@ -22,6 +22,7 @@ models = [
     "Conv2D_channels_last",
     "Conv2D_channels_first_padding_same_stride2",
     "Conv2D_padding_same",
+    "Conv2D_padding_same_dilation",
     "Conv2D_padding_valid",
     "Dense",
     "ELU",

--- a/bindings/pyroot/pythonizations/test/sofie_keras_parser_models.py
+++ b/bindings/pyroot/pythonizations/test/sofie_keras_parser_models.py
@@ -88,6 +88,13 @@ def generate_keras_models(dst_dir):
         model, random_generator.rand(1, 4, 4, 1), random_generator.rand(1, 4, 4, 8), "KerasModelConv2D_Same", 2
     )
 
+    # Conv2D model with same padding and dilation
+    model = Sequential()
+    model.add(Conv2D(4, kernel_size=3, activation="relu", input_shape=(8, 8, 1), padding="same", dilation_rate=2))
+    train_and_save(
+        model, random_generator.rand(1, 8, 8, 1), random_generator.rand(1, 8, 8, 4), "KerasModelConv2D_SameDilated", 2
+    )
+
     # Reshape model
     model = Sequential()
     model.add(Conv2D(8, kernel_size=3, activation="relu", input_shape=(4, 4, 1), padding="same"))
@@ -242,6 +249,10 @@ class SOFIE_Keras_Parser_Models(unittest.TestCase):
     def test_conv2d_same_padding(self):
         input_tensor = np.ones((1, 4, 4, 1), dtype=np.float32)
         self.run_model_test("KerasModelConv2D_Same", [input_tensor], batch_size=1)
+
+    def test_conv2d_same_padding_dilated(self):
+        input_tensor = np.ones((1, 8, 8, 1), dtype=np.float32)
+        self.run_model_test("KerasModelConv2D_SameDilated", [input_tensor], batch_size=1)
 
     def test_reshape(self):
         input_tensor = np.ones((1, 4, 4, 1), dtype=np.float32)


### PR DESCRIPTION
## Changes

The `padding='same'` calculation in the Keras Conv2D parser was using the raw kernel size instead of the effective kernel size, which for dilated convolutions is `dilation * (kernel - 1) + 1`. `fAttrDilations` was extracted from the layer attributes but never factored into the padding formula.

```python
# before
padding_height = max((outputHeight - 1) * strides[0] + kernel_shape[0] - inputHeight, 0)

# after
effective_kH = dilations[0] * (kernel_shape[0] - 1) + 1
padding_height = max((outputHeight - 1) * strides[0] + effective_kH - inputHeight, 0)
```

For `dilation=2, kernel=3, input=8, stride=1` the old formula produced padding=2 while the correct value is 4, causing the generated inference code to operate on tensors with wrong spatial dimensions. With `dilation=1` the effective kernel size reduces to the raw kernel size, so existing models are unaffected.

## Checklist

- [x] tested changes locally

This PR fixes #21684 