### PR TITLE
[cmake] Handle absolute install_dir in relative RPATH resolution

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2266,10 +2266,19 @@ endfunction()
 #
 # Arguments:
 #   target       - The CMake target (e.g., a shared library or executable)
-#   install_dir  - The install subdirectory relative to CMAKE_INSTALL_PREFIX
+#   install_dir  - The install subdirectory relative to CMAKE_INSTALL_PREFIX,
+#                  or an absolute directory.
 #----------------------------------------------------------------------------
 function(ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH target install_dir)
-  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR BASE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/${install_dir}" OUTPUT_VARIABLE to_libdir)
+
+  # Check if install_dir is absolute
+  if(IS_ABSOLUTE "${install_dir}")
+    set(base_dir "${install_dir}")
+  else()
+    set(base_dir "${CMAKE_INSTALL_PREFIX}/${install_dir}")
+  endif()
+
+  cmake_path(RELATIVE_PATH CMAKE_INSTALL_FULL_LIBDIR BASE_DIRECTORY "${base_dir}" OUTPUT_VARIABLE to_libdir)
 
   # New path
   if(APPLE)


### PR DESCRIPTION
`ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH` assumed that `install_dir` is always relative to `CMAKE_INSTALL_PREFIX` when computing the relative path to `CMAKE_INSTALL_FULL_LIBDIR`. However, some build environments (e.g. Fedora or Nix) pass an absolute `CMAKE_INSTALL_LIBDIR`, which results in an incorrect relative path.

Fix this by detecting whether `install_dir` is absolute and using it directly as the base directory when computing the relative path.

Thanks to the ROOT/Nix user at GSI reporting this issue!

To be backported to 6.36 and 6.38.