### PR TITLE
[ntuple] Add support for attributes reading

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -23,6 +23,7 @@ HEADERS
   ROOT/RFieldVisitor.hxx
   ROOT/RMiniFile.hxx
   ROOT/RNTuple.hxx
+  ROOT/RNTupleAttrReading.hxx
   ROOT/RNTupleAttrUtils.hxx
   ROOT/RNTupleAttrWriting.hxx
   ROOT/RNTupleDescriptor.hxx
@@ -68,6 +69,7 @@ SOURCES
   src/RFieldVisitor.cxx
   src/RMiniFile.cxx
   src/RNTuple.cxx
+  src/RNTupleAttrReading.cxx
   src/RNTupleAttrWriting.cxx
   src/RNTupleDescriptor.cxx
   src/RNTupleDescriptorFmt.cxx

--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -34,9 +34,13 @@ namespace ROOT {
 class RNTupleFillContext;
 class RNTupleReader;
 
-namespace Experimental::Internal {
+namespace Experimental {
+class RNTupleAttrSetReader;
+
+namespace Internal {
 struct RNTupleAttrEntry;
 }
+} // namespace Experimental
 
 // clang-format off
 /**
@@ -52,6 +56,7 @@ class REntry {
    friend class RNTupleFillContext;
    friend class RNTupleModel;
    friend class RNTupleReader;
+   friend class Experimental::RNTupleAttrSetReader;
    friend struct Experimental::Internal::RNTupleAttrEntry;
 
 private:

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -44,6 +44,10 @@ class RFieldVisitor;
 class RRawPtrWriteEntry;
 } // namespace Detail
 
+namespace Experimental {
+class RNTupleAttrSetReader;
+}
+
 namespace Internal {
 
 class RPageSink;
@@ -84,6 +88,7 @@ This is and can only be partially enforced through C++.
 class RFieldBase {
    friend class RFieldZero;                                    // to reset fParent pointer in ReleaseSubfields()
    friend class ROOT::Detail::RRawPtrWriteEntry;               // to call Append()
+   friend class ROOT::Experimental::RNTupleAttrSetReader;      // for field->Read() in LoadEntry()
    friend struct ROOT::Internal::RFieldCallbackInjector;       // used for unit tests
    friend struct ROOT::Internal::RFieldRepresentationModifier; // used for unit tests
    friend void Internal::CallFlushColumnsOnField(RFieldBase &);

--- a/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
@@ -25,6 +25,8 @@ class RNTupleModel;
 
 namespace Experimental {
 
+class RNTupleAttrEntryIterable;
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleAttrRange
@@ -111,6 +113,7 @@ for (auto idx : attrSet->GetAttributes(10)) {
 // clang-format on
 class RNTupleAttrSetReader final {
    friend class ROOT::RNTupleReader;
+   friend class RNTupleAttrEntryIterable;
 
    /// List containing pairs { entryRange, entryIndex }, used to quickly find out which entries in the Attribute
    /// RNTuple contain entries that overlap a given range. The list is sorted by range start, i.e.
@@ -148,6 +151,91 @@ public:
 
    /// Returns the number of all attribute entries in this attribute set.
    std::size_t GetNEntries() const { return fEntryRanges.size(); }
+
+   /// Returns all the attributes in this Set. The returned attributes are sorted by entry range start.
+   RNTupleAttrEntryIterable GetAttributes();
+   /// Returns all the attributes whose range contains index `entryIndex`.
+   RNTupleAttrEntryIterable GetAttributes(NTupleSize_t entryIndex);
+   /// Returns all the attributes whose range fully contains `[startEntry, endEntry)`
+   RNTupleAttrEntryIterable GetAttributesContainingRange(NTupleSize_t startEntry, NTupleSize_t endEntry);
+   /// Returns all the attributes whose range is fully contained in `[startEntry, endEntry)`
+   RNTupleAttrEntryIterable GetAttributesInRange(NTupleSize_t startEntry, NTupleSize_t endEntry);
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleAttrEntryIterable
+\ingroup NTuple
+\brief Iterable class used to loop over attribute entries.
+
+This class allows to perform range-for iteration on some set of attributes, typically returned by the
+RNTupleAttrSetReader::GetAttributes family of methods.
+
+See the documentation of RNTupleAttrSetReader for example usage.
+*/
+// clang-format on
+class RNTupleAttrEntryIterable final {
+public:
+   struct RFilter {
+      RNTupleAttrRange fRange;
+      bool fIsContained;
+   };
+
+private:
+   RNTupleAttrSetReader *fReader = nullptr;
+   std::optional<RFilter> fFilter;
+
+public:
+   class RIterator final {
+   private:
+      using Iter_t = decltype(std::declval<RNTupleAttrSetReader>().fEntryRanges.begin());
+      Iter_t fCur, fEnd;
+      std::optional<RFilter> fFilter;
+
+      Iter_t SkipFiltered() const;
+      bool FullyContained(RNTupleAttrRange range) const;
+
+   public:
+      using iterator_category = std::forward_iterator_tag;
+      using iterator = RIterator;
+      using value_type = NTupleSize_t;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const value_type *;
+      using reference = const value_type &;
+
+      RIterator(Iter_t iter, Iter_t end, std::optional<RFilter> filter) : fCur(iter), fEnd(end), fFilter(filter)
+      {
+         if (fFilter) {
+            if (fFilter->fRange.GetLength() == 0)
+               fCur = end;
+            else
+               fCur = SkipFiltered();
+         }
+      }
+      iterator operator++()
+      {
+         ++fCur;
+         fCur = SkipFiltered();
+         return *this;
+      }
+      iterator operator++(int)
+      {
+         iterator it = *this;
+         operator++();
+         return it;
+      }
+      reference operator*() { return fCur->second; }
+      bool operator!=(const iterator &rh) const { return !operator==(rh); }
+      bool operator==(const iterator &rh) const { return fCur == rh.fCur; }
+   };
+
+   explicit RNTupleAttrEntryIterable(RNTupleAttrSetReader &reader, std::optional<RFilter> filter = {})
+      : fReader(&reader), fFilter(filter)
+   {
+   }
+
+   RIterator begin() { return RIterator{fReader->fEntryRanges.begin(), fReader->fEntryRanges.end(), fFilter}; }
+   RIterator end() { return RIterator{fReader->fEntryRanges.end(), fReader->fEntryRanges.end(), fFilter}; }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
@@ -1,0 +1,156 @@
+/// \file ROOT/RNTupleAttrReading.hxx
+/// \ingroup NTuple
+/// \author Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2026-04-01
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+#ifndef ROOT7_RNTuple_Attr_Reading
+#define ROOT7_RNTuple_Attr_Reading
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <ROOT/RNTupleFillContext.hxx>
+#include <ROOT/RNTupleAttrUtils.hxx>
+#include <ROOT/RNTupleUtils.hxx>
+
+namespace ROOT {
+
+class REntry;
+class RNTupleDescriptor;
+class RNTupleModel;
+
+namespace Experimental {
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleAttrRange
+\ingroup NTuple
+\brief A range of main entries referred to by an attribute entry
+
+Each attribute entry contains a set of values referring to 0 or more contiguous entries in the main RNTuple.
+This class represents that contiguous range of entries.
+*/
+// clang-format on
+class RNTupleAttrRange final {
+   ROOT::NTupleSize_t fStart = 0;
+   ROOT::NTupleSize_t fLength = 0;
+
+   RNTupleAttrRange(ROOT::NTupleSize_t start, ROOT::NTupleSize_t length) : fStart(start), fLength(length) {}
+
+public:
+   static RNTupleAttrRange FromStartLength(ROOT::NTupleSize_t start, ROOT::NTupleSize_t length)
+   {
+      return RNTupleAttrRange{start, length};
+   }
+
+   /// Creates an AttributeRange from [start, end), where `end` is one past the last valid entry of the range
+   /// (`FromStartEnd(0, 10)` will create a range whose last valid index is 9).
+   static RNTupleAttrRange FromStartEnd(ROOT::NTupleSize_t start, ROOT::NTupleSize_t end)
+   {
+      R__ASSERT(end >= start);
+      return RNTupleAttrRange{start, end - start};
+   }
+
+   RNTupleAttrRange() = default;
+
+   /// Returns the first valid entry index in the range. Returns nullopt if the range has zero length.
+   std::optional<ROOT::NTupleSize_t> GetFirst() const { return fLength ? std::make_optional(fStart) : std::nullopt; }
+   /// Returns the beginning of the range. Note that this is *not* a valid index in the range if the range has zero
+   /// length.
+   ROOT::NTupleSize_t GetStart() const { return fStart; }
+   /// Returns the last valid entry index in the range. Returns nullopt if the range has zero length.
+   std::optional<ROOT::NTupleSize_t> GetLast() const
+   {
+      return fLength ? std::make_optional(fStart + fLength - 1) : std::nullopt;
+   }
+   /// Returns one past the last valid index of the range, equal to `GetStart() + GetLength()`.
+   ROOT::NTupleSize_t GetEnd() const { return fStart + fLength; }
+   ROOT::NTupleSize_t GetLength() const { return fLength; }
+
+   /// Returns the pair { firstEntryIdx, lastEntryIdx } (inclusive). Returns nullopt if the range has zero length.
+   std::optional<std::pair<ROOT::NTupleSize_t, ROOT::NTupleSize_t>> GetFirstLast() const
+   {
+      return fLength ? std::make_optional(std::make_pair(fStart, fStart + fLength - 1)) : std::nullopt;
+   }
+   /// Returns the pair { start, length }.
+   std::pair<ROOT::NTupleSize_t, ROOT::NTupleSize_t> GetStartLength() const { return {fStart, fLength}; }
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RNTupleAttrSetReader
+\ingroup NTuple
+\brief Class used to read a RNTupleAttrSet in the context of a RNTupleReader
+
+An RNTupleAttrSetReader is created via RNTupleReader::OpenAttributeSet. Once created, it may outlive its parent Reader.
+Reading Attributes works similarly to reading regular RNTuple entries: you can either create entries or just use the
+AttrSetReader Model's default entry and load data into it via LoadEntry.
+
+~~ {.cpp}
+// Reading Attributes via RNTupleAttrSetReader
+// -------------------------------------------
+
+// Assuming `reader` is a RNTupleReader:
+auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+
+// Just like how you would read a regular RNTuple, first get the pointer to the fields you want to read:
+auto &attrEntry = attrSet->GetModel().GetDefaultEntry();
+auto pAttr = attrEntry->GetPtr<std::string>("myAttr");
+
+// Then select which attributes you want to read. E.g. read all attributes linked to the entry at index 10:
+for (auto idx : attrSet->GetAttributes(10)) {
+   attrSet->LoadEntry(idx);
+   cout << "entry " << idx << " has attribute " << *pAttr << "\n";
+}
+~~
+*/
+// clang-format on
+class RNTupleAttrSetReader final {
+   friend class ROOT::RNTupleReader;
+
+   /// List containing pairs { entryRange, entryIndex }, used to quickly find out which entries in the Attribute
+   /// RNTuple contain entries that overlap a given range. The list is sorted by range start, i.e.
+   /// entryRange.first.Start().
+   std::vector<std::pair<RNTupleAttrRange, NTupleSize_t>> fEntryRanges;
+   /// The internal Reader used to read the AttributeSet RNTuple
+   std::unique_ptr<RNTupleReader> fReader;
+   /// The reconstructed user model
+   std::unique_ptr<ROOT::RNTupleModel> fUserModel;
+
+   RNTupleAttrSetReader(std::unique_ptr<RNTupleReader> reader, std::uint16_t vSchemaMajor);
+
+public:
+   RNTupleAttrSetReader(const RNTupleAttrSetReader &) = delete;
+   RNTupleAttrSetReader &operator=(const RNTupleAttrSetReader &) = delete;
+   RNTupleAttrSetReader(RNTupleAttrSetReader &&) = default;
+   RNTupleAttrSetReader &operator=(RNTupleAttrSetReader &&) = default;
+   ~RNTupleAttrSetReader() = default;
+
+   /// Returns the read-only descriptor of this attribute set
+   const ROOT::RNTupleDescriptor &GetDescriptor() const;
+   /// Returns the read-only model of this attribute set
+   const ROOT::RNTupleModel &GetModel() const { return *fUserModel; }
+
+   /// Creates an entry suitable for use with LoadEntry.
+   /// This is a convenience method equivalent to GetModel().CreateEntry().
+   std::unique_ptr<REntry> CreateEntry();
+
+   /// Loads the attribute entry at position `index` into the default entry.
+   /// Returns the range of main RNTuple entries that the loaded set of attributes refers to.
+   RNTupleAttrRange LoadEntry(NTupleSize_t index);
+   /// Loads the attribute entry at position `index` into the given entry.
+   /// Returns the range of main RNTuple entries that the loaded set of attributes refers to.
+   RNTupleAttrRange LoadEntry(NTupleSize_t index, REntry &entry);
+
+   /// Returns the number of all attribute entries in this attribute set.
+   std::size_t GetNEntries() const { return fEntryRanges.size(); }
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
@@ -39,13 +39,15 @@ The order and name of the meta Model's fields is defined by the schema version.
 inline const std::uint16_t kSchemaVersionMajor = 1;
 inline const std::uint16_t kSchemaVersionMinor = 0;
 
-inline const char *const kRangeStartName = "_rangeStart";
-inline const char *const kRangeLenName = "_rangeLen";
-inline const char *const kUserDataName = "_userData";
+enum : std::size_t {
+   kMetaFieldIndex_RangeStart,
+   kMetaFieldIndex_RangeLen,
+   kMetaFieldIndex_UserData,
 
-inline constexpr std::size_t kRangeStartIndex = 0;
-inline constexpr std::size_t kRangeLenIndex = 1;
-inline constexpr std::size_t kUserDataIndex = 2;
+   kMetaFieldIndex_Count
+};
+inline constexpr const char *kMetaFieldNames[] = {"_rangeStart", "_rangeLen", "_userData"};
+static_assert(kMetaFieldIndex_Count == sizeof(kMetaFieldNames) / sizeof(kMetaFieldNames[0]));
 
 } // namespace ROOT::Experimental::Internal::RNTupleAttributes
 

--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -527,6 +527,12 @@ public:
    /// ~~~
    void EnableMetrics() { fMetrics.Enable(); }
    const Experimental::Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
+
+   /// Looks for an attribute set with the given name and creates an RNTupleAttrSetReader for it, with the provided
+   /// read options.
+   /// The returned reader has an independent lifetime from this RNTupleReader.
+   std::unique_ptr<Experimental::RNTupleAttrSetReader>
+   OpenAttributeSet(std::string_view attrSetName, const ROOT::RNTupleReadOptions &options = {});
 }; // class RNTupleReader
 
 } // namespace ROOT

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -854,6 +854,11 @@ public:
    /// Forces the loading of ROOT StreamerInfo from the underlying file. This currently only has an effect for
    /// TFile-backed sources.
    virtual void LoadStreamerInfo() = 0;
+
+   /// Creates a new PageSource using the same underlying file as this but referring to a different RNTuple,
+   /// described by `anchorLink`.
+   virtual std::unique_ptr<RPageSource> OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
+                                                                const ROOT::RNTupleReadOptions &options = {}) = 0;
 }; // class RPageSource
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -183,6 +183,9 @@ public:
    std::string GetObjectClass() const;
 
    void LoadStreamerInfo() final;
+
+   std::unique_ptr<RPageSource> OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
+                                                        const ROOT::RNTupleReadOptions &options = {}) final;
 }; // class RPageSourceDaos
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -187,9 +187,9 @@ public:
    ~RPageSourceFile() override;
 
    /// Creates a new PageSourceFile using the same underlying file as this but referring to a different RNTuple,
