### PR TITLE
[geom] Remove x3d geometry viewer path

### DIFF
--- a/geom/geom/doc/index.md
+++ b/geom/geom/doc/index.md
@@ -292,7 +292,7 @@ represented by TGeoNode objects. This hierarchy is a tree since a
 node can have only one parent and several daughters. For a better
 understanding of the hierarchy, have a look at TGeoManage.
 
-Just close now the `X3D` window and focus at the wire frame picture
+Just close now the external 3D viewer and focus at the wire frame picture
 drawn in a pad. Activate Options/Event Status. Moving the mouse in the
 pad, you will notice that objects are sometimes changing color to red.
 Volumes are highlighted in this way whenever the mouse pointer is close
@@ -2269,8 +2269,7 @@ and volume hierarchies.
 
 The main component of the visualization system is volume primitive
 painting in a ROOT pad. Starting from this one, several specific options
-or subsystems are available, like: X3D viewing using hidden line and
-surface removal algorithms, OpenGL viewing\* or ray tracing.
+or subsystems are available, like: OpenGL viewing\* or ray tracing.
 
 The method TGeoManager::GetGeomPainter() loads the painting library in
 memory.
@@ -3153,4 +3152,3 @@ the volume editor interface to:
   - [Presentation at ROOT 2007](http://indico.cern.ch/materialDisplay.py?contribId=35&materialId=slides&confId=13356)
 
 See also [the use of the geometry classes in AliROOT package of ALICE](https://alice-offline.web.cern.ch/AliRoot/Manual.html).
-

--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -2716,7 +2716,6 @@ void TGeoManager::SaveAttributes(const char *filename)
    }
    out << "   // draw top volume with new settings" << std::endl;
    out << "   top->Draw();" << std::endl;
-   out << "   gPad->x3d();" << std::endl;
    out << "}" << std::endl;
    out.close();
 }

--- a/geom/geompainter/src/TGeoPainter.cxx
+++ b/geom/geompainter/src/TGeoPainter.cxx
@@ -49,13 +49,21 @@ using TBuffer3D mechanism.
 #include "TMath.h"
 #include "TVirtualGeoChecker.h"
 
-#include "X3DBuffer.h"
-
 #include "TBuffer3D.h"
 #include "TBuffer3DTypes.h"
 #include "TVirtualViewer3D.h"
 #include "TVirtualX.h"
 
