### PR TITLE
[xml] prevent files parsing from root folder

### DIFF
--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -38,6 +38,7 @@ protected:
    XMLNodePointer_t ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream *inp, Int_t &resvalue);
    void DisplayError(Int_t error, Int_t linenumber);
    XMLDocPointer_t ParseStream(TXMLInputStream *input);
+   static Bool_t VerifyFilePath(const char *fname);
 
    Bool_t fSkipComments; ///<! if true, do not create comments nodes in document during parsing
 

--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -36,7 +36,7 @@ protected:
    void OutputValue(char *value, TXMLOutputStream *out);
    void SaveNode(XMLNodePointer_t xmlnode, TXMLOutputStream *out, Int_t layout, Int_t level);
    XMLNodePointer_t ReadNode(XMLNodePointer_t xmlparent, TXMLInputStream *inp, Int_t &resvalue);
-   void DisplayError(Int_t error, Int_t linenumber);
+   void DisplayError(Int_t error, Int_t linenumber, Bool_t is_parse_file = kTRUE);
    XMLDocPointer_t ParseStream(TXMLInputStream *input);
    static Bool_t VerifyFilePath(const char *fname);
 

--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -169,7 +169,7 @@ public:
 
 class TXMLInputStream {
 protected:
-   std::istream *fInp;
+   std::ifstream *fInp;
    const char *fInpStr;
    Int_t fInpStrLen;
 
@@ -231,6 +231,16 @@ public:
       free(fBuf);
       fBuf = nullptr;
    }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// return true when file stream is configured
+
+   inline Bool_t IsFile() const { return fInp != nullptr; }
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// return true when file stream is open
+
+   inline Bool_t IsFileOpen() const { return fInp && fInp->is_open(); }
 
    ////////////////////////////////////////////////////////////////////////////
    /// return true if end of file is achieved
@@ -1380,6 +1390,10 @@ XMLDocPointer_t TXMLEngine::ParseFile(const char *filename, Int_t maxbuf)
    if (maxbuf < 100000)
       maxbuf = 100000;
    TXMLInputStream inp(true, filename, maxbuf);
+   if (!inp.IsFileOpen()) {
+      Error("ParseFile", "Fail open XML file %s", filename);
+      return nullptr;
+   }
    return ParseStream(&inp);
 }
 
@@ -1426,7 +1440,7 @@ XMLDocPointer_t TXMLEngine::ParseStream(TXMLInputStream *inp)
    } while (true);
 
    if (!success) {
-      DisplayError(resvalue, inp->CurrentLine());
+      DisplayError(resvalue, inp->CurrentLine(), inp->IsFile());
       FreeDoc(xmldoc);
       return nullptr;
    }
@@ -1492,7 +1506,7 @@ XMLNodePointer_t TXMLEngine::ReadSingleNode(const char *src)
    XMLNodePointer_t xmlnode = ReadNode(nullptr, &inp, resvalue);
 
    if (resvalue <= 0) {
-      DisplayError(resvalue, inp.CurrentLine());
+      DisplayError(resvalue, inp.CurrentLine(), kFALSE);
       FreeNode(xmlnode);
       return nullptr;
    }
@@ -2244,28 +2258,29 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
 ////////////////////////////////////////////////////////////////////////////////
 /// Displays xml parsing error
 
