### PR TITLE
[X11] adjust new attributes handling

### DIFF
--- a/graf2d/x11/inc/TGX11.h
+++ b/graf2d/x11/inc/TGX11.h
@@ -63,6 +63,8 @@ struct XWindow_t;
 
 class TGX11 : public TVirtualX {
 
+friend struct XWindow_t;
+
 private:
    std::unordered_map<Int_t,std::unique_ptr<XWindow_t>> fWindows; // map of windows
    TExMap    *fColors;                ///< Hash list of colors
@@ -108,9 +110,6 @@ protected:
    ULong_t    fBlackPixel;         ///< Value of black pixel in colormap
    ULong_t    fWhitePixel;         ///< Value of white pixel in colormap
    Int_t      fScreenNumber;       ///< Screen number
-   Int_t      fTextAlignH;         ///< Text Alignment Horizontal
-   Int_t      fTextAlignV;         ///< Text Alignment Vertical
-   Int_t      fTextAlign;          ///< Text alignment (set in SetTextAlign) !!! conflict with TAttText
    Float_t    fCharacterUpX;       ///< Character Up vector along X
    Float_t    fCharacterUpY;       ///< Character Up vector along Y
    Float_t    fTextMagnitude;      ///< Text Magnitude
@@ -125,12 +124,17 @@ protected:
    Bool_t     fHasXft;             ///< True when XftFonts are used
 
    // needed by TGX11TTF
+   enum EAlign {
+      kAlignNone,
+      kTLeft, kTCenter, kTRight, kMLeft, kMCenter, kMRight,
+      kBLeft, kBCenter, kBRight };
+
    Bool_t     AllocColor(Colormap cmap, RXColor *color);
    void       QueryColors(Colormap cmap, RXColor *colors, Int_t ncolors);
    void      *GetGC(Int_t which) const;
    Window_t  GetWindow(WinContext_t wctxt) const;
    void      *GetGCW(WinContext_t wctxt, Int_t which) const;
-   Int_t      GetTextAlignW(WinContext_t wctxt) const;
+   EAlign     GetTextAlignW(WinContext_t wctxt) const;
 
    XColor_t  &GetColor(Int_t cid);
 

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -124,7 +124,7 @@ struct XWindow_t {
    std::vector<XPoint> markerShape;   ///< marker shape points
    Int_t markerLineWidth = 0;         ///< line width used for marker
    TAttText fAttText;                 ///< current text attribute
-   Int_t textAlign = 0;               ///< selected text align
+   TGX11::EAlign textAlign = TGX11::kAlignNone;     ///< selected text align
    XFontStruct *textFont = nullptr;   ///< selected text font
 };
 
@@ -213,9 +213,6 @@ TGX11::TGX11()
    fDepth              = 0;
    fHasTTFonts         = kFALSE;
    fHasXft             = kFALSE;
-   fTextAlignH         = 1;
-   fTextAlignV         = 1;
-   fTextAlign          = 7;
    fTextMagnitude      = 1;
    for (i = 0; i < kNumCursors; i++) fCursors[i] = 0;
 }
@@ -247,9 +244,6 @@ TGX11::TGX11(const char *name, const char *title) : TVirtualX(name, title)
    fDepth              = 0;
    fHasTTFonts         = kFALSE;
    fHasXft             = kFALSE;
-   fTextAlignH         = 1;
-   fTextAlignV         = 1;
-   fTextAlign          = 7;
    fTextMagnitude      = 1;
    for (i = 0; i < kNumCursors; i++)
       fCursors[i] = 0;
@@ -272,9 +266,6 @@ TGX11::TGX11(TGX11 &&org) : TVirtualX(org)
    fWhitePixel      = org.fWhitePixel;
    fHasTTFonts      = org.fHasTTFonts;
    fHasXft          = org.fHasXft;
-   fTextAlignH      = org.fTextAlignH;
-   fTextAlignV      = org.fTextAlignV;
-   fTextAlign       = org.fTextAlign;
    fTextMagnitude   = org.fTextMagnitude;
    fCharacterUpX    = org.fCharacterUpX;
    fCharacterUpY    = org.fCharacterUpY;
@@ -862,12 +853,12 @@ void TGX11::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float
 
       case kClear:
          XRotDrawAlignedString((Display*)fDisplay, ctxt->textFont, angle,
-                      ctxt->fDrawing, ctxt->fGClist[kGCtext], x, y, (char*)text, ctxt->textAlign);
+                      ctxt->fDrawing, ctxt->fGClist[kGCtext], x, y, (char*)text, (int) ctxt->textAlign);
          break;
 
       case kOpaque:
          XRotDrawAlignedImageString((Display*)fDisplay, ctxt->textFont, angle,
-                      ctxt->fDrawing, ctxt->fGClist[kGCtext], x, y, (char*)text, ctxt->textAlign);
+                      ctxt->fDrawing, ctxt->fGClist[kGCtext], x, y, (char*)text, (int) ctxt->textAlign);
          break;
 
       default:
@@ -1077,10 +1068,10 @@ void *TGX11::GetGCW(WinContext_t wctxt, Int_t which) const
 /// Return text align value for specified window context.
 /// Protected method used by TGX11TTF.
 
