### PR TITLE
[tmva][sofie] Fix ONNX fusion child indexing

### DIFF
--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -873,7 +873,7 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
          std::cout << "\t" << i << "  " << nodesOrder[i] << " parsing operator " << op_type << std::endl;
       }
 
-      std::unique_ptr<ROperator> op = ParseOperator(i, graph, nodesOrder, nodesChildren[i]);
+      std::unique_ptr<ROperator> op = ParseOperator(i, graph, nodesOrder, nodesChildren[nodesOrder[i]]);
       if (!op) {
          if (verbose) {
             std::cout << "\t\tskipping operator since it is fused with previous one" << std::endl;


### PR DESCRIPTION
Fixes #21948.

In SOFIE ONNX parsing, `nodesChildren` is keyed by original ONNX node index, while the parsing loop iterates over execution order slots from `nodesOrder`.

Previously, the parser passed `nodesChildren[i]` to `ParseOperator`.  
For graphs that are not already topologically ordered in file layout, this can pass children for the wrong node and trigger invalid fusion attempts.

This patch fixes the lookup to use the current node id from reordered execution:

`nodesChildren[nodesOrder[i]]`

so fusion decisions are made using the correct child list of the node being parsed.

## Why this matters

This bug can cause runtime parse failures on valid models when reorder is required, e.g. wrong `MatMul` + `Add` pairing.

## Changes

- one-line fix in `tmva/sofie_parsers/src/RModelParser_ONNX.cxx`
- no extra functional changes

## Checklist

- tested changes locally

Respected @lmoneta and @sanjibansg,

Could you please review this fix?

Also, I have local bug reproduction scripts but they are currently not in ROOT standard test layout.  
Kindly advise if you would like me to add the standardized tests in this PR?

With regards,  
Samreedh Bhuyan