### PR TITLE
[meta] Check `TObject` inheritance before `TRef`

### DIFF
--- a/core/meta/src/TStreamerElement.cxx
+++ b/core/meta/src/TStreamerElement.cxx
@@ -311,6 +311,9 @@ Int_t TStreamerElement::GetExecID() const
       // However, it is needed to protect against non-loaded classes, previously also present in TClass::GetBaseClass.
       if (!cl || !cl->HasDataMemberInfo())
          return 0;
+      // Classes cannot both inherit from TRef/TRefArray and have a collection proxy.
+      if (cl->GetCollectionProxy())
+         return 0;
       // Only classes inheriting from TObject can inherit from TRef. Do not look inside other classes.
       if (!cl->IsTObject())
          return 0;


### PR DESCRIPTION
This avoids looking into implementation details of other classes, potentially triggering header parsing after commit https://github.com/root-project/root/commit/cdc439c38803084052658d1ab91270a942715ddd. For more details, see https://github.com/cms-sw/cmssw/issues/50580.