### PR TITLE
[cxxmodules] Add `format` to std.modulemap

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -161,6 +161,11 @@ module "std" [system] {
     export *
     header "fstream"
   }
+  module "format" {
+    requires cplusplus20
+    export *
+    header "format"
+  }
   module "functional" {
     export *
     header "functional"


### PR DESCRIPTION
This will speed up the compilation compilation time when including `<format>` in root.

Attempt to fix the slowdown reported in: https://github.com/root-project/root/issues/21283
# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

