### PR TITLE
[net] Deprecate TGrid* abstract classes

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -54,6 +54,7 @@ The following people have contributed to this new version:
   To fit 2D data with errors in and `x` and `y`, use specialized tools like `TGraphErrors::Fit()`, or build an explicit likelihood model if you want to stay with RooFit.
 * The **RooStats::HybridPlot** class and the related **HybridResult::GetPlot** method are deprecated and will be removed in ROOT 6.42.
   We kindly ask users to write their own ROOT-based plotting code, possibly based on the source code of the deprecated **HybridPlot** class, as pre-existing plot helpers are usually failing to be flexible enough for large-scale adoption.
+* The `TGrid*` family of abstract classes provided the basis for accessing GRID services from ROOT. All the concrete plugins (AliEn, glite, etc.) were removed years ago. These facilities should now be unused. The classes will be removed in ROOT 6.42.
 
 ## Removals
 
@@ -178,7 +179,7 @@ See: https://github.com/root-project/root/pull/20963 for implementation details 
 * Fixed a bug in `TDirectoryFile::mkdir` where passing `returnExistingDirectory = true` would not work properly in case of directory hierarchies. The option is now correctly propagated to `mkdir`'s inner invocations.
 ### File Permissions Now Respect System `umask`
 
-ROOT now respects the system `umask` when creating files, following standard Unix conventions. 
+ROOT now respects the system `umask` when creating files, following standard Unix conventions.
 
 **Previous behavior:** Files were created with hardcoded `0644` permissions (owner read/write, group/others read-only), ignoring the system `umask`.
 
@@ -484,7 +485,7 @@ sum(1 for x in collection if x == obj)   # value comparison (if defined for the 
 ## Versions of built-in packages
 
 The version of the following packages has been updated:
- 
+
  - cppzeromq: 4.10.0
  - fftw3: 3.3.10
  - freetype: 2.14.3

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -44,7 +44,7 @@
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
 #pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
-#pragma link C++ class TGridJobStatusList+;
+#pragma link C++ class ROOT::Deprecated::TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TSecContext;
 #pragma link C++ class TSecContextCleanup;
@@ -64,5 +64,6 @@
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 #pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
+#pragma read sourceClass="TGridJobStatusList" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatusList"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -42,7 +42,7 @@
 #pragma link C++ class ROOT::Deprecated::TGrid;
 #pragma link C++ class TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
-#pragma link C++ class TGridJob+;
+#pragma link C++ class ROOT::Deprecated::TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
@@ -62,5 +62,6 @@
 
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
+#pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -40,7 +40,7 @@
 #pragma link C++ class TSQLColumnInfo;
 #pragma link C++ class TSQLMonitoringWriter;
 #pragma link C++ class ROOT::Deprecated::TGrid;
-#pragma link C++ class TGridResult+;
+#pragma link C++ class ROOT::Deprecated::TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
 #pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
@@ -65,5 +65,6 @@
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 #pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
 #pragma read sourceClass="TGridJobStatusList" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatusList"
+#pragma read sourceClass="TGridResult" version="[-1]" targetClass="ROOT::Deprecated::TGridResult"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -14,7 +14,7 @@
 #pragma link C++ enum ESockOptions;
 #pragma link C++ enum ESendRecvOptions;
 
-#pragma link C++ global gGrid;
+#pragma link C++ global ROOT::Deprecated::gGrid;
 #pragma link C++ global gGridJobStatusList;
 
 #pragma link C++ global kSrvAuth;
@@ -39,7 +39,7 @@
 #pragma link C++ class TSQLTableInfo;
 #pragma link C++ class TSQLColumnInfo;
 #pragma link C++ class TSQLMonitoringWriter;
-#pragma link C++ class TGrid;
+#pragma link C++ class ROOT::Deprecated::TGrid;
 #pragma link C++ class TGridResult+;
 #pragma link C++ class TGridJDL+;
 #pragma link C++ class TGridJob+;

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -45,7 +45,7 @@
 #pragma link C++ class TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
-#pragma link C++ class TGridCollection+;
+#pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TSecContext;
 #pragma link C++ class TSecContextCleanup;
 #pragma link C++ class TFileStager;