-   /// represented by `anchor`.
+   /// described by `anchorLink`.
    std::unique_ptr<RPageSourceFile>
-   OpenWithDifferentAnchor(const RNTuple &anchor, const ROOT::RNTupleReadOptions &options = ROOT::RNTupleReadOptions());
+   OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink, const ROOT::RNTupleReadOptions &options = {});
 
    void
    LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) final;

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -186,10 +186,8 @@ public:
    RPageSourceFile &operator=(RPageSourceFile &&) = delete;
    ~RPageSourceFile() override;
 
-   /// Creates a new PageSourceFile using the same underlying file as this but referring to a different RNTuple,
-   /// described by `anchorLink`.
-   std::unique_ptr<RPageSourceFile>
-   OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink, const ROOT::RNTupleReadOptions &options = {});
+   std::unique_ptr<RPageSource> OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
+                                                        const ROOT::RNTupleReadOptions &options = {}) final;
 
    void
    LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) final;

--- a/tree/ntuple/src/RNTupleAttrReading.cxx
+++ b/tree/ntuple/src/RNTupleAttrReading.cxx
@@ -1,0 +1,114 @@
+/// \file RNTupleAttrReading.cxx
+/// \ingroup NTuple
+/// \author Giacomo Parolini <giacomo.parolini@cern.ch>
+/// \date 2026-04-01
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+#include <ROOT/RNTupleAttrReading.hxx>
+#include <ROOT/RNTupleAttrUtils.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleModel.hxx>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+using namespace ROOT::Experimental::Internal::RNTupleAttributes;
+
+ROOT::Experimental::RNTupleAttrSetReader::RNTupleAttrSetReader(std::unique_ptr<RNTupleReader> reader,
+                                                               std::uint16_t vSchemaMajor)
+   : fReader(std::move(reader))
+{
+   // Changes in major version imply forward incompatibility
+   if (vSchemaMajor != kSchemaVersionMajor)
+      throw ROOT::RException(R__FAIL("unsupported attribute schema version: " + std::to_string(vSchemaMajor)));
+
+   // Initialize user model
+   fUserModel = RNTupleModel::Create();
+
+   // Validate meta model format
+   const auto &metaDesc = fReader->GetDescriptor();
+   const auto &metaFieldIds = metaDesc.GetFieldZero().GetLinkIds();
+   if (metaFieldIds.size() != kMetaFieldIndex_Count) {
+      throw ROOT::RException(R__FAIL("invalid number of attribute meta-fields: expected " +
+                                     std::to_string(kMetaFieldIndex_Count) + ", got " +
+                                     std::to_string(metaFieldIds.size())));
+   }
+   for (std::size_t i = 0; i < kMetaFieldIndex_Count; ++i) {
+      const auto fieldId = metaFieldIds[i];
+      const auto &metaField = metaDesc.GetFieldDescriptor(fieldId);
+      if (metaField.GetFieldName() != kMetaFieldNames[i]) {
+         throw ROOT::RException(R__FAIL(std::string("invalid attribute meta-field name: expected '") +
+                                        kMetaFieldNames[i] + "', got '" + metaField.GetFieldName() + "'"));
+      }
+   }
+
+   const auto &userFieldRoot = metaDesc.GetFieldDescriptor(metaFieldIds[kMetaFieldIndex_UserData]);
+   for (const auto fieldId : userFieldRoot.GetLinkIds()) {
+      const auto &fdesc = metaDesc.GetFieldDescriptor(fieldId);
+      auto userField = RFieldBase::Create(fdesc.GetFieldName(), fdesc.GetTypeName()).Unwrap();
+      fUserModel->AddField(std::move(userField));
+   }
+   fUserModel->Freeze();
+
+   // Collect all entry ranges
+   auto entryRangeStartView = fReader->GetView<ROOT::NTupleSize_t>(kMetaFieldNames[kMetaFieldIndex_RangeStart]);
+   auto entryRangeLenView = fReader->GetView<ROOT::NTupleSize_t>(kMetaFieldNames[kMetaFieldIndex_RangeLen]);
+   fEntryRanges.reserve(fReader->GetNEntries());
+   for (auto i : fReader->GetEntryRange()) {
+      auto start = entryRangeStartView(i);
+      auto len = entryRangeLenView(i);
+      fEntryRanges.push_back({RNTupleAttrRange::FromStartLength(start, len), i});
+   }
+
+   std::stable_sort(fEntryRanges.begin(), fEntryRanges.end(),
+                    [](const auto &a, const auto &b) { return a.first.GetStart() < b.first.GetStart(); });
+
+   R__LOG_INFO(ROOT::Internal::NTupleLog()) << "Loaded " << fEntryRanges.size() << " attribute entries.";
+}
+
+const ROOT::RNTupleDescriptor &ROOT::Experimental::RNTupleAttrSetReader::GetDescriptor() const
+{
+   return fReader->GetDescriptor();
+}
+
+ROOT::Experimental::RNTupleAttrRange
+ROOT::Experimental::RNTupleAttrSetReader::LoadEntry(ROOT::NTupleSize_t index, REntry &entry)
+{
+   // TODO(gparolini): find a way to avoid this const_cast
+   auto &metaModel = const_cast<ROOT::RNTupleModel &>(fReader->GetModel());
+   auto &metaEntry = metaModel.GetDefaultEntry();
+
+   if (R__unlikely(entry.GetModelId() != fUserModel->GetModelId()))
+      throw RException(R__FAIL("mismatch between entry and model"));
+
+   // Load the meta fields
+   metaEntry.fValues[kMetaFieldIndex_RangeStart].Read(index);
+   metaEntry.fValues[kMetaFieldIndex_RangeLen].Read(index);
+
+   // Load the user fields into `entry`
+   auto *userRootField = ROOT::Internal::GetFieldZeroOfModel(metaModel).GetMutableSubfields()[kMetaFieldIndex_UserData];
+   const auto userFields = userRootField->GetMutableSubfields();
+   assert(entry.fValues.size() == userFields.size());
+   for (std::size_t i = 0; i < userFields.size(); ++i) {
+      auto *field = userFields[i];
+      field->Read(index, entry.fValues[i].GetPtr<void>().get());
+   }
+
+   auto pStart = metaEntry.fValues[kMetaFieldIndex_RangeStart].GetPtr<NTupleSize_t>();
+   auto pLen = metaEntry.fValues[kMetaFieldIndex_RangeLen].GetPtr<NTupleSize_t>();
+
+   return RNTupleAttrRange::FromStartLength(*pStart, *pLen);
+}
+
+ROOT::Experimental::RNTupleAttrRange ROOT::Experimental::RNTupleAttrSetReader::LoadEntry(ROOT::NTupleSize_t index)
+{
+   auto &entry = fUserModel->GetDefaultEntry();
+   return LoadEntry(index, entry);
+}
+
+std::unique_ptr<ROOT::REntry> ROOT::Experimental::RNTupleAttrSetReader::CreateEntry()
+{
+   return fUserModel->CreateEntry();
+}

