### PR TITLE
[cmake] special git patch args for Windows

### DIFF
--- a/builtins/cfitsio/CMakeLists.txt
+++ b/builtins/cfitsio/CMakeLists.txt
@@ -21,6 +21,11 @@ if(WIN32 AND NOT CMAKE_GENERATOR MATCHES Ninja)
   endif()
 endif()
 
+# flag required only on Windows, on old alma paltforms it make troubles
+if(WIN32)
+  set(patch_args --ignore-whitespace)
+endif()
+
 ExternalProject_Add(
   BUILTIN_CFITSIO
   PREFIX ${CFITSIO_PREFIX}
@@ -38,7 +43,7 @@ ExternalProject_Add(
              -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIRS}
              -DZLIB_LIBRARIES=$<TARGET_FILE:ZLIB::ZLIB>
   # Skip the find_package(ZLIB REQUIRED), because we feed CFITSIO our own ZLIB flags.
-  PATCH_COMMAND git apply --ignore-space-change --ignore-whitespace
+  PATCH_COMMAND git apply ${patch_args}
                 ${CMAKE_CURRENT_SOURCE_DIR}/cfitsio-no-find-zlib.diff
                 ${CMAKE_CURRENT_SOURCE_DIR}/no-fortran-wrapper.diff
   BUILD_COMMAND ${CMAKE_COMMAND} --build . ${CFITSIO_BUILD_COMMAND_FLAGS}

--- a/builtins/gl2ps/CMakeLists.txt
+++ b/builtins/gl2ps/CMakeLists.txt
@@ -14,8 +14,7 @@ set(ROOT_GL2PS_PATCH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/v142_post_tag_fixes.patch)
 
 set(ROOT_GL2PS_PREFIX ${CMAKE_BINARY_DIR}/builtins/GL2PS-prefix)
 
-set(ROOT_GL2PS_LIBRARY ${ROOT_GL2PS_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gl2ps${CMAKE_STATIC_LIBRARY_SUFFIX}
-)
+set(ROOT_GL2PS_LIBRARY ${ROOT_GL2PS_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gl2ps${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 if(WIN32 AND NOT CMAKE_GENERATOR MATCHES Ninja)
   if(winrtdebug)
@@ -25,12 +24,17 @@ if(WIN32 AND NOT CMAKE_GENERATOR MATCHES Ninja)
   endif()
 endif()
 
+# flag required only on Windows, on old alma paltforms it make troubles
+if(WIN32)
+  set(patch_args --ignore-whitespace)
+endif()
+
 ExternalProject_Add(
   BUILTIN_GL2PS
   PREFIX ${ROOT_GL2PS_PREFIX}
   URL ${lcgpackages}/gl2ps-${ROOT_GL2PS_VERSION}.tgz
   URL_HASH SHA256=${ROOT_GL2PS_HASH}
-  PATCH_COMMAND git apply ${ROOT_GL2PS_PATCH_FILE}
+  PATCH_COMMAND git apply ${patch_args} ${ROOT_GL2PS_PATCH_FILE}
   CMAKE_ARGS -G ${CMAKE_GENERATOR}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
              -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/builtins/libgif/CMakeLists.txt
+++ b/builtins/libgif/CMakeLists.txt
@@ -23,12 +23,17 @@ if(WIN32 AND NOT CMAKE_GENERATOR MATCHES Ninja)
     endif()
 endif()
 
+# flag required only on Windows, on old alma paltforms it make troubles
+if(WIN32)
+  set(patch_args --ignore-whitespace)
+endif()
+
 ExternalProject_Add(
     BUILTIN_LIBGIF
     PREFIX ${ROOT_LIBGIF_PREFIX}
     URL ${lcgpackages}/giflib-${ROOT_LIBGIF_VERSION}.tar.gz
     URL_HASH SHA256=${ROOT_LIBGIF_HASH}
-    PATCH_COMMAND git apply ${ROOT_LIBGIF_PATCH_FILE}
+    PATCH_COMMAND git apply ${patch_args} ${ROOT_LIBGIF_PATCH_FILE}
     CMAKE_ARGS -G ${CMAKE_GENERATOR}
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
On Windows line ending is different and therefore patch file generated on Linux cannot be applied as is.
Add "--ignore-whitespace" arguments to git apply command - but only for Windows, on alma flags are failing.
 Use ${GIT_EXECUTABLE} cmake variable to be more precise when invoking git

Resolves compilation on Windows with `-Dbuiltin_gl2ps=ON`, making similar changes in other builtins

Similar args already used in `fitsio` builtin