### PR TITLE
[hist] Add option I to TH1::Chisquare for bin integral chi2

### DIFF
--- a/hist/hist/inc/HFitInterface.h
+++ b/hist/hist/inc/HFitInterface.h
@@ -169,7 +169,7 @@ namespace ROOT {
       /**
          compute the chi2 value for an histogram given a function  (see TH1::Chisquare for the documentation)
       */
-      double Chisquare(const TH1 & h1, TF1 & f1, bool useRange, EChisquareType type);
+      double Chisquare(const TH1 & h1, TF1 & f1, bool useRange, EChisquareType type, bool useIntegral = false);
 
       /**
          compute the chi2 value for a graph given a function (see TGraph::Chisquare)

--- a/hist/hist/src/HFitImpl.cxx
+++ b/hist/hist/src/HFitImpl.cxx
@@ -77,7 +77,7 @@ namespace HFit {
    void StoreAndDrawFitFunction(FitObject * h1, TF1 * f1, const ROOT::Fit::DataRange & range, bool, bool, const char *goption);
 
    template <class FitObject>
-   double ComputeChi2(const FitObject & h1, TF1 &f1, bool useRange, ROOT::Fit::EChisquareType type );
+   double ComputeChi2(const FitObject & h1, TF1 &f1, bool useRange, ROOT::Fit::EChisquareType type, bool useIntegral = false);
 
 
 
@@ -1029,8 +1029,8 @@ TFitResultPtr ROOT::Fit::FitObject(THnBase * s1, TF1 *f1 , Foption_t & foption ,
 // function to compute the simple chi2 for graphs and histograms
 
 
-double ROOT::Fit::Chisquare(const TH1 & h1,  TF1 & f1, bool useRange, ROOT::Fit::EChisquareType type) {
-   return HFit::ComputeChi2(h1,f1,useRange, type);
+double ROOT::Fit::Chisquare(const TH1 & h1,  TF1 & f1, bool useRange, ROOT::Fit::EChisquareType type, bool useIntegral) {
+   return HFit::ComputeChi2(h1,f1,useRange, type, useIntegral);
 }
 
 double ROOT::Fit::Chisquare(const TGraph & g, TF1 & f1, bool useRange) {
@@ -1038,13 +1038,14 @@ double ROOT::Fit::Chisquare(const TGraph & g, TF1 & f1, bool useRange) {
 }
 
 template<class FitObject>
-double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, ROOT::Fit::EChisquareType type ) {
+double HFit::ComputeChi2(const FitObject & obj,  TF1  & f1, bool useRange, ROOT::Fit::EChisquareType type, bool useIntegral ) {
 
    // implement using the fitting classes
    ROOT::Fit::DataOptions opt;
    opt.fUseEmpty = (type != ROOT::Fit::EChisquareType::kNeyman);  // use empty bin when not using Neyman chisquare (observed error)
    opt.fExpErrors = (type == ROOT::Fit::EChisquareType::kPearson);
    opt.fErrors1 = (type == ROOT::Fit::EChisquareType::kPearson);  // not using observed errors in Pearson chi2
+   opt.fIntegral = useIntegral;  // use bin integral instead of value at bin center
 
    ROOT::Fit::DataRange range;
    // get range of function

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2495,6 +2495,7 @@ Double_t TH1::Chi2TestX(const TH1* h2,  Double_t &chi2, Int_t &ndf, Int_t &igood
 /// Use option "R" for restricting the chisquare calculation to the given range of the function
 /// Use option "L" for using the chisquare based on the poisson likelihood (Baker-Cousins Chisquare)
 /// Use option "P" for using the Pearson chisquare based on the expected bin errors
+/// Use option "I" for using the integral of the function in each bin instead of the value at the bin center
 
 Double_t TH1::Chisquare(TF1 * func, Option_t *option) const
 {
@@ -2505,11 +2506,12 @@ Double_t TH1::Chisquare(TF1 * func, Option_t *option) const
 
    TString opt(option); opt.ToUpper();
    bool useRange = opt.Contains("R");
+   bool useIntegral = opt.Contains("I");
    ROOT::Fit::EChisquareType type = ROOT::Fit::EChisquareType::kNeyman;  // default chi2 with observed error
    if (opt.Contains("L")) type = ROOT::Fit::EChisquareType::kPLikeRatio;
    else if (opt.Contains("P")) type = ROOT::Fit::EChisquareType::kPearson;
 
-   return ROOT::Fit::Chisquare(*this, *func, useRange, type);
+   return ROOT::Fit::Chisquare(*this, *func, useRange, type, useIntegral);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull Request
## Changes or fixes
`TH1::Fit` supports option "I" which uses the integral of the fitted function over each bin instead of the value at the bin center. `TH1::Chisquare` did not parse this option, so `TF1::GetChisquare()` and `TH1::Chisquare(f, "I")` returned different results after a fit with option "I".
Changes across 3 files:
- `TH1.cxx`: parse option "I" into useIntegral, pass it to `ROOT::Fit::Chisquare`, and
  document the new option alongside the existing "R", "L", "P" options.

- `HFitImpl.cxx`: add bool `useIntegral = false` to `ROOT::Fit::Chisquare(TH1)` and
  `HFit::ComputeChi2`. Set `DataOptions::fIntegral = useIntegral` before BinData is filled.

- `HFitInterface.h`: update the public declaration with the new parameter, defaulted to
  false for full backward compatibility.

### Before this fix:
  h.Fit(f, "QI")
  f.GetChisquare()      # 7.26965
  h.Chisquare(f, "I")  # 7.27083  <-- "I" was silently ignored
### After this fix:
  h.Fit(f, "QI")
  f.GetChisquare()      # 7.26965
  h.Chisquare(f, "I")  # 7.26965  <-- correct
## Checklist
- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #21695