--- a/tree/ntuple/src/RNTupleAttrReading.cxx
+++ b/tree/ntuple/src/RNTupleAttrReading.cxx
@@ -9,6 +9,7 @@
 #include <ROOT/RNTupleAttrUtils.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RLogger.hxx>
 
 #include <algorithm>
 #include <cstddef>

--- a/tree/ntuple/src/RNTupleAttrReading.cxx
+++ b/tree/ntuple/src/RNTupleAttrReading.cxx
@@ -112,3 +112,93 @@ std::unique_ptr<ROOT::REntry> ROOT::Experimental::RNTupleAttrSetReader::CreateEn
 {
    return fUserModel->CreateEntry();
 }
+
+ROOT::Experimental::RNTupleAttrEntryIterable
+ROOT::Experimental::RNTupleAttrSetReader::GetAttributesContainingRange(NTupleSize_t startEntry, NTupleSize_t endEntry)
+{
+   RNTupleAttrRange range;
+   if (endEntry <= startEntry) {
+      R__LOG_WARNING(ROOT::Internal::NTupleLog())
+         << "empty range given when getting attributes from Attribute Set '" << GetDescriptor().GetName()
+         << "' (range given: [" << startEntry << ", " << endEntry << ")).";
+      // Make sure we find 0 entries
+      range = RNTupleAttrRange::FromStartLength(startEntry, 0);
+   } else {
+      range = RNTupleAttrRange::FromStartEnd(startEntry, endEntry);
+   }
+   RNTupleAttrEntryIterable::RFilter filter{range, /*fIsContained=*/false};
+   return RNTupleAttrEntryIterable{*this, filter};
+}
+
+ROOT::Experimental::RNTupleAttrEntryIterable
+ROOT::Experimental::RNTupleAttrSetReader::GetAttributesInRange(NTupleSize_t startEntry, NTupleSize_t endEntry)
+{
+   RNTupleAttrRange range;
+   if (endEntry <= startEntry) {
+      R__LOG_WARNING(ROOT::Internal::NTupleLog())
+         << "empty range given when getting attributes from Attribute Set '" << GetDescriptor().GetName()
+         << "' (range given: [" << startEntry << ", " << endEntry << ")).";
+      // Make sure we find 0 entries
+      range = RNTupleAttrRange::FromStartLength(startEntry, 0);
+   } else {
+      range = RNTupleAttrRange::FromStartEnd(startEntry, endEntry);
+   }
+   RNTupleAttrEntryIterable::RFilter filter{range, /*fIsContained=*/true};
+   return RNTupleAttrEntryIterable{*this, filter};
+}
+
+ROOT::Experimental::RNTupleAttrEntryIterable
+ROOT::Experimental::RNTupleAttrSetReader::GetAttributes(NTupleSize_t entryIndex)
+{
+   RNTupleAttrEntryIterable::RFilter filter{RNTupleAttrRange::FromStartEnd(entryIndex, entryIndex + 1),
+                                            /*fIsContained=*/false};
+   return RNTupleAttrEntryIterable{*this, filter};
+}
+
+ROOT::Experimental::RNTupleAttrEntryIterable ROOT::Experimental::RNTupleAttrSetReader::GetAttributes()
+{
+   return RNTupleAttrEntryIterable{*this};
+}
+
+//
+//  RNTupleAttrEntryIterable
+//
+bool ROOT::Experimental::RNTupleAttrEntryIterable::RIterator::FullyContained(RNTupleAttrRange range) const
+{
+   assert(fFilter);
+   if (fFilter->fIsContained) {
+      return fFilter->fRange.GetStart() <= range.GetStart() && range.GetEnd() <= fFilter->fRange.GetEnd();
+   } else {
+      return range.GetStart() <= fFilter->fRange.GetStart() && fFilter->fRange.GetEnd() <= range.GetEnd();
+   }
+}
+
+ROOT::Experimental::RNTupleAttrEntryIterable::RIterator::Iter_t
+ROOT::Experimental::RNTupleAttrEntryIterable::RIterator::SkipFiltered() const
+{
+   // If we have no filter, every entry is valid.
+   if (!fFilter)
+      return fCur;
+
+   // TODO: consider using binary search, since fEntryRanges is sorted
+   // (maybe it should be done only if the size of the list is bigger than a threshold).
+   for (auto it = fCur; it != fEnd; ++it) {
+      const auto &[range, index] = *it;
+      const auto &firstLast = range.GetFirstLast();
+      // If this is nullopt it means this is a zero-length entry: we always skip those except
+      // for the "catch-all" GetAttributes() (which is when fFilter is also nullopt).
+      if (!firstLast)
+         continue;
+
+      const auto &[first, last] = *firstLast;
+      if (first >= fFilter->fRange.GetEnd()) {
+         // Since fEntryRanges is sorted we know we are at the end of the iteration
+         // TODO: tweak fEnd to directly pass the last entry?
+         return fEnd;
+      }
+
+      if (FullyContained(RNTupleAttrRange::FromStartEnd(first, last + 1)))
+         return it;
+   }
+   return fEnd;
+}

--- a/tree/ntuple/src/RNTupleAttrWriting.cxx
+++ b/tree/ntuple/src/RNTupleAttrWriting.cxx
@@ -1,5 +1,5 @@
 /// \file RNTupleAttrWriting.cxx
