### PR TITLE
[jupyter] introduce `%rootbrowse` magic

### DIFF
--- a/bindings/pyroot/pythonizations/python/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/python/CMakeLists.txt
@@ -113,6 +113,7 @@ set(py_sources
   ROOT/_jupyroot/magics/__init__.py
   ROOT/_jupyroot/magics/cppmagic.py
   ROOT/_jupyroot/magics/jsrootmagic.py
+  ROOT/_jupyroot/magics/rootbrowsemagic.py
   ROOT/_numbadeclare.py
   ROOT/_pythonization/__init__.py
   ROOT/_pythonization/_cppinstance.py

--- a/bindings/pyroot/pythonizations/python/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/python/CMakeLists.txt
@@ -110,6 +110,7 @@ set(py_sources
   ROOT/_jupyroot/kernel/magics/__init__.py
   ROOT/_jupyroot/kernel/magics/cppmagic.py
   ROOT/_jupyroot/kernel/magics/jsrootmagic.py
+  ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
   ROOT/_jupyroot/magics/__init__.py
   ROOT/_jupyroot/magics/cppmagic.py
   ROOT/_jupyroot/magics/jsrootmagic.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/handlers.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/handlers.py
@@ -169,8 +169,7 @@ class JupyROOTExecutor(Runner):
 def display_drawables(displayFunction):
     drawers = helpers.utils.GetDrawers()
     for drawer in drawers:
-        for dobj in drawer.GetDrawableObjects():
-            displayFunction(dobj)
+        drawer.Draw(displayFunction)
 
 
 class JupyROOTDisplayer(Runner):

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -38,6 +38,8 @@ ROOT.gROOT.SetBatch()
 
 cppMIME = "text/x-c++src"
 
+_enableJSVis = True
+
 # Keep display handle for canvases to be able update them
 _canvasHandles = {}
 
@@ -167,35 +169,11 @@ def _initializeJSVis():
 
 
 _initializeJSVis()
-_enableJSVisDebug = False
 
 
-def enableJSVis():
-    if not TBufferJSONAvailable():
-        return
+def enableJSVis(flag=True):
     global _enableJSVis
-    _enableJSVis = True
-
-
-def disableJSVis():
-    global _enableJSVis
-    _enableJSVis = False
-
-
-def enableJSVisDebug():
-    if not TBufferJSONAvailable():
-        return
-    global _enableJSVis
-    global _enableJSVisDebug
-    _enableJSVis = True
-    _enableJSVisDebug = True
-
-
-def disableJSVisDebug():
-    global _enableJSVis
-    global _enableJSVisDebug
-    _enableJSVis = False
-    _enableJSVisDebug = False
+    _enableJSVis = flag and TBufferJSONAvailable()
 
 
 def addVisualObject(object, kind="none", option=""):
@@ -743,18 +721,12 @@ class NotebookDrawer(object):
                display.display(img)
 
     def _display(self):
-        if _enableJSVisDebug:
-            self._pngDisplay()
-            self._jsDisplay()
-        elif self._canJsDisplay():
-            self._jsDisplay()
+        if self._canJsDisplay():
+           self._jsDisplay()
         else:
-            self._pngDisplay()
+           self._pngDisplay()
 
     def GetDrawableObjects(self):
-        if _enableJSVisDebug:
-            return [self._getJsDiv(), self._getPngImage()]
-
         if self._canJsDisplay():
             return [self._getJsDiv()]
         else:
@@ -799,9 +771,6 @@ TInterpreter::EErrorCode ProcessLineWrapper(const char* line) {
 
 def enhanceROOTModule():
     ROOT.enableJSVis = enableJSVis
-    ROOT.disableJSVis = disableJSVis
-    ROOT.enableJSVisDebug = enableJSVisDebug
-    ROOT.disableJSVisDebug = disableJSVisDebug
 
 
 def enableCppHighlighting():

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -74,6 +74,11 @@ Core.unzipJSON({jsonLength},'{jsonZip}').then(json => {{
 }});
 """
 
+_jsBrowseUrlCode = """
+Core.buildGUI('{jsDivId}','notebook').then(h => h.openRootFile('{fileUrl}'));
+"""
+
+
 _jsBrowseFileCode = """
 const binaryString = atob('{fileBase64}');
 const bytes = new Uint8Array(binaryString.length);
@@ -199,13 +204,19 @@ def enableJSVis(flag=True):
 
 def addVisualObject(object, kind="none", option=""):
     global _visualObjects
-    if kind == "tfile":
+    if kind == "url":
+        _visualObjects.append(NotebookDrawerUrl(object))
+    elif kind == "tfile":
         _visualObjects.append(NotebookDrawerFile(object, option))
     else:
         _visualObjects.append(NotebookDrawerJson(object))
 
 
 def browseRootFile(fname, force=False):
+    if not force and (fname.startswith("https://") or fname.startswith("http://")):
+        addVisualObject(fname, "url")
+        return True
+
     f = ROOT.TFile.Open(fname)
     if f:
         option = ""
@@ -511,6 +522,41 @@ class CaptureDrawnPrimitives(object):
     def register(self):
         self.shell.events.register("post_execute", self._post_execute)
 
+
+
+class NotebookDrawerUrl(object):
+    """
+    Special drawer for file URL - JSROOT uses url to load file directly, without root
+    """
+
+    def __init__(self, theUrl):
+       self.drawUrl = theUrl
+
+    def _getUrlJsCode(self):
+
+        id = _getUniqueDivId()
+
+        drawHtml = _jsFullWidthDiv.format(
+            jsDivId=id,
+            jsCanvasHeight=_jsCanvasHeight
+        )
+
+        browseUrlCode = _jsBrowseUrlCode.format(
+            jsDivId=id,
+            fileUrl=self.drawUrl
+        )
+
+        thisJsCode = _jsCode.format(
+            jsDivId=id,
+            jsDivHtml=drawHtml,
+            jsDrawCode=browseUrlCode
+        )
+
+        return thisJsCode
+
+    def Draw(self, displayFunction):
+        code = self._getUrlJsCode()
+        displayFunction(display.HTML(code))
 
 
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -205,10 +205,13 @@ def addVisualObject(object, kind="none", option=""):
         _visualObjects.append(NotebookDrawerJson(object))
 
 
-def browseRootFile(fname):
+def browseRootFile(fname, force=False):
     f = ROOT.TFile.Open(fname)
     if f:
-        addVisualObject(f, "tfile")
+        option = ""
+        if force:
+            option = "force"
+        addVisualObject(f, "tfile", option)
         return True
     return False
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -570,6 +570,9 @@ class NotebookDrawerFile:
             if not f:
                 return f"Fail to open file {self.drawFileName}"
 
+            if f.GetVersion() < 30000:
+                return f"File version {f.GetVersion()} is too old and not supported by JSROOT"
+
             sz = f.GetSize()
             if sz > 10000000 and not self.drawForce:
                 return f"File size {sz} is too large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -205,6 +205,14 @@ def addVisualObject(object, kind="none", option=""):
         _visualObjects.append(NotebookDrawerJson(object))
 
 
+def browseRootFile(fname):
+    f = ROOT.TFile.Open(fname)
+    if f:
+        addVisualObject(f, "tfile")
+        return True
+    return False
+
+
 def _getPlatform():
     return sys.platform
 
@@ -829,7 +837,7 @@ captures = []
 
 def loadMagicsAndCapturers():
     global captures
-    extNames = ["ROOT._jupyroot.magics." + name for name in ["cppmagic", "jsrootmagic"]]
+    extNames = ["ROOT._jupyroot.magics." + name for name in ["cppmagic", "jsrootmagic", "rootbrowsemagic"]]
     ip = get_ipython()
     extMgr = ExtensionManager(ip)
     for extName in extNames:

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -574,8 +574,10 @@ class NotebookDrawerFile:
                 return f"File version {f.GetVersion()} is too old and not supported by JSROOT"
 
             sz = f.GetSize()
+            if sz > 300000000:
+                return f"File size {sz} is too large for JSROOT display."
             if sz > 10000000 and not self.drawForce:
-                return f"File size {sz} is too large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"
+                return f"File size {sz} is large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"
 
             # create plain buffer and get pointer on it
             u_buffer = (ctypes.c_ubyte * sz)(*range(sz))

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -213,19 +213,15 @@ def addVisualObject(object, kind="none", option=""):
 
 
 def browseRootFile(fname, force=False):
+    if not fname:
+        return False
+
     if not force and (fname.startswith("https://") or fname.startswith("http://")):
         addVisualObject(fname, "url")
         return True
 
-    f = ROOT.TFile.Open(fname)
-    if f:
-        option = ""
-        if force:
-            option = "force"
-        addVisualObject(f, "tfile", option)
-        return True
+    addVisualObject(fname, "tfile", force)
     return False
-
 
 def _getPlatform():
     return sys.platform
@@ -565,21 +561,29 @@ class NotebookDrawerFile(object):
     Special drawer for TFile - shows files hierarchy with possibility to draw objects
     """
 
-    def __init__(self, theObject, theOption=""):
-       self.drawObject = theObject
-       self.drawOption = theOption
+    def __init__(self, theFileName, theForce=False):
+       self.drawFileName = theFileName
+       self.drawForce = theForce
 
     def _getFileJsCode(self):
-        sz = self.drawObject.GetSize()
-        if sz > 10000000 and self.drawOption != "force":
-            return f"File size {sz} is too large for JSROOT display. Use 'force' draw option to show file nevertheless"
+        f = ROOT.TFile.Open(self.drawFileName)
+        if not f:
+            return f"Fail to open file {self.drawFileName}"
+
+        sz = f.GetSize()
+        if sz > 10000000 and not self.drawForce:
+            f.Close()
+            return f"File size {sz} is too large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"
 
         # create plain buffer and get pointer on it
         u_buffer = (ctypes.c_ubyte * sz)(*range(sz))
         addrc = ctypes.cast(ctypes.pointer(u_buffer), ctypes.c_char_p)
 
-        if self.drawObject.ReadBuffer(addrc, 0, sz):
-           return f"Fail to read file {self.drawObject.GetName()} buffer of size {sz}"
+        if f.ReadBuffer(addrc, 0, sz):
+           f.Close()
+           return f"Fail to read file {self.drawFileName} buffer of size {sz}"
+
+        f.Close()
 
         base64 = ROOT.TBase64.Encode(addrc, sz)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/helpers/utils.py
@@ -477,9 +477,7 @@ def GetRCanvasDrawers():
 
 def GetVisualDrawers():
     global _visualObjects
-    res = []
-    for obj in _visualObjects:
-        res.append(obj)
+    res = [obj for obj in _visualObjects]
     _visualObjects.clear()
     return res
 
@@ -504,7 +502,7 @@ def NotebookDraw():
         drawer.Draw(display.display)
 
 
-class CaptureDrawnPrimitives(object):
+class CaptureDrawnPrimitives:
     """
     Capture the canvas which is drawn to display it.
     """
@@ -520,7 +518,7 @@ class CaptureDrawnPrimitives(object):
 
 
 
-class NotebookDrawerUrl(object):
+class NotebookDrawerUrl:
     """
     Special drawer for file URL - JSROOT uses url to load file directly, without root
     """
@@ -556,7 +554,7 @@ class NotebookDrawerUrl(object):
 
 
 
-class NotebookDrawerFile(object):
+class NotebookDrawerFile:
     """
     Special drawer for TFile - shows files hierarchy with possibility to draw objects
     """
@@ -566,26 +564,24 @@ class NotebookDrawerFile(object):
        self.drawForce = theForce
 
     def _getFileJsCode(self):
-        f = ROOT.TFile.Open(self.drawFileName)
-        if not f:
-            return f"Fail to open file {self.drawFileName}"
+        base64 = ""
 
-        sz = f.GetSize()
-        if sz > 10000000 and not self.drawForce:
-            f.Close()
-            return f"File size {sz} is too large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"
+        with ROOT.TDirectory.TContext(), ROOT.TFile.Open(self.drawFileName) as f:
+            if not f:
+                return f"Fail to open file {self.drawFileName}"
 
-        # create plain buffer and get pointer on it
-        u_buffer = (ctypes.c_ubyte * sz)(*range(sz))
-        addrc = ctypes.cast(ctypes.pointer(u_buffer), ctypes.c_char_p)
+            sz = f.GetSize()
+            if sz > 10000000 and not self.drawForce:
+                return f"File size {sz} is too large for JSROOT display. Use '-f' flag like '%rootbrowse {self.drawFileName} -f' to show file nevertheless"
 
-        if f.ReadBuffer(addrc, 0, sz):
-           f.Close()
-           return f"Fail to read file {self.drawFileName} buffer of size {sz}"
+            # create plain buffer and get pointer on it
+            u_buffer = (ctypes.c_ubyte * sz)(*range(sz))
+            addrc = ctypes.cast(ctypes.pointer(u_buffer), ctypes.c_char_p)
 
-        f.Close()
+            if f.ReadBuffer(addrc, 0, sz):
+                return f"Fail to read file {self.drawFileName} buffer of size {sz}"
 
-        base64 = ROOT.TBase64.Encode(addrc, sz)
+            base64 = ROOT.TBase64.Encode(addrc, sz)
 
         id = _getUniqueDivId()
 
@@ -613,7 +609,7 @@ class NotebookDrawerFile(object):
 
 
 
-class NotebookDrawerJson(object):
+class NotebookDrawerJson:
     """
     Generic class to create JSROOT drawing for the arbitrary object based on json conversion.
     """
@@ -673,8 +669,10 @@ class NotebookDrawerJson(object):
         return thisJsCode
 
     def _getCanvas(self):
+        gPadSave = ROOT.gPad
         c1 = ROOT.TCanvas("__tmp_draw_image_canvas__", "", self._getWidth(), self._getHeight())
         c1.Add(self.drawObject)
+        ROOT.gPad = gPadSave
         return c1
 
     def _getPngImage(self):
@@ -702,7 +700,7 @@ class NotebookDrawerJson(object):
 
 class NotebookDrawerGeometry(NotebookDrawerJson):
     """
-    Drawer for geometry - png is not works with it.
+    Drawer for geometry - png output is not supported.
     """
 
     def __del__(self):
@@ -719,7 +717,7 @@ class NotebookDrawerGeometry(NotebookDrawerJson):
 class NotebookDrawerCanvBase(NotebookDrawerJson):
     """
     Base class for TCanvas/RCanvas drawing.
-    Implementst specific Draw function where canvas update is handled
+    Implements a specific Draw function where canvas updating is handled
     """
 
     def _getCanvasId(self):
@@ -835,6 +833,7 @@ class NotebookDrawerTCanvas(NotebookDrawerCanvBase):
                 palette.Add(colors.At(pal[i]))
             prim.Add(palette)
 
+        # reset global flag to avoid automatic colors storage by canvas
         ROOT.TColor.DefinedColors()
 
         canvas_json = ROOT.TBufferJSON.ConvertToJSON(self.drawObject, 23)

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/jsrootmagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/jsrootmagic.py
@@ -17,9 +17,7 @@ from metakernel import Magic, option
 from ROOT._jupyroot.helpers.utils import (
     TBufferJSONAvailable,
     TBufferJSONErrorMessage,
-    disableJSVis,
-    enableJSVis,
-    enableJSVisDebug,
+    enableJSVis
 )
 
 
@@ -32,12 +30,9 @@ class JSRootMagics(Magic):
         """Change the visualisation of plots from images to interactive JavaScript objects."""
         if args == "on" or args == "":
             self.printErrorIfNeeded()
-            enableJSVis()
+            enableJSVis(True)
         elif args == "off":
-            disableJSVis()
-        elif args == "debug":
-            self.printErrorIfNeeded()
-            enableJSVisDebug()
+            enableJSVis(False)
 
     def printErrorIfNeeded(self):
         if not TBufferJSONAvailable():

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
@@ -1,0 +1,32 @@
+# -*- coding:utf-8 -*-
+# -----------------------------------------------------------------------------
+#  Copyright (c) 2016, ROOT Team.
+#  Authors: Danilo Piparo <Danilo.Piparo@cern.ch> CERN
+# -----------------------------------------------------------------------------
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from metakernel import Magic, option
+
+from ROOT._jupyroot.helpers.utils import browseRootFile
+
+
+class RootBrowseMagics(Magic):
+    def __init__(self, kernel):
+        super(RootBrowseMagics, self).__init__(kernel)
+
+    @option("arg", default="", help="Show JSROOT browser with file content")
+    def line_rootbrowse(self, args):
+        """Open file and start browser."""
+        if not browseRootFile(args):
+            self.kernel.Error("Not able to open file " + args)
+
+
+def register_magics(kernel):
+    kernel.register_magics(RootBrowseMagics)

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
@@ -22,10 +22,16 @@ class RootBrowseMagics(Magic):
         super(RootBrowseMagics, self).__init__(kernel)
 
     @option("arg", default="", help="Show JSROOT browser with file content")
-    def line_rootbrowse(self, args):
+    @option(
+        "-f", "--force",
+        action="store_true",
+        default=False,
+        help="Force opening of large files"
+    )
+    def line_rootbrowse(self, arg, force):
         """Open file and start browser."""
-        if not browseRootFile(args):
-            self.kernel.Error("Not able to open file " + args)
+        if not browseRootFile(arg, force):
+            self.kernel.Error(f"Not able to open file {arg}")
         else:
             self.kernel.do_display()
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/magics/rootbrowsemagic.py
@@ -26,6 +26,8 @@ class RootBrowseMagics(Magic):
         """Open file and start browser."""
         if not browseRootFile(args):
             self.kernel.Error("Not able to open file " + args)
+        else:
+            self.kernel.do_display()
 
 
 def register_magics(kernel):

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/rootkernel.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/kernel/rootkernel.py
@@ -80,6 +80,9 @@ class ROOTKernel(MetaKernel):
         for streamDict in filter(lambda d: d is not None, streamDicts):
             self.send_response(self.iopub_socket, "stream", streamDict)
 
+    def do_display(self):
+        Display(self.Displayer, self.Display)
+
     def do_execute_direct(self, code, silent=False):
         if not code.strip():
             return
@@ -88,7 +91,7 @@ class ROOTKernel(MetaKernel):
         try:
             RunAsyncAndPrint(self.Executor, code, self.ioHandler, self.print_output, silent, 0.1)
 
-            Display(self.Displayer, self.Display)
+            self.do_display()
 
         except KeyboardInterrupt:
             ROOT.gROOT.SetInterrupt()

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/jsrootmagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/jsrootmagic.py
@@ -15,7 +15,7 @@
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
 
-from ROOT._jupyroot.helpers.utils import disableJSVis, enableJSVis, enableJSVisDebug
+from ROOT._jupyroot.helpers.utils import enableJSVis
 
 
 @magics_class
@@ -35,11 +35,9 @@ class JSRootMagics(Magics):
         """Change the visualisation of plots from images to interactive JavaScript objects."""
         args = parse_argstring(self.jsroot, line)
         if args.arg == "on":
-            enableJSVis()
+            enableJSVis(True)
         elif args.arg == "off":
-            disableJSVis()
-        elif args.arg == "debug":
-            enableJSVisDebug()
+            enableJSVis(False)
 
 
 def load_ipython_extension(ipython):

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/rootbrowsemagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/rootbrowsemagic.py
@@ -1,0 +1,42 @@
+# -*- coding:utf-8 -*-
+# -----------------------------------------------------------------------------
+#  Copyright (c) 2026, ROOT Team.
+#  Authors: Sergey Linev <S.Linev@gsi.de> GSI
+# -----------------------------------------------------------------------------
+
+################################################################################
+# Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from IPython.core.magic import Magics, line_magic, magics_class
+from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
+
+from ROOT._jupyroot.helpers.utils import browseRootFile
+
+
+@magics_class
+class RootBrowseMagics(Magics):
+    def __init__(self, shell):
+        super(RootBrowseMagics, self).__init__(shell)
+
+    @line_magic
+    @magic_arguments()
+    @argument(
+        "arg",
+        nargs="?",
+        default="",
+        help="Open and browse ROOT file",
+    )
+    def rootbrowse(self, line):
+        """start root browser."""
+        args = parse_argstring(self.rootbrowse, line)
+        browseRootFile(args.arg)
+
+
+
+def load_ipython_extension(ipython):
+    ipython.register_magics(RootBrowseMagics)

--- a/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/rootbrowsemagic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_jupyroot/magics/rootbrowsemagic.py
@@ -31,10 +31,19 @@ class RootBrowseMagics(Magics):
         default="",
         help="Open and browse ROOT file",
     )
+    @argument(
+       "--force",
+       "-f",
+       action="store_true",
+       help="Force opening of large files"
+    )
     def rootbrowse(self, line):
         """start root browser."""
         args = parse_argstring(self.rootbrowse, line)
-        browseRootFile(args.arg)
+        if not args:
+            print("Provide ROOT file name")
+        else:
+            browseRootFile(args.arg, args.force)
 
 
 


### PR DESCRIPTION
First of all - refactor jupyter drawer codes to make separate classes for TCanvas, RCanvas, TGeoManager, TFile

Introduce `rootbrowse` magic in cpp and python kernels. It works like:

<img width="1565" height="727" alt="rootbrowse" src="https://github.com/user-attachments/assets/b972c50a-1aff-4909-b54b-0916c02c4d0c" />

By default file is opened and shown in JSROOT page. 
One can specify `-f` option to force opening of large files. By default file up to 10MB can be viewed.

Special handling for `http://` / `https://` files. JSROOT can load such files directly - so there is no need to load full file content first. So size limitation is not important for such files - while JSROOT uses partial I/O

Supersede  https://github.com/root-project/root/pull/21364
