### PR TITLE
[RF] Error out in RooStats::SPlot if yield is a discriminating variable

### DIFF
--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -400,10 +400,27 @@ Int_t SPlot::GetNumSWeightVars() const
 /// and will be considered parameters, not observables.
 /// \param[in] includeWeights Include weights of the input data in calculation of s weights.
 /// \param[in] arg5,arg6,arg7,arg8 Optional additional arguments for the fitting step.
-void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
-         const RooArgSet &projDeps, bool includeWeights,
-         const RooCmdArg& arg5, const RooCmdArg& arg6, const RooCmdArg& arg7, const RooCmdArg& arg8)
+void SPlot::AddSWeight(RooAbsPdf *pdf, const RooArgList &yieldsTmp, const RooArgSet &projDeps, bool includeWeights,
+                       const RooCmdArg &arg5, const RooCmdArg &arg6, const RooCmdArg &arg7, const RooCmdArg &arg8)
 {
+   // Check that no yield variable is also a discriminating variable used in the fit.
+   // The sPlot formalism requires that the yield parameters are independent of the
+   // discriminating observables; otherwise, the resulting sWeights are mathematically
+   // invalid. See https://github.com/root-project/root/issues/11768.
+   std::unique_ptr<RooArgSet> discrimVars{pdf->getObservables(fSData)};
+   for (auto const *yield : yieldsTmp) {
+      if (discrimVars->find(yield->GetName()) || yield->dependsOn(*discrimVars)) {
+         coutE(InputArguments) << "SPlot::AddSWeight(" << GetName() << ") the yield variable \"" << yield->GetName()
+                               << "\" is also a discriminating variable used in the fit, "
+                               << "or depends on one. The sPlot formalism requires the yield parameters to be "
+                               << "independent of the discriminating observables. The resulting sWeights would "
+                               << "be invalid. Please remove this variable from either the fit observables or "
+                               << "from the list of yields." << std::endl;
+         throw std::invalid_argument(Form("SPlot::AddSWeight(%s) yield variable \"%s\" is also used "
+                                          "as a discriminating variable in the fit.",
+                                          GetName(), yield->GetName()));
+      }
+   }
 
   // Find Parameters in the PDF to be considered fixed when calculating the SWeights
   // and be sure to NOT include the yields in that list

--- a/roofit/roostats/test/testSPlot.cxx
+++ b/roofit/roostats/test/testSPlot.cxx
@@ -32,3 +32,27 @@ TEST(SPlot, UseWithRooLinearVar) {
   EXPECT_EQ(splot.GetNumSWeightVars(), 2);
   EXPECT_NE(data->get(0)->find("c1_sw"), nullptr);
 }
+
+// Regression test for https://github.com/root-project/root/issues/11768:
+// passing a discriminating variable of the fit in the yields list must
+// produce an error, since the resulting sWeights would be invalid.
+TEST(SPlot, ErrorOnDiscriminatingVariableAsYield)
+{
+   RooRealVar x("x", "observable", 0, 0, 20);
+   RooRealVar m("m", "mean", 5., -10, 10);
+   RooRealVar s("s", "sigma", 2., 0.1, 10);
+   RooGaussian gauss("gauss", "gauss", x, m, s);
+
+   RooRealVar a("a", "exp", -0.2, -10., 0.);
+   RooExponential ex("ex", "ex", x, a);
+
+   RooRealVar nsig("nsig", "nsig", 500, 0, 1000);
+   RooRealVar nbkg("nbkg", "nbkg", 500, 0, 1000);
+   RooAddPdf sum("sum", "sum", RooArgSet(gauss, ex), RooArgSet(nsig, nbkg));
+
+   std::unique_ptr<RooDataSet> data{sum.generate(x, 1000)};
+
+   // "x" is a discriminating variable of the fit, so using it in the yields
+   // list is a user error that must throw.
+   EXPECT_THROW(RooStats::SPlot("splot", "splot", *data, &sum, RooArgList(nsig, x)), std::invalid_argument);
+}


### PR DESCRIPTION
The sPlot formalism requires that yield parameters are independent of the discriminating observables used in the likelihood fit. Using the same variable for both produces mathematically invalid sWeights, which has confused users multiple times on the ROOT forum.

Add a check in `SPlot::AddSWeight()` that logs a RooFit error and throws `std::invalid_argument` if any yield is (or depends on) one of the fit's discriminating variables. Also turn the arXiv reference in the class documentation into a clickable link, and add a regression test.

Fixes https://github.com/root-project/root/issues/11768