### PR TITLE
[geom] Added optional persistence for TGeoTessellated optimization

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -91,12 +91,17 @@ auto-parsing during `TClass::GetClass`, you can either set the shell environment
 ## Geometry
 
 * The list of logical volumes gets now rehashed automatically, giving an important performance improvement for setups having a large number of those.
-* `TGeoTessellated` now has efficient, BVH accelerated, navigation function implementations. This makes it possible to use `TGeoTessellated` in applications using `TGeoNavigator` (such as detector simulation).
+
+### Navigation implementation for tessellations
+`TGeoTessellated` now has efficient, BVH accelerated, navigation function implementations. This makes it possible to use `TGeoTessellated` in applications using `TGeoNavigator` (such as detector simulation).
+
+* The persistence of the acceleration structure is possible. This increases the file size in the order of 30-40%, speeding-up geometry loading by a factor 2x-3x, but in absolute terms loading a 1 million facets solid takes ~1 second. So persistence is disabled by default and can be enabled using:
+`TGeoTessellated::fgStreamOptimization = true`
 
 ### Extensible color schemes for geometry visualization
-ROOT now provides an extensible mechanism to assign colors and transparency to geometry volumes via the new `TGeoColorScheme` strategy class, used by `TGeoManager::DefaultColors()`.
+ROOT now provides an extensible mechanism to assign colors and transparency to geometry volumes via the new `TGeoColorScheme` policy class, used by `TGeoManager::DefaultColors()`.
 
-This improves the readability of geometries imported from formats such as GDML that do not store volume colors. The default behavior now uses a name-based material classification (e.g. metals, polymers, composites, gases) with a Z-binned fallback. Three predefined color sets are provided:
+This improves the readability of geometries imported from formats such as GDML that do not store volume colors. The default behavior now uses a name-based material classification (e.g. metals, polymers, composites, gases) with an effective Z-binned fallback. Three predefined color sets are provided:
 * `EGeoColorSet::kNatural` (default): material-inspired colors
 * `EGeoColorSet::kFlashy`: high-contrast, presentation-friendly colors
 * `EGeoColorSet::kHighContrast`: darker, saturated colors suited for light backgrounds

--- a/geom/geom/inc/LinkDef.h
+++ b/geom/geom/inc/LinkDef.h
@@ -1,2 +1,3 @@
 #include "LinkDef1.h"
 #include "LinkDef2.h"
+#include "LinkDef3.h"

--- a/geom/geom/inc/LinkDef3.h
+++ b/geom/geom/inc/LinkDef3.h
@@ -1,5 +1,5 @@
 // @(#)root/geom:$Id$