+#include <cstring>
+
+namespace {
+
+bool IsX3DViewer(const TVirtualViewer3D *viewer)
+{
+   return viewer && viewer->IsA() && std::strcmp(viewer->IsA()->GetName(), "TViewerX3D") == 0;
+}
+
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
@@ -115,9 +123,10 @@ TGeoPainter::~TGeoPainter()
 
 void TGeoPainter::AddSize3D(Int_t numpoints, Int_t numsegs, Int_t numpolys)
 {
-   gSize3D.numPoints += numpoints;
-   gSize3D.numSegs += numsegs;
-   gSize3D.numPolys += numpolys;
+   // Legacy no-op kept for the obsolete x3d sizing interface.
+   (void)numpoints;
+   (void)numsegs;
+   (void)numpolys;
 }
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a primary TGeoTrack.
@@ -938,6 +947,11 @@ void TGeoPainter::DrawCurrentPoint(Int_t color)
       return;
    if (!gPad->GetView())
       return;
+
+   TVirtualViewer3D *viewer = gPad->GetViewer3D();
+   if (!viewer || IsX3DViewer(viewer))
+      return;
+
    TPolyMarker3D *pm = new TPolyMarker3D();
    pm->SetMarkerColor(color);
    const Double_t *point = fGeoManager->GetCurrentPoint();

--- a/geom/geompainter/src/TGeoTrack.cxx
+++ b/geom/geompainter/src/TGeoTrack.cxx
@@ -524,7 +524,7 @@ void TGeoTrack::PaintMarker(Double_t *point, Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint this track with its current attributes.
 
-void TGeoTrack::PaintTrack(Option_t *option)
+void TGeoTrack::PaintTrack(Option_t * /*option*/)
 {
    // Check whether there is some 3D view class for this TPad
    //   TPadView3D *view3D = (TPadView3D*)gPad->GetView3D();

--- a/geom/geompainter/src/TGeoTrack.cxx
+++ b/geom/geompainter/src/TGeoTrack.cxx
@@ -32,7 +32,6 @@ of all tracks that will be deleted on destruction of
 gGeoManager.
 */
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
@@ -531,14 +530,7 @@ void TGeoTrack::PaintTrack(Option_t *option)
    //   TPadView3D *view3D = (TPadView3D*)gPad->GetView3D();
    //   if (view3D) view3D->PaintGeoTrack(this,option); // to be implemented
 
-   // Check if option is 'x3d'.      NOTE: This is a simple checking
-   //                                      but since there is no other
-   //                                      options yet, this works fine.
-   TString opt(option);
-   opt.ToLower();
    TObject::SetBit(kGeoPDrawn, kFALSE);
-   if (opt.Contains("x"))
-      return;
    Int_t np = fNpoints >> 2;
    Int_t imin = 0;
    Int_t imax = np - 1;

--- a/gui/gui/inc/TRootCanvas.h
+++ b/gui/gui/inc/TRootCanvas.h
@@ -121,6 +121,7 @@ public:
    void     SetWindowTitle(const char *newTitle) override;
    void     SetCanvasSize(UInt_t w, UInt_t h) override;
    void     SetStatusText(const char *txt = nullptr, Int_t partidx = 0) override;
+   void UpdateViewWithMenu();
 
    void     Show() override { MapRaised(); }
    void     ShowMenuBar(Bool_t show = kTRUE) override;

--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -73,6 +73,45 @@ drawing area. The widgets used are the new native ROOT GUI widgets.
 
 #include "HelpText.h"
 
+namespace {
+
+bool IsGeometryPrimitive(TObject *obj)
+{
+   static TClass *geoVolumeClass = TClass::GetClass("TGeoVolume");
+   static TClass *geoShapeClass = TClass::GetClass("TGeoShape");
+   static TClass *geoOverlapClass = TClass::GetClass("TGeoOverlap");
+   static TClass *geoTrackClass = TClass::GetClass("TGeoTrack");
+
+   if (!obj)
+      return false;
+
+   return (geoVolumeClass && obj->InheritsFrom(geoVolumeClass)) ||
+          (geoShapeClass && obj->InheritsFrom(geoShapeClass)) ||
+          (geoOverlapClass && obj->InheritsFrom(geoOverlapClass)) ||
+          (geoTrackClass && obj->InheritsFrom(geoTrackClass));
+}
+
+bool PadHasGeometryContent(TVirtualPad *pad)
+{
+   if (!pad)
+      return false;
+
+   TList *primitives = pad->GetListOfPrimitives();
+   if (!primitives)
+      return false;
+
+   TIter next(primitives);
+   while (TObject *obj = next()) {
+      if (IsGeometryPrimitive(obj))
+         return true;
+      if (obj->InheritsFrom(TVirtualPad::Class()) && PadHasGeometryContent(static_cast<TVirtualPad *>(obj)))
+         return true;
+   }
+
+   return false;
+}
+
+} // namespace
 
 // Canvas menu command ids
 enum ERootCanvasCommands {
@@ -473,6 +512,7 @@ void TRootCanvas::CreateCanvas(const char *name)
    fEditClearMenu->Associate(this);
    fViewMenu->Associate(this);
    fViewWithMenu->Associate(this);
+   fViewWithMenu->Connect("PoppedUp()", "TRootCanvas", this, "UpdateViewWithMenu()");
    fOptionMenu->Associate(this);
    fToolsMenu->Associate(this);
    fHelpMenu->Associate(this);
@@ -1044,9 +1084,14 @@ again:
                   case kViewIconify:
                      Iconify();
                      break;
-                  case kViewX3D:
-                     gPad->GetViewer3D("x3d");
+                  case kViewX3D: {
+                     TVirtualPad *pad = gPad ? gPad : (fCanvas ? fCanvas->GetSelectedPad() : nullptr);
+                     if (!pad)
+                        pad = fCanvas;
+                     if (!PadHasGeometryContent(pad))
+                        pad->GetViewer3D("x3d");
                      break;
+                  }
                   case kViewOpenGL:
                      gPad->GetViewer3D("ogl");
                      break;
@@ -2091,6 +2136,21 @@ void TRootCanvas::Activated(Int_t id)
          }
       }
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Update the "View With" submenu based on the currently selected pad content.
+
+void TRootCanvas::UpdateViewWithMenu()
+{
+   TVirtualPad *pad = fCanvas ? fCanvas->GetSelectedPad() : nullptr;
+   if (!pad)
+      pad = fCanvas;
+
+   if (PadHasGeometryContent(pad))
+      fViewWithMenu->DisableEntry(kViewX3D);
+   else
+      fViewWithMenu->EnableEntry(kViewX3D);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tutorials/geom/geodemo.C
+++ b/tutorials/geom/geodemo.C
@@ -195,8 +195,8 @@ void help()
    hdemo->AddText("- .... press j/k to zoom/unzoom");
    hdemo->AddText("- .... press l/h/u/i to move the view center around");
    hdemo->AddText("- Click Ray-trace ON/OFF to toggle ray-tracing");
-   hdemo->AddText("- Use <View with x3d> from the <View> menu to get an x3d view");
-   hdemo->AddText("- .... same methods to rotate/zoom/move the view");
+   hdemo->AddText("- Use <View>/<View With>/<OpenGL> for an external 3D view");
+   hdemo->AddText("- .... use the OpenGL viewer controls to rotate/zoom/move the view");
    hdemo->AddText("- Execute box(1,8) to divide a box in 8 equal slices along X");
    hdemo->AddText("- Most shapes can be divided on X,Y,Z,Rxy or Phi :");
    hdemo->AddText("- .... root[0] <shape>(IAXIS, NDIV, START, STEP);");


### PR DESCRIPTION
Remove the geometry-specific x3d integration while keeping the legacy x3d plugin available for non-geometry content.

On the geometry side this drops the remaining explicit x3d dependency from GeomPainter by turning AddSize3D() into a compatibility no-op, stopping SaveAttributes() from emitting gPad->x3d(), and avoiding DrawCurrentPoint() publication to x3d viewers. Track painting no longer special-cases an x3d option, so geometry drawing code only follows the regular pad/OpenGL paths.

On the GUI side the generic View With menu now detects geometry content in the selected pad and disables the X3D entry there, with the same guard in the action handler for consistency. This avoids the previous inconsistent behavior where simple geometry opened an empty x3d window while composite geometry failed with an x3d error dialog.

The geometry docs and geodemo tutorial text were updated accordingly to refer to external/OpenGL viewing instead of x3d for geometry.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

