### PR TITLE
Fix pad border highlight in GL mode

### DIFF
--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -66,6 +66,8 @@ protected:
    //
    TVirtualPadPainter *fPainter;   ///<! Canvas (pad) painter.
 
+   TVirtualPad *fHilightPadBorder = nullptr; ///<! pad which border will be hilghlighrt when paint canvas
+
    static Bool_t fgIsFolder;       ///< Indicates if canvas can be browsed as a folder
 
 private:

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1140,30 +1140,28 @@ void TCanvas::FeedbackMode(Bool_t set)
 
 void TCanvas::Flush()
 {
-   if ((fCanvasID == -1) || IsWeb()) return;
+   if ((fCanvasID == -1) || IsWeb() || IsBatch())
+      return;
 
-   TContext ctxt(this, kTRUE);
-   if (!IsBatch()) {
-      if (!UseGL() || fGLDevice == -1) {
-         fPainter->SelectDrawable(fCanvasID);
-         gPad = ctxt.GetSaved(); //don't do cd() because than also the pixmap is changed
-         CopyPixmaps();
-         fPainter->UpdateDrawable(1);
-      } else {
-         TVirtualPS *tvps = gVirtualPS;
-         gVirtualPS = nullptr;
-         gGLManager->MakeCurrent(fGLDevice);
-         fPainter->InitPainter();
-         Paint();
-         if (ctxt.GetSaved() && ctxt.GetSaved()->GetCanvas() == this) {
-            ctxt.GetSaved()->cd();
-            ctxt.GetSaved()->HighLight(ctxt.GetSaved()->GetHighLightColor());
-            //cd();
-         }
-         fPainter->LockPainter();
-         gGLManager->Flush(fGLDevice);
-         gVirtualPS = tvps;
-      }
+   if (!UseGL() || fGLDevice == -1) {
+      fPainter->SelectDrawable(fCanvasID);
+      CopyPixmaps();
+      fPainter->UpdateDrawable(1);
+   } else {
+      if (IsEditable())
+         fHilightPadBorder = gPad;
+
+      TContext ctxt(this, kTRUE);
+
+      TVirtualPS *tvps = gVirtualPS;
+      gVirtualPS = nullptr;
+      gGLManager->MakeCurrent(fGLDevice);
+      fPainter->InitPainter();
+      Paint();
+      fPainter->LockPainter();
+      gGLManager->Flush(fGLDevice);
+      gVirtualPS = tvps;
+      fHilightPadBorder = nullptr;
    }
 }
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3629,6 +3629,9 @@ void TPad::Paint(Option_t * /*option*/)
          obj->Paint(lnk->GetOption());
          lnk = lnk->Next();
       }
+
+      if (fCanvas && (fCanvas->fHilightPadBorder == this))
+         PaintBorder(-GetHighLightColor(), kTRUE);
    }
 
    fPadPaint = 0;


### PR DESCRIPTION
Was drawn before at the very end and therefore render order was not correct. If active pad was hidden by other pad border was drawn on the top anyway.

Can be generalized also for normal painting later