### PR TITLE
[BP][6.38] Limit the maximum number of opened files in TFileMerger to 128 (#21853)

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -78,7 +78,11 @@ static Int_t R__GetSystemMaxOpenedFiles()
    }
 #endif
    if (maxfiles > kCintFileNumber) {
-      return maxfiles - kCintFileNumber;
+      // Limit the maximum number of opened files to 128 to mitigate memory
+      // consumption issues that may arise during merges with many files.
+      // For further details see analysis at:
+      // https://github.com/root-project/root/issues/21660
+      return std::min(128, maxfiles - kCintFileNumber);
    } else if (maxfiles > 5) {
       return maxfiles - 5;
    } else {


### PR DESCRIPTION
to mitigate memory consumption issues that may arise during merges with many files

Backport of github.com/root-project/root/pull/21853
See issue: https://github.com/root-project/root/pull/21853
