### PR TITLE
[cppyy] Only alias size() to __len__ for container-like classes

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/Cppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Cppyy.h
@@ -139,6 +139,8 @@ namespace Cppyy {
     CPPYY_IMPORT
     bool IsAggregate(TCppType_t type);
     CPPYY_IMPORT
+    bool IsIntegerType(const std::string &type_name);
+    CPPYY_IMPORT
     bool IsDefaultConstructable(TCppType_t type);
 
     CPPYY_IMPORT

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -52,6 +52,19 @@ bool HasAttrDirect(PyObject* pyclass, PyObject* pyname, bool mustBeCPyCppyy = fa
     return false;
 }
 
+bool HasAttrInMRO(PyObject *pyclass, PyObject *pyname)
+{
+   // Check base classes in the MRO (skipping the class itself) for a CPyCppyy overload.
+   PyObject *mro = ((PyTypeObject *)pyclass)->tp_mro;
+   if (mro && PyTuple_Check(mro)) {
+      for (Py_ssize_t i = 1; i < PyTuple_GET_SIZE(mro); ++i) {
+         if (HasAttrDirect(PyTuple_GET_ITEM(mro, i), pyname, /*mustBeCPyCppyy=*/true))
+            return true;
+      }
+   }
+   return false;
+}
+
 PyObject* GetAttrDirect(PyObject* pyclass, PyObject* pyname) {
 // get an attribute without causing getattr lookups
     PyObject* dct = PyObject_GetAttr(pyclass, PyStrings::gDict);
@@ -1755,12 +1768,36 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
         Utility::AddToClass(pyclass, pybool_name, (PyCFunction)NullCheckBool, METH_NOARGS);
     }
 
-// for STL containers, and user classes modeled after them
-// the attribute must be a CPyCppyy overload, otherwise the check gives false
-// positives in the case where the class has a non-function attribute that is
-// called "size".
-    if (HasAttrDirect(pyclass, PyStrings::gSize, /*mustBeCPyCppyy=*/ true)) {
-        Utility::AddToClass(pyclass, "__len__", "size");
+    // for STL containers, and user classes modeled after them. Guard the alias to
+    // __len__ by verifying that size() returns an integer type and the class has
+    // begin()/end() or operator[] (i.e. is container-like). This prevents bool()
+    // returning False for valid objects whose size() returns non-integer types like
+    // std::optional<std::size_t>. Skip if size() has multiple overloads, as that
+    // indicates it is not the simple container-style size() one would map to __len__.
+    if (HasAttrDirect(pyclass, PyStrings::gSize, /*mustBeCPyCppyy=*/true) || HasAttrInMRO(pyclass, PyStrings::gSize)) {
+       bool sizeIsInteger = false;
+       PyObject *pySizeMethod = PyObject_GetAttr(pyclass, PyStrings::gSize);
+       if (pySizeMethod && CPPOverload_Check(pySizeMethod)) {
+          auto *ol = (CPPOverload *)pySizeMethod;
+          if (ol->HasMethods() && ol->fMethodInfo->fMethods.size() == 1) {
+             PyObject *pyrestype =
+                ol->fMethodInfo->fMethods[0]->Reflex(Cppyy::Reflex::RETURN_TYPE, Cppyy::Reflex::AS_STRING);
+             if (pyrestype) {
+                sizeIsInteger = Cppyy::IsIntegerType(CPyCppyy_PyText_AsString(pyrestype));
+                Py_DECREF(pyrestype);
+             }
+          }
+       }
+       Py_XDECREF(pySizeMethod);
+
+       if (sizeIsInteger) {
+          bool hasIterators = (HasAttrDirect(pyclass, PyStrings::gBegin) || HasAttrInMRO(pyclass, PyStrings::gBegin)) &&
+                              (HasAttrDirect(pyclass, PyStrings::gEnd) || HasAttrInMRO(pyclass, PyStrings::gEnd));
+          bool hasSubscript = HasAttrDirect(pyclass, PyStrings::gGetItem) || HasAttrInMRO(pyclass, PyStrings::gGetItem);
+          if (hasIterators || hasSubscript) {
+             Utility::AddToClass(pyclass, "__len__", "size");
+          }
+       }
     }
 
     if (HasAttrDirect(pyclass, PyStrings::gContains)) {

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -1247,6 +1247,18 @@ bool Cppyy::IsAggregate(TCppType_t type)
     return false;
 }
 
+bool Cppyy::IsIntegerType(const std::string &type_name)
+{
+   // Test if the named type is an integer type
+   TypeInfo_t *ti = gInterpreter->TypeInfo_Factory(type_name.c_str());
+   if (!ti)
+      return false;
+   void *qtp = gInterpreter->TypeInfo_QualTypePtr(ti);
+   bool result = qtp ? gInterpreter->IsIntegerType(qtp) : false;
+   gInterpreter->TypeInfo_Delete(ti);
+   return result;
+}
+
 bool Cppyy::IsDefaultConstructable(TCppType_t type)
 {
 // Test if this type has a default constructor or is a "plain old data" type

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/cpp_cppyy.h
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/cpp_cppyy.h
@@ -136,6 +136,8 @@ namespace Cppyy {
     RPY_EXPORTED
     bool IsAggregate(TCppType_t type);
     RPY_EXPORTED
+    bool IsIntegerType(const std::string &type_name);
+    RPY_EXPORTED
     bool IsDefaultConstructable(TCppType_t type);
 
     RPY_EXPORTED

--- a/bindings/pyroot/cppyy/cppyy/test/pythonizables.h
+++ b/bindings/pyroot/cppyy/cppyy/test/pythonizables.h
@@ -123,4 +123,43 @@ public:
 
 class IndexableDerived : public IndexableBase {};
 
+//===========================================================================
+// for testing size() -> __len__ pythonization guards
+class SizeReturnsInt {
+public:
+   int size() { return 3; }
+   int *begin() { return m_data; }
+   int *end() { return m_data + 3; }
+
+private:
+   int m_data[3] = {1, 2, 3};
+};
+
+class SizeReturnsNonInt {
+public:
+   struct OptSize {};
+   OptSize size() { return {}; }
+   int *begin() { return nullptr; }
+   int *end() { return nullptr; }
+};
+
+class SizeWithoutIterator {
+public:
+   int size() { return 5; }
+   // no begin()/end() or operator[]
+};
+
+// for testing __len__ with fully inherited container interface
+class ContainerBase {
+public:
+   int size() { return 2; }
+   int *begin() { return m_data; }
+   int *end() { return m_data + 2; }
+
+private:
+   int m_data[2] = {10, 20};
+};
+
+class InheritedContainer : public ContainerBase {};
+
 } // namespace pyzables

--- a/bindings/pyroot/cppyy/cppyy/test/stltypes.h
+++ b/bindings/pyroot/cppyy/cppyy/test/stltypes.h
@@ -82,15 +82,6 @@ public:
     value_type& operator[](ptrdiff_t i) { return fData[i]; }
 };
 
-template<class value_type, size_t sz>
-class stl_like_class3 : public stl_like_class2<value_type, sz> {
-    using stl_like_class2<value_type, sz>::fData;
-public:
-    size_t size() { return sz; }
-    value_type& begin() { return fData; }
-    value_type& end() { return fData + sz; }
-};
-
 class stl_like_class4 {
 public:
     struct iterator {

--- a/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_pythonization.py
@@ -370,6 +370,33 @@ class TestClassPYTHONIZATION:
         optr.__smartptr__().reset(o2)
         assert optr == o2
 
+    def test11_size_len_pythonization_guards(self):
+        """Verify __len__ is only installed when size() returns int and class is iterable"""
+
+        import cppyy
+
+        # size() returns int AND has begin/end -> __len__ installed
+        obj_int = cppyy.gbl.pyzables.SizeReturnsInt()
+        assert hasattr(obj_int, "__len__")
+        assert len(obj_int) == 3
+        assert bool(obj_int)
+
+        # size() returns non-integer type -> __len__ NOT installed
+        obj_opt = cppyy.gbl.pyzables.SizeReturnsNonInt()
+        assert not hasattr(obj_opt, "__len__")
+        assert bool(obj_opt)  # should be True (valid object)
+
+        # size() returns int but no begin/end or operator[] -> __len__ NOT installed
+        obj_noiter = cppyy.gbl.pyzables.SizeWithoutIterator()
+        assert not hasattr(obj_noiter, "__len__")
+        assert bool(obj_noiter)
+
+        # fully inherited container interface -> __len__ installed via MRO
+        obj_inherited = cppyy.gbl.pyzables.InheritedContainer()
+        assert hasattr(obj_inherited, "__len__")
+        assert len(obj_inherited) == 2
+
+
 ## actual test run
 if __name__ == "__main__":
     exit(pytest.main(args=['-sv', '-ra', __file__]))

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1484,16 +1484,12 @@ class TestSTLITERATOR:
 
         assert i == len(a)-1
 
-        for cls in [cppyy.gbl.stl_like_class2, cppyy.gbl.stl_like_class3]:
-            b = cls[float, 2]()
-            b[0] = 27; b[1] = 42
-            limit = len(b)+1
-            for x in b:
-                limit -= 1
-                assert limit and "iterated too far!"
-                assert x in [27, 42]
-            assert x == 42
-            del x, b
+        b = cppyy.gbl.stl_like_class2[float, 2]()
+        b[0] = 27
+        b[1] = 42
+        assert len(b) == 2
+        for i in range(len(b)):
+            assert b[i] in [27, 42]
 
         for num in [4, 5, 6, 7]:
             cls = getattr(cppyy.gbl, 'stl_like_class%d' % num)


### PR DESCRIPTION
# Summary

If a C++ class has a `size()` method that returns a non-integer type cppyy adds a `__len__` method but it always crashes. This can then affect the result of `__bool__` in unexpected ways.

This PR fixes it by only pythonising `size()` -> `__len__` if the return type is valid and it also appears to be iterable (has `begin()`+`end()` or `operator[]`).

Feel free to close this if you think there is a better solution.

# This Pull request:

This was triggered by this issue in LHCb and Gaudi:

> In order to understand the bootom issue, probably in cppyy), here is a simple reproducer, only based on Gaudi :
> ```python
> from GaudiPython import gbl as Cpp
> intObj = Cpp.AnyDataWrapper[int](1)
> print(bool(intObj))
> print(bool(intObj.getData()))
> dataObj = Cpp.DataObject()
> print(bool(dataObj))
> ```
> It will output :
> ```
> False
> True
> True
> ```
> The first one should also be True. Note how DataObject works differently from AnyDataWrapper.
> One difference is that DataObject is not templated while AnyDataWrapper is.

I debugged this to find:

> So this comes from unlucky interaction between two cppyy mechanisms and the signature of `AnyDataWrapperBase::size()`.
> 
> The smoking gun is that the two objects differ in whether they have `__len__` at all:
> 
> ```python
> >>> hasattr(intObj, "__len__")
> True
> >>> hasattr(dataObj, "__len__")
> False
> ```
> 
> Two pieces in ROOT's vendored CPyCppyy are relevant:
> 
> 1. Any class with a method named size gets `__len__` aliased to it. No check on the return type. See [here](https://github.com/root-project/root/blob/v6-36-08/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx#L1752-L1758):
> 
> ```c++
> // for STL containers, and user classes modeled after them
> if (HasAttrDirect(pyclass, PyStrings::gSize, /*mustBeCPyCppyy=*/ true)) {
>     Utility::AddToClass(pyclass, "__len__", "size");
> }
> ```
> 
> 2. So bool(x) on any cppyy object is: non-null pointer → consult __len__ if there is one, otherwise True. See [`op_nonzero`](https://github.com/root-project/root/blob/v6-36-08/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx#L241-L262):
> 
> ```c++
> if (!self->GetObject())
>     return 0;
> PyObject* pylen = PyObject_CallMethodObjArgs((PyObject*)self, PyStrings::gLen, NULL);
> if (!pylen) { PyErr_Clear(); return 1; }
> return PyObject_IsTrue(pylen);
> ```
> 
> Put those together with `AnyDataWrapperBase::size()` in `GaudiKernel/AnyDataWrapper.h`, which is declared as `std::optional<std::size_t>` and returns `std::nullopt` for any non-container T (via the `details::size` fallback). `AnyDataWrapper<int>` inherits that, (1) aliases it to __len__, then (2) bool() goes through op_nonzero and calls it. You can see the mess directly:
> 
> ```python
> >>> intObj.__len__.__doc__
> 'optional<unsigned long> AnyDataWrapper<int>::size()'
> >>> len(intObj)
> TypeError: 'optional<unsigned long>' object cannot be interpreted as an integer
> ```
> 
> DataObject has no `size()` at all, so no `__len__` is installed, `op_nonzero` hits the `PyErr_Clear(); return 1;` branch, and you get `True`.

## Changes or fixes:

Guard the automatic `size()` -> `__len__` pythonization to require that `size()` returns an integer type and the class has either `begin()`/`end()` methods or accepts `operator[]`. This prevents `bool()` returning `False` for valid objects whose `size()` returns non-integer types like `std::optional<std::size_t>`.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)