@@ -59,5 +59,7 @@
 #pragma link C++ class ROOT::Deprecated::TS3WebFile+;
 #pragma link C++ class TSSLSocket;
 #endif
+
+#pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -41,7 +41,7 @@
 #pragma link C++ class TSQLMonitoringWriter;
 #pragma link C++ class ROOT::Deprecated::TGrid;
 #pragma link C++ class TGridResult+;
-#pragma link C++ class TGridJDL+;
+#pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
@@ -61,5 +61,6 @@
 #endif
 
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
+#pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -43,7 +43,7 @@
 #pragma link C++ class TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
-#pragma link C++ class TGridJobStatus+;
+#pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TSecContext;
@@ -63,5 +63,6 @@
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
+#pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
 
 #endif

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -34,14 +34,13 @@
 
 #include "TGridJob.h"
 
-class TGridResult;
-
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
 class TGridJob;
 class TGridJobStatusList;
+class TGridResult;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
-class TGridJDL;
 class TGridJob;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
+class TGridJDL;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
-class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
 class TGridJob;
+class TGridJobStatusList;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -37,10 +37,11 @@
 class TGridResult;
 class TGridJDL;
 class TGridJob;
-class TGridCollection;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
+
+class TGridCollection;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
-class TGridJob;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
+class TGridJob;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -40,6 +40,7 @@ class TGridJob;
 class TGridCollection;
 class TGridJobStatusList;
 
+namespace ROOT::Deprecated {
 
 class TGrid : public TObject {
 
@@ -126,5 +127,10 @@ public:
 };
 
 R__EXTERN TGrid *gGrid;
+
+} // namespace ROOT::Deprecated
+
+using TGrid R__DEPRECATED(6, 42, "TGrid is expected to be unused and thus deprecated") = ROOT::Deprecated::TGrid;
+R__EXTERN ROOT::Deprecated::TGrid *&gGrid R__DEPRECATED(6, 42, "gGrid is expected to be unused and thus deprecated");
 
 #endif

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -30,6 +30,7 @@ class TDSet;
 class TGridResult;
 class TFileCollection;
 