-void TXMLEngine::DisplayError(Int_t error, Int_t linenumber)
+void TXMLEngine::DisplayError(Int_t error, Int_t linenumber, Bool_t is_parse_file)
 {
+   const char *method = is_parse_file ? "ParseFile" : "ParseString";
    switch (error) {
-   case -15: Error("ParseFile", "Block access to external XML file at line %d", linenumber); break;
-   case -14: Error("ParseFile", "Error include external XML file at line %d", linenumber); break;
-   case -13: Error("ParseFile", "Error processing DTD part of XML file at line %d", linenumber); break;
-   case -12: Error("ParseFile", "DOCTYPE missing after <! at line %d", linenumber); break;
+   case -15: Error(method, "Block access to external XML file at line %d", linenumber); break;
+   case -14: Error(method, "Error include external XML file at line %d", linenumber); break;
+   case -13: Error(method, "Error processing DTD part of XML file at line %d", linenumber); break;
+   case -12: Error(method, "DOCTYPE missing after <! at line %d", linenumber); break;
    case -11:
-      Error("ParseFile", "Node cannot be closed with > symbol at line %d, for instance <?xml ... ?> node", linenumber);
+      Error(method, "Node cannot be closed with > symbol at line %d, for instance <?xml ... ?> node", linenumber);
       break;
    case -10:
-      Error("ParseFile", "Error in xml comments definition at line %d, must be <!-- comments -->", linenumber);
+      Error(method, "Error in xml comments definition at line %d, must be <!-- comments -->", linenumber);
       break;
-   case -9: Error("ParseFile", "Multiple namespace definitions not allowed, line %d", linenumber); break;
-   case -8: Error("ParseFile", "Invalid namespace specification, line %d", linenumber); break;
-   case -7: Error("ParseFile", "Invalid attribute value, line %d", linenumber); break;
-   case -6: Error("ParseFile", "Invalid identifier for node attribute, line %d", linenumber); break;
-   case -5: Error("ParseFile", "Mismatch between open and close nodes, line %d", linenumber); break;
-   case -4: Error("ParseFile", "Unexpected close node, line %d", linenumber); break;
-   case -3: Error("ParseFile", "Valid identifier for close node is missing, line %d", linenumber); break;
-   case -2: Error("ParseFile", "No multiple content entries allowed, line %d", linenumber); break;
-   case -1: Error("ParseFile", "Unexpected end of xml file"); break;
-   default: Error("ParseFile", "XML syntax error at line %d", linenumber); break;
+   case -9: Error(method, "Multiple namespace definitions not allowed, line %d", linenumber); break;
+   case -8: Error(method, "Invalid namespace specification, line %d", linenumber); break;
+   case -7: Error(method, "Invalid attribute value, line %d", linenumber); break;
+   case -6: Error(method, "Invalid identifier for node attribute, line %d", linenumber); break;
+   case -5: Error(method, "Mismatch between open and close nodes, line %d", linenumber); break;
+   case -4: Error(method, "Unexpected close node, line %d", linenumber); break;
+   case -3: Error(method, "Valid identifier for close node is missing, line %d", linenumber); break;
+   case -2: Error(method, "No multiple content entries allowed, line %d", linenumber); break;
+   case -1: Error(method, "Unexpected end of xml file"); break;
+   default: Error(method, "XML syntax error at line %d", linenumber); break;
    }
 }

