### PR TITLE
[graphics] prevent crash when dragging line, box or ellipse [6.38]

### DIFF
--- a/graf2d/graf/src/TBox.cxx
+++ b/graf2d/graf/src/TBox.cxx
@@ -543,6 +543,8 @@ void TBox::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    case kButton1Up:
       if (gROOT->IsEscaped()) {
          gROOT->SetEscape(kFALSE);
+         if (opaque || ropaque)
+            gPad->ShowGuidelines(this, event);
          if (opaque) {
             this->SetX1(oldX1);
             this->SetY1(oldY1);

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -479,6 +479,7 @@ void TEllipse::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       if (gROOT->IsEscaped()) {
         gROOT->SetEscape(kFALSE);
         if (opaque) {
+            gPad->ShowGuidelines(this, event);
             this->SetX1(oldX1);
             this->SetY1(oldY1);
             this->SetR1(oldR1);

--- a/graf2d/graf/src/TLine.cxx
+++ b/graf2d/graf/src/TLine.cxx
@@ -288,10 +288,12 @@ void TLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       if (gROOT->IsEscaped()) {
          gROOT->SetEscape(kFALSE);
          if (opaque) {
+            gPad->ShowGuidelines(this, event);
             SetX1(oldX1);
             SetY1(oldY1);
             SetX2(oldX2);
             SetY2(oldY2);
+            SetNDC(ndcsav);
             gPad->Modified(kTRUE);
             gPad->Update();
          }


### PR DESCRIPTION
If `Esc` key pressed when dragging object guideline pad not cleaned correctly and leave invalid pointer.

Also restore NDC flag of TLine in such case.

This is backport of some changes from https://github.com/root-project/root/pull/21872
