### PR TITLE
[cppyy] Allow passing of const reference to pointer args

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Converters.cxx
@@ -3365,18 +3365,18 @@ CPyCppyy::Converter* CPyCppyy::CreateConverter(const std::string& fullType, cdim
     const std::string& cpd = TypeManip::compound(resolvedType);
     std::string realType   = TypeManip::clean_type(resolvedType, false, true);
 
-// mutable pointer references (T*&) are incompatible with Python's object model
-   if (cpd == "*&") {
-       return new NotImplementedConverter{PyExc_TypeError,
-           "argument type '" + resolvedType + "' is not supported: non-const references to pointers (T*&) allow a"
-           " function to replace the pointer itself. Python cannot represent this safely. Consider changing the"
-           " C++ API to return the new pointer or use a wrapper"};
-   }
-
 // accept unqualified type (as python does not know about qualifiers)
     h = gConvFactories.find((isConst ? "const " : "") + realType + cpd);
     if (h != gConvFactories.end())
         return (h->second)(dims);
+
+// mutable pointer references (T*&) are incompatible with Python's object model
+    if (!isConst && cpd == "*&") {
+        return new NotImplementedConverter{PyExc_TypeError,
+            "argument type '" + resolvedType + "' is not supported: non-const references to pointers (T*&) allow a"
+            " function to replace the pointer itself. Python cannot represent this safely. Consider changing the"
+            " C++ API to return the new pointer or use a wrapper"};
+    }
 
 // drop const, as that is mostly meaningless to python (with the exception
 // of c-strings, but those are specialized in the converter map)
@@ -3827,7 +3827,8 @@ public:
         gf["const std::wstring&"] =         gf["std::wstring"];
         gf["const " WSTRING1 "&"] =         gf["std::wstring"];
         gf["const " WSTRING2 "&"] =         gf["std::wstring"];
-        gf["void*&"] =                      (cf_t)+[](cdims_t) { static VoidPtrRefConverter c{};     return &c; };
+        // VoidPtrRefConverter should only be used for const references to pointers
+        gf["const void*&"] =                (cf_t)+[](cdims_t) { static VoidPtrRefConverter c{};     return &c; };
         gf["void**"] =                      (cf_t)+[](cdims_t d) { return new VoidPtrPtrConverter{d}; };
         gf["void ptr"] =                    gf["void**"];
         gf["PyObject*"] =                   (cf_t)+[](cdims_t) { static PyObjectConverter c{};       return &c; };


### PR DESCRIPTION
This commit follows up on https://github.com/root-project/root/commit/d35e11473c32bb0f7d31425a7ce6c83002519bf2 wehere interfaces taking references to pointers were disallowed from being used in Python. That was a nice change, but we should continue to allow immutable references to pointers since that prevents pointer rebinding and can be used safely from Python. This commit enables the same and updates the `VoidPtrRefConverter` to map only to the const case.

Test:

```py
>>> cppyy.cppdef("""
... struct MyClass {
...    int val = 0;
... };
... 
... void changePtr(MyClass *& ptr) {}
... void constchangePtr(const MyClass *& ptr) {}
... """)
True
>>> ptr = cppyy.gbl.MyClass()
>>> cppyy.gbl.changePtr(ptr)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    cppyy.gbl.changePtr(ptr)
    ~~~~~~~~~~~~~~~~~~~^^^^^
TypeError: void changePtr(MyClass *& ptr) =>
    TypeError: could not convert argument 1: [Converter] (argument type 'MyClass *&' is not supported: non-const references to pointers (T*&) allow a function to replace the pointer itself. Python cannot represent this safely. Consider changing the C++ API to return the new pointer or use a wrapper)
>>> cppyy.gbl.constchangePtr(ptr) # works
>>> 
```

~I also revert a change in the test function signature that was previously one of these cases of const reference to a pointer.~ Edit: This still fails due to some weird handling of template args here:

```
>       assert ns.testfun["testptr"](cppyy.bind_object(cppyy.nullptr, ns.Test))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: Could not find "testfun<testptr>" (set cppyy.set_debug() for C++ errors):
E         bool UsingPtr::testfun<UsingPtr::Test *>(UsingPtr::Test *const & x) =>
``` 
and the resolution loses the const. since that test is about using aliases in templates, this is an implementation detail so we keep the version that #21655 proposed