### PR TITLE
[df] Mention VecOps namespace in RDF docs

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -534,6 +534,8 @@ h = df.Define("good_pts", "pt[pt > 0]").Histo1D("good_pts")
 
 Learn more at ROOT::VecOps::RVec.
 
+ROOT provides convenience utility functions to work with RVec which are available in the [ROOT::VecOps namespace](\ref vecops)
+
 \anchor transformations
 ## Transformations: manipulating data
 \anchor Filters


### PR DESCRIPTION
Tested locally, generates a link to the VecOps namespace docs (will be https://root.cern/doc/master/group__vecops.html)

<img width="798" height="45" alt="Screenshot 2026-04-17 at 13 40 35" src="https://github.com/user-attachments/assets/ea619324-10e8-489e-a239-62bbea084435" />


