### PR TITLE
[df] Fix casting of projected cardinality fields to int

### DIFF
--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -331,6 +331,18 @@ void ROOT::RDF::RNTupleDS::AddField(const ROOT::RNTupleDescriptor &desc, std::st
    if (!fieldOrException)
       return;
    auto valueField = fieldOrException.Unwrap();
+   if (const auto cardinalityField = dynamic_cast<const ROOT::RCardinalityField *>(valueField.get())) {
+      // Cardinality fields in RDataFrame are presented as integers
+      if (cardinalityField->As32Bit()) {
+         valueField =
+            std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint32_t>>(fieldDesc.GetFieldName());
+      } else if (cardinalityField->As64Bit()) {
+         valueField =
+            std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint64_t>>(fieldDesc.GetFieldName());
+      } else {
+         R__ASSERT(false && "cardinality field stored with an unexpected integer type");
+      }
+   }
    valueField->SetOnDiskId(fieldId);
    for (auto &f : *valueField) {
       f.SetOnDiskId(desc.FindFieldId(f.GetFieldName(), f.GetParent()->GetOnDiskId()));

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -50,37 +50,29 @@
 // clang-format on
 
 namespace ROOT::Internal::RDF {
-/// An artificial field that transforms an RNTuple column that contains the offset of collections into
-/// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
-/// `R_rdf_sizeof_jets` for a collection named `jets`.
-///
-/// This is similar to the RCardinalityField but it presents itself as an integer type.
-/// The template argument T must be an integral type.
-template <typename T>
-class RRDFCardinalityField final : public ROOT::RFieldBase {
-   static_assert(std::is_integral_v<T>, "T must be an integral type");
-
+class RRDFCardinalityFieldBase : public ROOT::RFieldBase {
 protected:
-   std::unique_ptr<ROOT::RFieldBase> CloneImpl(std::string_view newName) const final
-   {
-      return std::make_unique<RRDFCardinalityField>(newName);
-   }
-   void ConstructValue(void *where) const final { *static_cast<T *>(where) = 0; }
-
    // We construct these fields and know that they match the page source
    void ReconcileOnDiskField(const RNTupleDescriptor &) final {}
 
-public:
-   RRDFCardinalityField(std::string_view name)
-      : ROOT::RFieldBase(name, ROOT::Internal::GetRenormalizedTypeName(typeid(T)), ROOT::ENTupleStructure::kPlain,
-                         false /* isSimple */)
+   RRDFCardinalityFieldBase(std::string_view name, std::string_view type)
+      : ROOT::RFieldBase(name, type, ROOT::ENTupleStructure::kPlain, false /* isSimple */)
    {
    }
-   RRDFCardinalityField(const RRDFCardinalityField &other) = delete;
-   RRDFCardinalityField &operator=(const RRDFCardinalityField &other) = delete;
-   RRDFCardinalityField(RRDFCardinalityField &&other) = default;
-   RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
-   ~RRDFCardinalityField() override = default;
+
+   // Field is only used for reading
+   void GenerateColumns() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
+   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final
+   {
+      GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
+   }
+
+public:
+   RRDFCardinalityFieldBase(const RRDFCardinalityFieldBase &other) = delete;
+   RRDFCardinalityFieldBase &operator=(const RRDFCardinalityFieldBase &other) = delete;
+   RRDFCardinalityFieldBase(RRDFCardinalityFieldBase &&other) = default;
+   RRDFCardinalityFieldBase &operator=(RRDFCardinalityFieldBase &&other) = default;
+   ~RRDFCardinalityFieldBase() override = default;
 
    const RColumnRepresentations &GetColumnRepresentations() const final
    {
@@ -91,12 +83,35 @@ public:
                                                     {});
       return representations;
    }
-   // Field is only used for reading
-   void GenerateColumns() final { throw RException(R__FAIL("Cardinality fields must only be used for reading")); }
-   void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final
+};
+
+/// An artificial field that transforms an RNTuple column that contains the offset of collections into
+/// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
+/// `R_rdf_sizeof_jets` for a collection named `jets`.
+///
+/// This is similar to the RCardinalityField but it presents itself as an integer type.
+/// The template argument T must be an integral type.
+template <typename T>
+class RRDFCardinalityField final : public RRDFCardinalityFieldBase {
+   static_assert(std::is_integral_v<T>, "T must be an integral type");
+
+protected:
+   std::unique_ptr<ROOT::RFieldBase> CloneImpl(std::string_view newName) const final
    {
-      GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
+      return std::make_unique<RRDFCardinalityField>(newName);
    }
+   void ConstructValue(void *where) const final { *static_cast<T *>(where) = 0; }
+
+public:
+   RRDFCardinalityField(std::string_view name)
+      : RRDFCardinalityFieldBase(name, ROOT::Internal::GetRenormalizedTypeName(typeid(T)))
+   {
+   }
+   RRDFCardinalityField(const RRDFCardinalityField &other) = delete;
+   RRDFCardinalityField &operator=(const RRDFCardinalityField &other) = delete;
+   RRDFCardinalityField(RRDFCardinalityField &&other) = default;
+   RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
+   ~RRDFCardinalityField() override = default;
 
    std::size_t GetValueSize() const final { return sizeof(T); }
    std::size_t GetAlignment() const final { return alignof(T); }
@@ -150,7 +165,8 @@ private:
 
 public:
    RArraySizeField(std::string_view name, std::size_t arrayLength)
-      : ROOT::RFieldBase(name, "std::size_t", ROOT::ENTupleStructure::kPlain, false /* isSimple */),
+      : ROOT::RFieldBase(name, ROOT::Internal::GetRenormalizedTypeName(typeid(std::size_t)),
+                         ROOT::ENTupleStructure::kPlain, false /* isSimple */),
         fArrayLength(arrayLength)
    {
    }
@@ -491,10 +507,10 @@ ROOT::RFieldBase *ROOT::RDF::RNTupleDS::GetFieldWithTypeChecks(std::string_view 
    // The user explicitly requested a type
    const auto requestedType = ROOT::Internal::GetRenormalizedTypeName(ROOT::Internal::RDF::TypeID2TypeName(tid));
 
-   // If the field corresponding to the provided name is not a cardinality column and the requested type is different
-   // from the proto field that was created when the data source was constructed, we first have to create an
-   // alternative proto field for the column reader. Otherwise, we can directly use the existing proto field.
-   if (fieldName.substr(0, 13) != "R_rdf_sizeof_" && requestedType != fColumnTypes[index]) {
+   // If the requested type is different from the proto field that was created when the data source was constructed,
+   // we first have to create an alternative proto field for the column reader.
+   // Otherwise, we can directly use the existing proto field.
+   if (requestedType != fColumnTypes[index]) {
       auto &altProtoFields = fAlternativeProtoFields[index];
 
       // If we can find the requested type in the registered alternative protofields, return the corresponding field
@@ -507,12 +523,41 @@ ROOT::RFieldBase *ROOT::RDF::RNTupleDS::GetFieldWithTypeChecks(std::string_view 
       }
 
       // Otherwise, create a new protofield and register it in the alternatives before returning
-      auto newAltProtoFieldOrException = ROOT::RFieldBase::Create(std::string(fieldName), requestedType);
-      if (!newAltProtoFieldOrException) {
-         throw std::runtime_error("RNTupleDS: Could not create field with type \"" + requestedType +
-                                  "\" for column \"" + std::string(fieldName) + "\"");
+      std::unique_ptr<RFieldBase> newAltProtoField;
+      const std::string strName = std::string(fieldName);
+      if (dynamic_cast<ROOT::Internal::RDF::RRDFCardinalityFieldBase *>(fProtoFields[index].get())) {
+         if (requestedType == "bool") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<bool>>(strName);
+         } else if (requestedType == "char") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<char>>(strName);
+         } else if (requestedType == "std::int8_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::int8_t>>(strName);
+         } else if (requestedType == "std::uint8_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint8_t>>(strName);
+         } else if (requestedType == "std::int16_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::int16_t>>(strName);
+         } else if (requestedType == "std::uint16_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint16_t>>(strName);
+         } else if (requestedType == "std::int32_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::int32_t>>(strName);
+         } else if (requestedType == "std::uint32_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint32_t>>(strName);
+         } else if (requestedType == "std::int64_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::int64_t>>(strName);
+         } else if (requestedType == "std::uint64_t") {
+            newAltProtoField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::uint64_t>>(strName);
+         } else {
+            throw std::runtime_error("RNTupleDS: Could not create field with type \"" + requestedType +
+                                     "\" for column \"" + std::string(fieldName) + "\"");
+         }
+      } else {
+         auto newAltProtoFieldOrException = ROOT::RFieldBase::Create(strName, requestedType);
+         if (!newAltProtoFieldOrException) {
+            throw std::runtime_error("RNTupleDS: Could not create field with type \"" + requestedType +
+                                     "\" for column \"" + std::string(fieldName) + "\"");
+         }
+         newAltProtoField = newAltProtoFieldOrException.Unwrap();
       }
-      auto newAltProtoField = newAltProtoFieldOrException.Unwrap();
       newAltProtoField->SetOnDiskId(fProtoFields[index]->GetOnDiskId());
       auto *newField = newAltProtoField.get();
       altProtoFields.emplace_back(std::move(newAltProtoField));

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -27,6 +27,7 @@
 #include <TSystem.h>
 
 #include <cassert>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -95,6 +96,16 @@ template <typename T>
 class RRDFCardinalityField final : public RRDFCardinalityFieldBase {
    static_assert(std::is_integral_v<T>, "T must be an integral type");
 
+   inline void CheckSize(ROOT::NTupleSize_t size) const
+   {
+      if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, std::uint64_t>)
+         return;
+      if (size > std::numeric_limits<T>::max()) {
+         throw RException(R__FAIL(std::string("integer overflow in field ") + GetFieldName() +
+                                  ". Please read the column with a larger-sized integral type."));
+      }
+   }
+
 protected:
    std::unique_ptr<ROOT::RFieldBase> CloneImpl(std::string_view newName) const final
    {
@@ -122,6 +133,7 @@ public:
       RNTupleLocalIndex collectionStart;
       ROOT::NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
+      CheckSize(size);
       *static_cast<T *>(to) = size;
    }
 
@@ -131,6 +143,7 @@ public:
       RNTupleLocalIndex collectionStart;
       ROOT::NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(localIndex, &collectionStart, &size);
+      CheckSize(size);
       *static_cast<T *>(to) = size;
    }
 };

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -32,6 +32,7 @@
 #include <string>
 #include <vector>
 #include <typeinfo>
+#include <type_traits>
 #include <utility>
 
 // clang-format off
@@ -53,25 +54,30 @@ namespace ROOT::Internal::RDF {
 /// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
 /// `R_rdf_sizeof_jets` for a collection named `jets`.
 ///
-/// This field owns the collection offset field but instead of exposing the collection offsets it exposes
-/// the collection sizes (offset(N+1) - offset(N)).  For the time being, we offer this functionality only in RDataFrame.
-/// TODO(jblomer): consider providing a general set of useful virtual fields as part of RNTuple.
+/// This is similar to the RCardinalityField but it presents itself as an integer type.
+/// The template argument T must be an integral type.
+template <typename T>
 class RRDFCardinalityField final : public ROOT::RFieldBase {
+   static_assert(std::is_integral_v<T>, "T must be an integral type");
+
 protected:
    std::unique_ptr<ROOT::RFieldBase> CloneImpl(std::string_view newName) const final
    {
       return std::make_unique<RRDFCardinalityField>(newName);
    }
-   void ConstructValue(void *where) const final { *static_cast<std::size_t *>(where) = 0; }
+   void ConstructValue(void *where) const final { *static_cast<T *>(where) = 0; }
 
    // We construct these fields and know that they match the page source
    void ReconcileOnDiskField(const RNTupleDescriptor &) final {}
 
 public:
    RRDFCardinalityField(std::string_view name)
-      : ROOT::RFieldBase(name, "std::size_t", ROOT::ENTupleStructure::kPlain, false /* isSimple */)
+      : ROOT::RFieldBase(name, ROOT::Internal::GetRenormalizedTypeName(typeid(T)), ROOT::ENTupleStructure::kPlain,
+                         false /* isSimple */)
    {
    }
+   RRDFCardinalityField(const RRDFCardinalityField &other) = delete;
+   RRDFCardinalityField &operator=(const RRDFCardinalityField &other) = delete;
    RRDFCardinalityField(RRDFCardinalityField &&other) = default;
    RRDFCardinalityField &operator=(RRDFCardinalityField &&other) = default;
    ~RRDFCardinalityField() override = default;
@@ -92,8 +98,8 @@ public:
       GenerateColumnsImpl<ROOT::Internal::RColumnIndex>(desc);
    }
 
-   size_t GetValueSize() const final { return sizeof(std::size_t); }
-   size_t GetAlignment() const final { return alignof(std::size_t); }
+   std::size_t GetValueSize() const final { return sizeof(T); }
+   std::size_t GetAlignment() const final { return alignof(T); }
 
    /// Get the number of elements of the collection identified by globalIndex
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final
@@ -101,7 +107,7 @@ public:
       RNTupleLocalIndex collectionStart;
       ROOT::NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &size);
-      *static_cast<std::size_t *>(to) = size;
+      *static_cast<T *>(to) = size;
    }
 
    /// Get the number of elements of the collection identified by clusterIndex
@@ -110,7 +116,7 @@ public:
       RNTupleLocalIndex collectionStart;
       ROOT::NTupleSize_t size;
       fPrincipalColumn->GetCollectionInfo(localIndex, &collectionStart, &size);
-      *static_cast<std::size_t *>(to) = size;
+      *static_cast<T *>(to) = size;
    }
 };
 
@@ -337,7 +343,7 @@ void ROOT::RDF::RNTupleDS::AddField(const ROOT::RNTupleDescriptor &desc, std::st
       if (info.fNRepetitions > 0) {
          cardinalityField = std::make_unique<ROOT::Internal::RDF::RArraySizeField>(name, info.fNRepetitions);
       } else {
-         cardinalityField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField>(name);
+         cardinalityField = std::make_unique<ROOT::Internal::RDF::RRDFCardinalityField<std::size_t>>(name);
       }
       cardinalityField->SetOnDiskId(info.fFieldId);
    }

--- a/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_ntuple.cxx
@@ -563,10 +563,7 @@ TEST(RDFSnapshotRNTuple, CardinalityColumns)
    opts.fMode = "UPDATE";
    opts.fOutputFormat = ROOT::RDF::ESnapshotOutputFormat::kRNTuple;
    ROOT::RDataFrame df("ntuple", fileGuard.GetPath());
-
-   ROOT_EXPECT_WARNING(df.Snapshot("ntuple_snap", fileGuard.GetPath(), "", opts), "Snapshot",
-                       "Column \"nElectrons\" is a read-only \"ROOT::RNTupleCardinality<std::uint32_t>\" column. It "
-                       "will be snapshot as its inner type \"std::uint32_t\" instead.");
+   df.Snapshot("ntuple_snap", fileGuard.GetPath(), "", opts);
 
    ROOT::RDataFrame sdf("ntuple_snap", fileGuard.GetPath());
    EXPECT_EQ("std::uint32_t", sdf.GetColumnType("nElectrons"));

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -107,7 +107,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    EXPECT_STREQ("float", ds.GetTypeName("energy").c_str());
    EXPECT_EQ(ROOT::Internal::GetRenormalizedTypeName(typeid(std::size_t)), ds.GetTypeName("R_rdf_sizeof_jets"));
    EXPECT_STREQ("ROOT::VecOps::RVec<std::int32_t>", ds.GetTypeName("rvec").c_str());
-   EXPECT_STREQ("ROOT::RNTupleCardinality<std::uint64_t>", ds.GetTypeName("nElectron").c_str());
+   EXPECT_STREQ("std::uint64_t", ds.GetTypeName("nElectron").c_str());
 
    try {
       ds.GetTypeName("Address");
@@ -153,6 +153,8 @@ TEST_F(RNTupleDSTest, ProjectedCardinalityColumn)
    auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
 
    EXPECT_EQ(2u, *df.Filter("nElectron == 2").Max("nElectron"));
+
+   EXPECT_EQ(2u, *df.Filter([](std::uint64_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
 }
 
 static void ReadTest(const std::string &name, const std::string &fname)

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -68,6 +68,8 @@ protected:
       auto fldVecElectron = model->MakeField<std::vector<Electron>>("VecElectron");
       fldVecElectron->push_back(*fldElectron);
       fldVecElectron->push_back(*fldElectron);
+      auto fldNElectron = std::make_unique<ROOT::RField<ROOT::RNTupleCardinality<std::uint64_t>>>("nElectron");
+      model->AddProjectedField(std::move(fldNElectron), [](const std::string &) { return "VecElectron"; });
       {
          auto ntuple = RNTupleWriter::Recreate(std::move(model), fNtplName, fFileName);
          ntuple->Fill();
@@ -84,7 +86,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    RNTupleDS ds(fNtplName, fFileName);
 
    auto colNames = ds.GetColumnNames();
-   ASSERT_EQ(15, colNames.size());
+   ASSERT_EQ(16, colNames.size());
 
    EXPECT_TRUE(ds.HasColumn("pt"));
    EXPECT_TRUE(ds.HasColumn("energy"));
@@ -96,12 +98,14 @@ TEST_F(RNTupleDSTest, ColTypeNames)
    EXPECT_TRUE(ds.HasColumn("R_rdf_sizeof_VecElectron"));
    EXPECT_TRUE(ds.HasColumn("VecElectron.pt"));
    EXPECT_TRUE(ds.HasColumn("R_rdf_sizeof_VecElectron.pt"));
+   EXPECT_TRUE(ds.HasColumn("nElectron"));
    EXPECT_FALSE(ds.HasColumn("Address"));
 
    EXPECT_STREQ("std::string", ds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", ds.GetTypeName("energy").c_str());
    EXPECT_STREQ("std::size_t", ds.GetTypeName("R_rdf_sizeof_jets").c_str());
    EXPECT_STREQ("ROOT::VecOps::RVec<std::int32_t>", ds.GetTypeName("rvec").c_str());
+   EXPECT_STREQ("ROOT::RNTupleCardinality<std::uint64_t>", ds.GetTypeName("nElectron").c_str());
 
    try {
       ds.GetTypeName("Address");
@@ -140,6 +144,13 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
    EXPECT_EQ(*max_njets_jitted3, *max_njets_jitted2);
    EXPECT_EQ(2, *max_njets_jitted);
    EXPECT_EQ(3, *max_rvec2);
+}
+
+TEST_F(RNTupleDSTest, ProjectedCardinalityColumn)
+{
+   auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
+
+   EXPECT_EQ(2u, *df.Filter("nElectron == 2").Max("nElectron"));
 }
 
 static void ReadTest(const std::string &name, const std::string &fname)

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -1,4 +1,5 @@
 #include <ROOT/RDataFrame.hxx>
+#include <ROOT/RFieldUtils.hxx>
 #include <ROOT/RNTupleDS.hxx>
 #include <ROOT/RVec.hxx>
 
@@ -14,6 +15,7 @@
 #include "ClassWithArrays.h"
 
 #include <limits>
+#include <typeinfo>
 
 #include <TFile.h>
 
@@ -103,7 +105,7 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_STREQ("std::string", ds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", ds.GetTypeName("energy").c_str());
-   EXPECT_STREQ("std::size_t", ds.GetTypeName("R_rdf_sizeof_jets").c_str());
+   EXPECT_EQ(ROOT::Internal::GetRenormalizedTypeName(typeid(std::size_t)), ds.GetTypeName("R_rdf_sizeof_jets"));
    EXPECT_STREQ("ROOT::VecOps::RVec<std::int32_t>", ds.GetTypeName("rvec").c_str());
    EXPECT_STREQ("ROOT::RNTupleCardinality<std::uint64_t>", ds.GetTypeName("nElectron").c_str());
 

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -155,6 +155,14 @@ TEST_F(RNTupleDSTest, ProjectedCardinalityColumn)
    EXPECT_EQ(2u, *df.Filter("nElectron == 2").Max("nElectron"));
 
    EXPECT_EQ(2u, *df.Filter([](std::uint64_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::int32_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::uint32_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::int16_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::uint16_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::int8_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](std::uint8_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](char x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(2u, *df.Filter([](bool x) { return x; }, {"nElectron"}).Max("nElectron"));
 }
 
 static void ReadTest(const std::string &name, const std::string &fname)

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -130,7 +130,7 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
 
    // Check that the special column #<collection> works without jitting...
    auto identity = [](std::size_t sz) { return sz; };
-   auto max_njets = df.Define("njets", identity, {"R_rdf_sizeof_jets"}).Max<std::size_t>("njets");
+   auto max_njets = df.Define("njets", identity, {"R_rdf_sizeof_jets"}).Max("njets");
    auto max_njets2 = df.Max<std::size_t>("#jets");
    auto max_rvec = df.Max<std::size_t>("#rvec");
    EXPECT_EQ(*max_njets, *max_njets2);
@@ -138,8 +138,8 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
    EXPECT_EQ(*max_rvec, 3);
 
    // ...and with jitting
-   auto max_njets_jitted = df.Define("njets", "R_rdf_sizeof_jets").Max<std::size_t>("njets");
-   auto max_njets_jitted2 = df.Define("njets", "#jets").Max<std::size_t>("njets");
+   auto max_njets_jitted = df.Define("njets", "R_rdf_sizeof_jets").Max("njets");
+   auto max_njets_jitted2 = df.Define("njets", "#jets").Max("njets");
    auto max_njets_jitted3 = df.Max("#jets");
    auto max_rvec2 = df.Max("#rvec");
    EXPECT_EQ(*max_njets_jitted, *max_njets_jitted2);

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -68,8 +68,8 @@ protected:
       auto fldElectron = model->MakeField<Electron>("electron");
       fldElectron->pt = 137.0;
       auto fldVecElectron = model->MakeField<std::vector<Electron>>("VecElectron");
-      fldVecElectron->push_back(*fldElectron);
-      fldVecElectron->push_back(*fldElectron);
+      for (int i = 0; i < 128; ++i)
+         fldVecElectron->push_back(*fldElectron);
       auto fldNElectron = std::make_unique<ROOT::RField<ROOT::RNTupleCardinality<std::uint64_t>>>("nElectron");
       model->AddProjectedField(std::move(fldNElectron), [](const std::string &) { return "VecElectron"; });
       {
@@ -152,17 +152,21 @@ TEST_F(RNTupleDSTest, ProjectedCardinalityColumn)
 {
    auto df = ROOT::RDF::FromRNTuple(fNtplName, fFileName);
 
-   EXPECT_EQ(2u, *df.Filter("nElectron == 2").Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter("nElectron == 128").Max("nElectron"));
 
-   EXPECT_EQ(2u, *df.Filter([](std::uint64_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::int32_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::uint32_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::int16_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::uint16_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::int8_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](std::uint8_t x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](char x) { return x == 2; }, {"nElectron"}).Max("nElectron"));
-   EXPECT_EQ(2u, *df.Filter([](bool x) { return x; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::uint64_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::int32_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::uint32_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::int16_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::uint16_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](std::uint8_t x) { return x == 128; }, {"nElectron"}).Max("nElectron"));
+   EXPECT_EQ(128u, *df.Filter([](bool x) { return x; }, {"nElectron"}).Max("nElectron"));
+   try {
+      *df.Filter([](std::int8_t x) { return x == 0; }, {"nElectron"}).Count();
+      FAIL() << "integer overflow should fail";
+   } catch (const ROOT::RException &e) {
+      EXPECT_THAT(e.what(), ::testing::HasSubstr("integer overflow"));
+   }
 }
 
 static void ReadTest(const std::string &name, const std::string &fname)
@@ -206,7 +210,7 @@ static void ReadTest(const std::string &name, const std::string &fname)
    EXPECT_TRUE(All(rvec->at(0) == ROOT::RVecI{1, 2, 3}));
    EXPECT_TRUE(All(vectorasrvec->at(0) == ROOT::RVecF{1.f, 2.f}));
    EXPECT_FLOAT_EQ(137.0, sumElectronPt.GetValue());
-   EXPECT_FLOAT_EQ(2. * 137.0, sumVecElectronPt.GetValue());
+   EXPECT_FLOAT_EQ(128. * 137.0, sumVecElectronPt.GetValue());
 }
 
 static void ChainTest(const std::string &name, const std::string &fname)


### PR DESCRIPTION
This patch enables projected cardinality fields (e.g., `nMuon` in imported nanoAOD) to be used as integers of different widths. So far, this has been working only for jitted code.