-/// \ingroup NTuple ROOT7
+/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-01-27
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleAttrWriting.cxx
+++ b/tree/ntuple/src/RNTupleAttrWriting.cxx
@@ -35,12 +35,13 @@ std::size_t ROOT::Experimental::Internal::RNTupleAttrEntry::Append()
 {
    std::size_t bytesWritten = 0;
    // Write the meta entry values
-   bytesWritten += fMetaEntry.fValues[kRangeStartIndex].Append();
-   bytesWritten += fMetaEntry.fValues[kRangeLenIndex].Append();
+   bytesWritten += fMetaEntry.fValues[kMetaFieldIndex_RangeStart].Append();
+   bytesWritten += fMetaEntry.fValues[kMetaFieldIndex_RangeLen].Append();
 
    // Bind the user model's memory to the meta model's subfields
-   const auto &userFields =
-      ROOT::Internal::GetFieldZeroOfModel(fMetaModel).GetMutableSubfields()[kUserDataIndex]->GetMutableSubfields();
+   const auto &userFields = ROOT::Internal::GetFieldZeroOfModel(fMetaModel)
+                               .GetMutableSubfields()[kMetaFieldIndex_UserData]
+                               ->GetMutableSubfields();
    assert(userFields.size() == fScopedEntry.fValues.size());
    for (std::size_t i = 0; i < fScopedEntry.fValues.size(); ++i) {
       std::shared_ptr<void> userPtr = fScopedEntry.fValues[i].GetPtr<void>();
@@ -70,15 +71,16 @@ ROOT::Experimental::RNTupleAttrSetWriter::Create(const RNTupleFillContext &mainF
    // the user model and store them under the meta model's fields (see RNTupleAttrEntry::Append())
    auto metaModel = RNTupleModel::Create();
    metaModel->SetDescription(userModel->GetDescription());
-   auto rangeStartPtr = metaModel->MakeField<ROOT::NTupleSize_t>(kRangeStartName);
-   auto rangeLenPtr = metaModel->MakeField<ROOT::NTupleSize_t>(kRangeLenName);
+   auto rangeStartPtr = metaModel->MakeField<ROOT::NTupleSize_t>(kMetaFieldNames[kMetaFieldIndex_RangeStart]);
+   auto rangeLenPtr = metaModel->MakeField<ROOT::NTupleSize_t>(kMetaFieldNames[kMetaFieldIndex_RangeLen]);
    std::vector<std::unique_ptr<RFieldBase>> fields;
    const auto subfields = userModel->GetConstFieldZero().GetConstSubfields();
    fields.reserve(subfields.size());
    for (const auto *field : subfields) {
       fields.push_back(field->Clone(field->GetFieldName()));
    }
-   auto userRootField = std::make_unique<ROOT::RRecordField>(kUserDataName, std::move(fields));
+   auto userRootField =
+      std::make_unique<ROOT::RRecordField>(kMetaFieldNames[kMetaFieldIndex_UserData], std::move(fields));
    metaModel->AddField(std::move(userRootField));
 
    metaModel->Freeze();

--- a/tree/ntuple/src/RNTupleReader.cxx
+++ b/tree/ntuple/src/RNTupleReader.cxx
@@ -15,6 +15,7 @@
 
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldVisitor.hxx>
+#include <ROOT/RNTupleAttrReading.hxx>
 #include <ROOT/RNTupleImtTaskScheduler.hxx>
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleModel.hxx>
@@ -365,4 +366,21 @@ ROOT::DescriptorId_t ROOT::RNTupleReader::RetrieveFieldId(std::string_view field
                                fSource->GetSharedDescriptorGuard()->GetName() + "'"));
    }
    return fieldId;
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleAttrSetReader>
+ROOT::RNTupleReader::OpenAttributeSet(std::string_view attrSetName, const ROOT::RNTupleReadOptions &readOpts)
+{
+   auto attrSets = GetDescriptor().GetAttrSetIterable();
+   const auto it =
+      std::find_if(attrSets.begin(), attrSets.end(), [&](const auto &d) { return d.GetName() == attrSetName; });
+   if (it == attrSets.end())
+      throw ROOT::RException(R__FAIL(std::string("No such attribute set: ") + std::string(attrSetName)));
+
+   auto attrSource = fSource->OpenWithDifferentAnchor({it->GetAnchorLocator(), it->GetAnchorLength()}, readOpts);
+   auto newReader = std::unique_ptr<RNTupleReader>(new RNTupleReader(std::move(attrSource), readOpts));
+   R__ASSERT(newReader);
+   auto attrSetReader = std::unique_ptr<ROOT::Experimental::RNTupleAttrSetReader>(
+      new ROOT::Experimental::RNTupleAttrSetReader(std::move(newReader), it->GetSchemaVersionMajor()));
+   return attrSetReader;
 }

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -716,3 +716,10 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadStreamerInfo()
 {
    R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "DAOS-backed sources have no associated StreamerInfo to load.";
 }
+
+std::unique_ptr<ROOT::Internal::RPageSource>
+ROOT::Experimental::Internal::RPageSourceDaos::OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &,
+                                                                       const ROOT::RNTupleReadOptions &)
+{
+   throw ROOT::RException(R__FAIL("method not implemented"));
+}

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -364,8 +364,14 @@ ROOT::Internal::RPageSourceFile::~RPageSourceFile()
 }
 
 std::unique_ptr<ROOT::Internal::RPageSourceFile>
-ROOT::Internal::RPageSourceFile::OpenWithDifferentAnchor(const RNTuple &anchor, const ROOT::RNTupleReadOptions &options)
+ROOT::Internal::RPageSourceFile::OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
+                                                         const ROOT::RNTupleReadOptions &options)
 {
+   assert(anchorLink.fLocator.GetType() == RNTupleLocator::kTypeFile);
+
+   const auto anchorPos = anchorLink.fLocator.GetPosition<std::uint64_t>();
+   auto anchor =
+      fReader.GetNTupleProperAtOffset(anchorPos, anchorLink.fLocator.GetNBytesOnStorage(), anchorLink.fLength).Unwrap();
    auto pageSource = std::make_unique<RPageSourceFile>("", fFile->Clone(), options);
    pageSource->fAnchor = anchor;
    // NOTE: fNTupleName gets set only upon Attach().

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -363,7 +363,7 @@ ROOT::Internal::RPageSourceFile::~RPageSourceFile()
    fClusterPool.StopBackgroundThread();
 }
 
-std::unique_ptr<ROOT::Internal::RPageSourceFile>
+std::unique_ptr<ROOT::Internal::RPageSource>
 ROOT::Internal::RPageSourceFile::OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
                                                          const ROOT::RNTupleReadOptions &options)
 {

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -19,11 +19,11 @@ if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
                                      ${CMAKE_CURRENT_BINARY_DIR}/libCustomStruct.dll)
 endif()
 
-ROOT_ADD_GTEST(ntuple_attributes ntuple_attributes.cxx LIBRARIES ROOTNTuple)
+ROOT_ADD_GTEST(ntuple_attributes ntuple_attributes.cxx ntuple_test.cxx LIBRARIES ROOTNTuple xxHash::xxHash)
 ROOT_ADD_GTEST(ntuple_basics ntuple_basics.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_bulk ntuple_bulk.cxx LIBRARIES ROOTNTuple CustomStruct)
 ROOT_ADD_GTEST(ntuple_cast ntuple_cast.cxx LIBRARIES ROOTNTuple)
-ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx ntuple_test.cxx LIBRARIES ROOTNTuple)
+ROOT_ADD_GTEST(ntuple_checksum ntuple_checksum.cxx ntuple_test.cxx LIBRARIES ROOTNTuple xxHash::xxHash)
 ROOT_ADD_GTEST(ntuple_cluster ntuple_cluster.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_compat ntuple_compat.cxx RXTuple.cxx LIBRARIES ROOTNTuple xxHash::xxHash)
 ROOT_GENERATE_DICTIONARY(RXTupleDict ${CMAKE_CURRENT_SOURCE_DIR}/RXTuple.hxx
@@ -46,7 +46,7 @@ if(NOT MSVC)
 endif()
 ROOT_ADD_GTEST(ntuple_field_name ntuple_field_name.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_join_table ntuple_join_table.cxx LIBRARIES ROOTNTuple)
-ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx
+ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx ntuple_test.cxx
   LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB Tree xxHash::xxHash
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/tree/tree/inc)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple)
@@ -167,7 +167,7 @@ if(daos OR daos_mock)
     set(daos_test_pool ntuple-daos-test-pool)
   endif()
 
-  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx ntuple_test.cxx LIBRARIES ROOTNTuple MathCore CustomStruct)
+  ROOT_ADD_GTEST(ntuple_storage_daos ntuple_storage_daos.cxx ntuple_test.cxx LIBRARIES ROOTNTuple MathCore CustomStruct xxHash::xxHash)
   target_compile_definitions(ntuple_storage_daos PRIVATE R__DAOS_TEST_POOL="${daos_test_pool}")
 
   if(daos_mock)

--- a/tree/ntuple/test/ntuple_attributes.cxx
+++ b/tree/ntuple/test/ntuple_attributes.cxx
@@ -2,6 +2,14 @@
 #include <ROOT/RNTupleAttrWriting.hxx>
 #include <ROOT/RNTupleAttrReading.hxx>
 
+static std::size_t Count(ROOT::Experimental::RNTupleAttrEntryIterable iterable)
+{
+   std::size_t n = 0;
+   for ([[maybe_unused]] auto _ : iterable)
+      ++n;
+   return n;
+}
+
 TEST(RNTupleAttributes, CreateWriter)
 {
    FileRaii fileGuard("ntuple_attr_create_writer.root");
@@ -233,12 +241,120 @@ TEST(RNTupleAttributes, NoCommitRange)
    // Forgot to commit the range!
 }
 