--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 
 
 struct SXmlAttr_t {
@@ -1348,6 +1349,26 @@ XMLNodePointer_t TXMLEngine::DocGetRootElement(XMLDocPointer_t xmldoc)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Checked that filename does not contains relative path below current directory
+///
+/// Used to prevent access to files below current directory
+
+Bool_t TXMLEngine::VerifyFilePath(const char *fname)
+{
+   if (!fname || !*fname)
+      return kFALSE;
+
+   std::filesystem::path rel = std::filesystem::proximate(fname, std::filesystem::current_path());
+
+   // absolute path not allowed
+   if (rel.is_absolute())
+      return kFALSE;
+
+   // relative path should not start with ".."
+   return rel.empty() || (*rel.begin() != "..");
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Parses content of file and tries to produce xml structures.
 /// The maxbuf argument specifies the max size of the XML file to be
 /// parsed. The default value is 100000.
@@ -1864,6 +1885,10 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
                AddNodeContent(xmlparent, lastentity, beg - lastentity);
 
             if (entity->IsSystem()) {
+               if (!VerifyFilePath(entity->GetTitle())) {
+                  resvalue = -15;
+                  return contnode;
+               }
                XMLDocPointer_t entitydoc = ParseFile(entity->GetTitle());
                if (!entitydoc) {
                   resvalue = -14;
@@ -2222,6 +2247,7 @@ XMLNodePointer_t TXMLEngine::ReadNode(XMLNodePointer_t xmlparent, TXMLInputStrea
 void TXMLEngine::DisplayError(Int_t error, Int_t linenumber)
 {
    switch (error) {
+   case -15: Error("ParseFile", "Block access to external XML file at line %d", linenumber); break;
    case -14: Error("ParseFile", "Error include external XML file at line %d", linenumber); break;
    case -13: Error("ParseFile", "Error processing DTD part of XML file at line %d", linenumber); break;
    case -12: Error("ParseFile", "DOCTYPE missing after <! at line %d", linenumber); break;

--- a/roottest/root/io/xml/CMakeLists.txt
+++ b/roottest/root/io/xml/CMakeLists.txt
@@ -15,6 +15,11 @@ ROOTTEST_ADD_TEST(enginexml
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                   OUTREF enginexml.ref)
 
+ROOTTEST_ADD_TEST(enginestr
+                  MACRO runenginestr.C
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF enginestr.ref)
+
 ROOTTEST_ADD_TEST(XmlDir
                   MACRO runXmlDir.C
                   OUTREF XmlDir.ref)

--- a/roottest/root/io/xml/CMakeLists.txt
+++ b/roottest/root/io/xml/CMakeLists.txt
@@ -20,6 +20,11 @@ ROOTTEST_ADD_TEST(enginestr
                   WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                   OUTREF enginestr.ref)
 
+ROOTTEST_ADD_TEST(enginebad
+                  MACRO runenginebad.C
+                  WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTREF enginebad.ref)
+
 ROOTTEST_ADD_TEST(XmlDir
                   MACRO runXmlDir.C
                   OUTREF XmlDir.ref)

--- a/roottest/root/io/xml/enginebad.ref
+++ b/roottest/root/io/xml/enginebad.ref
@@ -1,0 +1,7 @@
+Processing runenginebad.C...
+Error in <TXMLEngine::ParseString>: Block access to external XML file at line 5
+Include from parent directory is not allowed
+Error in <TXMLEngine::ParseString>: Block access to external XML file at line 5
+Include from parent directory is not allowed
+Error in <TXMLEngine::ParseString>: Block access to external XML file at line 5
+Include from top directory is not allowed

--- a/roottest/root/io/xml/enginestr.ref
+++ b/roottest/root/io/xml/enginestr.ref
@@ -1,0 +1,21 @@
+Processing runenginestr.C...
+  node: main
+    node: child1
+      content: Content of child1 string node
+    node: child2
+      attr: attr1 value: strvalue1
+      attr: attr2 value: strvalue2
+    node: child3
+      node: subchild1
+        content: subchild1 string content
+      node: subchild2
+        content: subchild2 string content
+      node: subchild3
+        content: subchild3 string content
+    node: child4
+      node: subchild4
+        content: subchild4 content
+      node: subchild5
+        content: subchild5 content
+      node: subchild6
+        content: subchild6 content

--- a/roottest/root/io/xml/runenginebad.C
+++ b/roottest/root/io/xml/runenginebad.C
@@ -1,0 +1,63 @@
+// Test string parsing with TXMLEngine
+// Also keep file include via ENTITY
+// Author: Sergey Linev   7.04.2026
+
+#include "TXMLEngine.h"
+
+void runenginebad()
+{
+   // First create engine
+   TXMLEngine xml;
+
+   // Try to include file using path via parent directory
+   // File in principle exists but in generally it is not allowed to navigate via parent path
+   XMLDocPointer_t xmldoc1 = xml.ParseString(
+    "<?xml version=\"1.0\"?>\n"
+    "   <!DOCTYPE main [\n"
+    "     <!ENTITY file_in_parent_dir SYSTEM \"../include.xml\">\n"
+    "   ]>\n"
+    "<main>&file_in_parent_dir;</main>");
+   if (!xmldoc1) {
+      std::cout << "Include from parent directory is not allowed" << std::endl;
+   } else {
+      std::cerr << "FAILURE - parsing must not work when parent directory is specified" << std::endl;
+      xml.FreeDoc(xmldoc1);
+   }
+
+   XMLDocPointer_t xmldoc2 = xml.ParseString(
+    "<?xml version=\"1.0\"?>\n"
+    "   <!DOCTYPE main [\n"
+    "     <!ENTITY file_in_parents_dir SYSTEM \"path/inside/../../../../core/include.xml\">\n"
+    "   ]>\n"
+    "<main>&file_in_parents_dir;</main>");
+   if (!xmldoc2) {
+      std::cout << "Include from parent directory is not allowed" << std::endl;
+   } else {
+      std::cerr << "FAILURE - parsing must not work when parent directory is specified" << std::endl;
+      xml.FreeDoc(xmldoc2);
+   }
+
+   // Try to include file using global path
+   // Should be refused before trying to open such file so checking proper error message as well
+#ifdef R__WIN32
+   XMLDocPointer_t xmldoc3 = xml.ParseString(
+    "<?xml version=\"1.0\"?>\n"
+    "   <!DOCTYPE main [\n"
+    "     <!ENTITY file_from_top_dir SYSTEM \"c:/Windows/System32/sti.dll\">\n"
+    "  ]>\n"
+    "<main>&file_from_top_dir;</main>");
+#else
+   XMLDocPointer_t xmldoc3 = xml.ParseString(
+    "<?xml version=\"1.0\"?>\n"
+    "   <!DOCTYPE main [\n"
+    "     <!ENTITY file_from_top_dir SYSTEM \"/usr/lib/firewalld/services/irc.xml\">\n"
+    "   ]>\n"
+    "<main>&file_from_top_dir;</main>");
+#endif
+   if (!xmldoc3) {
+      std::cout << "Include from top directory is not allowed" << std::endl;
+   } else {
+      std::cerr << "FAILURE - parsing must not work when top directory is specified" << std::endl;
+      xml.FreeDoc(xmldoc3);
+   }
+}

--- a/roottest/root/io/xml/runenginestr.C
+++ b/roottest/root/io/xml/runenginestr.C
@@ -1,0 +1,83 @@
+// Test string parsing with TXMLEngine
+// Also keep file include via ENTITY
+// Author: Sergey Linev   7.04.2026
+
+#include "TXMLEngine.h"
+
+void DisplayNode(TXMLEngine &xml, XMLNodePointer_t node, Int_t level)
+{
+   // this function display all accessible information about xml node and its children
+
+   // display node with content
+   if (xml.IsContentNode(node)) {
+      printf("%*c content: %s\n",level,' ', xml.GetNodeName(node));
+      return;
+   }
+
+   if (xml.IsCommentNode(node)) {
+      printf("%*c comment: %s\n",level,' ', xml.GetNodeName(node));
+      return;
+   }
+
+   if (!xml.IsXmlNode(node))
+      return;
+
+   printf("%*c node: %s\n",level,' ', xml.GetNodeName(node));
+
+   // display namespace
+   XMLNsPointer_t ns = xml.GetNS(node);
+   if (ns)
+      printf("%*c namespace: %s refer: %s\n",level+2,' ', xml.GetNSName(ns), xml.GetNSReference(ns));
+
+   // display attributes
+   XMLAttrPointer_t attr = xml.GetFirstAttr(node);
+   while (attr!=0) {
+       printf("%*c attr: %s value: %s\n",level+2,' ', xml.GetAttrName(attr), xml.GetAttrValue(attr));
+       attr = xml.GetNextAttr(attr);
+   }
+
+   // display all child nodes (including special nodes)
+   XMLNodePointer_t child = xml.GetChild(node, kFALSE);
+   while (child) {
+      DisplayNode(xml, child, level+2);
+      child = xml.GetNext(child, kFALSE);
+   }
+}
+
+
+void runenginestr()
+{
+   // First create engine
+   TXMLEngine xml;
+
+   // Now try to parse xml string
+   // Only file with restricted xml syntax are supported
+   XMLDocPointer_t xmldoc = xml.ParseString(
+    "<?xml version=\"1.0\"?>\n"
+    "   <!DOCTYPE main [\n"
+    "     <!ENTITY child4 SYSTEM \"include.xml\">\n"
+    "  ]>\n"
+    "<main>\n"
+    "  <child1>Content of child1 string node</child1>\n"
+    "  <child2 attr1=\"strvalue1\" attr2=\"strvalue2\"/>\n"
+    "  <child3>\n"
+    "     <subchild1>subchild1 string content</subchild1>\n"
+    "     <subchild2>subchild2 string content</subchild2>\n"
+    "     <subchild3>subchild3 string content</subchild3>\n"
+    "  </child3>\n"
+    "  &child4;"
+    "</main>");
+   if (!xmldoc) {
+      std::cerr << "Fail to parse string" << std::endl;
+      return;
+   }
+
+   // take access to main node
+   XMLNodePointer_t mainnode = xml.DocGetRootElement(xmldoc);
+
+   // display recursively all nodes and subnodes
+   DisplayNode(xml, mainnode, 1);
+
+   // Release memory before exit
+   xml.FreeDoc(xmldoc);
+}


### PR DESCRIPTION
When parsing xml file, `TXMLEngine` can include other files via syntax:
```
<!ENTITY xxe SYSTEM "/user/home/secret.file">
```
So prevent inclusion of files which are not in current directory or sub-directory.
Check extra in windows that file name does not starts with drive letter like 'C:filename.ext'

Add correspondent tests to `roottest/root/io/xml` folder
