### PR TITLE
[Python] Don't use limited C API on Windows yet

### DIFF
--- a/bindings/pyroot/pythonizations/src/PythonLimitedAPI.h
+++ b/bindings/pyroot/pythonizations/src/PythonLimitedAPI.h
@@ -2,7 +2,12 @@
 #define ROOT_PythonLimitedAPI_h
 
 // Use what is in the limited API since Python 3.10
+// On Windows we can't use the stable ABI yet: it requires linking against a
+// different libpython, so as long as we don't build all translation units in
+// the ROOT Pythonization library with the stable ABI we should not use it.
+#ifndef _WIN32
 #define Py_LIMITED_API 0x030A0000
+#endif
 
 #include <Python.h>
 


### PR DESCRIPTION
According to the CPyton docs [1]:

> On Windows, extensions that use the Stable ABI should be linked against python3.dll rather than a version-specific library such as python39.dll.

So I guess it's not a great idea to mix stable and regular CPython APIs in the same library on Windows.

Let's still do it on the other platforms, so we don't regress on restricting ourselves to use the limited API subset.

Once all of the ROOT Python bindings are migrated to the limited API, we can use the stable ABI also on Windows.

https://docs.python.org/3/c-api/stable.html#stable-abi