### PR TITLE
[graphics] fix crash during objects dragging, improve TLine::ExecuteEvent

### DIFF
--- a/graf2d/graf/src/TBox.cxx
+++ b/graf2d/graf/src/TBox.cxx
@@ -531,6 +531,8 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    case kButton1Up:
       if (gROOT->IsEscaped()) {
          gROOT->SetEscape(kFALSE);
+         if (opaque || ropaque)
+            parent->ShowGuidelines(this, event);
          if (opaque) {
             SetX1(oldX1);
             SetY1(oldY1);

--- a/graf2d/graf/src/TBox.cxx
+++ b/graf2d/graf/src/TBox.cxx
@@ -238,8 +238,8 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
    Bool_t isBox = !(InheritsFrom("TPave") || InheritsFrom("TWbox"));
 
-   const Int_t kMaxDiff = 7;
-   const Int_t kMinSize = 20;
+   constexpr Int_t kMaxDiff = 7;
+   constexpr Int_t kMinSize = 20;
 
    static Int_t px1, px2, py1, py2, pxl, pyl, pxt, pyt, pxold, pyold;
    static Int_t px1p, px2p, py1p, py2p, pxlp, pylp, pxtp, pytp;
@@ -247,12 +247,11 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    static Bool_t pA, pB, pC, pD, pTop, pL, pR, pBot, pINSIDE;
    Int_t  wx, wy;
    auto parent = gPad;
-   auto pp = parent->GetPainter();
-   Bool_t opaque  = gPad->OpaqueMoving();
-   Bool_t ropaque = gPad->OpaqueResizing();
+   Bool_t opaque  = parent->OpaqueMoving();
+   Bool_t ropaque = parent->OpaqueResizing();
 
    // convert to user coordinates and either paint ot set back
-   auto action = [parent,pp,isBox,this](Bool_t paint, Int_t _x1, Int_t _y1, Int_t _x2, Int_t _y2) {
+   auto action = [parent,isBox,this](Bool_t paint, Int_t _x1, Int_t _y1, Int_t _x2, Int_t _y2) {
       auto x1 = parent->AbsPixeltoX(_x1);
       auto y1 = parent->AbsPixeltoY(_y1);
       auto x2 = parent->AbsPixeltoX(_x2);
@@ -268,6 +267,8 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
          }
       }
       if (paint) {
+         auto pp = parent->GetPainter();
+         pp->SetAttLine({GetFillColor() > 0 ? GetFillColor() : (Color_t) 1, GetLineStyle(), 2});
          pp->DrawBox(x1, y1, x2, y2, TVirtualPadPainter::kHollow);
       } else {
          SetX1(x1);
@@ -296,27 +297,15 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       oldY1 = fY1;
       oldX2 = fX2;
       oldY2 = fY2;
-      pp->SetAttLine({GetFillColor() > 0 ? GetFillColor() : (Color_t) 1, GetLineStyle(), 2});
 
       // No break !!!
 
    case kMouseMotion:
 
-      px1 = gPad->XtoAbsPixel(GetX1());
-      py1 = gPad->YtoAbsPixel(GetY1());
-      px2 = gPad->XtoAbsPixel(GetX2());
-      py2 = gPad->YtoAbsPixel(GetY2());
-
-      if (isBox) {
-         if (gPad->GetLogx()) {
-           if (GetX1() > 0) px1 = gPad->XtoAbsPixel(TMath::Log10(GetX1()));
-           if (GetX2() > 0) px2 = gPad->XtoAbsPixel(TMath::Log10(GetX2()));
-         }
-         if (gPad->GetLogy()) {
-           if (GetY1() > 0) py1 = gPad->YtoAbsPixel(TMath::Log10(GetY1()));
-           if (GetY2() > 0) py2 = gPad->YtoAbsPixel(TMath::Log10(GetY2()));
-         }
-      }
+      px1 = parent->XtoAbsPixel(isBox ? parent->XtoPad(GetX1()) : GetX1());
+      py1 = parent->YtoAbsPixel(isBox ? parent->YtoPad(GetY1()) : GetY1());
+      px2 = parent->XtoAbsPixel(isBox ? parent->XtoPad(GetX2()) : GetX2());
+      py2 = parent->YtoAbsPixel(isBox ? parent->YtoPad(GetY2()) : GetY2());
 
       if (px1 < px2) {
          pxl = px1;
@@ -355,64 +344,59 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
       pA = pB = pC = pD = pTop = pL = pR = pBot = pINSIDE = kFALSE;
 
-                                                         // case pA
+      // case pA
       if (TMath::Abs(px - pxl) <= kMaxDiff && TMath::Abs(py - pyl) <= kMaxDiff) {
          pxold = pxl; pyold = pyl; pA = kTRUE;
-         gPad->SetCursor(kTopLeft);
+         parent->SetCursor(kTopLeft);
       }
-                                                         // case pB
+      // case pB
       if (TMath::Abs(px - pxt) <= kMaxDiff && TMath::Abs(py - pyl) <= kMaxDiff) {
          pxold = pxt; pyold = pyl; pB = kTRUE;
-         gPad->SetCursor(kTopRight);
+         parent->SetCursor(kTopRight);
       }
-                                                         // case pC
+      // case pC
       if (TMath::Abs(px - pxt) <= kMaxDiff && TMath::Abs(py - pyt) <= kMaxDiff) {
          pxold = pxt; pyold = pyt; pC = kTRUE;
-         gPad->SetCursor(kBottomRight);
+         parent->SetCursor(kBottomRight);
       }
-                                                         // case pD
+      // case pD
       if (TMath::Abs(px - pxl) <= kMaxDiff && TMath::Abs(py - pyt) <= kMaxDiff) {
          pxold = pxl; pyold = pyt; pD = kTRUE;
-         gPad->SetCursor(kBottomLeft);
+         parent->SetCursor(kBottomLeft);
       }
-
-      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) &&
-          TMath::Abs(py - pyl) < kMaxDiff) {             // top edge
+      // top edge
+      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) && TMath::Abs(py - pyl) < kMaxDiff) {
          pxold = pxl; pyold = pyl; pTop = kTRUE;
-         gPad->SetCursor(kTopSide);
+         parent->SetCursor(kTopSide);
       }
-
-      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) &&
-          TMath::Abs(py - pyt) < kMaxDiff) {             // bottom edge
+      // bottom edge
+      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) && TMath::Abs(py - pyt) < kMaxDiff) {
          pxold = pxt; pyold = pyt; pBot = kTRUE;
-         gPad->SetCursor(kBottomSide);
+         parent->SetCursor(kBottomSide);
       }
