### PR TITLE
[win] Use correct syntax for #pragma warning

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -164,7 +164,7 @@ TDirectory::TContext::~TContext()
 // Mask deprecation warnings to allow for deprecating the fgAddDirectory bit.
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable : C4996)
+#pragma warning(disable : 4996)
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Fixes the following warning:
```
TDirectory.cxx(167,27): warning C4083: expected ')'; found identifier 'C4996'`
``` 