### PR TITLE
[afterimage] prevent nullptr access

### DIFF
--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -77,7 +77,7 @@ protected:
    void MapQuality(EImageQuality &quality, UInt_t &asquality, Bool_t toas = kTRUE);
 
    static Bool_t InitVisual();
-   Bool_t InitImage(const TString &caller);
+   Bool_t InitImage(const char *caller);
 
 public:
    TASImage();

--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -77,6 +77,7 @@ protected:
    void MapQuality(EImageQuality &quality, UInt_t &asquality, Bool_t toas = kTRUE);
 
    static Bool_t InitVisual();
+   Bool_t InitImage(const TString &caller);
 
 public:
    TASImage();

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -3836,11 +3836,6 @@ void TASImage::FillRectangleInternal(UInt_t col, Int_t x, Int_t y, UInt_t width,
 
 void TASImage::FillRectangle(const char *col, Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
-   if (!InitVisual()) {
-      Warning("Fill", "Visual not initiated");
-      return;
-   }
-
    ARGB32 color = ARGB32_White;
 
    if (col) {
@@ -3862,6 +3857,11 @@ void TASImage::FillRectangle(const char *col, Int_t x, Int_t y, UInt_t width, UI
 
 void TASImage::DrawVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t col, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawVLine", "Visual not initiated");
+      return;
+   }
+
    ARGB32 color = (ARGB32)col;
    UInt_t half = 0;
 
@@ -3897,6 +3897,11 @@ void TASImage::DrawVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t col, UInt_t thic
 
 void TASImage::DrawHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t col, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawHLine", "Visual not initiated");
+      return;
+   }
+
    ARGB32 color = (ARGB32)col;
    UInt_t half = 0;
 
@@ -4192,6 +4197,10 @@ void TASImage::DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, const char *col,
 void TASImage::DrawDashHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t nDash,
                              const char *pDash, UInt_t col, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawDashHLine", "Visual not initiated");
+      return;
+   }
    UInt_t iDash = 0;    // index of current dash
    int i = 0;
 
@@ -4246,6 +4255,10 @@ void TASImage::DrawDashHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t nDash,
 void TASImage::DrawDashVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t nDash,
                              const char *pDash, UInt_t col, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawDashVLine", "Visual not initiated");
+      return;
+   }
    UInt_t iDash = 0;    // index of current dash
    int i = 0;
 
@@ -4303,6 +4316,10 @@ void TASImage::DrawDashVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t nDash,
 void TASImage::DrawDashZLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                              UInt_t nDash, const char *tDash, UInt_t color)
 {
+   if (!InitVisual()) {
+      Warning("DrawDashZLine", "Visual not initiated");
+      return;
+   }
    int dx, dy, d;
    int i, i1, i2;
    int x, y, xend, yend;
@@ -4487,6 +4504,10 @@ void TASImage::DrawDashZLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 void TASImage::DrawDashZTLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                              UInt_t nDash, const char *tDash, UInt_t color, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawDashZTLine", "Visual not initiated");
+      return;
+   }
    int dx, dy;
    int i;
    double x, y, xend=0, yend=0, x0, y0;
@@ -5691,6 +5712,10 @@ static CARD32 gBrushCache[kBrushCacheSize*kBrushCacheSize];
 void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                             UInt_t color, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawWideLine", "Visual not initiated");
+      return;
+   }
    Int_t sz = thick*thick;
    CARD32 *matrix;
    Bool_t use_cache = thick < kBrushCacheSize;