-Int_t TGX11::GetTextAlignW(WinContext_t wctxt) const
+TGX11::EAlign TGX11::GetTextAlignW(WinContext_t wctxt) const
 {
    auto ctxt = (XWindow_t *) wctxt;
-   return ctxt ? ctxt->textAlign : 0;
+   return ctxt ? ctxt->textAlign : kAlignNone;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2653,9 +2644,6 @@ void TGX11::SetTextAlign(Short_t talign)
    arg.SetTextAlign(talign);
 
    SetAttText((WinContext_t) gCws, arg);
-
-   // FIXME: member fTextAlign conflicts with TAttText::fTextAlign
-   fTextAlign = gCws->textAlign;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -3863,44 +3851,46 @@ void TGX11::SetAttText(WinContext_t wctxt, const TAttText &att)
    Int_t txalh = att.GetTextAlign() / 10;
    Int_t txalv = att.GetTextAlign() % 10;
 
+   ctxt->textAlign = kAlignNone;
+
    switch (txalh) {
       case 0 :
       case 1 :
          switch (txalv) {  //left
             case 1 :
-               ctxt->textAlign = 7;   //bottom
+               ctxt->textAlign = kBLeft;   //bottom
                break;
             case 2 :
-               ctxt->textAlign = 4;   //center
+               ctxt->textAlign = kMLeft;   //middle
                break;
             case 3 :
-               ctxt->textAlign = 1;   //top
+               ctxt->textAlign = kTLeft;   //top
                break;
          }
          break;
       case 2 :
          switch (txalv) { //center
             case 1 :
-               ctxt->textAlign = 8;   //bottom
+               ctxt->textAlign = kBCenter;   //bottom
                break;
             case 2 :
-               ctxt->textAlign = 5;   //center
+               ctxt->textAlign = kMCenter;   //middle
                break;
             case 3 :
-               ctxt->textAlign = 2;   //top
+               ctxt->textAlign = kTCenter;   //top
                break;
          }
          break;
       case 3 :
          switch (txalv) {  //right
             case 1 :
-               ctxt->textAlign = 9;   //bottom
+               ctxt->textAlign = kBRight;   //bottom
                break;
             case 2 :
-               ctxt->textAlign = 6;   //center
+               ctxt->textAlign = kMRight;   //center
                break;
             case 3 :
-               ctxt->textAlign = 3;   //top
+               ctxt->textAlign = kTRight;   //top
                break;
          }
          break;

--- a/graf2d/x11ttf/inc/TGX11TTF.h
+++ b/graf2d/x11ttf/inc/TGX11TTF.h
@@ -27,26 +27,12 @@ class TXftFontHash;
 class TGX11TTF : public TGX11 {
 
 private:
-   enum EAlign {
-// clang++ <v20 (-Wshadow) complains about shadowing GuiTypes.h global variable kNone. Let's silence warning:
-#if defined(__clang__) && __clang_major__ < 20
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wshadow"
-#endif
-      kNone,
-#if defined(__clang__) && __clang_major__ < 20
-#pragma clang diagnostic pop
-#endif
-
-      kTLeft, kTCenter, kTRight, kMLeft, kMCenter, kMRight,
-      kBLeft, kBCenter, kBRight };
-
    FT_Vector   fAlign;                 ///< alignment vector
 #ifdef R__HAS_XFT
    TXftFontHash  *fXftFontHash;        ///< hash table for Xft fonts
 #endif
 
-   void     Align(Int_t value);
+   void     Align(WinContext_t wctxt);
    void     DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back, RXImage *xim,
                       Int_t bx, Int_t by);
    Bool_t   IsVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -208,9 +208,9 @@ Bool_t TGX11TTF::Init(void *display)
 /// then the rotation is applied on the alignment variables.
 /// SetRotation and LayoutGlyphs should have been called before.
 
-void TGX11TTF::Align(Int_t value)
+void TGX11TTF::Align(WinContext_t wctxt)
 {
-   EAlign align = (EAlign) value;
+   auto align = GetTextAlignW(wctxt);
 
    // vertical alignment
    if (align == kTLeft || align == kTCenter || align == kTRight) {
@@ -372,7 +372,7 @@ void TGX11TTF::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Fl
       TTF::SetRotationMatrix(angle);
       TTF::PrepareString(text);
       TTF::LayoutGlyphs();
-      Align(GetTextAlignW(wctxt));
+      Align(wctxt);
       RenderString(wctxt, x, y, mode);
    }
 }
@@ -391,7 +391,7 @@ void TGX11TTF::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Fl
       TTF::SetRotationMatrix(angle);
       TTF::PrepareString(text);
       TTF::LayoutGlyphs();
-      Align(GetTextAlignW(wctxt));
+      Align(wctxt);
       RenderString(wctxt, x, y, mode);
    }
 }
@@ -548,7 +548,6 @@ void TGX11TTF::RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set specified font.
-
 
 void TGX11TTF::SetAttText(WinContext_t wctxt, const TAttText &att)
 {


### PR DESCRIPTION
1. For `textAlign` use protected `EAlign` enum with constants which were defined only in TGX11TTF while exactly same constants used in plain X11 text drawing
2. Remove duplication of `fTextAlign` member in TGX11. Now text align attributes stored in window context 
3. In `TGX11::GetWindowId()` check if window exists. `TASImage` in some cases tries to use zero window id
4. Use draw mode which is configured for window when setting color to `GC` - prevent interference between window 
5. Remove commented out old code
