### PR TITLE
[tmva][sofie] Fix an issue with the NotWritable tensors and with inf/nan

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator.hxx
@@ -33,6 +33,9 @@ public:
    virtual std::string GenerateSessionMembersCode(std::string /*opName*/) { return ""; }
    virtual std::string Header() { return "";}
 
+   /// check if the output of the operator is Constant and is evaluated at initialization time
+   bool IsOutputConstant() const { return fIsOutputConstant; }
+
    //virtual void Forward_reference() = 0;
    //virtual void Forward_blas() = 0;
    virtual ~ROperator(){}

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -258,7 +258,7 @@ public:
    std::shared_ptr<void> const &sharedptr() const { return fData; }
    // query if tensor comes from a Constant operator
    bool IsConstantTensor() const { return fConstant;}
-   // query if tensor needs to be written in a weight file. Constant tensors are not written in a file
+   // query if tensor needs to be written in a weight file. Constant tensors are not written in a separate file
    bool IsWeightTensor() const { return !fConstant && !fIsNotWritable;}
    // check if a Tensor is Writable (need to be written in the file or in the generated code (e.g. as a constant tensor)
    // if an initialized tensors is used in a constant operator at compile time does not need to be written and can be omitted in
@@ -266,6 +266,8 @@ public:
    bool IsNotWritable() const { return fIsNotWritable; }
    // set not writable initialized tensors - i.e. tensor that must not be written in a file
    void SetNotWritable() { fIsNotWritable = true;}
+   // set writable initialized tensors - i.e. tensor that must be written in a file
+   void SetWritable() { fIsNotWritable = false;}
    // set as constant (needed for non-float initialized tensors)
    void SetConstant() { fConstant = true;}
 
@@ -788,6 +790,13 @@ inline void Relu(float *output, float const *input, int size)
       output[i] = (input[i] > 0.0f) ? input[i] : 0.0f;
    }
 }
+// function to read float from the file dealing with inf and nan values
+inline float ParseFloatToken (const std::string & s)  {
+   if (s == "inf")  return  std::numeric_limits<float>::infinity();
+   if (s == "-inf") return -std::numeric_limits<float>::infinity();
+   if (s == "nan")  return  std::numeric_limits<float>::quiet_NaN();
+   return std::stof(s);
+}
 
 template <class T>
 void ReadTensorFromStream(std::istream &is, T &target, std::string const &expectedName, std::size_t expectedLength)
@@ -805,8 +814,10 @@ void ReadTensorFromStream(std::istream &is, T &target, std::string const &expect
                             std::to_string(expectedLength) + " , read " + std::to_string(length);
       throw std::runtime_error(err_msg);
    }
+   std::string token;
    for (size_t i = 0; i < length; ++i) {
-      is >> target[i];
+      is >> token;
+      target[i] = ParseFloatToken(token);
    }
    if (is.fail()) {
       throw std::runtime_error("TMVA-SOFIE failed to read the values for tensor " + expectedName);

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -292,8 +292,7 @@ void RModel::AddIntermediateTensor(std::string tensor_name, ETensorType type, st
 void RModel::AddIntermediateTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape) {
     tensor_name = UTILITY::Clean_name(tensor_name);
     if (CheckIfTensorAlreadyExist(tensor_name)) {
-        //throw std::runtime_error("TMVA-SOFIE: intermediate tensor with name " + tensor_name + " already exists \n");
-        tensor_name += "_" + std::to_string(rand());
+        throw std::runtime_error("TMVA-SOFIE: intermediate tensor with name " + tensor_name + " already exists \n");
     }
     TensorInfo new_tensor {type, shape};
     fIntermediateTensorInfos[tensor_name] = new_tensor;
@@ -630,6 +629,8 @@ void RModel::Initialize(const std::map<std::string, size_t> & inputParams, bool 
 
    std::vector<size_t> temp_available_stack; // vector stores individual chunks of available memory that maybe reused
 
+   // Build set of initialized tensors consumed by at least one runtime operator (need for later)
+   std::unordered_set<std::string> runtimeInitializedInputs;
    for(size_t op_idx = 0; op_idx < fOperators.size(); ++op_idx){
       if (verbose) {
          auto& r = *fOperators[op_idx].get();
@@ -646,14 +647,35 @@ void RModel::Initialize(const std::map<std::string, size_t> & inputParams, bool 
             fIntermediateTensorFrequencyLookup[it] = op_idx;
          }
       }
+      // loop for non-constant operators and flag the inputs which are initialized tensors to make sure they are writable
+      if (!fOperators[op_idx]->IsOutputConstant()) {
+         for (auto &it : fOperators[op_idx]->GetOpInputTensors()) {
+            std::string name = std::string{it};
+            if (fInitializedTensors.find(name) != fInitializedTensors.end()) {
+               runtimeInitializedInputs.insert(name);
+            }
+         }
+      }
+
       i++;
    }
 
    // loop on initialized tensors and make the integers as constant to be
-   // not written in a weight file
+   // not written in a weight file and check if the tensors flagged as not writable are really not writable,
+   // i.e. are not used by non constant operators
    for (auto &it : fInitializedTensors) {
-      if (it.second.IsWeightTensor() && it.second.type() !=  ETensorType::FLOAT)
+      // check if not-writable tensors are really not writable, i.e. are not used by non constant operators
+      if (it.second.IsNotWritable() && runtimeInitializedInputs.find(it.first) != runtimeInitializedInputs.end()) {
+         it.second.SetWritable();
+         if (verbose) {
+            std::cout << "Initialized tensor " << it.first << " is flagged as not writable but is used by non constant operators, set it as writable \n";
+         }
+      }
+      // if the tensor is an integer we can flag it as constant since it will not be written in a weight file and it is considered equivalent as being created from a Constant operator
+      // only FLOAT tensors are written in a weight file
+      if (it.second.type() !=  ETensorType::FLOAT) {
          it.second.SetConstant();
+      }
    }
 
    // check if there are initialized tensors to write in a weight file
@@ -1630,7 +1652,13 @@ long RModel::WriteInitializedTensorsToFile(std::string filename) {
                   // round to zero sub-normal values
                   float value = data[idx];
                   if (value != 0. && std::abs(value) < std::numeric_limits<float>::min() ) value = 0;
-                  f << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+                  // handle non-finite values explicitly
+                  if (std::isinf(value))
+                     f << (value > 0 ? "inf" : "-inf");
+                  else if (std::isnan(value))
+                     f << "nan";
+                  else
+                     f << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
                   f <<  ( (idx < length-1) ? " " : "\n" );
                }
             }
@@ -1705,7 +1733,7 @@ void RModel::PrintInitializedTensors() const {
         }
         std::cout << "]";
         if (it.second.IsConstantTensor()) std::cout << " (Constant)";
-        else if (!it.second.IsWeightTensor()) std::cout << " (Not Writable)";
+        if (it.second.IsNotWritable()) std::cout << " (Not Writable)";
         std::cout << std::endl;
     }
     std::cout << "\n";


### PR DESCRIPTION


- Fix the setting of NotWritable tensors for inputs to constant operator and not constant. If a constant operator (an operator which can be evaluated at initialization time) is using an initialized tensors it was set to not writable, because it was not needed in the generated code. However if the same tensor is used later by another operator (non constant) the tensor was needed.

- when writing weights in a file if there are inf or Nan the reading fails. Added now correct support for this

This Pull request allows parsing of the ParT model