@@ -5737,6 +5762,10 @@ void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 
 void TASImage::DrawGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by)
 {
+   if (!InitVisual()) {
+      Warning("DrawGlyph", "Visual not initiated");
+      return;
+   }
    static UInt_t col[5];
    Int_t x, y, yy, y0, xx;
    Bool_t has_alpha = (color & 0xff000000) != 0xff000000;
@@ -6343,6 +6372,10 @@ void TASImage::SetTitle(const char *title)
 void TASImage::DrawCubeBezier(Int_t x1, Int_t y1, Int_t x2, Int_t y2,
                              Int_t x3, Int_t y3, const char *col, UInt_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawCubeBezier", "Visual not initiated");
+      return;
+   }
    Int_t sz = thick*thick;
    CARD32 *matrix;
    Bool_t use_cache = thick < kBrushCacheSize;
@@ -6382,6 +6415,10 @@ void TASImage::DrawCubeBezier(Int_t x1, Int_t y1, Int_t x2, Int_t y2,
 void TASImage::DrawStraightEllips(Int_t x, Int_t y, Int_t rx, Int_t ry,
                                   const char *col, Int_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawStraightEllips", "Visual not initiated");
+      return;
+   }
    thick = !thick ? 1 : thick;
    Int_t sz = thick*thick;
    CARD32 *matrix;
@@ -6421,6 +6458,11 @@ void TASImage::DrawStraightEllips(Int_t x, Int_t y, Int_t rx, Int_t ry,
 
 void TASImage::DrawCircle(Int_t x, Int_t y, Int_t r, const char *col, Int_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawCircle", "Visual not initiated");
+      return;
+   }
+
    thick = !thick ? 1 : thick;
    Int_t sz = thick*thick;
    CARD32 *matrix;
@@ -6462,6 +6504,10 @@ void TASImage::DrawCircle(Int_t x, Int_t y, Int_t r, const char *col, Int_t thic
 void TASImage::DrawEllips(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
                            const char *col, Int_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawEllips", "Visual not initiated");
+      return;
+   }
    thick = !thick ? 1 : thick;
    Int_t sz = thick*thick;
    CARD32 *matrix;
@@ -6502,6 +6548,10 @@ void TASImage::DrawEllips(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
 void TASImage::DrawEllips2(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
                            const char *col, Int_t thick)
 {
+   if (!InitVisual()) {
+      Warning("DrawEllips2", "Visual not initiated");
+      return;
+   }
    thick = !thick ? 1 : thick;
    Int_t sz = thick*thick;
    CARD32 *matrix;

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -484,7 +484,7 @@ const char *TASImage::TypeFromMagicNumber(const char *file)
 void TASImage::ReadImage(const char *filename, EImageFileTypes /*type*/)
 {
    if (!InitVisual()) {
-      Warning("Scale", "Visual not initiated");
+      Warning("ReadImage", "Visual not initiated");
       return;
    }
 
@@ -1977,12 +1977,12 @@ void TASImage::Slice(UInt_t xStart, UInt_t xEnd, UInt_t yStart,  UInt_t yEnd,
                      UInt_t toWidth, UInt_t toHeight)
 {
    if (!IsValid()) {
-      Warning("Scale", "Image not initiated");
+      Warning("Slice", "Image not initiated");
       return;
    }
 
    if (!InitVisual()) {
-      Warning("Scale", "Visual not initiated");
+      Warning("Slice", "Visual not initiated");
       return;
    }
 
@@ -2269,6 +2269,31 @@ Bool_t TASImage::InitVisual()
 #endif
 
    return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Static function to initialize the image.
+Bool_t TASImage::InitImage(const TString &caller)
+{
+   if (!InitVisual()) {
+      Warning(caller.Data(), "Visual not initiated");
+      return false;
+   }
+
+   if (!fImage) {
+      Warning(caller.Data(), "no image");
+      return false;
+   }
+
+   if (!fImage->alt.argb32) {
+      BeginPaint();
+   }
+
+   if (!fImage->alt.argb32) {
+      Warning(caller.Data(), "Failed to get argb32 pixel array");
+      return false;
+   }
+   return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2609,8 +2634,7 @@ void TASImage::DrawText(Int_t x, Int_t y, const char *text, Int_t size,
    ASImage *text_im = nullptr;
    Bool_t ttfont = kFALSE;
 
-   if (!InitVisual()) {
-      Warning("DrawText", "Visual not initiated");
+   if (!InitImage("DrawText")) {
       return;
    }
 
@@ -3759,22 +3783,7 @@ UInt_t *TASImage::GetScanline(UInt_t y)
 void TASImage::FillRectangleInternal(UInt_t col, Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
 
-   if (!InitVisual()) {
-      Warning("FillRectangle", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("FillRectangle", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("FillRectangle", "Failed to get pixel array");
+   if (!InitImage("FillRectangleInternal")) {
       return;
    }
 
@@ -3836,6 +3845,11 @@ void TASImage::FillRectangleInternal(UInt_t col, Int_t x, Int_t y, UInt_t width,
 
 void TASImage::FillRectangle(const char *col, Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
+   if (!InitVisual()) {
+      Warning("FillRectangle", "Visual not initiated");
+      return;
+   }
+
    ARGB32 color = ARGB32_White;
 
    if (col) {
@@ -3857,8 +3871,7 @@ void TASImage::FillRectangle(const char *col, Int_t x, Int_t y, UInt_t width, UI
 
 void TASImage::DrawVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t col, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawVLine", "Visual not initiated");
+   if (!InitImage("DrawVLine")) {
       return;
    }
 
@@ -3897,8 +3910,7 @@ void TASImage::DrawVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t col, UInt_t thic
 
 void TASImage::DrawHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t col, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawHLine", "Visual not initiated");
+   if (!InitImage("DrawHLine")) {
       return;
    }
 
@@ -3957,22 +3969,7 @@ void TASImage::DrawLineInternal(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
    int idx;
    int yy;
 
-   if (!InitVisual()) {
-      Warning("DrawLine", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("DrawLine", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("DrawLine", "Failed to get pixel array");
+   if (!InitImage("DrawLineInternal")) {
       return;
    }
 
@@ -4128,7 +4125,7 @@ void TASImage::DrawRectangle(UInt_t x, UInt_t y, UInt_t w, UInt_t h,
    }
 
    if (!fImage->alt.argb32) {
-      Warning("DrawRectangle", "Failed to get pixel array");
+      Warning("DrawRectangle", "Failed to get argb32 pixel array");
       return;
    }
 
@@ -4197,10 +4194,10 @@ void TASImage::DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, const char *col,
 void TASImage::DrawDashHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t nDash,
                              const char *pDash, UInt_t col, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawDashHLine", "Visual not initiated");
+   if (!InitImage("DrawDashHLine")) {
       return;
    }
+
    UInt_t iDash = 0;    // index of current dash
    int i = 0;
 
@@ -4255,8 +4252,7 @@ void TASImage::DrawDashHLine(UInt_t y, UInt_t x1, UInt_t x2, UInt_t nDash,
 void TASImage::DrawDashVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t nDash,
                              const char *pDash, UInt_t col, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawDashVLine", "Visual not initiated");
+   if (!InitImage("DrawDashVLine")) {
       return;
    }
    UInt_t iDash = 0;    // index of current dash
@@ -4316,8 +4312,7 @@ void TASImage::DrawDashVLine(UInt_t x, UInt_t y1, UInt_t y2, UInt_t nDash,
 void TASImage::DrawDashZLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                              UInt_t nDash, const char *tDash, UInt_t color)
 {
-   if (!InitVisual()) {
-      Warning("DrawDashZLine", "Visual not initiated");
+   if (!InitImage("DrawDashZLine")) {
       return;
    }
    int dx, dy, d;
@@ -4504,8 +4499,7 @@ void TASImage::DrawDashZLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 void TASImage::DrawDashZTLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                              UInt_t nDash, const char *tDash, UInt_t color, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawDashZTLine", "Visual not initiated");
+   if (!InitImage("DrawDashZTLine")) {
       return;
    }
    int dx, dy;
@@ -4667,22 +4661,7 @@ void TASImage::DrawDashLine(UInt_t x1,  UInt_t y1, UInt_t x2, UInt_t y2, UInt_t 
                             const char *pDash, const char *col, UInt_t thick)
 
 {
-   if (!InitVisual()) {
-      Warning("DrawDashLine", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("DrawDashLine", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("DrawDashLine", "Failed to get pixel array");
+   if (!InitImage("DrawDashLine")) {
       return;
    }
 
@@ -4734,22 +4713,7 @@ void TASImage::DrawPolyLine(UInt_t nn, TPoint *xy, const char *col, UInt_t thick
 
 void TASImage::PutPixel(Int_t x, Int_t y, const char *col)
 {
-   if (!InitVisual()) {
-      Warning("PutPixel", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("PutPixel", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("PutPixel", "Failed to get pixel array");
+   if (!InitImage("PutPixel")) {
       return;
    }
 
@@ -4769,22 +4733,7 @@ void TASImage::PutPixel(Int_t x, Int_t y, const char *col)
 
 void TASImage::PolyPoint(UInt_t npt, TPoint *ppt, const char *col, TImage::ECoordMode mode)
 {
-   if (!InitVisual()) {
-      Warning("PolyPoint", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("PolyPoint", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("PolyPoint", "Failed to get pixel array");
+   if (!InitImage("PolyPoint")) {
       return;
    }
 
@@ -4853,22 +4802,7 @@ void TASImage::DrawSegments(UInt_t nseg, Segment_t *seg, const char *col, UInt_t
 void TASImage::FillSpans(UInt_t npt, TPoint *ppt, UInt_t *widths, const char *col,
                          const char *stipple, UInt_t w, UInt_t h)
 {
-   if (!InitVisual()) {
-      Warning("FillSpans", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("FillSpans", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("FillSpans", "Failed to get pixel array");
+   if (!InitImage("FillSpans")) {
       return;
    }
 
@@ -4911,22 +4845,7 @@ void TASImage::FillSpans(UInt_t npt, TPoint *ppt, UInt_t *widths, const char *co
 
 void TASImage::FillSpans(UInt_t npt, TPoint *ppt, UInt_t *widths, TImage *tile)
 {
-   if (!InitVisual()) {
-      Warning("FillSpans", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("FillSpans", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("FillSpans", "Failed to get pixel array");
+   if (!InitImage("FillSpans")) {
       return;
    }
 
@@ -4965,22 +4884,7 @@ void TASImage::FillSpans(UInt_t npt, TPoint *ppt, UInt_t *widths, TImage *tile)
 
 void TASImage::CropSpans(UInt_t npt, TPoint *ppt, UInt_t *widths)
 {
-   if (!InitVisual()) {
-      Warning("CropSpans", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("CropSpans", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("CropSpans", "Failed to get pixel array");
+   if (!InitImage("CropSpans")) {
       return;
    }
 
@@ -5270,22 +5174,7 @@ Bool_t TASImage::GetPolygonSpans(UInt_t npt, TPoint *ppt, UInt_t *nspans,
 
    *nspans = 0;
 
-   if (!InitVisual()) {
-      Warning("GetPolygonSpans", "Visual not initiated");
-      return kFALSE;
-   }
-
-   if (!fImage) {
-      Warning("GetPolygonSpans", "no image");
-      return kFALSE;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("GetPolygonSpans", "Failed to get pixel array");
+   if (!InitImage("GetPolygonSpans")) {
       return kFALSE;
    }
 
@@ -5472,22 +5361,7 @@ static const UInt_t NUMPTSTOBUFFER = 512;
 void TASImage::DrawFillArea(UInt_t count, TPoint *ptsIn, const char *col,
                            const char *stipple, UInt_t w, UInt_t h)
 {
-   if (!InitVisual()) {
-      Warning("DrawFillArea", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("DrawFillArea", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("DrawFillArea", "Failed to get pixel array");
+   if (!InitImage("DrawFillArea")) {
       return;
    }
 
@@ -5588,22 +5462,7 @@ void TASImage::DrawFillArea(UInt_t count, TPoint *ptsIn, const char *col,
 
 void TASImage::DrawFillArea(UInt_t count, TPoint *ptsIn, TImage *tile)
 {
-   if (!InitVisual()) {
-      Warning("DrawFillArea", "Visual not initiated");
-      return;
-   }
-
-   if (!fImage) {
-      Warning("DrawFillArea", "no image");
-      return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
-   }
-
-   if (!fImage->alt.argb32) {
-      Warning("DrawFillArea", "Failed to get pixel array");
+   if (!InitImage("DrawFillArea")) {
       return;
    }
 
@@ -5712,8 +5571,7 @@ static CARD32 gBrushCache[kBrushCacheSize*kBrushCacheSize];
 void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
                             UInt_t color, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawWideLine", "Visual not initiated");
+   if (!InitImage("DrawWideLine")) {
       return;
    }
    Int_t sz = thick*thick;
@@ -5762,8 +5620,7 @@ void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 
 void TASImage::DrawGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by)
 {
-   if (!InitVisual()) {
-      Warning("DrawGlyph", "Visual not initiated");
+   if (!InitImage("DrawGlyph")) {
       return;
    }
    static UInt_t col[5];
@@ -5865,16 +5722,10 @@ void TASImage::DrawGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by)
 void TASImage::DrawText(TText *text, Int_t x, Int_t y)
 {
    if (!text)   return;
-   if (!fImage) return;
-   if (!gPad)   return;
-
-   if (!InitVisual()) {
-      Warning("DrawText", "Visual not initiated");
+   if (!gPad)
       return;
-   }
-
-   if (!fImage->alt.argb32) {
-      BeginPaint();
+   if (!InitImage("DrawText")) {
+      return;
    }
 
    if (!TTF::IsInitialized()) TTF::Init();
@@ -6148,10 +5999,12 @@ void TASImage::CreateThumbnail()
    const int sz = 64;
 
    if (!fImage) {
+      Warning("CreateThumbnail", "No image");
       return;
    }
 
    if (!InitVisual()) {
+      Warning("CreateThumbnail", "Visual not initiated");
       return;
    }
 
@@ -6372,8 +6225,7 @@ void TASImage::SetTitle(const char *title)
 void TASImage::DrawCubeBezier(Int_t x1, Int_t y1, Int_t x2, Int_t y2,
                              Int_t x3, Int_t y3, const char *col, UInt_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawCubeBezier", "Visual not initiated");
+   if (!InitImage("DrawCubeBezier")) {
       return;
    }
    Int_t sz = thick*thick;
@@ -6415,8 +6267,7 @@ void TASImage::DrawCubeBezier(Int_t x1, Int_t y1, Int_t x2, Int_t y2,
 void TASImage::DrawStraightEllips(Int_t x, Int_t y, Int_t rx, Int_t ry,
                                   const char *col, Int_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawStraightEllips", "Visual not initiated");
+   if (!InitImage("DrawStraightEllips")) {
       return;
    }
    thick = !thick ? 1 : thick;
@@ -6458,8 +6309,7 @@ void TASImage::DrawStraightEllips(Int_t x, Int_t y, Int_t rx, Int_t ry,
 
 void TASImage::DrawCircle(Int_t x, Int_t y, Int_t r, const char *col, Int_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawCircle", "Visual not initiated");
+   if (!InitImage("DrawCircle")) {
       return;
    }
 
@@ -6504,8 +6354,7 @@ void TASImage::DrawCircle(Int_t x, Int_t y, Int_t r, const char *col, Int_t thic
 void TASImage::DrawEllips(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
                            const char *col, Int_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawEllips", "Visual not initiated");
+   if (!InitImage("DrawEllips")) {
       return;
    }
    thick = !thick ? 1 : thick;
@@ -6548,8 +6397,7 @@ void TASImage::DrawEllips(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
 void TASImage::DrawEllips2(Int_t x, Int_t y, Int_t rx, Int_t ry, Int_t angle,
                            const char *col, Int_t thick)
 {
-   if (!InitVisual()) {
-      Warning("DrawEllips2", "Visual not initiated");
+   if (!InitImage("DrawEllips2")) {
       return;
    }
    thick = !thick ? 1 : thick;

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -2273,15 +2273,15 @@ Bool_t TASImage::InitVisual()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Static function to initialize the image.
-Bool_t TASImage::InitImage(const TString &caller)
+Bool_t TASImage::InitImage(const char *caller)
 {
    if (!InitVisual()) {
-      Warning(caller.Data(), "Visual not initiated");
+      Warning(caller, "Visual not initiated");
       return false;
    }
 
    if (!fImage) {
-      Warning(caller.Data(), "no image");
+      Warning(caller, "no image");
       return false;
    }
 
@@ -2290,7 +2290,7 @@ Bool_t TASImage::InitImage(const TString &caller)
    }
 
    if (!fImage->alt.argb32) {
-      Warning(caller.Data(), "Failed to get argb32 pixel array");
+      Warning(caller, "Failed to get argb32 pixel array");
       return false;
    }
    return true;

--- a/graf2d/asimage/src/libAfterImage/draw.c
+++ b/graf2d/asimage/src/libAfterImage/draw.c
@@ -1016,10 +1016,6 @@ asim_apply_path( ASDrawContext *ctx, int start_x, int start_y, Bool fill, int fi
 	clear_flags( ctx->flags, ASDrawCTX_UsingScratch );	 
 
 	/* actually applying scratch : */
-	if (!ctx->canvas) { // ctx->canvas = im->alt.argb32; <-- argb32 may be null
-		LOCAL_DEBUG_CALLER_OUT("empty ctx canvas");
-        return False;
-	}
 	{
 		int i = ctx->canvas_width*ctx->canvas_height ;
 		if (get_flags (ctx->flags, ASDrawCTX_CanvasIsARGB))

--- a/graf2d/asimage/src/libAfterImage/draw.c
+++ b/graf2d/asimage/src/libAfterImage/draw.c
@@ -1017,7 +1017,8 @@ asim_apply_path( ASDrawContext *ctx, int start_x, int start_y, Bool fill, int fi
 
 	/* actually applying scratch : */
 	if (!ctx->canvas) { // ctx->canvas = im->alt.argb32; <-- argb32 may be null
-        ctx->canvas = safecalloc(ctx->canvas_width * ctx->canvas_height, sizeof(CARD32));
+		LOCAL_DEBUG_CALLER_OUT("empty ctx canvas");
+        return False;
 	}
 	{
 		int i = ctx->canvas_width*ctx->canvas_height ;

--- a/graf2d/asimage/src/libAfterImage/draw.c
+++ b/graf2d/asimage/src/libAfterImage/draw.c
@@ -1016,6 +1016,9 @@ asim_apply_path( ASDrawContext *ctx, int start_x, int start_y, Bool fill, int fi
 	clear_flags( ctx->flags, ASDrawCTX_UsingScratch );	 
 
 	/* actually applying scratch : */
+	if (!ctx->canvas) { // ctx->canvas = im->alt.argb32; <-- argb32 may be null
+        ctx->canvas = safecalloc(ctx->canvas_width * ctx->canvas_height, sizeof(CARD32));
+	}
 	{
 		int i = ctx->canvas_width*ctx->canvas_height ;
 		if (get_flags (ctx->flags, ASDrawCTX_CanvasIsARGB))


### PR DESCRIPTION
# This Pull request:

Fixes https://github.com/root-project/root/issues/21880

Fixes crash reported in https://root-forum.cern.ch/t/timage-drawcircle-cause-core-dump/64784

But not sure if this is the right spot to initialize the canvas or if it should error earlier

It crashes also on 6.36 so seems unrelated to recent changes in build system.

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
