### PR TITLE
[RooFit] Guard against zero bin errors in RooPlot::chiSquareHandle zero bin error in chiSquare calculation (in: Roofit)

### DIFF
--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -560,6 +560,12 @@ double RooCurve::chiSquare(const RooHist& hist, Int_t nFitParam) const
 
     // Add pull^2 to chisq
     if (point.y!=0) {
+       if (eyl == 0 || eyh == 0) {
+          Warning("RooPlot::chiSquare",
+              "Zero bin error encountered. Result may be undefined. "
+              "RooPlot::chiSquare is deprecated; use RooAbsReal::createChi2 instead.");
+          continue;
+        }
       double pull = (point.y>avg) ? ((point.y-avg)/eyl) : ((point.y-avg)/eyh) ;
       chisq += pull*pull ;
       nbin++ ;


### PR DESCRIPTION
(closes #21697 )

RooPlot::chiSquare can have zero bin errors (e.g. when using Expected data errors), leading to division by zero in the pull calculation and resulting in NaN values.

I Added a warning for zero bin error and deprecated method usage as discussed in the issue: #21697   .



Until RooPlot::chiSquare gets deprecated in favor of RooAbsReal::createChi2 (as mentioned by @guitargeek ), this guard will be helpful for users who come across this error..







