### PR TITLE
[ntuple] allow passing opts to CreateAttributeSet, reuse otherwise

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -268,8 +268,11 @@ public:
 
    /// Creates a new Attribute Set called `name` associated to this Writer and returns a non-owning pointer to it.
    /// The lifetime of the Attribute Set ends at the same time as the Writer's.
+   /// If `options` are passed, they will be used for the attribute set writer; otherwise, they will be derived from
+   /// the main writer.
    ROOT::Experimental::RNTupleAttrSetWriterHandle
-   CreateAttributeSet(std::unique_ptr<RNTupleModel> model, std::string_view name);
+   CreateAttributeSet(std::unique_ptr<RNTupleModel> model, std::string_view name,
+                      const ROOT::RNTupleWriteOptions *options = nullptr);
 
    /// Writes the given AttributeSet to the underlying storage and closes it. This method is only useful if you
    /// want to close the AttributeSet early: otherwise it will automatically closed when the RNTupleWriter gets

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -111,8 +111,6 @@ public:
 
    void UpdateSchema(const ROOT::Internal::RNTupleModelChangeset &changeset, ROOT::NTupleSize_t firstEntry) final;
 
-   /// Creates a new sink that uses the same underlying file/directory but writes to a different RNTuple with the
-   /// given `name`.
    std::unique_ptr<RPageSink>
    CloneAsHidden(std::string_view name, const ROOT::RNTupleWriteOptions &opts) const override;
 }; // class RPageSinkFile

--- a/tree/ntuple/src/RNTupleWriter.cxx
+++ b/tree/ntuple/src/RNTupleWriter.cxx
@@ -174,7 +174,8 @@ ROOT::Experimental::RNTupleWriter_Append(std::unique_ptr<ROOT::RNTupleModel> mod
 }
 
 ROOT::Experimental::RNTupleAttrSetWriterHandle
-ROOT::RNTupleWriter::CreateAttributeSet(std::unique_ptr<ROOT::RNTupleModel> model, std::string_view name)
+ROOT::RNTupleWriter::CreateAttributeSet(std::unique_ptr<ROOT::RNTupleModel> model, std::string_view name,
+                                        const ROOT::RNTupleWriteOptions *optsPtr)
 {
    if (IsReservedRNTupleAttrSetName(name)) {
       throw ROOT::RException(R__FAIL("Cannot create Attribute Set named \"" + std::string(name) +
@@ -184,7 +185,7 @@ ROOT::RNTupleWriter::CreateAttributeSet(std::unique_ptr<ROOT::RNTupleModel> mode
    if (name.empty())
       throw ROOT::RException(R__FAIL("cannot create an Attribute Set with an empty name"));
 
-   auto opts = ROOT::RNTupleWriteOptions();
+   const RNTupleWriteOptions &opts = optsPtr != nullptr ? *optsPtr : fFillContext.fSink->GetWriteOptions();
    auto attrSink = fFillContext.fSink->CloneAsHidden(name, opts);
 
    std::string nameStr{name};

--- a/tree/ntuple/test/ntuple_attributes.cxx
+++ b/tree/ntuple/test/ntuple_attributes.cxx
@@ -197,7 +197,9 @@ TEST(RNTupleAttributes, MultipleSets)
 
       auto attrModel2 = RNTupleModel::Create();
       auto pString2 = attrModel2->MakeField<std::string>("string");
-      auto attrSet2 = writer->CreateAttributeSet(attrModel2->Clone(), "MyAttrSet2");
+      auto attrOpts2 = ROOT::RNTupleWriteOptions();
+      attrOpts2.SetCompression(404);
+      auto attrSet2 = writer->CreateAttributeSet(attrModel2->Clone(), "MyAttrSet2", &attrOpts2);
 
       auto attrRange2 = attrSet2->BeginRange();
       for (int i = 0; i < 100; ++i) {
@@ -211,12 +213,39 @@ TEST(RNTupleAttributes, MultipleSets)
       attrSet2->CommitRange(std::move(attrRange2));
    }
 
-   auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto tfile = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str()));
+   auto ntpl = tfile->Get<ROOT::RNTuple>("ntpl");
+   auto reader = RNTupleReader::Open(*ntpl);
    EXPECT_EQ(reader->GetDescriptor().GetNAttributeSets(), 2);
    int n = 1;
    for (const auto &attrSetIt : reader->GetDescriptor().GetAttrSetIterable()) {
       EXPECT_EQ(attrSetIt.GetName(), "MyAttrSet" + std::to_string(n));
       ++n;
+   }
+
+   // Verify compression
+   auto tkeys = tfile->WalkTKeys();
+   int nHeader = 0;
+   for (const auto &key : tkeys) {
+      if (key.fType != ROOT::Detail::TKeyMapNode::kKey || key.fClassName != "RBlob")
+         continue;
+
+      // The first 3 RBlobs we're gonna find are, in order: the main RNTuple header, MyAttrSet1's header
+      // and MyAttrSet2's header.
+      const auto headerSeek = key.fSeekKey + key.fKeyLen;
+
+      // Extract the header's compression
+      tfile->Seek(headerSeek);
+      unsigned char zipHeader[9];
+      bool ok = tfile->ReadBuffer(reinterpret_cast<char *>(zipHeader), sizeof(zipHeader));
+      ASSERT_FALSE(ok);
+
+      const int expectedCompression = nHeader < 2 ? ROOT::RCompressionSetting::EAlgorithm::kZSTD : 4;
+      const auto realCompression = R__getCompressionAlgorithm(zipHeader, sizeof(zipHeader));
+      ASSERT_EQ(realCompression, expectedCompression);
+
+      if (++nHeader == 3)
+         break;
    }
 }
 


### PR DESCRIPTION
Currently CreateAttributeSet is just passing an empty WriteOptions struct to sink->CloneAsHidden().
This PR changes CloneAsHidden()'s signature to accept an optional instead of a const ref and, if nothing is passed, the "parent" sink's options are reused.

This means e.g. that by default CreateAttributeSet will preserve the same compression as the main RNTuple, which is what you would intuitively expect.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


