### PR TITLE
[ML] Fix data loader undersampling test

### DIFF
--- a/bindings/pyroot/pythonizations/test/ml_dataloader.py
+++ b/bindings/pyroot/pythonizations/test/ml_dataloader.py
@@ -4725,7 +4725,7 @@ class DataLoaderRandomUndersampling(unittest.TestCase):
 
         # max samling strategy to guarantee duplicate sampled entires
         max_sampling_ratio = entries_in_rdf_minor / entries_in_rdf_major
-        sampling_ratio = round(uniform(0.01, max_sampling_ratio), 2)
+        sampling_ratio = round(uniform(0.01, max_sampling_ratio - 0.01), 2)
 
         error_message = f"\n Batch size: {batch_size}\
             Number of major entries: {entries_in_rdf_major} \


### PR DESCRIPTION
`uniform(a, b) `is inclusive on both ends here:
```py
sampling_ratio = round(uniform(0.01, max_sampling_ratio), 2)
```
meaning `max_sampling_ratio` could be selected as the `sampling_ratio`, however if that's the case then we won't need (nor see) any replacement even with `replacement=True` and the following checks fail:

```python
# check if there are duplicate entries (replacement=True)
self.assertLess(len(set(flat_z_train)), len(flat_z_train))
self.assertLess(len(set(flat_z_val)), len(flat_z_val))
```

With this change we make sure we are strictly below that value.

This PR fixes #21747

