### PR TITLE
[gui] let use some classes in batch mode

### DIFF
--- a/gui/gui/src/TGGC.cxx
+++ b/gui/gui/src/TGGC.cxx
@@ -50,7 +50,6 @@ TGGC::TGGC(GCValues_t *values, Bool_t)
       }
    } else {
       fValues = {};
-      fContext = 0;
    }
    SetRefCount(1);
 }
@@ -61,20 +60,14 @@ TGGC::TGGC(GCValues_t *values, Bool_t)
 TGGC::TGGC(GCValues_t *values)
 {
    fContext = 0;
+   SetRefCount(1);
    // case of default ctor at program startup before gClient exists
-   if (!values) {
+   if (!values)
       fValues = {};
-      fContext = 0;
-      SetRefCount(1);
-      return;
-   }
-
-   if (gClient)
+   else if (gClient)
       gClient->GetGC(values, kTRUE);
-   else {
-      fContext = 0;
+   else
       Error("TGGC", "TGClient not yet initialized, should never happen");
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGLabel.cxx
+++ b/gui/gui/src/TGLabel.cxx
@@ -340,8 +340,8 @@ void TGLabel::SetTextFont(TGFont *font, Bool_t global)
    if (!global) {
       if (gc == &GetDefaultGC() ) { // create new GC
          gc = pool->GetGC((GCValues_t*)gc->GetAttributes(), kTRUE); // copy ctor.
+         fHasOwnFont = kTRUE;
       }
-      fHasOwnFont = kTRUE;
    }
    if (oldfont != fgDefaultFont) {
       fClient->FreeFont(oldfont);
@@ -366,8 +366,8 @@ void TGLabel::SetTextColor(Pixel_t color, Bool_t global)
    if (!global) {
       if (gc == &GetDefaultGC() ) {
          gc = pool->GetGC((GCValues_t*)gc->GetAttributes(), kTRUE); // copy
+         fHasOwnFont = kTRUE;
       }
-      fHasOwnFont = kTRUE;
    }
    if (gc) {
       gc->SetForeground(color);

--- a/gui/gui/src/TGPicture.cxx
+++ b/gui/gui/src/TGPicture.cxx
@@ -94,42 +94,36 @@ const TGPicture *TGPicturePool::GetPicture(const char *name)
 
    TGPicture *pic = (TGPicture *)fPicList->FindObject(pname);
    if (pic && !pic->IsScaled()) {
-      if (pic->fPic == kNone)
-         return 0;
+      // in batch mode allow to return dummy image
+      if ((pic->fPic == kNone) && !gROOT->IsBatch())
+         return nullptr;
       pic->AddReference();
       return pic;
    }
 
    char *picnam = gSystem->Which(fPath, pname, kReadPermission);
-   if (!picnam) {
-      pic = new TGPicture(pname);
-      pic->fAttributes.fColormap  = fClient->GetDefaultColormap();
-      pic->fAttributes.fCloseness = 40000; // Allow for "similar" colors
-      pic->fAttributes.fMask      = kPASize | kPAColormap | kPACloseness;
-      fPicList->Add(pic);
-      return 0;
-   }
 
-   TImage *img = TImage::Open(picnam);
+   TImage *img = picnam ? TImage::Open(picnam) : nullptr;
+
+   delete [] picnam;
+
    if (!img) {
       pic = new TGPicture(pname);
       pic->fAttributes.fColormap  = fClient->GetDefaultColormap();
       pic->fAttributes.fCloseness = 40000; // Allow for "similar" colors
       pic->fAttributes.fMask      = kPASize | kPAColormap | kPACloseness;
       fPicList->Add(pic);
-      delete [] picnam;
-      return 0;
+      return nullptr;
    }
 
    pic = new TGPicture(pname, img->GetPixmap(), img->GetMask());
-   delete [] picnam;
    delete img;
    fPicList->Add(pic);
    return pic;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Like TGPicturePool::GetPicture() but, instead of returning null when the 
+/// Like TGPicturePool::GetPicture() but, instead of returning null when the
 /// picture is not found, it returns a valid empty picture.
 
 const TGPicture *TGPicturePool::GetPictureOrEmpty(const char *name)


### PR DESCRIPTION
1. Let work with "dummy" `TGPicture` objects in batch. Even if pixmap is empty - return pointer on existing object to suppress warnings in the `TG...` constructors
2. Correctly set ref counter in TGGC constructor. Otherwise instance can be created with wrong refcount value. 
3. In `TGLabel` set `fHasOwnFont` flag only when really new `TGGC` object is allocated. Otherwise in destructor TGLabel tries to delete instance which is not owned. Appears in batch mode

This PR will help to run GUI tests in batch mode like prepared in https://github.com/root-project/root/pull/21882