### PR TITLE
[TPython] Fix preprocessor condition for PyObject_GetOptionalAttrString

### DIFF
--- a/bindings/tpython/src/TPyClassGenerator.cxx
+++ b/bindings/tpython/src/TPyClassGenerator.cxx
@@ -35,7 +35,7 @@ public:
    ~PyGILRAII() { PyGILState_Release(m_GILState); }
 };
 
-#ifdef Py_LIMITED_API
+#if (defined(Py_LIMITED_API) || PY_VERSION_HEX < 0x30d00f0)
 
 // Implementation of PyObject_GetOptionalAttr and
 // PyObject_GetOptionalAttrString from


### PR DESCRIPTION
The `PyObject_GetOptionalAttrString` doesn't only need to be defined when the limited API is used, but also if the Python version doesn't have it yet.

Follows up on 94af72623b451.

This should fix the CI failures on Windows, and I have no idea why the failures didn't appear in the PR that introduced this problem.