+TEST(RNTupleAttributes, MultipleCommitRange)
+{
+   // Calling CommitRange multiple times on the same handle is an error (technically it cannot be on the "same handle"
+   // since CommitRange requires you to move the handle - meaning the second time you are passing an invalid handle.)
+
+   FileRaii fileGuard("test_ntuple_attrs_multipleend.root");
+
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   auto model = RNTupleModel::Create();
+   auto pInt = model->MakeField<int>("int");
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+   auto attrModel = RNTupleModel::Create();
+   attrModel->MakeField<std::string>("string");
+   auto attrSet = writer->CreateAttributeSet(attrModel->Clone(), "MyAttrSet");
+
+   auto &wModel = writer->GetModel();
+
+   auto attrRange = attrSet->BeginRange();
+   auto pMyAttr = attrSet->GetModel().GetDefaultEntry().GetPtr<std::string>("string");
+   *pMyAttr = "Run 1";
+   for (int i = 0; i < 100; ++i) {
+      auto entry = wModel.CreateEntry();
+      *pInt = i;
+      writer->Fill(*entry);
+   }
+   attrSet->CommitRange(std::move(attrRange));
+   try {
+      attrSet->CommitRange(std::move(attrRange));
+      FAIL() << "committing the same range twice should fail.";
+   } catch (const ROOT::RException &ex) {
+      EXPECT_THAT(ex.what(), testing::HasSubstr("was not created by it or was already committed"));
+   }
+}
+
+TEST(RNTupleAttributes, AccessPastCommitRange)
+{
+   FileRaii fileGuard("test_ntuple_attrs_pastcommitrange.root");
+
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   auto model = RNTupleModel::Create();
+   auto pInt = model->MakeField<int>("int");
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+   auto attrModel = RNTupleModel::Create();
+   auto pMyAttr = attrModel->MakeField<std::string>("string");
+   auto attrSet = writer->CreateAttributeSet(attrModel->Clone(), "MyAttrSet");
+
+   auto &wModel = writer->GetModel();
+
+   auto attrRange = attrSet->BeginRange();
+   *pMyAttr = "Run 1";
+   for (int i = 0; i < 100; ++i) {
+      auto entry = wModel.CreateEntry();
+      *pInt = i;
+      writer->Fill(*entry);
+   }
+   attrSet->CommitRange(std::move(attrRange));
+   // Cannot access attrRange after CommitRange()
+   EXPECT_THROW(attrRange.GetStart(), ROOT::RException);
+}
+
+TEST(RNTupleAttributes, NoImplicitCommitRange)
+{
+   // CommitRange doesn't get called automatically when a AttributeRangeHandle goes out of scope:
+   // forgetting to call CommitRange will cause the attribute range not to be saved.
+
+   FileRaii fileGuard("test_ntuple_attrs_auto_end_range.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModel = RNTupleModel::Create();
+      auto pMyAttr = attrModel->MakeField<std::string>("string");
+      auto attrSet = writer->CreateAttributeSet(attrModel->Clone(), "MyAttrSet");
+
+      ROOT::TestSupport::CheckDiagsRAII diags;
+      diags.requiredDiag(kWarning, "NTuple", "range was not committed", false);
+
+      [[maybe_unused]] auto attrRange = attrSet->BeginRange();
+      *pMyAttr = "Run 1";
+      for (int i = 0; i < 10; ++i) {
+         *pInt = i;
+         writer->Fill();
+      }
+
+      // Not calling CommitRange, so the attributes are not written.
+   }
+
+   // Read back the attributes
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      // Fetch a specific attribute set
+      auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+      EXPECT_EQ(Count(attrSet->GetAttributes()), 0);
+   }
+}
+
 TEST(RNTupleAttributes, MultipleSets)
 {
    // Create multiple sets and interleave attribute ranges
 
    FileRaii fileGuard("test_ntuple_attrs_multiplesets.root");
-
    ROOT::TestSupport::CheckDiagsRAII diagsRaii;
    diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
 
@@ -404,6 +520,71 @@ TEST(RNTupleAttributes, AttributeInvalidModel)
    }
 }
 
+TEST(RNTupleAttributes, InterleavingRanges)
+{
+   // Calling BeginRange multiple times without calling CommitRange in between is valid:
+   // the user gets separate AttributeEntries that they can commit at their will.
+
+   FileRaii fileGuard("test_ntuple_attrs_multiplebegin.root");
+
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto wopts = RNTupleWriteOptions();
+      wopts.SetCompression(0);
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file, wopts);
+
+      auto attrModel = RNTupleModel::Create();
+      attrModel->MakeField<int>("attrInt");
+      auto attrSet = writer->CreateAttributeSet(attrModel->Clone(), "MyAttrSet");
+
+      auto attrEntry1 = attrSet->CreateEntry();
+      auto attrRange1 = attrSet->BeginRange();
+      auto attrEntry2 = attrSet->CreateEntry();
+      auto attrRange2 = attrSet->BeginRange();
+      int i1 = 0, i2 = 0;
+      *attrEntry1->GetPtr<int>("attrInt") = i1++;
+      *attrEntry2->GetPtr<int>("attrInt") = i2++;
+      for (int i = 0; i < 30; ++i) {
+         if (i > 0 && (i % 5) == 0) {
+            attrSet->CommitRange(std::move(attrRange1), *attrEntry1);
+            attrRange1 = attrSet->BeginRange();
+            *attrEntry1->GetPtr<int>("attrInt") = i1++;
+         }
+         if (i > 0 && (i % 11) == 0) {
+            attrSet->CommitRange(std::move(attrRange2), *attrEntry2);
+            attrRange2 = attrSet->BeginRange();
+            *attrEntry2->GetPtr<int>("attrInt") = i2++;
+         }
+         *pInt = i;
+         writer->Fill();
+      }
+      attrSet->CommitRange(std::move(attrRange1), *attrEntry1);
+      attrSet->CommitRange(std::move(attrRange2), *attrEntry2);
+   }
+
+   // read back
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+   auto attrEntry = attrSet->CreateEntry();
+   for (auto i : reader->GetEntryRange()) {
+      auto attrs = attrSet->GetAttributes(i);
+      const auto nAttrs = Count(attrs);
+      EXPECT_EQ(nAttrs, 2);
+      int totVal = 0;
+      for (auto idx : attrs) {
+         attrSet->LoadEntry(idx, *attrEntry);
+         totVal += *attrEntry->GetPtr<int>("attrInt");
+      }
+      int expected = (i / 5) + (i / 11);
+      EXPECT_EQ(totVal, expected);
+   }
+}
+
 TEST(RNTupleAttributes, AttributeInvalidCommitRange)
 {
    // Same as AttributeMultipleSets but try to pass the wrong range to a Set and verify it fails.
@@ -484,4 +665,284 @@ TEST(RNTupleAttributes, ReassignPendingRange)
    attrRange = attrSet->BeginRange();
 
    diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "A pending attribute range was not committed", false);
