### PR TITLE
[CI] Update the ruff install action to v4.

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -70,7 +70,7 @@ jobs:
         git diff --diff-filter=AMR --name-only HEAD~1 | tee changed_files.txt
 
     - name: Install ruff
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4
       with:
         version: "latest"
         args: "--version"


### PR DESCRIPTION
This should fix the last node 20 deprecation warning in our CI.
