### PR TITLE
[PyROOT] Implement Python `gDirectory` adapter to restore lazy semantics

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -43,6 +43,86 @@ class _gROOTWrapper(object):
         return setattr(self._gROOT, name, value)
 
 
+class TDirectoryPythonAdapter:
+    """Class analogous to the `ROOT::Internal::TDirectoryAtomicAdapter` on the
+    C++ side, implementing the semantics that is expected from a
+    `TDirectory *&` to the global directory (which is what gDirectory was
+    originally), but in a thread-safe way.
+
+    On the C++ side the following trick is used in TDirectory.h to achieve this
+    We're re-implementing the expected semantics in Python, because the way how
+    it is implemented in C++ is too contrived for it to get Pythonized
+    automatically:
+
+    ```C++
+    #define gDirectory (::ROOT::Internal::TDirectoryAtomicAdapter{})
+    ```
+
+    So in C++, gDirectory is an adapter object that lazily converts to current
+    TDirectory when you use it. It's implemented as as a preprocessor macro,
+    which is then pretending to be a `TDirectory *` to the ROOT reflection system
+    in TROOT.cxx:
+
+    ```C++
+    TGlobalMappedFunction::MakeFunctor("gDirectory", "TDirectory*", TDirectory::CurrentDirectory);
+    ```
+
+    This is quite hacky, and it is ambiguous to the the dynamic Python bindings
+    layer at which point the implicit conversion to the current directory
+    pointer should happen.
+
+    For this reason, it's better to re-implement a specific adapter for Python,
+    which skips all of that.
+
+    Note: the C++ adapter also implements an assignment operator (operator=),
+    but since this concept doesn't exist in Python outside data member
+    re-assignment, it is not implemented here.
+    """
+
+    def _current_directory(self):
+        import ROOT
+
+        return ROOT.TDirectory.CurrentDirectory().load()
+
+    def __getattr__(self, name):
+        return getattr(self._current_directory(), name)
+
+    def __str__(self):
+        return str(self._current_directory())
+
+    def __repr__(self):
+        return repr(self._current_directory())
+
+    def __eq__(self, other):
+        import ROOT
+
+        if other is self:
+            return True
+        cd = self._current_directory()
+        if cd == ROOT.nullptr:
+            return other == ROOT.nullptr
+        return cd.IsEqual(other)
+
+    def __ne__(self, other):
+        import ROOT
+
+        if other is self:
+            return False
+        cd = self._current_directory()
+        if cd == ROOT.nullptr:
+            return other != ROOT.nullptr
+        return not cd.IsEqual(other)
+
+    def __bool__(self):
+        import ROOT
+
+        return self._current_directory() != ROOT.nullptr
+
+    def __cast_cpp__(self):
+        """Casting to TDirectory for use in C++ functions."""
+        return self._current_directory()
+
+
 def _subimport(name):
     # type: (str) -> types.ModuleType
     """
@@ -70,6 +150,10 @@ class ROOTFacade(types.ModuleType):
 
         # Inject gROOT global
         self.gROOT = _gROOTWrapper(self)
+
+        # Inject the gDirectory adapter, mimicking the behavior of the
+        # gDirectory preprocessor macro on the C++ side
+        self.gDirectory = TDirectoryPythonAdapter()
 
         # Initialize configuration
         self.PyConfig = PyROOTConfiguration()
@@ -208,7 +292,7 @@ class ROOTFacade(types.ModuleType):
         if not self.gROOT.IsBatch() and self.PyConfig.StartGUIThread:
             self.app.init_graphics(self._cppyy.gbl.gEnv, self._cppyy.gbl.gSystem)
 
-        # The automatic conversion of ordinary obejcts to smart pointers is
+        # The automatic conversion of ordinary objects to smart pointers is
         # disabled for ROOT because it can cause trouble with overload
         # resolution. If a function has overloads for both ordinary objects and
         # smart pointers, then the implicit conversion to smart pointers can

--- a/bindings/pyroot/pythonizations/test/root_module.py
+++ b/bindings/pyroot/pythonizations/test/root_module.py
@@ -126,6 +126,35 @@ class ROOTModule(unittest.TestCase):
                 ROOT.SetHeuristicMemoryPolicy(True)
                 ROOT.SetHeuristicMemoryPolicy(False)
 
+    def test_lazy_gdirectory(self):
+        """Check that gDirectory is always lazy evaluated to the current
+        directory.
+
+        Reproducer for GitHub issue
+        https://github.com/root-project/root/issues/21693
+        """
+        import ROOT
+
+        # Should be gROOT initially
+        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
+
+        gDirectory_1 = ROOT.gDirectory
+
+        f = ROOT.TFile("Hybrid.root", "RECREATE")
+        f.cd()
+
+        gDirectory_2 = ROOT.gDirectory
+
+        # Now, both gDirectory_1 and _2 should resolve to the current TFile
+        # directory, no matter when the adapters were created.
+        self.assertEqual(gDirectory_1, gDirectory_2)
+        self.assertNotEqual(gDirectory_1, ROOT.gROOT)
+
+        # If we re-assign the gDirectory now, it should be considered
+        ROOT.gDirectory = ROOT.nullptr
+        self.assertEqual(gDirectory_1, ROOT.nullptr)
+        self.assertEqual(gDirectory_2, ROOT.nullptr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
+++ b/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
@@ -16,15 +16,15 @@ class TContextContextManager(unittest.TestCase):
         Check status of gDirectory with default constructor.
         """
         filename = "TContextContextManager_test_default_constructor.root"
