### PR TITLE
[tmva][sofie] Remove dead ParseMod float/double fmod check

### DIFF
--- a/tmva/sofie_parsers/src/ParseBasicBinary.cxx
+++ b/tmva/sofie_parsers/src/ParseBasicBinary.cxx
@@ -117,12 +117,6 @@ ParserFuncSignature ParseMod = [] (RModelParser_ONNX &parser, const onnx::NodePr
    if (nodeproto.attribute_size() > 0) {
       fmod = nodeproto.attribute(0).i();
    }
-   // case of float or double fmod must be 1
-   if (input_type ==ETensorType::FLOAT || input_type ==ETensorType::FLOAT ) {
-      if (fmod != 1)
-         std::runtime_error("TMVA::SOFIE ONNX parser Mod operator has fmod = 0 for floating inputs");
-   }
-
    std::unique_ptr<ROperator> op;
    std::string output_name = nodeproto.output(0);
 


### PR DESCRIPTION
## Changes :
Removed dead validation block in `ParseMod` in `tmva/sofie_parsers/src/ParseBasicBinary.cxx`. Reason for removing the block was that it was inoperative (`FLOAT || FLOAT` typo and missing `throw`) and redundant with current switch behavior for floating types. Going through the code, I believe there are not going to be any runtime behavior change. `FLOAT/DOUBLE` still maps to `FMod`; `INT32/INT64` still uses `fmod` to select `Mod` vs `FMod`.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #21736