-// Author : Andrei Gheata 10/06/02
+// Author : Andrei Gheata 30/03/26
 /*************************************************************************
  * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *

--- a/geom/geom/inc/LinkDef3.h
+++ b/geom/geom/inc/LinkDef3.h
@@ -1,0 +1,20 @@
+// @(#)root/geom:$Id$
+// Author : Andrei Gheata 10/06/02
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifdef __CLING__
+
+// Third-party BVH headers
+#include <bvh2_third_party.h>
+#pragma extra_include "bvh2_third_party.h";
+#pragma link C++ struct bvh::v2::Bvh < bvh::v2::Node < float, 3, sizeof(float) * CHAR_BIT, 4>> + ;
+#pragma link C++ struct bvh::v2::Node < float, 3, sizeof(float) * CHAR_BIT, 4> + ;
+#pragma link C++ struct bvh::v2::Index < sizeof(float) * CHAR_BIT, 4> + ;
+
+#endif

--- a/geom/geom/inc/TGeoTessellated.h
+++ b/geom/geom/inc/TGeoTessellated.h
@@ -13,10 +13,19 @@
 #define ROOT_TGeoTessellated
 
 #include <map>
+#include <limits.h>
 #include "TGeoVector3.h"
 #include "TGeoTypedefs.h"
 #include "TGeoBBox.h"
 
+namespace bvh {
+namespace v2 {
+template <typename T, size_t Dim, size_t IndexBits /* = sizeof(T) * CHAR_BIT*/, size_t PrimCountBits /* = 4*/>
+class Node;
+template <typename T>
+struct Bvh;
+} // namespace v2
+} // namespace bvh
 class TGeoFacet {
 public:
    using Vertex_t = Tessellated::Vertex_t;
@@ -58,6 +67,8 @@ class TGeoTessellated : public TGeoBBox {
 
 public:
    using Vertex_t = Tessellated::Vertex_t;
+   using Node_t = bvh::v2::Node<float, 3, sizeof(float) * CHAR_BIT, 4>;
+   static Bool_t fgStreamOptimization;
 
 private:
    int fNfacets = 0;                      // Number of facets
@@ -70,8 +81,8 @@ private:
    std::multimap<long, int> fVerticesMap; ///<! Temporary map used to deduplicate vertices
    std::vector<Vertex_t> fOutwardNormals; // Vector of outward-facing normals (to be streamed !)
 
-   bool fIsClosed = false; //! to know if shape still needs closure/initialization
-   void *fBVH = nullptr;   //! BVH acceleration structure for safety and navigation
+   bool fIsClosed = false;               //! to know if shape still needs closure/initialization
+   bvh::v2::Bvh<Node_t> *fBVH = nullptr; // BVH acceleration structure for safety and navigation
 
    TGeoTessellated(const TGeoTessellated &) = delete;
    TGeoTessellated &operator=(const TGeoTessellated &) = delete;
@@ -154,7 +165,7 @@ private:
    template <bool closest_facet = false>
    Double_t SafetyKernel(const Double_t *point, bool in, int *closest_facet_id = nullptr) const;
 
-   ClassDefOverride(TGeoTessellated, 2) // tessellated shape class
+   ClassDefOverride(TGeoTessellated, 3) // tessellated shape class
 };
 
 #endif

--- a/geom/geom/inc/bvh/v2/top_down_sah_builder.h
+++ b/geom/geom/inc/bvh/v2/top_down_sah_builder.h
@@ -6,17 +6,19 @@
 #include "bvh/v2/bbox.h"
 #include "bvh/v2/split_heuristic.h"
 #include <stack>
-#if __has_include(<span>)
-#include <span>
-#else
-// Falling back to ROOT span
+// #if __has_include(<span>)
+//  A.G The dictionary generation expects c++20 span even when compiled with lower standard
+// #include <span>
+// #else
+//  Falling back to ROOT span
 #include "ROOT/span.hxx"
-#endif
+// #endif
 #include <algorithm>
 #include <optional>
 #include <numeric>
 #include <cassert>
 
+// clang-format off
 namespace bvh::v2 {
 
 /// Base class for all SAH-based, top-down builders.
@@ -144,5 +146,5 @@ protected:
 };
 
 } // namespace bvh::v2
-
+// clang-format on
 #endif

--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -43,8 +43,6 @@ for the composing faces.
 #include <cmath>
 #include <limits>
 
-ClassImp(TGeoTessellated);
-
 using Vertex_t = Tessellated::Vertex_t;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,6 +96,8 @@ bool TGeoFacet::IsNeighbour(const TGeoFacet &other, bool &flip) const
    }
    return neighbour;
 }
