### PR TITLE
[RF][HF] Update HistoToWorkspaceFactoryFast.cxx - change interpCode from 4 to 5

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -683,7 +683,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
        assert(lowVec.size() == params.size());
 
        FlexibleInterpVar interp( (interpName).c_str(), "", params, 1., lowVec, highVec);
-       interp.setAllInterpCodes(4); // LM: change to 4 (piece-wise exponential to 6th order polynomial interpolation + exponential extrapolation )
+       interp.setAllInterpCodes(5); // LM: change to 5 (piece-wise exponential to 6th order polynomial interpolation + exponential extrapolation )
        //interp.setAllInterpCodes(0); // simple linear interpolation
        proto.import(interp); // params have already been imported in first loop of this function
     } else{


### PR DESCRIPTION
This better distinguishes the interpolation codes being used in FlexibleInterpVar vs PiecewiseInterpolation; in the former "4" gets converted to code "5" in the eval methods. So might as well just set it to 5 ... yes?

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

