### PR TITLE
[core] Compress TClonesArray before writing

### DIFF
--- a/core/cont/src/TClonesArray.cxx
+++ b/core/cont/src/TClonesArray.cxx
@@ -861,6 +861,10 @@ void TClonesArray::Streamer(TBuffer &b)
       Changed();
       b.CheckByteCount(R__s, R__c,TClonesArray::IsA());
    } else {
+
+      // ROOT-6788: eliminate empty slots
+      Compress();
+
       //Make sure TStreamerInfo is not optimized, otherwise it will not be
       //possible to support schema evolution in read mode.
       //In case the StreamerInfo has already been computed and optimized,

--- a/core/cont/test/CMakeLists.txt
+++ b/core/cont/test/CMakeLists.txt
@@ -6,6 +6,4 @@
 
 ROOT_ADD_UNITTEST_DIR(Core)
 
-ROOT_ADD_GTEST(testTypedIteration testTypedIteration.cxx LIBRARIES Core)
-ROOT_ADD_GTEST(TSeqTests TSeqTests.cxx LIBRARIES Core)
-ROOT_ADD_GTEST(testIter testIter.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(testCont testTypedIteration.cxx TSeqTests.cxx testIter.cxx LIBRARIES Core)

--- a/io/io/test/TBufferFileTests.cxx
+++ b/io/io/test/TBufferFileTests.cxx
@@ -2,6 +2,8 @@
 
 #include "TBufferFile.h"
 #include "TClass.h"
+#include "TClonesArray.h"
+#include "TObjString.h"
 #include <vector>
 #include <iostream>
 
@@ -26,3 +28,24 @@ TEST(TBufferFile, ROOT_8367)
    EXPECT_FLOAT_EQ(v2[6], 7.);
    EXPECT_EQ(v2.size(), 7);
 }
+
+// ROOT-6788
+TEST(TBufferFile, TClonesArrayEmptySlotsStreaming)
+{
+	TClonesArray clArray(TObjString::Class(), 100);
+	for (Int_t i=0; i<28; i++) {
+		new (clArray[i]) TObjString();
+	}
+	for (Int_t i=0; i<27; i++) {
+		delete clArray.RemoveAt(i);
+	}
+	
+   TBufferFile buf(TBuffer::kWrite, 10000);
+   buf.WriteObject(&clArray);
+   buf.SetReadMode();
+   buf.Reset();
+   auto obj = buf.ReadObject(TClonesArray::Class());
+   auto &readClArray = *dynamic_cast<TClonesArray*>(obj);
+   EXPECT_EQ(readClArray.GetEntries(), clArray.GetEntries());
+}
+


### PR DESCRIPTION
to avoid issues with empty slots.
A test is added.

Fixes [ROOT-6788](https://its.cern.ch/jira/browse/ROOT-6788)