+
+Bool_t TGeoTessellated::fgStreamOptimization = false;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor. In case nfacets is zero, it is user's responsibility to
@@ -798,7 +798,7 @@ inline bool rayFacetHit(const Vertex_t &orig, const Vertex_t &dir, const TGeoFac
 template <typename T = float>
 struct Vec3f {
    T x, y, z;
-   Vec3f(T x_, T y_, T z_) : x(x_), y(y_), z(z_){};
+   Vec3f(T x_, T y_, T z_) : x(x_), y(y_), z(z_) {};
 };
 
 template <typename T>
@@ -922,9 +922,7 @@ Double_t TGeoTessellated::DistFromOutside(const Double_t *point, const Double_t 
    using Bvh = bvh::v2::Bvh<Node>;
    using Ray = bvh::v2::Ray<Scalar, 3>;
 
-   // let's fetch the bvh
-   auto mybvh = (Bvh *)fBVH;
-   if (!mybvh) {
+   if (!fBVH) {
       assert(false);
       return -1.;
    }
@@ -936,7 +934,7 @@ Double_t TGeoTessellated::DistFromOutside(const Double_t *point, const Double_t 
    };
 
    // let's do very quick checks against the top node
-   const auto topnode_bbox = mybvh->get_root().get_bbox();
+   const auto topnode_bbox = fBVH->get_root().get_bbox();
    if ((-point[0] + topnode_bbox.min[0]) > stepmax) {
       return Big();
    }
@@ -967,9 +965,9 @@ Double_t TGeoTessellated::DistFromOutside(const Double_t *point, const Double_t 
    Vertex_t dir_v{dir[0], dir[1], dir[2]};
    // Traverse the BVH and apply concrete object intersection in BVH leafs
    bvh::v2::GrowingStack<Bvh::Index> stack;
-   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+   fBVH->intersect<false, use_robust_traversal>(ray, fBVH->get_root().index, stack, [&](size_t begin, size_t end) {
       for (size_t prim_id = begin; prim_id < end; ++prim_id) {
-         auto objectid = mybvh->prim_ids[prim_id];
+         auto objectid = fBVH->prim_ids[prim_id];
          const auto &facet = fFacets[objectid];
          const auto &n = fOutwardNormals[objectid];
 
@@ -1005,9 +1003,7 @@ Double_t TGeoTessellated::DistFromInside(const Double_t *point, const Double_t *
    using Bvh = bvh::v2::Bvh<Node>;
    using Ray = bvh::v2::Ray<Scalar, 3>;
 
-   // let's fetch the bvh
-   auto mybvh = (Bvh *)fBVH;
-   if (!mybvh) {
+   if (!fBVH) {
       assert(false);
       return -1.;
    }
@@ -1029,9 +1025,9 @@ Double_t TGeoTessellated::DistFromInside(const Double_t *point, const Double_t *
    Vertex_t dir_v{dir[0], dir[1], dir[2]};
    // Traverse the BVH and apply concrete object intersection in BVH leafs
    bvh::v2::GrowingStack<Bvh::Index> stack;
-   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+   fBVH->intersect<false, use_robust_traversal>(ray, fBVH->get_root().index, stack, [&](size_t begin, size_t end) {
       for (size_t prim_id = begin; prim_id < end; ++prim_id) {
-         auto objectid = mybvh->prim_ids[prim_id];
+         auto objectid = fBVH->prim_ids[prim_id];
          auto facet = fFacets[objectid];
          const auto &n = fOutwardNormals[objectid];
 
@@ -1122,7 +1118,7 @@ void TGeoTessellated::BuildBVH()
 
    // check if some previous object is registered and delete if necessary
    if (fBVH) {
-      delete (Bvh *)fBVH;
+      delete fBVH;
       fBVH = nullptr;
    }
 
@@ -1132,7 +1128,7 @@ void TGeoTessellated::BuildBVH()
    auto bvh = bvh::v2::DefaultBuilder<Node>::build(bboxes, centers, config);
    auto bvhptr = new Bvh;
    *bvhptr = std::move(bvh); // copy structure
-   fBVH = (void *)(bvhptr);
+   fBVH = bvhptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1147,9 +1143,7 @@ bool TGeoTessellated::Contains(Double_t const *point) const
    using Bvh = bvh::v2::Bvh<Node>;
    using Ray = bvh::v2::Ray<Scalar, 3>;
 
-   // let's fetch the bvh
-   auto mybvh = (Bvh *)fBVH;
-   if (!mybvh) {
+   if (!fBVH) {
       assert(false);
       return false;
    }
@@ -1182,9 +1176,9 @@ bool TGeoTessellated::Contains(Double_t const *point) const
    // Traverse the BVH and apply concrete object intersection in BVH leafs
    bvh::v2::GrowingStack<Bvh::Index> stack;
    size_t crossings = 0;
-   mybvh->intersect<false, use_robust_traversal>(ray, mybvh->get_root().index, stack, [&](size_t begin, size_t end) {
+   fBVH->intersect<false, use_robust_traversal>(ray, fBVH->get_root().index, stack, [&](size_t begin, size_t end) {
       for (size_t prim_id = begin; prim_id < end; ++prim_id) {
-         auto objectid = mybvh->prim_ids[prim_id];
+         auto objectid = fBVH->prim_ids[prim_id];
          auto &facet = fFacets[objectid];
 
          // for the parity test, we probe all crossing surfaces
@@ -1234,16 +1228,11 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
 
    using Scalar = float;
    using Vec3 = bvh::v2::Vec<Scalar, 3>;
-   using Node = bvh::v2::Node<Scalar, 3>;
-   using Bvh = bvh::v2::Bvh<Node>;
-
-   // let's fetch the bvh
-   auto mybvh = (Bvh *)fBVH;
 
    // testpoint object in float for quick BVH interaction
    Vec3 testpoint(point[0], point[1], point[2]);
 
-   auto currnode = mybvh->nodes[0]; // we start from the top BVH node
+   auto currnode = fBVH->nodes[0]; // we start from the top BVH node
    // we do a quick check on the top node (in case we are outside shape)
    bool outside_top = false;
    if (!in) {
@@ -1274,11 +1263,10 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
          const auto end_prim_id = begin_prim_id + currnode.index.prim_count();
 
          for (auto p_id = begin_prim_id; p_id < end_prim_id; p_id++) {
-            const auto object_id = mybvh->prim_ids[p_id];
+            const auto object_id = fBVH->prim_ids[p_id];
 
             const auto &facet = fFacets[object_id];
-            auto thissafetySQ =
-               pointFacetDistSq(Vec3f<float>(point[0], point[1], point[2]), facet, fVertices);
+            auto thissafetySQ = pointFacetDistSq(Vec3f<float>(point[0], point[1], point[2]), facet, fVertices);
 
             if (thissafetySQ < smallest_safety_sq) {
                smallest_safety_sq = thissafetySQ;
@@ -1294,11 +1282,11 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
          const auto rightchild_id = leftchild_id + 1;
 
          for (size_t childid : {leftchild_id, rightchild_id}) {
-            if (childid >= mybvh->nodes.size()) {
+            if (childid >= fBVH->nodes.size()) {
                continue;
             }
 
-            const auto &node = mybvh->nodes[childid];
+            const auto &node = fBVH->nodes[childid];
             const auto inside = bvh::v2::extra::contains(node.get_bbox(), testpoint);
 
             if (inside) {
@@ -1316,7 +1304,7 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
 
       if (queue.size() > 0) {
          auto currElement = queue.top();
-         currnode = mybvh->nodes[currElement.bvh_node_id];
+         currnode = fBVH->nodes[currElement.bvh_node_id];
          current_safety_to_node_sq = currElement.value;
          queue.pop();
       } else {
@@ -1381,10 +1369,20 @@ void TGeoTessellated::ComputeNormal(const Double_t *point, const Double_t *dir, 
 void TGeoTessellated::Streamer(TBuffer &b)
 {
    if (b.IsReading()) {
-      b.ReadClassBuffer(TGeoTessellated::Class(), this);
-      CloseShape(false); // close shape but do not re-perform checks
+      UInt_t R__s, R__c;
+      Version_t R__v = b.ReadVersion(&R__s, &R__c);
+      b.ReadClassBuffer(TGeoTessellated::Class(), this, R__v, R__s, R__c);
+      if (!fBVH)
+         CloseShape(false); // close shape but do not re-perform checks
    } else {
-      b.WriteClassBuffer(TGeoTessellated::Class(), this);
+      if (fgStreamOptimization) {
+         b.WriteClassBuffer(TGeoTessellated::Class(), this);
+      } else {
+         auto bvh = fBVH;
+         fBVH = nullptr;
+         b.WriteClassBuffer(TGeoTessellated::Class(), this);
+         fBVH = bvh;
+      }
    }
 }
 


### PR DESCRIPTION
Persistence capability of the `bvh::v2::Bvh` data structure is now enabled. It can be controlled by `TGeoTessellated::fgStreamOptimization`, which is set to false (not streaming) by default, because although there is a gain in speed (2-3x faster), it is still fast to create the optimization on the fly, even for complex cases (1M facets).

co-authored by @pcanal 

# This Pull request:

## Changes or fixes:
Optionally enables persistence for the tessellated acceleration structure

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