+}
+
+TEST(RNTupleAttributes, AssignMetadataAfterData)
+{
+   // Assigning the attribute range's value to the pointer can be done either before or after filling
+   // the corresponding rows - provided it's done between a BeginRange() and an CommitRange().
+
+   FileRaii fileGuard("test_ntuple_attrs_assign_after.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModel = RNTupleModel::Create();
+      auto pAttrString = attrModel->MakeField<std::string>("string");
+      auto pAttrInt = attrModel->MakeField<int>("int");
+      auto attrSet = writer->CreateAttributeSet(std::move(attrModel), "MyAttrSet");
+
+      // First attribute entry
+      {
+         auto attrRange = attrSet->BeginRange();
+         *pAttrString = "Run 1";
+         *pAttrInt = 1;
+         for (int i = 0; i < 10; ++i) {
+            *pInt = i;
+            writer->Fill();
+         }
+         attrSet->CommitRange(std::move(attrRange));
+      }
+
+      // Second attribute entry
+      {
+         auto attrRange = attrSet->BeginRange();
+         for (int i = 0; i < 10; ++i) {
+            *pInt = i;
+            writer->Fill();
+         }
+         *pAttrString = "Run 2";
+         *pAttrInt = 2;
+         attrSet->CommitRange(std::move(attrRange));
+      }
+   }
+
+   // Read back the attributes
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      // Fetch a specific attribute set
+      auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+      auto nAttrs = 0;
+      auto attrEntry = attrSet->CreateEntry();
+      for (const auto idx : attrSet->GetAttributes()) {
+         const auto range = attrSet->LoadEntry(idx, *attrEntry);
+         auto pAttrStr = attrEntry->GetPtr<std::string>("string");
+         auto pAttrInt = attrEntry->GetPtr<int>("int");
+         EXPECT_EQ(range.GetStart(), nAttrs * 10);
+         EXPECT_EQ(range.GetEnd(), (1 + nAttrs) * 10);
+         EXPECT_EQ(*pAttrStr, nAttrs == 0 ? "Run 1" : "Run 2");
+         EXPECT_EQ(*pAttrInt, nAttrs == 0 ? 1 : 2);
+         ++nAttrs;
+      }
+      EXPECT_EQ(nAttrs, 2);
+   }
+}
+
+TEST(RNTupleAttributes, ReadRanges)
+{
+   // Testing reading attribute ranges with a [startIdx, endIdx].
+
+   FileRaii fileGuard("test_ntuple_attrs_readranges.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModelRuns = RNTupleModel::Create();
+      auto pRun = attrModelRuns->MakeField<std::string>("run");
+      auto attrSetRuns = writer->CreateAttributeSet(std::move(attrModelRuns), "Attr_Runs");
+      auto attrModelEpochs = RNTupleModel::Create();
+      auto pEpoch = attrModelEpochs->MakeField<std::string>("epoch");
+      auto attrSetEpochs = writer->CreateAttributeSet(std::move(attrModelEpochs), "Attr_Epochs");
+
+      {
+         auto attrRangeEpoch = attrSetEpochs->BeginRange();
+         *pEpoch = "Epoch 1";
+
+         {
+            auto attrRange = attrSetRuns->BeginRange();
+            *pRun = "Run 1";
+            for (int i = 0; i < 10; ++i) {
+               *pInt = i;
+               writer->Fill();
+            }
+            attrSetRuns->CommitRange(std::move(attrRange));
+         }
+
+         // Second attribute entry
+         {
+            auto attrRange = attrSetRuns->BeginRange();
+            for (int i = 0; i < 10; ++i) {
+               *pInt = i;
+               writer->Fill();
+            }
+            *pRun = "Run 2";
+            attrSetRuns->CommitRange(std::move(attrRange));
+         }
+         attrSetEpochs->CommitRange(std::move(attrRangeEpoch));
+      }
+      {
+         auto attrRangeEpoch = attrSetEpochs->BeginRange();
+         *pEpoch = "Epoch 2";
+
+         {
+            auto attrRange = attrSetRuns->BeginRange();
+            *pRun = "Run 3";
+            for (int i = 0; i < 10; ++i) {
+               *pInt = i;
+               writer->Fill();
+            }
+            attrSetRuns->CommitRange(std::move(attrRange));
+         }
+         attrSetEpochs->CommitRange(std::move(attrRangeEpoch));
+      }
+   }
+
+   // Read back the attributes
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+      // Fetch a specific attribute set
+      auto attrSetRuns = reader->OpenAttributeSet("Attr_Runs");
+      EXPECT_EQ(Count(attrSetRuns->GetAttributes()), 3);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributes(4)), 1);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(4, 5)), 1);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(0, 10)), 1);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(0, 11)), 0);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(0, 100)), 0);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesInRange(4, 5)), 0);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributesInRange(0, 100)), 3);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributes(12)), 1);
+      EXPECT_EQ(Count(attrSetRuns->GetAttributes(120)), 0);
+
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSetRuns->GetAttributesInRange(4, 3)), 0), "ROOT.NTuple",
+                                  "empty range");
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(4, 3)), 0), "ROOT.NTuple",
+                                  "empty range");
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSetRuns->GetAttributesInRange(4, 4)), 0), "ROOT.NTuple",
+                                  "empty range");
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSetRuns->GetAttributesContainingRange(4, 4)), 0), "ROOT.NTuple",
+                                  "empty range");
+
+      auto attrSetEpochs = reader->OpenAttributeSet("Attr_Epochs");
+      EXPECT_EQ(Count(attrSetEpochs->GetAttributes()), 2);
+   }
+}
+
+TEST(RNTupleAttributes, EmptyAttrRange)
+{
+   FileRaii fileGuard("test_ntuple_attrs_empty.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModel = RNTupleModel::Create();
+      auto pAttr = attrModel->MakeField<std::string>("myAttr");
+      auto attrSet = writer->CreateAttributeSet(std::move(attrModel), "MyAttrSet");
+
+      auto attrRange = attrSet->BeginRange();
+      *pAttr = "This is range is empty.";
+      // No values written to the main RNTuple...
+      attrSet->CommitRange(std::move(attrRange));
+   }
+
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+      // Read back the list of available attribute sets
+      auto attrSets = reader->GetDescriptor().GetAttrSetIterable();
+      int n = 0;
+      for (const auto &attrSet : attrSets) {
+         ++n;
+         EXPECT_EQ(attrSet.GetName(), "MyAttrSet");
+      }
+      EXPECT_EQ(n, 1);
+
+      // Fetch a specific attribute set
+      auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+      EXPECT_EQ(Count(attrSet->GetAttributes()), 1);
+      EXPECT_EQ(Count(attrSet->GetAttributes(0)), 0);
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSet->GetAttributesInRange(0, reader->GetNEntries())), 0),
+                                  "ROOT.NTuple", "empty range");
+      ROOT_EXPECT_WARNING_PARTIAL(EXPECT_EQ(Count(attrSet->GetAttributesContainingRange(0, reader->GetNEntries())), 0),
+                                  "ROOT.NTuple", "empty range");
+   }
+}
+
+TEST(RNTupleAttributes, AccessAttrSetReaderAfterClosingMainReader)
+{
+   FileRaii fileGuard("test_ntuple_attrs_readerafterclosing.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModel = RNTupleModel::Create();
+      auto pAttr = attrModel->MakeField<std::string>("myAttr");
+      auto attrSet = writer->CreateAttributeSet(std::move(attrModel), "MyAttrSet");
+
+      auto attrRange = attrSet->BeginRange();
+      *pAttr = "This is an attribute";
+
+      for (int i = 0; i < 10; ++i) {
+         *pInt = i;
+         writer->Fill();
+      }
+      attrSet->CommitRange(std::move(attrRange));
+   }
+
+   {
+      auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+      // Fetch an attribute set
+      auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+
+      const auto nEntries = reader->GetNEntries();
+
+      // Close the main reader
+      reader.reset();
+
+      // Access the attribute set reader
+      EXPECT_EQ(Count(attrSet->GetAttributes()), 1);
+      EXPECT_EQ(Count(attrSet->GetAttributes(0)), 1);
+      EXPECT_EQ(Count(attrSet->GetAttributesInRange(0, nEntries)), 1);
+      EXPECT_EQ(Count(attrSet->GetAttributesContainingRange(0, nEntries)), 1);
+   }
+}
+
+TEST(RNTupleAttributes, AccessAttrSetWriterAfterClosingMainWriter)
+{
+   FileRaii fileGuard("test_ntuple_attrs_writerafterclosing.root");
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   {
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto writer = RNTupleWriter::Append(std::move(model), "ntpl", *file);
+
+      auto attrModel = RNTupleModel::Create();
+      auto pMyAttr = attrModel->MakeField<std::string>("myAttr");
+      auto attrSet = writer->CreateAttributeSet(std::move(attrModel), "MyAttrSet");
+
+      diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "range was not committed", false);
+
+      auto attrEntry = attrSet->BeginRange();
+
+      *pMyAttr = "This is an attribute";
+      for (int i = 0; i < 10; ++i) {
+         *pInt = i;
+         writer->Fill();
+      }
+      writer.reset();
+      EXPECT_THROW(attrSet->CommitRange(std::move(attrEntry)), ROOT::RException);
+   }
 }

--- a/tree/ntuple/test/ntuple_attributes.cxx
+++ b/tree/ntuple/test/ntuple_attributes.cxx
@@ -1,5 +1,6 @@
 #include "ntuple_test.hxx"
 #include <ROOT/RNTupleAttrWriting.hxx>
+#include <ROOT/RNTupleAttrReading.hxx>
 
 TEST(RNTupleAttributes, CreateWriter)
 {
@@ -63,33 +64,36 @@ TEST(RNTupleAttributes, AttributeSetDuplicateName)
    }
 }
 
-TEST(RNTupleAttributes, BasicWriting)
+TEST(RNTupleAttributes, BasicReadingWriting)
 {
-   FileRaii fileGuard("ntuple_attr_basic_writing.root");
+   FileRaii fileGuard("ntuple_attr_basic_readwriting.root");
 
    ROOT::TestSupport::CheckDiagsRAII diagsRaii;
    diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
 
-   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
-   auto model = RNTupleModel::Create();
-   auto pInt = model->MakeField<int>("int");
-   auto writer = RNTupleWriter::Append(std::move(model), "ntuple", *file);
+   /// Writing
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto model = RNTupleModel::Create();
+      auto pInt = model->MakeField<int>("int");
+      auto writer = RNTupleWriter::Append(std::move(model), "ntuple", *file);
 
-   auto attrModel = RNTupleModel::Create();
-   auto pAttr = attrModel->MakeField<std::string>("attr");
-   auto attrSetWriter = writer->CreateAttributeSet(std::move(attrModel), "AttrSet1");
+      auto attrModel = RNTupleModel::Create();
+      auto pAttr = attrModel->MakeField<std::string>("attr");
+      auto attrSetWriter = writer->CreateAttributeSet(std::move(attrModel), "AttrSet1");
 
-   auto attrRange = attrSetWriter->BeginRange();
-   *pAttr = "My Attribute";
-   for (int i = 0; i < 100; ++i) {
-      *pInt = i;
-      writer->Fill();
+      auto attrRange = attrSetWriter->BeginRange();
+      *pAttr = "My Attribute";
+      for (int i = 0; i < 100; ++i) {
+         *pInt = i;
+         writer->Fill();
+      }
+      attrSetWriter->CommitRange(std::move(attrRange));
+      writer.reset();
+
+      // Cannot create new ranges after closing the main writer
+      EXPECT_THROW((attrRange = attrSetWriter->BeginRange()), ROOT::RException);
    }
-   attrSetWriter->CommitRange(std::move(attrRange));
-   writer.reset();
-
-   // Cannot create new ranges after closing the main writer
-   EXPECT_THROW((attrRange = attrSetWriter->BeginRange()), ROOT::RException);
 
    // Cannot directly fetch the attribute RNTuple from the TFile
    {
@@ -147,6 +151,9 @@ TEST(RNTupleAttributes, BasicWritingWithExplicitEntry)
    for (const auto &attrSetIt : reader->GetDescriptor().GetAttrSetIterable()) {
       EXPECT_EQ(attrSetIt.GetName(), "AttrSet1");
    }
+
+   auto attrSetReader = reader->OpenAttributeSet("AttrSet1");
+   EXPECT_EQ(attrSetReader->GetNEntries(), 1);
 }
 
 TEST(RNTupleAttributes, NoCommitRange)
@@ -185,6 +192,7 @@ TEST(RNTupleAttributes, MultipleSets)
    ROOT::TestSupport::CheckDiagsRAII diagsRaii;
    diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
 
+   /// Writing
    {
       auto model = RNTupleModel::Create();
       auto pInt = model->MakeField<int>("int");
@@ -213,6 +221,7 @@ TEST(RNTupleAttributes, MultipleSets)
       attrSet2->CommitRange(std::move(attrRange2));
    }
 
+   /// Reading
    auto tfile = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
    auto ntpl = tfile->Get<ROOT::RNTuple>("ntpl");
    auto reader = RNTupleReader::Open(*ntpl);
@@ -222,6 +231,16 @@ TEST(RNTupleAttributes, MultipleSets)
       EXPECT_EQ(attrSetIt.GetName(), "MyAttrSet" + std::to_string(n));
       ++n;
    }
+
+   auto sets = reader->GetDescriptor().GetAttrSetIterable();
+   // NOTE: there is no guaranteed order in which the attribute sets appear in the iterable
+   EXPECT_NE(std::find_if(sets.begin(), sets.end(), [](auto &&s) { return s.GetName() == "MyAttrSet1"; }), sets.end());
+   EXPECT_NE(std::find_if(sets.begin(), sets.end(), [](auto &&s) { return s.GetName() == "MyAttrSet2"; }), sets.end());
+
+   auto attrSetReader1 = reader->OpenAttributeSet("MyAttrSet1");
+   EXPECT_EQ(attrSetReader1->GetNEntries(), 100);
+   auto attrSetReader2 = reader->OpenAttributeSet("MyAttrSet2");
+   EXPECT_EQ(attrSetReader2->GetNEntries(), 1);
 
    // Verify compression
    auto tkeys = tfile->WalkTKeys();

--- a/tree/ntuple/test/ntuple_attributes.cxx
+++ b/tree/ntuple/test/ntuple_attributes.cxx
@@ -102,10 +102,60 @@ TEST(RNTupleAttributes, BasicReadingWriting)
       EXPECT_EQ(ntuple, nullptr);
    }
 
