### PR TITLE
[CPyCppyy] Handle LowLevelView conversion via direct pointer conversion

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -444,8 +444,21 @@ static inline PY_LONG_LONG CPyCppyy_PyLong_AsStrictLongLong(PyObject* pyobject)
 static inline bool CArraySetArg(
     PyObject* pyobject, CPyCppyy::Parameter& para, char tc, int size, bool check=true)
 {
+// Case of LowLevelView. In general, they also implement the buffer protocol,
+// but for views around nullptr or C-style arrays without size info the buffer
+// protocol implementation is incomplete and PyObject_GetBuffer will fail.
+    if (CPyCppyy::LowLevelView_Check(pyobject)) {
+        auto llview = ((CPyCppyy::LowLevelView*)pyobject);
+        if (llview->fBufInfo.itemsize != size || !strchr(llview->fBufInfo.format, tc)) {
+            PyErr_Format(PyExc_TypeError,
+                "could not convert argument to buffer or nullptr");
+            return false;
+        }
+
+        para.fValue.fVoidp = llview->get_buf();
+    }
 // general case of loading a C array pointer (void* + type code) as function argument
-    if (pyobject == CPyCppyy::gNullPtrObject || pyobject == CPyCppyy::gDefaultObject)
+    else if (pyobject == CPyCppyy::gNullPtrObject || pyobject == CPyCppyy::gDefaultObject)
         para.fValue.fVoidp = nullptr;
     else {
         Py_ssize_t buflen = CPyCppyy::Utility::GetBuffer(pyobject, tc, size, para.fValue.fVoidp, check);

--- a/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_lowlevel.py
@@ -513,6 +513,24 @@ class TestLOWLEVEL:
         g = cppyy.gbl
         assert g.test15_templated_arrays_gmpxx.vector.value_type[g.std.vector[g.mpz_class]]
 
+    def test16_empy_llview_as_argument(self):
+        """Verify that empty LowLevelViews from nullptr can be used for C++
+        function calls. This covers the problem that was reported in
+        https://github.com/root-project/root/issues/20687.
+        """
+        import cppyy
+
+        cppyy.cppdef("""
+        int *getCStyleArray() { return nullptr; }
+        void takeCStyleArray(int *arr) {}
+        """)
+
+        ll_view = cppyy.gbl.getCStyleArray()
+
+        assert(len(ll_view) == 0)
+
+        cppyy.gbl.takeCStyleArray(ll_view)
+
 
 class TestMULTIDIMARRAYS:
     def setup_class(cls):


### PR DESCRIPTION
LowLevelView instances may represent C-style arrays with unknown size. While they nominally implement the Python buffer protocol, this only produces a valid `Py_buffer` when the size is known. For unsized views, the exported buffer metadata can be incomplete or inconsistent, causing `Utility::GetBuffer()` to fail and fall back to legacy handling, which we want to avoid to be able to remove the legacy code path eventually.

Since LowLevelView already provides direct access to the underlying pointer, add a dedicated conversion path in `CArraySetArg` that bypasses the buffer protocol entirely. Instead, validate the expected itemsize and type code against the stored buffer info and pass the raw pointer directly.

This also fixes dealing with LowLevelViews of size zero, which tripped up the conversion via the buffer protocol, because no distinction was made between invalid buffers and size-zero buffers.

A unit test that verifies this case is now handled correctly is also implemented.

Closes #20687.