### PR TITLE
[ntuple] Attributes: change _userModel field to _userData in accordance with specs

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
@@ -23,14 +23,14 @@ Attribute RNTuples have a fixed Model schema that looks like this:
        +--------------+---------------+
        |              |               |
 +------+------+ +-----+------+ +------+------+
-| _rangeStart | | _rangeLen  | | _userModel  |
+| _rangeStart | | _rangeLen  | |  _userData  |
 +-------------+ +------------+ +------+------+
                                       |
                                 +-----+-----+
                                 | UserModel |
                                 +-----------+
 
-Where "_userModel" is an untyped record field containing all the user-defined Model's fields
+Where "_userData" is an untyped record field containing all the user-defined Model's fields
 as its children.
 
 The order and name of the meta Model's fields is defined by the schema version.
@@ -41,11 +41,11 @@ inline const std::uint16_t kSchemaVersionMinor = 0;
 
 inline const char *const kRangeStartName = "_rangeStart";
 inline const char *const kRangeLenName = "_rangeLen";
-inline const char *const kUserModelName = "_userModel";
+inline const char *const kUserDataName = "_userData";
 
 inline constexpr std::size_t kRangeStartIndex = 0;
 inline constexpr std::size_t kRangeLenIndex = 1;
-inline constexpr std::size_t kUserModelIndex = 2;
+inline constexpr std::size_t kUserDataIndex = 2;
 
 } // namespace ROOT::Experimental::Internal::RNTupleAttributes
 

--- a/tree/ntuple/src/RNTupleAttrWriting.cxx
+++ b/tree/ntuple/src/RNTupleAttrWriting.cxx
@@ -40,7 +40,7 @@ std::size_t ROOT::Experimental::Internal::RNTupleAttrEntry::Append()
 
    // Bind the user model's memory to the meta model's subfields
    const auto &userFields =
-      ROOT::Internal::GetFieldZeroOfModel(fMetaModel).GetMutableSubfields()[kUserModelIndex]->GetMutableSubfields();
+      ROOT::Internal::GetFieldZeroOfModel(fMetaModel).GetMutableSubfields()[kUserDataIndex]->GetMutableSubfields();
    assert(userFields.size() == fScopedEntry.fValues.size());
    for (std::size_t i = 0; i < fScopedEntry.fValues.size(); ++i) {
       std::shared_ptr<void> userPtr = fScopedEntry.fValues[i].GetPtr<void>();
@@ -78,7 +78,7 @@ ROOT::Experimental::RNTupleAttrSetWriter::Create(const RNTupleFillContext &mainF
    for (const auto *field : subfields) {
       fields.push_back(field->Clone(field->GetFieldName()));
    }
-   auto userRootField = std::make_unique<ROOT::RRecordField>(kUserModelName, std::move(fields));
+   auto userRootField = std::make_unique<ROOT::RRecordField>(kUserDataName, std::move(fields));
    metaModel->AddField(std::move(userRootField));
 
    metaModel->Freeze();


### PR DESCRIPTION
In the [binary format specs](https://github.com/root-project/root/blob/master/tree/ntuple/doc/BinaryFormatSpecification.md#attribute-schema-version) the internal field storing the user model for attributes is called `"_userData"`, but in code we're storing it wrongly as `"_userModel"`. 
This was an oversight on my end, since we decided to change the name to _userData during the binary format PR review but I didn't update it in the code I already had locally. Luckily the RNTupleAttrSetWriter has never appeared in a ROOT release yet so we're in time to fix this.

Kudos to @hahnjo for spotting this mistake on time!
