### PR TITLE
[cling] Ensure RAII-pushed transactions are deregistered on pop

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -118,6 +118,7 @@ namespace cling {
       = m_Interpreter->m_IncrParser->endTransaction(m_Transaction);
     if (PRT.getPointer()) {
       assert(PRT.getPointer()==m_Transaction && "Ended different transaction?");
+      m_Interpreter->m_IncrParser->deregisterTransaction(*PRT.getPointer());
       m_Interpreter->m_IncrParser->commitTransaction(PRT);
     }
   }


### PR DESCRIPTION
Transactions created via `PushTransactionRAII` were committed but remained in the IncrementalParser's transaction list (m_Transactions)

This led to some issues where we try to remove transactions out-of-order and unloading sometimes crashing.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

