### PR TITLE
[geom] Correct trap safety and fitting behavior

### DIFF
--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -2097,7 +2097,7 @@ TGeoGtra::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact
 {
    if (iact < 3 && safe) {
       // compute safe distance
-      *safe = Safety(point, kTRUE);
+      *safe = Safety(point, kFALSE);
       if (iact == 0)
          return TGeoShape::Big();
       if (iact == 1 && step < *safe)

--- a/geom/geom/src/TGeoTrd1.cxx
+++ b/geom/geom/src/TGeoTrd1.cxx
@@ -585,9 +585,9 @@ Int_t TGeoTrd1::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
    Double_t fx = 0.5 * (fDx1 - fDx2) / fDz;
    Double_t dx0 = 0.5 * (fDx1 + fDx2);
    Double_t z = origin[2] - dd[2];
-   dd[0] = dx0 - fx * z - origin[0];
+   dd[0] = dx0 - fx * z - TMath::Abs(origin[0]);
    z = origin[2] + dd[2];
-   dd[0] = TMath::Min(dd[0], dx0 - fx * z - origin[0]);
+   dd[0] = TMath::Min(dd[0], dx0 - fx * z - TMath::Abs(origin[0]));
    if (dd[0] < 0) {
       Error("GetFittingBox", "wrong matrix");
       return 1;

--- a/geom/geom/src/TGeoTrd2.cxx
+++ b/geom/geom/src/TGeoTrd2.cxx
@@ -601,11 +601,11 @@ Int_t TGeoTrd2::GetFittingBox(const TGeoBBox *parambox, TGeoMatrix *mat, Double_
    Double_t dx0 = 0.5 * (fDx1 + fDx2);
    Double_t dy0 = 0.5 * (fDy1 + fDy2);
    Double_t z = origin[2] - dd[2];
-   dd[0] = dx0 - fx * z - origin[0];
-   dd[1] = dy0 - fy * z - origin[1];
+   dd[0] = dx0 - fx * z - TMath::Abs(origin[0]);
+   dd[1] = dy0 - fy * z - TMath::Abs(origin[1]);
    z = origin[2] + dd[2];
-   dd[0] = TMath::Min(dd[0], dx0 - fx * z - origin[0]);
-   dd[1] = TMath::Min(dd[1], dy0 - fy * z - origin[1]);
+   dd[0] = TMath::Min(dd[0], dx0 - fx * z - TMath::Abs(origin[0]));
+   dd[1] = TMath::Min(dd[1], dy0 - fy * z - TMath::Abs(origin[1]));
    if (dd[0] < 0 || dd[1] < 0) {
       Error("GetFittingBox", "wrong matrix");
       return 1;


### PR DESCRIPTION
## This PR fixes three geometry regressions in trapezoid-related shapes.

## It fixes:
- wrong outside safety in TGeoGtra::DistFromOutside
- wrong fitted box size in TGeoTrd1::GetFittingBox
- wrong fitted box size in TGeoTrd2::GetFittingBox

For TGeoGtra, the outside-distance code used the wrong safety mode. It used inside safety for a point that is outside the shape. This could return wrong safety values.

For TGeoTrd1 and TGeoTrd2, GetFittingBox could return a box that does not really fit inside the shape for some negative offsets.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR could be related to #20981