+namespace ROOT::Deprecated {
 
 class TGridCollection : public TObject {
 public:
@@ -114,5 +115,10 @@ public:
 
    ClassDefOverride(TGridCollection,1)  // ABC managing collection of files on the Grid
 };
+
+} // namespace ROOT::Deprecated
+
+using TGridCollection R__DEPRECATED(6, 42, "TGridCollection is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridCollection;
 
 #endif

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -27,10 +27,11 @@ class TFile;
 class TEntryList;
 class TList;
 class TDSet;
-class TGridResult;
 class TFileCollection;
 
 namespace ROOT::Deprecated {
+
+class TGridResult;
 
 class TGridCollection : public TObject {
 public:

--- a/net/net/inc/TGridJDL.h
+++ b/net/net/inc/TGridJDL.h
@@ -28,6 +28,7 @@
 #include "TString.h"
 #include "TMap.h"
 
+namespace ROOT::Deprecated {
 
 class TGridJDL : public TObject {
 protected:
@@ -74,5 +75,10 @@ public:
 
    ClassDefOverride(TGridJDL,1)  // ABC defining interface JDL generator
 };
+
+} // namespace ROOT::Deprecated
+
+using TGridJDL R__DEPRECATED(6, 42, "TGridJDL is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJDL;
 
 #endif

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -25,10 +25,9 @@
 #include "TObject.h"
 #include "TString.h"
 
+namespace ROOT::Deprecated {
 
 class TGridJobStatus;
-
-namespace ROOT::Deprecated {
 
 class TGridJob : public TObject {
 

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -28,6 +28,8 @@
 
 class TGridJobStatus;
 
+namespace ROOT::Deprecated {
+
 class TGridJob : public TObject {
 
 protected:
@@ -46,5 +48,10 @@ public:
    virtual Bool_t          Cancel () = 0;
    ClassDefOverride(TGridJob,1)  // ABC defining interface to a GRID job
 };
+
+} // namespace ROOT::Deprecated
+
+using TGridJob R__DEPRECATED(6, 42, "TGridJob is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJob;
 
 #endif

--- a/net/net/inc/TGridJobStatus.h
+++ b/net/net/inc/TGridJobStatus.h
@@ -22,6 +22,7 @@
 
 #include "TNamed.h"
 
+namespace ROOT::Deprecated {
 
 class TGridJobStatus : public TNamed {
 
@@ -49,5 +50,10 @@ public:
 
   ClassDefOverride(TGridJobStatus,1)  // ABC defining status of a Grid job
 };
+
+} // namespace ROOT::Deprecated
+
+using TGridJobStatus R__DEPRECATED(6, 42, "TGridJobStatus is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJobStatus;
 
 #endif

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -22,6 +22,8 @@
 
 #include "TList.h"
 
+namespace ROOT::Deprecated {
+
 class TGridJobStatusList : public TList {
 
 protected:
@@ -35,5 +37,12 @@ public:
 };
 
 R__EXTERN TGridJobStatusList *gGridJobStatusList;
+
+} // namespace ROOT::Deprecated
+
+using TGridJobStatusList R__DEPRECATED(6, 42, "TGridJobStatusList is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJobStatusList;
+R__EXTERN ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList
+   R__DEPRECATED(6, 42, "gGridJobStatusList is expected to be unused and thus deprecated");
 
 #endif

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -22,11 +22,6 @@
 
 #include "TList.h"
 
-#include "TGridJob.h"
-
-
-class TGridJob;
-
 class TGridJobStatusList : public TList {
 
 protected:

--- a/net/net/inc/TGridResult.h
+++ b/net/net/inc/TGridResult.h
@@ -27,6 +27,7 @@
 
 class TEntryList;
 
+namespace ROOT::Deprecated {
 
 class TGridResult : public TList {
 
@@ -51,5 +52,10 @@ public:
 
    ClassDefOverride(TGridResult,1)  // ABC defining interface to GRID result set
 };
+
+} // namespace ROOT::Deprecated
+
+using TGridResult R__DEPRECATED(6, 42, "TGridResult is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridResult;
 
 #endif

--- a/net/net/src/TGrid.cxx
+++ b/net/net/src/TGrid.cxx
@@ -30,7 +30,8 @@
 #include "TPluginManager.h"
 #include "TError.h"
 
-TGrid *gGrid = 0;
+ROOT::Deprecated::TGrid *ROOT::Deprecated::gGrid = 0;
+ROOT::Deprecated::TGrid *&gGrid = ROOT::Deprecated::gGrid;
 
 
 
@@ -45,8 +46,8 @@ TGrid *gGrid = 0;
 /// -debug=`<debug level from 1 to 10>`
 /// Example: "-domain=cern.ch -debug=5"
 
-TGrid *TGrid::Connect(const char *grid, const char *uid, const char *pw,
-                      const char *options)
+ROOT::Deprecated::TGrid *
+ROOT::Deprecated::TGrid::Connect(const char *grid, const char *uid, const char *pw, const char *options)
 {
    TPluginHandler *h;
    TGrid *g = 0;

--- a/net/net/src/TGridJDL.cxx
+++ b/net/net/src/TGridJDL.cxx
@@ -30,7 +30,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// Cleanup.
 
-TGridJDL::~TGridJDL()
+ROOT::Deprecated::TGridJDL::~TGridJDL()
 {
    Clear();
 }
@@ -38,7 +38,7 @@ TGridJDL::~TGridJDL()
 ////////////////////////////////////////////////////////////////////////////////
 /// Clears the JDL information.
 
-void TGridJDL::Clear(const Option_t*)
+void ROOT::Deprecated::TGridJDL::Clear(const Option_t*)
 {
    fMap.DeleteAll();
 }
@@ -46,7 +46,7 @@ void TGridJDL::Clear(const Option_t*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Sets a value. If the entry already exists the old one is replaced.
 
-void TGridJDL::SetValue(const char *key, const char *value)
+void ROOT::Deprecated::TGridJDL::SetValue(const char *key, const char *value)
 {
    TObject *object = fMap.FindObject(key);
    TPair *pair = dynamic_cast<TPair*>(object);
@@ -73,7 +73,7 @@ void TGridJDL::SetValue(const char *key, const char *value)
 /// Returns the value corresponding to the provided key. Return 0 in case
 /// key is not found.
 
-const char *TGridJDL::GetValue(const char *key)
+const char *ROOT::Deprecated::TGridJDL::GetValue(const char *key)
 {
    if (!key)
       return 0;
@@ -100,7 +100,7 @@ const char *TGridJDL::GetValue(const char *key)
 ////////////////////////////////////////////////////////////////////////////////
 /// Sets a value. If the entry already exists the old one is replaced.
 
-void TGridJDL::SetDescription(const char *key, const char* description)
+void ROOT::Deprecated::TGridJDL::SetDescription(const char *key, const char* description)
 {
    TObject *object = fDescriptionMap.FindObject(key);
    TPair *pair = dynamic_cast<TPair*>(object);
@@ -127,7 +127,7 @@ void TGridJDL::SetDescription(const char *key, const char* description)
 /// Returns the value corresponding to the provided key. Return 0 in case
 /// key is not found.
 
-const char *TGridJDL::GetDescription(const char *key)
+const char *ROOT::Deprecated::TGridJDL::GetDescription(const char *key)
 {
    if (!key)
       return 0;
@@ -155,7 +155,7 @@ const char *TGridJDL::GetDescription(const char *key)
 /// Adds quotes to the provided string.
 ///  E.g. Value --> "Value"
 
-TString TGridJDL::AddQuotes(const char *value)
+TString ROOT::Deprecated::TGridJDL::AddQuotes(const char *value)
 {
    TString temp = TString("\"");
    temp += value;
@@ -168,7 +168,7 @@ TString TGridJDL::AddQuotes(const char *value)
 /// Adds a value to a key value which hosts a set of values.
 /// E.g. InputSandbox: {"file1","file2"}
 
-void TGridJDL::AddToSet(const char *key, const char *value)
+void ROOT::Deprecated::TGridJDL::AddToSet(const char *key, const char *value)
 {
    const char *oldValue = GetValue(key);
    TString newString;
@@ -191,7 +191,7 @@ void TGridJDL::AddToSet(const char *key, const char *value)
 /// Adds a value to a key value which hosts a set of values.
 /// E.g. InputSandbox: {"file1","file2"}
 
-void TGridJDL::AddToSetDescription(const char *key, const char *description)
+void ROOT::Deprecated::TGridJDL::AddToSetDescription(const char *key, const char *description)
 {
    const char *oldValue = GetDescription(key);
    TString newString;
@@ -204,7 +204,7 @@ void TGridJDL::AddToSetDescription(const char *key, const char *description)
 ////////////////////////////////////////////////////////////////////////////////
 /// Generates the JDL snippet.
 
-TString TGridJDL::Generate()
+TString ROOT::Deprecated::TGridJDL::Generate()
 {
    TString output("");
 

--- a/net/net/src/TGridJob.cxx
+++ b/net/net/src/TGridJob.cxx
@@ -27,7 +27,7 @@
 /// Must be implemented by actual GRID job implementation. Returns -1 in
 /// case of error, 0 otherwise.
 
-Int_t TGridJob::GetOutputSandbox(const char *, Option_t *)
+Int_t ROOT::Deprecated::TGridJob::GetOutputSandbox(const char *, Option_t *)
 {
    MayNotUse("GetOutputSandbox");
    return -1;

--- a/net/net/src/TGridJobStatusList.cxx
+++ b/net/net/src/TGridJobStatusList.cxx
@@ -19,6 +19,5 @@
 
 #include "TGridJobStatusList.h"
 
-TGridJobStatusList *gGridJobStatusList = 0;
-
-
+ROOT::Deprecated::TGridJobStatusList *ROOT::Deprecated::gGridJobStatusList = 0;
+ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList = ROOT::Deprecated::gGridJobStatusList;


### PR DESCRIPTION
The TGrid* family of abstract classes provided the basis for accessing GRID services from ROOT. All the concrete plugins (AliEn, glite, etc.) were removed years ago. These facilities should now be unused.