### PR TITLE
[tmva][sofie] throw on invalid BatchNormalization input count

### DIFF
--- a/tmva/sofie_parsers/src/ParseBatchNormalization.cxx
+++ b/tmva/sofie_parsers/src/ParseBatchNormalization.cxx
@@ -29,6 +29,9 @@ ParserFuncSignature ParseBatchNormalization = [](RModelParser_ONNX &parser, cons
          op.reset(new ROperator_BatchNormalization<float>(fepsilon, fmomentum, ftraining_mode, nodeproto.input(0),
                                                           nodeproto.input(1), nodeproto.input(2), nodeproto.input(3),
                                                           nodeproto.input(4), output_name));
+      } else {
+         throw std::runtime_error("TMVA::SOFIE ONNX Parser BatchNormalization op requires exactly 5 inputs, got " +
+                                  std::to_string(nodeproto.input_size()));
       }
       break;
    default:


### PR DESCRIPTION
## Changes:

`ParseBatchNormalization` only constructed the operator when `input_size() == 5` but had no `else` clause, so nodes with fewer inputs silently returned a null `unique_ptr` and crashed later in `Generate()` with an unrelated error message.

I've simply added an `else throw` to reject invalid input counts immediately at parse time with a clear error message, consistent with other parsers in the codebase.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #21759 

