### PR TITLE
[x11] call XftInit() before using other functions [6.36]

### DIFF
--- a/graf2d/x11ttf/inc/TGX11TTF.h
+++ b/graf2d/x11ttf/inc/TGX11TTF.h
@@ -33,6 +33,7 @@ private:
    FT_Vector   fAlign;                 ///< alignment vector
 #ifdef R__HAS_XFT
    TXftFontHash  *fXftFontHash;        ///< hash table for Xft fonts
+   static Bool_t  gXftInit;            ///< does xft was initialized
 #endif
 
    void     Align(void);

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -127,6 +127,9 @@ public:
       delete data;
    }
 };
+
+Bool_t TGX11TTF::gXftInit = kFALSE;
+
 #endif  // R__HAS_XFT
 
 /** \class TTFX11Init
@@ -603,6 +606,11 @@ FontStruct_t TGX11TTF::LoadQueryFont(const char *font_name)
    // already loaded
    if (data) {
       return (FontStruct_t)data->fXftFont;
+   }
+
+   if (!gXftInit) {
+      XftInit(nullptr);
+      gXftInit = kTRUE;
    }
 
    XftFont *xftfont = XftFontOpenXlfd((Display*)fDisplay, fScreenNumber, font_name);


### PR DESCRIPTION
With recent fontconfig version warning appears when starting root:

Fontconfig warning: using without calling FcInit()

It is because of use of Xft library without initialization.

Adding XftInit() call before first use of Xft library resolves the issue