-        self.assertIs(ROOT.gDirectory, ROOT.gROOT)
+        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
 
         with TDirectory.TContext():
             # Create a file to change gDirectory
             testfile = ROOT.TFile(filename, "recreate")
-            self.assertIs(ROOT.gDirectory, testfile)
+            self.assertEqual(ROOT.gDirectory, testfile)
             testfile.Close()
 
-        self.assertIs(ROOT.gDirectory, ROOT.gROOT)
+        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
         os.remove(filename)
 
     def constructor_onearg(self):
@@ -35,12 +35,12 @@ class TContextContextManager(unittest.TestCase):
 
         file0 = ROOT.TFile(filenames[0], "recreate")
         file1 = ROOT.TFile(filenames[1], "recreate")
-        self.assertIs(ROOT.gDirectory, file1)
+        self.assertEqual(ROOT.gDirectory, file1)
 
         with TDirectory.TContext(file0):
-            self.assertIs(ROOT.gDirectory, file0)
+            self.assertEqual(ROOT.gDirectory, file0)
 
-        self.assertIs(ROOT.gDirectory, file1)
+        self.assertEqual(ROOT.gDirectory, file1)
         file0.Close()
         file1.Close()
         for filename in filenames:
@@ -55,12 +55,12 @@ class TContextContextManager(unittest.TestCase):
         file0 = ROOT.TFile(filenames[0], "recreate")
         file1 = ROOT.TFile(filenames[1], "recreate")
         file2 = ROOT.TFile(filenames[2], "recreate")
-        self.assertIs(ROOT.gDirectory, file2)
+        self.assertEqual(ROOT.gDirectory, file2)
 
         with TDirectory.TContext(file0, file1):
-            self.assertIs(ROOT.gDirectory, file1)
+            self.assertEqual(ROOT.gDirectory, file1)
 
-        self.assertIs(ROOT.gDirectory, file0)
+        self.assertEqual(ROOT.gDirectory, file0)
         file0.Close()
         file1.Close()
         file2.Close()


### PR DESCRIPTION
Introduce a Python-side adapter (**TDirectoryPythonAdapter**) to implement the expected lazy semantics of gDirectory, analogous to `ROOT::Internal::TDirectoryAtomicAdapter` on the C++ side.

In C++, `gDirectory` is defined as a macro expanding to a temporary adapter object that implicitly converts to the current `TDirectory*`. This relies on implicit conversions, operator overloading, preprocessor tricks, and pretending to ROOT meta that the type of `gDirectory` is a functor returning a `TDirectory*` that cannot be faithfully represented in Python bindings. This results in problems like #21693, which shows that the coupling between these hacks and cppyy conversion is very brittle.

The new TDirectoryPythonAdapter restores the intended semantics by:
  * Resolving the current directory lazily on every attribute access
  * Forwarding attribute access, string representation, truthiness, and equality comparisons to the current TDirectory

Note that identity comparisons (`is`) are no longer meaningful for gDirectory, as it represents a dynamic proxy rather than a stable object. Tests are updated to use equality (`==`), matching the C++ adapter semantics, reverting a change that was only made recently (commit a6e780e86810e).

Assignment semantics (`gDirectory = ...`) are intentionally not supported, as Python does not provide a mechanism equivalent to C++ operator= on proxy objects without introducing fragile or intrusive behavior.

Closes #21693.

A unit test covering the reproducer for that issue is also implemented.