+   /// Reading
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(reader->GetDescriptor().GetNAttributeSets(), 1);
    for (const auto &attrSetIt : reader->GetDescriptor().GetAttrSetIterable()) {
       EXPECT_EQ(attrSetIt.GetName(), "AttrSet1");
+   }
+
+   auto attrSetReader = reader->OpenAttributeSet("AttrSet1");
+   EXPECT_EQ(attrSetReader->GetNEntries(), 1);
+   auto pAttr = attrSetReader->GetModel().GetDefaultEntry().GetPtr<std::string>("attr");
+   {
+      int nAttrs = 0;
+      // iterate all attributes
+      for (auto idx : attrSetReader->GetAttributes()) {
+         attrSetReader->LoadEntry(idx);
+         EXPECT_EQ(*pAttr, "My Attribute");
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 1);
+   }
+   {
+      int nAttrs = 0;
+      // attributes containing entry 99
+      for (auto idx : attrSetReader->GetAttributes(99)) {
+         attrSetReader->LoadEntry(idx);
+         EXPECT_EQ(*pAttr, "My Attribute");
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 1);
+   }
+   {
+      // attributes containing entry 100 (no entry)
+      auto iter = attrSetReader->GetAttributes(100);
+      EXPECT_EQ(iter.begin(), iter.end());
+   }
+   {
+      // attributes contained in entry range 50-200 (no entry)
+      auto iter = attrSetReader->GetAttributesInRange(50, 200);
+      EXPECT_EQ(iter.begin(), iter.end());
+   }
+   {
+      int nAttrs = 0;
+      // attributes contained in entry range 0-1000
+      for (auto idx : attrSetReader->GetAttributesInRange(0, 1000)) {
+         attrSetReader->LoadEntry(idx);
+         EXPECT_EQ(*pAttr, "My Attribute");
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 1);
+   }
+   {
+      // attributes containing entry range 200-300 (no entry)
+      auto iter = attrSetReader->GetAttributesContainingRange(200, 300);
+      EXPECT_EQ(iter.begin(), iter.end());
    }
 }
 
@@ -201,13 +251,13 @@ TEST(RNTupleAttributes, MultipleSets)
 
       auto attrModel1 = RNTupleModel::Create();
       auto pInt1 = attrModel1->MakeField<int>("int");
-      auto attrSet1 = writer->CreateAttributeSet(attrModel1->Clone(), "MyAttrSet1");
+      auto attrSet1 = writer->CreateAttributeSet(std::move(attrModel1), "MyAttrSet1");
 
       auto attrModel2 = RNTupleModel::Create();
       auto pString2 = attrModel2->MakeField<std::string>("string");
       auto attrOpts2 = ROOT::RNTupleWriteOptions();
       attrOpts2.SetCompression(404);
-      auto attrSet2 = writer->CreateAttributeSet(attrModel2->Clone(), "MyAttrSet2", &attrOpts2);
+      auto attrSet2 = writer->CreateAttributeSet(std::move(attrModel2), "MyAttrSet2", &attrOpts2);
 
       auto attrRange2 = attrSet2->BeginRange();
       for (int i = 0; i < 100; ++i) {
@@ -265,6 +315,56 @@ TEST(RNTupleAttributes, MultipleSets)
 
       if (++nHeader == 3)
          break;
+   }
+
+   // check attribute ranges
+   auto attrEntry1 = attrSetReader1->CreateEntry();
+   auto pAttrInt = attrEntry1->GetPtr<int>("int");
+   auto attrEntry2 = attrSetReader2->CreateEntry();
+   auto pAttrString = attrEntry2->GetPtr<std::string>("string");
+   {
+      int nAttrs = 0;
+      for (auto idx : attrSetReader1->GetAttributesInRange(0, 1000)) {
+         auto range = attrSetReader1->LoadEntry(idx, *attrEntry1);
+         EXPECT_EQ(*pAttrInt, idx);
+         EXPECT_EQ(range.GetStart(), idx);
+         EXPECT_EQ(range.GetLength(), 1);
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 100);
+   }
+   {
+      int nAttrs = 0;
+      for (auto idx : attrSetReader1->GetAttributes(42)) {
+         auto range = attrSetReader1->LoadEntry(idx, *attrEntry1);
+         EXPECT_EQ(*pAttrInt, 42);
+         EXPECT_EQ(range.GetStart(), 42);
+         EXPECT_EQ(range.GetLength(), 1);
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 1);
+   }
+   {
+      int nAttrs = 0;
+      for (auto idx : attrSetReader2->GetAttributes()) {
+         auto range = attrSetReader2->LoadEntry(idx, *attrEntry2);
+         EXPECT_EQ(*pAttrString, "Run 1");
+         EXPECT_EQ(range.GetStart(), 0);
+         EXPECT_EQ(range.GetLength(), 100);
+         nAttrs += 1;
+      }
+      EXPECT_EQ(nAttrs, 1);
+   }
+   {
+      for (auto idx : attrSetReader2->GetAttributes()) {
+         // Reading into the wrong entry
+         try {
+            attrSetReader2->LoadEntry(idx, *attrEntry1);
+            FAIL() << "reading into an unrelated entry should fail";
+         } catch (const ROOT::RException &ex) {
+            EXPECT_THAT(ex.what(), testing::HasSubstr("mismatch between entry and model"));
+         }
+      }
    }
 }
 

--- a/tree/ntuple/test/ntuple_attributes.cxx
+++ b/tree/ntuple/test/ntuple_attributes.cxx
@@ -1,6 +1,7 @@
 #include "ntuple_test.hxx"
 #include <ROOT/RNTupleAttrWriting.hxx>
 #include <ROOT/RNTupleAttrReading.hxx>
+#include <TKey.h>
 
 static std::size_t Count(ROOT::Experimental::RNTupleAttrEntryIterable iterable)
 {
@@ -945,4 +946,99 @@ TEST(RNTupleAttributes, AccessAttrSetWriterAfterClosingMainWriter)
       writer.reset();
       EXPECT_THROW(attrSet->CommitRange(std::move(attrEntry)), ROOT::RException);
    }
+}
+
+TEST(RNTupleAttributes, ReadAttributesUnknownMajor)
+{
+   // Try reading an attribute set with an unknown Major schema version and verify it fails.
+   FileRaii fileGuard("test_ntuple_attrs_futuremajorschema.root");
+
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   // Write a regular RNTuple with attributes
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto writer = RNTupleWriter::Append(RNTupleModel::Create(), "ntpl", *file, opts);
+      auto attrSet = writer->CreateAttributeSet(RNTupleModel::Create(), "MyAttrSet");
+
+      auto attrRange = attrSet->BeginRange();
+      for (int i = 0; i < 10; ++i) {
+         writer->Fill();
+      }
+      attrSet->CommitRange(std::move(attrRange));
+   }
+
+   // Get metadata about the main footer that we're gonna patch.
+   std::uint64_t footerSeek = 0, footerNBytes = 0;
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
+      const ROOT::RNTuple *mainAnchor = file->Get<ROOT::RNTuple>("ntpl");
+      ASSERT_NE(mainAnchor, nullptr);
+
+      footerSeek = mainAnchor->GetSeekFooter();
+      footerNBytes = mainAnchor->GetNBytesFooter() - 8;
+   }
+
+   // Patch the attribute schema version (and update the footer checksum)
+   const std::uint64_t majorOff = 0xA0;
+   const std::byte newMajorVersion{0x99};
+   PatchRNTupleSection(fileGuard.GetPath(), footerSeek, footerNBytes, majorOff, &newMajorVersion,
+                       sizeof(newMajorVersion), EEndianness::LE);
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   // Fetch an attribute set
+   try {
+      auto attrSet = reader->OpenAttributeSet("MyAttrSet");
+      FAIL() << "opening an attribute set with an unknown major version should fail.";
+   } catch (const ROOT::RException &ex) {
+      EXPECT_THAT(ex.what(), testing::HasSubstr("unsupported attribute schema version"));
+   }
+}
+
+TEST(RNTupleAttributes, ReadAttributesUnknownMinor)
+{
+   // Try reading an attribute set with an unknown Minor schema version and verify it works.
+   FileRaii fileGuard("test_ntuple_attrs_futureminorschema.root");
+
+   ROOT::TestSupport::CheckDiagsRAII diagsRaii;
+   diagsRaii.requiredDiag(kWarning, "ROOT.NTuple", "RNTuple Attributes are experimental", false);
+
+   // Write a regular RNTuple with attributes
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto opts = RNTupleWriteOptions();
+      opts.SetCompression(0);
+      auto writer = RNTupleWriter::Append(RNTupleModel::Create(), "ntpl", *file, opts);
+      auto attrSet = writer->CreateAttributeSet(RNTupleModel::Create(), "MyAttrSet");
+
+      auto attrRange = attrSet->BeginRange();
+      for (int i = 0; i < 10; ++i) {
+         writer->Fill();
+      }
+      attrSet->CommitRange(std::move(attrRange));
+   }
+
+   // Get metadata about the main footer that we're gonna patch.
+   std::uint64_t footerSeek = 0, footerNBytes = 0;
+   {
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
+      const ROOT::RNTuple *mainAnchor = file->Get<ROOT::RNTuple>("ntpl");
+      ASSERT_NE(mainAnchor, nullptr);
+
+      footerSeek = mainAnchor->GetSeekFooter();
+      footerNBytes = mainAnchor->GetNBytesFooter() - 8;
+   }
+
+   // Patch the attribute schema version (and update the footer checksum)
+   const std::uint64_t majorOff = 0xA2;
+   const std::byte newMinorVersion{0x99};
+   PatchRNTupleSection(fileGuard.GetPath(), footerSeek, footerNBytes, majorOff, &newMinorVersion,
+                       sizeof(newMinorVersion), EEndianness::LE);
+
+   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_NO_THROW(reader->OpenAttributeSet("MyAttrSet"));
 }

