### PR TITLE
[cmake] check for specific components required by xrootd

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -732,6 +732,14 @@ if(xrootd AND NOT builtin_xrootd)
         set(builtin_xrootd ON CACHE BOOL "Enabled because xrootd is enabled, but external xrootd was not found (${xrootd_description})" FORCE)
       endif()
     endif()
+  else()
+    # XROOTD was found. Check now for required components
+    foreach (component CLIENT UTILS) # ROOT requires XrdCl and XrdUtils
+      if("${XROOTD_${component}_LIBRARIES}" STREQUAL "XROOTD_${component}_LIBRARIES-NOTFOUND")
+        message(SEND_ERROR "XROOTD found but missing component ${component}. Install missing package on your system (preferred). "
+                           "Alternatively, you can also enable the option 'builtin_xrootd' to build XROOTD internally")
+      endif()
+    endforeach()
   endif()
 
   if(XRootD_VERSION VERSION_LESS 5.8.4)


### PR DESCRIPTION
so that configuration fails if missing prerequisite.

Fixes https://github.com/root-project/root/issues/21915

Then I did `apt install xrootd-client` (utils was already installed) and hoped that the error would be gone, but nope.
The difference I saw between the FOUND and NOT-FOUND component is a missing link.

```
lrwxrwxrwx 1 root root      16 feb 24  2022 /usr/lib/x86_64-linux-gnu/libXrdUtils.so -> libXrdUtils.so.3
lrwxrwxrwx 1 root root      20 feb 24  2022 /usr/lib/x86_64-linux-gnu/libXrdUtils.so.3 -> libXrdUtils.so.3.0.0
-rw-r--r-- 1 root root 1081376 feb 24  2022 /usr/lib/x86_64-linux-gnu/libXrdUtils.so.3.0.0
```

vs

```
lrwxrwxrwx 1 root root      17 feb 24  2022 /usr/lib/x86_64-linux-gnu/libXrdCl.so.3 -> libXrdCl.so.3.0.0
-rw-r--r-- 1 root root 1975096 feb 24  2022 /usr/lib/x86_64-linux-gnu/libXrdCl.so.3.0.0
```

so 
```
FIND_LIBRARY( XROOTD_CLIENT_UTILS XrdCl
  HINTS
  ${XROOTD_DIR}
  $ENV{XROOTD_DIR}
  /usr
  /opt/xrootd
  PATH_SUFFIXES lib lib64
)
```

returns NOT-FOUND

If I do:

`sudo ln -s /usr/lib/x86_64-linux-gnu/libXrdCl.so.3 /usr/lib/x86_64-linux-gnu/libXrdCl.so`

Then I no longer get the error.
So maybe Ubu22 has a bug with their packages, no idea.

Anyway this PR gives a more sensible return error.