-
-      if ((py > pyl+kMaxDiff && py < pyt-kMaxDiff) &&
-          TMath::Abs(px - pxl) < kMaxDiff) {             // left edge
+      // left edge
+      if ((py > pyl+kMaxDiff && py < pyt-kMaxDiff) && TMath::Abs(px - pxl) < kMaxDiff) {
          pxold = pxl; pyold = pyl; pL = kTRUE;
-         gPad->SetCursor(kLeftSide);
+         parent->SetCursor(kLeftSide);
       }
-
-      if ((py > pyl+kMaxDiff && py < pyt-kMaxDiff) &&
-          TMath::Abs(px - pxt) < kMaxDiff) {             // right edge
+      // right edge
+      if ((py > pyl+kMaxDiff && py < pyt-kMaxDiff) && TMath::Abs(px - pxt) < kMaxDiff) {
          pxold = pxt; pyold = pyt; pR = kTRUE;
-         gPad->SetCursor(kRightSide);
+         parent->SetCursor(kRightSide);
       }
-
-      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) &&
-          (py > pyl+kMaxDiff && py < pyt-kMaxDiff)) {    // inside box
+      // inside box
+      if ((px > pxl+kMaxDiff && px < pxt-kMaxDiff) && (py > pyl+kMaxDiff && py < pyt-kMaxDiff)) {
          pxold = px; pyold = py; pINSIDE = kTRUE;
          if (event == kButton1Down)
-            gPad->SetCursor(kMove);
+            parent->SetCursor(kMove);
          else
-            gPad->SetCursor(kCross);
+            parent->SetCursor(kCross);
       }
 
       fResizing = pA || pB || pC || pD || pTop || pL || pR || pBot;
 
       if (!fResizing && !pINSIDE)
-         gPad->SetCursor(kCross);
+         parent->SetCursor(kCross);
 
       break;
 
@@ -568,9 +552,6 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
       if (pA || pB || pC || pD || pTop || pL || pR || pBot)
          parent->Modified(kTRUE);
-
-      if (!opaque)
-         pp->SetAttLine({-1, 1, -1});
 
       break;
 

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -479,6 +479,7 @@ void TEllipse::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       if (gROOT->IsEscaped()) {
         gROOT->SetEscape(kFALSE);
         if (opaque) {
+            gPad->ShowGuidelines(this, event);
             this->SetX1(oldX1);
             this->SetY1(oldY1);
             this->SetR1(oldR1);

--- a/graf2d/graf/src/TLine.cxx
+++ b/graf2d/graf/src/TLine.cxx
@@ -292,6 +292,7 @@ void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             SetY1(oldY1);
             SetX2(oldX2);
             SetY2(oldY2);
+            gPad->ShowGuidelines(this, event);
             gPad->Modified(kTRUE);
             gPad->Update();
          }

--- a/graf2d/graf/src/TLine.cxx
+++ b/graf2d/graf/src/TLine.cxx
@@ -17,7 +17,8 @@
 #include "TLine.h"
 #include "TVirtualPad.h"
 #include "TClass.h"
-#include "TVirtualX.h"
+#include "TVirtualPadPainter.h"
+#include "TCanvasImp.h"
 #include "TMath.h"
 #include "TPoint.h"
 
@@ -130,19 +131,69 @@ TLine *TLine::DrawLineNDC(Double_t x1, Double_t y1, Double_t x2, Double_t  y2)
 
 void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 {
-   if (!gPad) return;
+   if (!gPad || !gPad->IsEditable()) return;
 
-   Int_t kMaxDiff = 20;
-   static Int_t d1,d2,px1,px2,py1,py2;
-   static Int_t pxold, pyold, px1old, py1old, px2old, py2old;
+   constexpr Int_t kMaxDiff = 20;
+   static Int_t px1,px2,py1,py2,pxold,pyold;
    static Double_t oldX1, oldY1, oldX2, oldY2;
-   static Bool_t p1, p2, pL, ndcsav;
-   Double_t dpx,dpy,xp1,yp1;
-   Int_t dx, dy;
+   static Int_t selectPoint;
 
-   Bool_t opaque  = gPad->OpaqueMoving();
+   auto parent = gPad;
 
-   if (!gPad->IsEditable()) return;
+   Bool_t opaque  = parent->OpaqueMoving();
+
+   auto action = [this, parent](Int_t code, Int_t _x1, Int_t _y1, Int_t _x2 = 0, Int_t _y2 = 0) {
+      Double_t x1, y1, x2, y2;
+
+      if (TestBit(kLineNDC)) {
+         x1 = (1. * _x1 / parent->GetWw() - parent->GetAbsXlowNDC()) / parent->GetAbsWNDC();
+         y1 = ((1 - 1. * _y1 / parent->GetWh()) - parent->GetAbsYlowNDC()) / parent->GetAbsHNDC();
+         x2 = (1. * _x2 / parent->GetWw() - parent->GetAbsXlowNDC()) / parent->GetAbsWNDC();
+         y2 = ((1 - 1. * _y2 / parent->GetWh()) - parent->GetAbsYlowNDC()) / parent->GetAbsHNDC();
+      } else {
+         x1 = parent->AbsPixeltoX(_x1);
+         y1 = parent->AbsPixeltoY(_y1);
+         x2 = parent->AbsPixeltoX(_x2);
+         y2 = parent->AbsPixeltoY(_y2);
+         if (parent->GetLogx()) {
+            x1 = TMath::Power(10, x1);
+            x2 = TMath::Power(10, x2);
+         }
+         if (parent->GetLogy()) {
+            y1 = TMath::Power(10, y1);
+            y2 = TMath::Power(10, y2);
+         }
+      }
+      if (code == 0) {
+         auto pp = parent->GetPainter();
+         pp->SetAttLine(*this);
+         if (TestBit(kLineNDC))
+            pp->DrawLineNDC(x1, y1, x2, y2);
+         else
+            pp->DrawLine(x1, y1, x2, y2);
+      } else {
+         if (code & 1) {
+            SetX1(x1);
+            SetY1(y1);
+         }
+         if (code & 2) {
+            SetX2(x2);
+            SetY2(y2);
+         }
+         if (TestBit(kVertical)) {
+            if (code & 1)
+               SetX2(GetX1());
+            else
+               SetX1(GetX2());
+         }
+         if (TestBit(kHorizontal)) {
+            if (code & 1)
+               SetY2(GetY1());
+            else
+               SetY1(GetY2());
+         }
+      }
+   };
 
    switch (event) {
 
@@ -152,134 +203,76 @@ void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       oldY1 = GetY1();
       oldX2 = GetX2();
       oldY2 = GetY2();
-      ndcsav = TestBit(kLineNDC);
-      if (!opaque) {
-         gVirtualX->SetLineColor(-1);
-         TAttLine::Modify();  //Change line attributes only if necessary
-      }
 
       // No break !!!
 
    case kMouseMotion:
 
       if (TestBit(kLineNDC)) {
-         px1 = gPad->UtoPixel(GetX1());
-         py1 = gPad->VtoPixel(GetY1());
-         px2 = gPad->UtoPixel(GetX2());
-         py2 = gPad->VtoPixel(GetY2());
+         px1 = parent->UtoAbsPixel(GetX1());
+         py1 = parent->VtoAbsPixel(GetY1());
+         px2 = parent->UtoAbsPixel(GetX2());
+         py2 = parent->VtoAbsPixel(GetY2());
       } else {
-         px1 = gPad->XtoAbsPixel(gPad->XtoPad(GetX1()));
-         py1 = gPad->YtoAbsPixel(gPad->YtoPad(GetY1()));
-         px2 = gPad->XtoAbsPixel(gPad->XtoPad(GetX2()));
-         py2 = gPad->YtoAbsPixel(gPad->YtoPad(GetY2()));
-      }
-      p1 = p2 = pL = kFALSE;
-
-      d1  = abs(px1 - px) + abs(py1-py); //simply take sum of pixels differences
-      if (d1 < kMaxDiff) { //*-*================>OK take point number 1
-         px1old = px1; py1old = py1;
-         p1 = kTRUE;
-         gPad->SetCursor(kPointer);
-         return;
-      }
-      d2  = abs(px2 - px) + abs(py2-py); //simply take sum of pixels differences
-      if (d2 < kMaxDiff) { //*-*================>OK take point number 2
-         px2old = px2; py2old = py2;
-         p2 = kTRUE;
-         gPad->SetCursor(kPointer);
-         return;
+         px1 = parent->XtoAbsPixel(parent->XtoPad(GetX1()));
+         py1 = parent->YtoAbsPixel(parent->YtoPad(GetY1()));
+         px2 = parent->XtoAbsPixel(parent->XtoPad(GetX2()));
+         py2 = parent->YtoAbsPixel(parent->YtoPad(GetY2()));
       }
 
-      pL = kTRUE;
-      pxold = px; pyold = py;
-      gPad->SetCursor(kMove);
+      //simply take sum of pixels differences
+      if (abs(px1 - px) + abs(py1 - py) < kMaxDiff) { //*-*================>OK take point number 1
+         selectPoint = 1;
+         parent->SetCursor(kPointer);
+      } else if (abs(px2 - px) + abs(py2 - py) < kMaxDiff) { //*-*================>OK take point number 2
+         selectPoint = 2;
+         parent->SetCursor(kPointer);
+      } else {
+         selectPoint = 3;
+         pxold = px;
+         pyold = py;
+         parent->SetCursor(kMove);
+      }
 
       break;
 
    case kArrowKeyRelease:
    case kButton1Motion:
-
-      if (p1) {
-         if (!opaque) {
-            gVirtualX->DrawLine(px1old, py1old, px2, py2);
-            gVirtualX->DrawLine(px, py, px2, py2);
-         } else {
-            if (ndcsav) {
-               SetNDC(kFALSE);
-               SetX2(gPad->GetX1() + oldX2*(gPad->GetX2()-gPad->GetX1()));
-               SetY2(gPad->GetY1() + oldY2*(gPad->GetY2()-gPad->GetY1()));
-            }
-            SetX1(gPad->AbsPixeltoX(px));
-            SetY1(gPad->AbsPixeltoY(py));
-         }
-         px1old = px;
-         py1old = py;
-      }
-      if (p2) {
-         if (!opaque) {
-            gVirtualX->DrawLine(px1, py1, px2old, py2old);
-            gVirtualX->DrawLine(px1, py1, px, py);
-         } else {
-            if (ndcsav) {
-               SetNDC(kFALSE);
-               SetX1(gPad->GetX1() + oldX1*(gPad->GetX2()-gPad->GetX1()));
-               SetY1(gPad->GetY1() + oldY1*(gPad->GetY2()-gPad->GetY1()));
-            }
-            SetX2(gPad->AbsPixeltoX(px));
-            SetY2(gPad->AbsPixeltoY(py));
-         }
-         px2old = px;
-         py2old = py;
-      }
-      if (pL) {
-         if (!opaque) gVirtualX->DrawLine(px1, py1, px2, py2);
-         dx = px-pxold;  dy = py-pyold;
-         px1 += dx; py1 += dy; px2 += dx; py2 += dy;
-         if (!opaque) gVirtualX->DrawLine(px1, py1, px2, py2);
+      if (!opaque)
+         action(0, px1, py1, px2, py2);
+      if (selectPoint == 1) {
+         px1 = px;
+         py1 = py;
+      } else if (selectPoint == 2) {
+         px2 = px;
+         py2 = py;
+      } else if (selectPoint == 3) {
+         px1 += px - pxold;
+         py1 += py - pyold;
+         px2 += px - pxold;
+         py2 += py  -pyold;
          pxold = px;
          pyold = py;
-         if (opaque) {
-            if (ndcsav) SetNDC(kFALSE);
-            SetX1(gPad->AbsPixeltoX(px1));
-            SetY1(gPad->AbsPixeltoY(py1));
-            SetX2(gPad->AbsPixeltoX(px2));
-            SetY2(gPad->AbsPixeltoY(py2));
-         }
       }
+      action(!opaque ? 0 : selectPoint, px1, py1, px2, py2);
       if (opaque) {
-         if (p1) {
+         if (selectPoint == 1) {
             //check in which corner the BBox is edited
-            if (GetX1() > GetX2()) {
-               if (GetY1() > GetY2())
-                  gPad->ShowGuidelines(this, event, '2', true);
-               else
-                  gPad->ShowGuidelines(this, event, '3', true);
-            } else {
-               if (GetY1() > GetY2())
-                  gPad->ShowGuidelines(this, event, '1', true);
-               else
-                  gPad->ShowGuidelines(this, event, '4', true);
-            }
-         }
-         if (p2) {
+            if (GetX1() > GetX2())
+               parent->ShowGuidelines(this, event, GetY1() > GetY2() ? '2' : '3', true);
+            else
+               parent->ShowGuidelines(this, event, GetY1() > GetY2() ? '1' : '4', true);
+         } else if (selectPoint == 2) {
             //check in which corner the BBox is edited
-            if (GetX1() > GetX2()) {
-               if (GetY1() > GetY2())
-                  gPad->ShowGuidelines(this, event, '4', true);
-               else
-                  gPad->ShowGuidelines(this, event, '1', true);
-            } else {
-               if (GetY1() > GetY2())
-                  gPad->ShowGuidelines(this, event, '3', true);
-               else
-                  gPad->ShowGuidelines(this, event, '2', true);
-            }
+            if (GetX1() > GetX2())
+               parent->ShowGuidelines(this, event, GetY1() > GetY2() ? '4' : '1', true);
+            else
+               parent->ShowGuidelines(this, event, GetY1() > GetY2() ? '3' : '2', true);
+         } else if (selectPoint == 3) {
+            parent->ShowGuidelines(this, event, 'i', true);
          }
-         if (pL) {
-            gPad->ShowGuidelines(this, event, 'i', true);
-         }
-         gPad->Modified(kTRUE);
-         gPad->Update();
+         parent->Modified(kTRUE);
+         parent->Update();
       }
       break;
 
@@ -292,77 +285,29 @@ void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             SetY1(oldY1);
             SetX2(oldX2);
             SetY2(oldY2);
-            gPad->ShowGuidelines(this, event);
-            gPad->Modified(kTRUE);
-            gPad->Update();
+            parent->ShowGuidelines(this, event);
+            parent->Modified(kTRUE);
+            parent->Update();
          }
          break;
       }
       if (opaque) {
-         if (ndcsav && !TestBit(kLineNDC)) {
-            SetX1((GetX1() - gPad->GetX1())/(gPad->GetX2()-gPad->GetX1()));
-            SetX2((GetX2() - gPad->GetX1())/(gPad->GetX2()-gPad->GetX1()));
-            SetY1((GetY1() - gPad->GetY1())/(gPad->GetY2()-gPad->GetY1()));
-            SetY2((GetY2() - gPad->GetY1())/(gPad->GetY2()-gPad->GetY1()));
-            SetNDC();
-         }
-         gPad->ShowGuidelines(this, event);
+         parent->ShowGuidelines(this, event);
       } else {
-         if (TestBit(kLineNDC)) {
-            dpx  = gPad->GetX2() - gPad->GetX1();
-            dpy  = gPad->GetY2() - gPad->GetY1();
-            xp1  = gPad->GetX1();
-            yp1  = gPad->GetY1();
-            if (p1) {
-               SetX1((gPad->AbsPixeltoX(px)-xp1)/dpx);
-               SetY1((gPad->AbsPixeltoY(py)-yp1)/dpy);
-            }
-            if (p2) {
-               SetX2((gPad->AbsPixeltoX(px)-xp1)/dpx);
-               SetY2((gPad->AbsPixeltoY(py)-yp1)/dpy);
-            }
-            if (pL) {
-               SetX1((gPad->AbsPixeltoX(px1)-xp1)/dpx);
-               SetY1((gPad->AbsPixeltoY(py1)-yp1)/dpy);
-               SetX2((gPad->AbsPixeltoX(px2)-xp1)/dpx);
-               SetY2((gPad->AbsPixeltoY(py2)-yp1)/dpy);
-            }
-         } else {
-            if (p1) {
-               SetX1(gPad->PadtoX(gPad->AbsPixeltoX(px)));
-               SetY1(gPad->PadtoY(gPad->AbsPixeltoY(py)));
-            }
-            if (p2) {
-               SetX2(gPad->PadtoX(gPad->AbsPixeltoX(px)));
-               SetY2(gPad->PadtoY(gPad->AbsPixeltoY(py)));
-            }
-            if (pL) {
-               SetX1(gPad->PadtoX(gPad->AbsPixeltoX(px1)));
-               SetY1(gPad->PadtoY(gPad->AbsPixeltoY(py1)));
-               SetX2(gPad->PadtoX(gPad->AbsPixeltoX(px2)));
-               SetY2(gPad->PadtoY(gPad->AbsPixeltoY(py2)));
-            }
-         }
-         if (TestBit(kVertical)) {
-            if (p1) SetX2(GetX1());
-            if (p2) SetX1(GetX2());
-         }
-         if (TestBit(kHorizontal)) {
-            if (p1) SetY2(GetY1());
-            if (p2) SetY1(GetY2());
-         }
-         gPad->Modified(kTRUE);
-         gPad->Update();
-         if (!opaque) gVirtualX->SetLineColor(-1);
+         action(selectPoint, px1, py1, px2, py2);
+         parent->Modified(kTRUE);
+         parent->Update();
       }
+      selectPoint = 0;
       break;
 
    case kButton1Locate:
 
+      // Sergey: code is never used, has to be removed in ROOT7
       ExecuteEvent(kButton1Down, px, py);
       while (true) {
          px = py = 0;
-         event = gVirtualX->RequestLocator(1,1,px,py);
+         event = parent->GetCanvasImp()->RequestLocator(px, py);
 
          ExecuteEvent(kButton1Motion, px, py);
 


### PR DESCRIPTION
For several classes like `TBox`, `TLine`, `TEllipse` ROOT will crash if during mouse dragging one press `Esc` key
and then will try to click on pad or just do something. Problem is remaining invalid pointer on temporary `guideline` pad which then accessed by mouse clicking. Fixing all concerned classes, backport for older ROOT versions will be provided.

Adjust `TLine::ExecuteEvent`:
   - use only `TPadPainter` functionality, avoid `gVirtualX`
   - do not change `TLine` coordinates from/to NDC during dragging
   - fix dragging on pad with log scale (was not working)
   - reduce `gPad` usage, reduce number of static variables. 
 
 Also adjust a bit code in `TBox::ExecuteEvent`. 

One need to fully avoids usage of static variables in `ExecuteEvent` methods. This will be done in next PRs.