--- a/tree/ntuple/test/ntuple_cluster.cxx
+++ b/tree/ntuple/test/ntuple_cluster.cxx
@@ -43,6 +43,11 @@ protected:
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
+   std::unique_ptr<ROOT::Internal::RPageSource>
+   OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final
+   {
+      throw ROOT::RException(R__FAIL("method not implemented"));
+   }
 
 public:
    /// Records the cluster IDs requests by LoadClusters() calls

--- a/tree/ntuple/test/ntuple_endian.cxx
+++ b/tree/ntuple/test/ntuple_endian.cxx
@@ -96,6 +96,12 @@ protected:
    RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
 
+   std::unique_ptr<ROOT::Internal::RPageSource>
+   OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final
+   {
+      throw ROOT::RException(R__FAIL("method not implemented"));
+   }
+
 public:
    RPageSourceMock(const std::vector<RPageStorage::RSealedPage> &pages, const RColumnElementBase &elt)
       : RPageSource("test", ROOT::RNTupleReadOptions()), fElement(elt), fPages(pages)

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -3984,33 +3984,12 @@ TEST(RNTupleMerger, MergeNewerVersion)
    }
 
    // Patch the anchor version (and update its checksum)
-   {
-      auto file = fopen(fileGuard.GetPath().c_str(), "r+b");
-      // change the major version to 0x99
-      fseek(file, anchorSeek + 9, SEEK_SET);
-      fputc(0x99, file);
-
-      // NOTE: skipping the first 6 bytes (nbytes and class version) for checksum calculation
-      anchorSeek += 6;
-      anchorNbytes -= 6;
-      fseek(file, anchorSeek, SEEK_SET);
-
-      // recompute checksum
-      auto buf = MakeUninitArray<std::byte>(anchorNbytes);
-      auto read = fread(buf.get(), 1, anchorNbytes, file);
-      ASSERT_EQ(read, anchorNbytes);
-      std::uint64_t checksum = XXH3_64bits(buf.get(), anchorNbytes);
-#if !IS_BIG_ENDIAN
-      // checksum needs to be stored in little endian. We byteswap here if we're in LE because fwrite will write
-      // this bytes effectively in "big endian".
-      checksum = RByteSwap<8>::bswap(checksum);
-#endif
-      // NOTE: we need to seek here to guarantee that the writing operation following the previous read will succeed
-      // (see "File access flags" here https://en.cppreference.com/w/c/io/fopen).
-      fseek(file, anchorSeek + anchorNbytes, SEEK_SET);
-      fwrite(&checksum, 1, sizeof(checksum), file);
-      fclose(file);
-   }
+   const std::byte newMajorVersion{0x99};
+   // NOTE: skipping the first 6 bytes (nbytes and class version) for checksum calculation
+   anchorSeek += 6;
+   anchorNbytes -= 6;
+   PatchRNTupleSection(fileGuard.GetPath(), anchorSeek, anchorNbytes, 3, &newMajorVersion, sizeof(newMajorVersion),
+                       EEndianness::BE);
 
    // Merge
    FileRaii fileGuardOut("test_ntuple_merge_newer_version_out.root");

--- a/tree/ntuple/test/ntuple_pages.cxx
+++ b/tree/ntuple/test/ntuple_pages.cxx
@@ -13,6 +13,11 @@ protected:
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
+   std::unique_ptr<ROOT::Internal::RPageSource>
+   OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final
+   {
+      throw ROOT::RException(R__FAIL("method not implemented"));
+   }
 
 public:
    RPageSourceMock() : RPageSource("test", RNTupleReadOptions()) {}

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1,4 +1,5 @@
 #include "ntuple_test.hxx"
+#include <TKey.h>
 #include <TRandom3.h>
 #include <TMemFile.h>
 #include <TVirtualStreamerInfo.h>
@@ -1187,9 +1188,14 @@ TEST(RPageSourceFile, OpenDifferentAnchor)
       EXPECT_NE(desc->FindFieldId("f"), ROOT::kInvalidDescriptorId);
    }
 
+   TKey *anchor2Key = file->GetKey("ntpl2");
+   ROOT::RNTupleLocator anchorLoc;
+   anchorLoc.SetPosition(anchor2Key->GetSeekKey() + anchor2Key->GetKeylen());
+   anchorLoc.SetNBytesOnStorage(anchor2Key->GetNbytes() - anchor2Key->GetKeylen());
+   ROOT::Internal::RNTupleLink anchorLink{anchorLoc, static_cast<std::uint32_t>(anchor2Key->GetObjlen())};
    auto anchor2 = file->Get<ROOT::RNTuple>("ntpl2");
    ASSERT_NE(anchor2, nullptr);
-   auto source2 = source->OpenWithDifferentAnchor(*anchor2);
+   auto source2 = source->OpenWithDifferentAnchor(anchorLink);
    source2->Attach();
    EXPECT_EQ(source2->GetNTupleName(), "ntpl2");
    EXPECT_EQ(source2->GetNEntries(), 20);

--- a/tree/ntuple/test/ntuple_test.cxx
+++ b/tree/ntuple/test/ntuple_test.cxx
@@ -1,6 +1,20 @@
 #include "ntuple_test.hxx"
 
+#include <ROOT/RConfig.hxx>
+#ifndef R__BYTESWAP
+#define IS_BIG_ENDIAN 1
+#else
+#define IS_BIG_ENDIAN 0
+#endif
+
+#if IS_BIG_ENDIAN
+#include <Byteswap.h>
+#endif
+
+#include <xxhash.h>
+
 #include <cstring> // for memset
+#include <cstdio>
 
 void CreateCorruptedRNTuple(const std::string &uri)
 {
@@ -63,4 +77,37 @@ void CreateCorruptedRNTuple(const std::string &uri)
    pageSink->CommitClusterGroup();
    pageSink->CommitDataset();
    modelClone.reset();
+}
+
+void PatchRNTupleSection(std::string_view filePath, std::uint64_t sectionSeek, std::uint64_t sectionLen,
+                         std::uint64_t patchedOffsetIntoSection, const std::byte *bytesToWrite,
+                         std::size_t bytesToWriteLen, EEndianness sectionEndianness)
+{
+   // sanity check
+   R__ASSERT(sectionLen > 6);
+   R__ASSERT(patchedOffsetIntoSection + bytesToWriteLen <= sectionLen);
+
+   FILE *file = fopen(std::string(filePath).c_str(), "r+b");
+
+   fseek(file, sectionSeek + patchedOffsetIntoSection, SEEK_SET);
+   std::size_t written = fwrite(bytesToWrite, 1, bytesToWriteLen, file);
+   R__ASSERT(written == bytesToWriteLen);
+
+   int err = fseek(file, sectionSeek, SEEK_SET);
+   R__ASSERT(!err);
+
+   // recompute checksum
+   auto buf = MakeUninitArray<std::byte>(sectionLen);
+   auto read = fread(buf.get(), 1, sectionLen, file);
+   R__ASSERT(read == sectionLen);
+
+   std::uint64_t checksum = XXH3_64bits(buf.get(), sectionLen);
+   if ((sectionEndianness == EEndianness::BE) != IS_BIG_ENDIAN) {
+      checksum = RByteSwap<8>::bswap(checksum);
+   }
+   // NOTE: we need to seek here to guarantee that the writing operation following the previous read will succeed
+   // (see "File access flags" here https://en.cppreference.com/w/c/io/fopen).
+   fseek(file, sectionSeek + sectionLen, SEEK_SET);
+   fwrite(&checksum, 1, sizeof(checksum), file);
+   fclose(file);
 }

--- a/tree/ntuple/test/ntuple_test.hxx
+++ b/tree/ntuple/test/ntuple_test.hxx
@@ -129,4 +129,23 @@ struct IMTRAII {
 /// The function is backend agnostic (file, DAOS, ...).
 void CreateCorruptedRNTuple(const std::string &uri);
 
+enum class EEndianness {
+   LE,
+   BE
+};
+
+/// Given the file at `filePath` containing an UNCOMPRESSED RNTuple, and given the seek/len of a section of this
+/// RNTuple, patches a byte range of this section with the given buffer `bytesToWrite`. After doing this, it recomputes
+/// and updates the section's checksum.
+/// `sectionSeek` must point to the start of the section's payload, excluding the key (and, in case of the Anchor, the
+/// first 6 bytes containing the object's version and nbytes).
+/// `sectionLen` must refer to the in-memory of the section's payload, excluding the key and the checksum.
+/// Note that this is assumed to be equal to the on-disk size since the section must be uncompressed.
+///
+/// This function does very minimal checks (e.g. it does not verify that the given section is actually correct or in
+/// the file at all), so the caller must validate these assumptions.
+void PatchRNTupleSection(std::string_view filePath, std::uint64_t sectionSeek, std::uint64_t sectionLen,
+                         std::uint64_t patchedOffsetIntoSection, const std::byte *bytesToWrite,
+                         std::size_t bytesToWriteLen, EEndianness sectionEndianness);
+
 #endif


### PR DESCRIPTION
Adds support for RNTuple attribute reading in the form of the `ROOT::Experimental::RNTupleAttrSetReader` class plus some ancillary classes.

Main features added:
* `RNTupleReader::OpenAttributeSet` -> returns an RNTupleAttrSetReader for a specific attribute set
* `RNTupleAttrSetReader::GetAttributes*` -> various methods that return iterables over attribute entry indices
* `RNTupleAttrSetReader::LoadEntry(index[, entry])` -> loads `index`-th attribute entry (similar to `RNTupleReader::LoadEntry`). Meant to be used with `RNTupleAttrSetReader::GetAttributes*` 

See the tests for basic usage, e.g. `BasicReadingWriting` in `ntuple_attributes.cxx`