### PR TITLE
[RF][RS] Route all RooStats prints through RooFit message logger

### DIFF
--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -334,7 +334,7 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
           paramsSetConstant.add(*poiVar);
        }
        if (poiSet->size() > 1)
-          std::cout << "Model with more than one POI are not supported - ignore extra parameters, consider only first one" << std::endl;
+          oocoutW(nullptr,InputArguments) << "Model with more than one POI are not supported - ignore extra parameters, consider only first one" << std::endl;
 
 
 
@@ -386,8 +386,8 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
        TString algorithm = ROOT::Math::MinimizerOptions::DefaultMinimizerAlgo();
 
        if (verbose > 0) {
-          std::cout << "AsymptoticCalculator::EvaluateNLL  ........ using " << minimizer << " / " << algorithm
-                    << " with strategy  " << strategy << " and tolerance " << tol << std::endl;
+          oocoutP(nullptr,Eval) << "AsymptoticCalculator::EvaluateNLL  ........ using " << minimizer << " / " << algorithm
+                                << " with strategy  " << strategy << " and tolerance " << tol << std::endl;
        }
 
        for (int tries = 1, maxtries = 4; tries <= maxtries; ++tries) {
@@ -398,19 +398,19 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
              break;
           } else {
              if (tries == 1) {
-                std::cout << "    ----> Doing a re-scan first\n";
+                oocoutW(nullptr,Minimization) << "    ----> Doing a re-scan first" << std::endl;
                 minim.minimize(minimizer,"Scan");
              }
              if (tries == 2) {
                 if (ROOT::Math::MinimizerOptions::DefaultStrategy() == 0 ) {
-                   std::cout << "    ----> trying with strategy = 1\n";
+                   oocoutW(nullptr,Minimization) << "    ----> trying with strategy = 1" << std::endl;
                    minim.setStrategy(1);
                 }
                 else
                    tries++; // skip this trial if strategy is already 1
              }
              if (tries == 3) {
-                std::cout << "    ----> trying with improve\n";
+                oocoutW(nullptr,Minimization) << "    ----> trying with improve" << std::endl;
                 minimizer = "Minuit";
                 algorithm = "migradimproved";
              }
@@ -444,16 +444,16 @@ double EvaluateNLL(RooStats::ModelConfig const& modelConfig, RooAbsData& data, c
 
     double muTest = 0;
     if (verbose > 0) {
-       std::cout << "AsymptoticCalculator::EvaluateNLL -  value = " << val;
+       oocoutP(nullptr,Eval) << "AsymptoticCalculator::EvaluateNLL -  value = " << val;
        if (poiSet) {
           muTest = ( static_cast<RooRealVar*>(poiSet->first()) )->getVal();
-          std::cout << " for poi fixed at = " << muTest;
+          ooccoutP(nullptr,Eval) << " for poi fixed at = " << muTest;
        }
        if (!skipFit) {
-          std::cout << "\tfit time : ";
-          tw.Print();
+          tw.Stop();
+          ooccoutP(nullptr,Eval) << "\tfit time : " << tw.RealTime() << " s (real) " << tw.CpuTime() << " s (cpu)" << std::endl;
        } else {
-          std::cout << std::endl;
+          ooccoutP(nullptr,Eval) << std::endl;
        }
     }
 
@@ -525,8 +525,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
 
 
    if (verbose> 0) {
-      std::cout << std::endl;
-      oocoutI(nullptr,Eval) << "AsymptoticCalculator::GetHypoTest: - perform  an hypothesis test for  POI ( " << muTest->GetName() << " ) = " << muTest->getVal() << std::endl;
+      oocoutI(nullptr,Eval) << "\nAsymptoticCalculator::GetHypoTest: - perform  an hypothesis test for  POI ( " << muTest->GetName() << " ) = " << muTest->getVal() << std::endl;
       oocoutP(nullptr,Eval) << "AsymptoticCalculator::GetHypoTest -  Find  best conditional NLL on OBSERVED data set ..... " << std::endl;
    }
 
@@ -867,7 +866,7 @@ void FillBins(const RooAbsPdf & pdf, const RooArgList &obs, RooAbsData & data, i
    RooArgSet obstmp(obs);
    double expectedEvents = pdf.expectedEvents(obstmp);
 
-   if (debug) std::cout << "looping on observable " << v->GetName() << std::endl;
+   if (debug) oocoutI(nullptr,Generation) << "looping on observable " << v->GetName() << std::endl;
    for (int i = 0; i < v->getBins(); ++i) {
       v->setBin(i);
       if (index < int(obs.size()) -1) {
@@ -903,17 +902,17 @@ void FillBins(const RooAbsPdf & pdf, const RooArgList &obs, RooAbsData & data, i
          }
 
          if (debug) {
-            std::cout << "bin " << ibin << "\t";
-            for (std::size_t j=0; j < obs.size(); ++j) { std::cout << "  " <<  (static_cast<RooRealVar&>( obs[j])).getVal(); }
-            std::cout << " w = " << fval*expectedEvents;
-            std::cout << std::endl;
+            oocoutI(nullptr,Generation) << "bin " << ibin << "\t";
+            for (std::size_t j=0; j < obs.size(); ++j) { ooccoutI(nullptr,Generation) << "  " <<  (static_cast<RooRealVar&>( obs[j])).getVal(); }
+            ooccoutI(nullptr,Generation) << " w = " << fval*expectedEvents;
+            ooccoutI(nullptr,Generation) << std::endl;
          }
          ibin++;
       }
    }
    //reset bin values
    if (debug) {
-      std::cout << "ending loop on .. " << v->GetName() << std::endl;
+      oocoutI(nullptr,Generation) << "ending loop on .. " << v->GetName() << std::endl;
    }
 
    v->setBin(0);
@@ -961,7 +960,7 @@ bool setObsToExpected(std::span<RooAbsArg *> servers, const RooArgSet &obs, std:
    myobs->setVal(myexp->getVal());
 
    if (fgPrintLevel() > 2) {
-      std::cout << "SetObsToExpected : setting " << myobs->GetName() << " to expected value " << myexp->getVal() << " of " << myexp->GetName() << std::endl;
+      oocoutI(nullptr,Generation) << "SetObsToExpected : setting " << myobs->GetName() << " to expected value " << myexp->getVal() << " of " << myexp->GetName() << std::endl;
    }
 
    return true;
@@ -1048,7 +1047,7 @@ RooAbsData *GenerateCountingAsimovData(RooAbsPdf & pdf, const RooArgSet & observ
     RooMultiVarGaussian *mvgauss = nullptr;
 
     if (fgPrintLevel() > 1)
-       std::cout << "generate counting Asimov data for pdf of type " << pdf.ClassName() << std::endl;
+       oocoutI(nullptr,Generation) << "generate counting Asimov data for pdf of type " << pdf.ClassName() << std::endl;
 
     bool r = false;
     if (prod != nullptr) {
@@ -1114,8 +1113,8 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
 
     // loop on observables and on the bins
     if (printLevel >= 2) {
-       std::cout << "Generating Asimov data for pdf " << pdf.GetName() << std::endl;
-       std::cout << "list of observables  " << std::endl;
+       oocoutI(nullptr,Generation) << "Generating Asimov data for pdf " << pdf.GetName() << std::endl;
+       oocoutI(nullptr,Generation) << "list of observables  " << std::endl;
        obsList.Print();
     }
 
@@ -1124,7 +1123,7 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
     int nbins = 0;
     FillBins(pdf, obsList, *asimovData, obsIndex, binVolume, nbins);
     if (printLevel >= 2)
-       std::cout << "filled from " << pdf.GetName() << "   " << nbins << " nbins " << " volume is " << binVolume << std::endl;
+       oocoutI(nullptr,Generation) << "filled from " << pdf.GetName() << "   " << nbins << " nbins " << " volume is " << binVolume << std::endl;
 
     // for (int iobs = 0; iobs < obsList.size(); ++iobs) {
     //    RooRealVar * thisObs = dynamic_cast<RooRealVar*> &obsList[i];
@@ -1147,7 +1146,7 @@ RooAbsData * GenerateAsimovDataSinglePdf(const RooAbsPdf & pdf, const RooArgSet 
       asimovData->Print();
     }
     if( TMath::IsNaN(asimovData->sumEntries()) ){
-      std::cout << "sum entries is nan"<< std::endl;
+      oocoutE(nullptr,Generation) << "sum entries is nan"<< std::endl;
       assert(0);
       asimovData = nullptr;
     }
@@ -1169,7 +1168,7 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
    RooRealVar weightVar{"binWeightAsimov", "binWeightAsimov", 1, 0, 1.e30};
 
-   if (printLevel > 1) std::cout <<" Generate Asimov data for observables"<< std::endl;
+   if (printLevel > 1) oocoutI(nullptr,Generation) <<" Generate Asimov data for observables"<< std::endl;
    // RooDataSet *simData = nullptr;
    const RooProdPdf *prodPdf = dynamic_cast<const RooProdPdf *>(&pdf);
    RooArgList strippedPdfSet("strippedPdfSet");
@@ -1214,7 +1213,7 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
     if (printLevel > 1)
     {
-      std::cout << "on type " << channelCat.getCurrentLabel() << " " << channelCat.getCurrentIndex() << std::endl;
+      oocoutI(nullptr,Generation) << "on type " << channelCat.getCurrentLabel() << " " << channelCat.getCurrentIndex() << std::endl;
     }
 
     std::unique_ptr<RooDataSet> dataSinglePdf{static_cast<RooDataSet*>(GenerateAsimovDataSinglePdf( *pdftmp, observables, weightVar, &channelCat))};
@@ -1231,9 +1230,9 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
 
     if (printLevel > 1)
     {
-      std::cout << "channel: " << channelCat.getCurrentLabel() << ", data: ";
+      oocoutI(nullptr,Generation) << "channel: " << channelCat.getCurrentLabel() << ", data: ";
       dataSinglePdf->Print();
-      std::cout << std::endl;
+      ooccoutI(nullptr,Generation) << std::endl;
     }
 
     asimovDataMap[string(channelCat.getCurrentLabel())] = std::move(dataSinglePdf);
@@ -1272,7 +1271,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
    for (auto *tmpPar : static_range_cast<RooRealVar *>(poi)) {
       tmpPar->setConstant();
       if (verbose>0)
-         std::cout << "MakeAsimov: Setting poi " << tmpPar->GetName() << " to a constant value = " << tmpPar->getVal() << std::endl;
+         oocoutI(nullptr,Generation) << "MakeAsimov: Setting poi " << tmpPar->GetName() << " to a constant value = " << tmpPar->getVal() << std::endl;
       paramsSetConstant.add(*tmpPar);
    }
 
@@ -1297,12 +1296,12 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
       TStopwatch tw2; tw2.Start();
       int minimPrintLevel = ROOT::Math::MinimizerOptions::DefaultPrintLevel();
       if (verbose>0) {
-         std::cout << "MakeAsimov: doing a conditional fit for finding best nuisance values " << std::endl;
+         oocoutP(nullptr,Generation) << "MakeAsimov: doing a conditional fit for finding best nuisance values " << std::endl;
          minimPrintLevel = verbose;
          if (verbose>1) {
-            std::cout << "POI values:\n"; poi.Print("v");
+            oocoutI(nullptr,Generation) << "POI values:\n"; poi.Print("v");
             if (verbose > 2) {
-               std::cout << "Nuis param values:\n";
+               oocoutI(nullptr,Generation) << "Nuis param values:\n";
                constrainParams.Print("v");
             }
          }
@@ -1326,11 +1325,14 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
         argList.Add(&arg);
       }
       model.fitTo(realData, argList);
-      if (verbose>0) { std::cout << "fit time "; tw2.Print();}
+      if (verbose>0) {
+         tw2.Stop();
+         oocoutP(nullptr,Generation) << "fit time : " << tw2.RealTime() << " s (real) " << tw2.CpuTime() << " s (cpu)" << std::endl;
+      }
       if (verbose > 1) {
          // after the fit the nuisance parameters will have their best fit value
          if (model.GetNuisanceParameters() ) {
-            std::cout << "Nuisance parameters after fit for asimov dataset: " << std::endl;
+            oocoutI(nullptr,Generation) << "Nuisance parameters after fit for asimov dataset: " << std::endl;
             model.GetNuisanceParameters()->Print("V");
          }
       }
@@ -1384,16 +1386,17 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
    RooAbsData * asimov = GenerateAsimovData(*model.GetPdf() , *model.GetObservables() );
 
    if (verbose>0) {
-      std::cout << "Generated Asimov data for observables "; (model.GetObservables() )->Print();
+      oocoutI(nullptr,Generation) << "Generated Asimov data for observables "; (model.GetObservables() )->Print();
       if (verbose > 1) {
          if (asimov->numEntries() == 1 ) {
-            std::cout << "--- Asimov data values \n";
+            oocoutI(nullptr,Generation) << "--- Asimov data values \n";
             asimov->get()->Print("v");
          }
          else {
-            std::cout << "--- Asimov data numEntries = " << asimov->numEntries() << " sumOfEntries = " << asimov->sumEntries() << std::endl;
+            oocoutI(nullptr,Generation) << "--- Asimov data numEntries = " << asimov->numEntries() << " sumOfEntries = " << asimov->sumEntries() << std::endl;
          }
-         std::cout << "\ttime for generating : ";  tw.Print();
+         tw.Stop();
+         oocoutI(nullptr,Generation) << "\ttime for generating : " << tw.RealTime() << " s (real) " << tw.CpuTime() << " s (cpu)" << std::endl;
       }
    }
 
@@ -1413,7 +1416,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
    if (model.GetGlobalObservables() && !model.GetGlobalObservables()->empty()) {
 
       if (verbose>1) {
-         std::cout << "Generating Asimov data for global observables " << std::endl;
+         oocoutI(nullptr,Generation) << "Generating Asimov data for global observables " << std::endl;
       }
 
       RooArgSet gobs(*model.GetGlobalObservables());
@@ -1487,7 +1490,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
          // note : this will work only for this type of constraints
          // expressed as RooPoisson, RooGaussian, RooLognormal, RooGamma
          TClass * cClass = cterm->IsA();
-         if (verbose > 2) std::cout << "Constraint " << cterm->GetName() << " of type " << cClass->GetName() << std::endl;
+         if (verbose > 2) oocoutI(nullptr,Generation) << "Constraint " << cterm->GetName() << " of type " << cClass->GetName() << std::endl;
          if ( cClass != RooGaussian::Class() && cClass != RooPoisson::Class() &&
               cClass != RooGamma::Class() && cClass != RooLognormal::Class() &&
               cClass != RooBifurGauss::Class()  ) {
@@ -1537,12 +1540,12 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
                                                << cterm->GetName() << " is a Gamma distribution and no server named theta is found. Assume that the Gamma scale is  1 " << std::endl;
             }
             else if (verbose>2) {
-                  std::cout << "Gamma constraint has a scale " << thetaGamma->GetName() << "  = " << thetaGamma->getVal() << std::endl;
+                  oocoutI(nullptr,Generation) << "Gamma constraint has a scale " << thetaGamma->GetName() << "  = " << thetaGamma->getVal() << std::endl;
             }
          }
          for (RooAbsArg *a2 : cterm->servers()) {
             RooAbsReal * rrv2 = dynamic_cast<RooAbsReal *>(a2);
-            if (verbose > 2) std::cout << "Loop on constraint server term  " << a2->GetName() << std::endl;
+            if (verbose > 2) oocoutI(nullptr,Generation) << "Loop on constraint server term  " << a2->GetName() << std::endl;
             if (rrv2 && rrv2->dependsOn(nuis) ) {
 
 
@@ -1562,17 +1565,17 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
                foundServer = true;
 
                if (verbose > 2) {
-                  std::cout << "setting global observable " << rrv.GetName() << " to value " << rrv.getVal()
-                            << " which comes from " << rrv2->GetName() << std::endl;
+                  oocoutI(nullptr,Generation) << "setting global observable " << rrv.GetName() << " to value " << rrv.getVal()
+                                              << " which comes from " << rrv2->GetName() << std::endl;
                }
             }
          }
 
          if (!foundServer) {
             oocoutE(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData - can't find nuisance for constraint term - global observables will not be set to Asimov value " << cterm->GetName() << std::endl;
-            std::cerr << "Parameters: " << std::endl;
+            oocoutE(nullptr,Generation) << "Parameters: " << std::endl;
             cpars->Print("V");
-            std::cerr << "Observables: " << std::endl;
+            oocoutE(nullptr,Generation) << "Observables: " << std::endl;
             cgobs->Print("V");
          }
       }
@@ -1588,14 +1591,14 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       gobs.assign(snapGlobalObsData);
 
       if (verbose>0) {
-         std::cout << "Generated Asimov data for global observables ";
+         oocoutI(nullptr,Generation) << "Generated Asimov data for global observables ";
          if (verbose == 1) gobs.Print();
       }
 
       if (verbose > 1) {
-         std::cout << "\nGlobal observables for data: " << std::endl;
+         oocoutI(nullptr,Generation) << "\nGlobal observables for data: " << std::endl;
          gobs.Print("V");
-         std::cout << "\nGlobal observables for asimov: " << std::endl;
+         oocoutI(nullptr,Generation) << "\nGlobal observables for asimov: " << std::endl;
          asimovGlobObs.Print("V");
       }
 

--- a/roofit/roostats/src/BernsteinCorrection.cxx
+++ b/roofit/roostats/src/BernsteinCorrection.cxx
@@ -64,6 +64,7 @@ generating the toys (either via a histogram or via an independent model that is 
 #include "RooHistPdf.h"
 
 #include "RooBernstein.h"
+#include "RooMsgService.h"
 
 #include "Math/MinimizerOptions.h"
 
@@ -93,11 +94,11 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
   RooAbsData* data = wks->data(dataName);
 
   if (!x || !nominal || !data) {
-     std::cout << "Error:  wrong name for pdf or variable or dataset - return -1 " << std::endl;
+     oocoutE(nullptr,InputArguments) << "Error:  wrong name for pdf or variable or dataset - return -1 " << std::endl;
      return -1;
   }
 
-  std::cout << "BernsteinCorrection::ImportCorrectedPdf -  Doing initial Fit with nominal model " << std::endl;
+  oocoutP(nullptr,Eval) << "BernsteinCorrection::ImportCorrectedPdf -  Doing initial Fit with nominal model " << std::endl;
 
   // initialize alg, by checking how well nominal model fits
   int printLevel =  ROOT::Math::MinimizerOptions::DefaultPrintLevel()-1;
@@ -106,7 +107,7 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
   double lastNll= nominalResult->minNll();
 
   if (nominalResult->status() != 0 ) {
-     std::cout << "BernsteinCorrection::ImportCorrectedPdf  - Error fit with nominal model failed - exit" << std::endl;
+     oocoutE(nullptr,Fitting) << "BernsteinCorrection::ImportCorrectedPdf  - Error fit with nominal model failed - exit" << std::endl;
      return -1;
   }
 
@@ -151,7 +152,7 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
     std::unique_ptr<RooFitResult> result{corrected->fitTo(*data,Save(),Minos(false), Hesse(false),PrintLevel(printLevel))};
 
     if (result->status() != 0) {
-       std::cout << "BernsteinCorrection::ImportCorrectedPdf  - Error fit with corrected model failed" << std::endl;
+       oocoutE(nullptr,Fitting) << "BernsteinCorrection::ImportCorrectedPdf  - Error fit with corrected model failed" << std::endl;
        return -1;
     }
 
@@ -188,7 +189,7 @@ Int_t BernsteinCorrection::ImportCorrectedPdf(RooWorkspace* wks,
   }
 
   log << "------ End Bernstein Correction Log --------" << std::endl;
-  std::cout << log.str();
+  oocoutI(nullptr,Eval) << log.str();
 
   return degree;
 }
@@ -211,7 +212,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
   RooAbsData* data = wks->data(dataName);
 
   if (!x || !nominal || !data) {
-     std::cout << "Error:  wrong name for pdf or variable or dataset ! " << std::endl;
+     oocoutE(nullptr,InputArguments) << "Error:  wrong name for pdf or variable or dataset ! " << std::endl;
      return;
   }
 
@@ -265,7 +266,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
     = new RooEffProd("correctedExtra","",*nominal,*polyExtra);
 
 
-  std::cout << "made pdfs, make toy generator" << std::endl;
+  oocoutI(nullptr,Generation) << "made pdfs, make toy generator" << std::endl;
 
   // make a PDF to generate the toys
   RooDataHist dataHist("dataHist","",*x,*data);
@@ -284,7 +285,7 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
     double qExtra = 0;
     // do toys
     for (int i = 0; i < nToys; ++i) {
-       std::cout << "on toy " << i << std::endl;
+       oocoutP(nullptr,Generation) << "on toy " << i << std::endl;
 
        std::unique_ptr<RooDataSet> tmpData{toyGen.generate(*x, data->numEntries())};
        // check to see how well this correction fits
@@ -306,8 +307,8 @@ void BernsteinCorrection::CreateQSamplingDist(RooWorkspace* wks,
        samplingDist->Fill(q);
        samplingDistExtra->Fill(qExtra);
        if (printLevel > 0) {
-      std::cout << "NLL Results: null " << resultNull->minNll() << " ref = " << result->minNll() << " extra"
-           << resultExtra->minNll() << std::endl;
+      oocoutI(nullptr,Eval) << "NLL Results: null " << resultNull->minNll() << " ref = " << result->minNll() << " extra"
+                            << resultExtra->minNll() << std::endl;
        }
   }
 

--- a/roofit/roostats/src/ConfidenceBelt.cxx
+++ b/roofit/roostats/src/ConfidenceBelt.cxx
@@ -33,6 +33,7 @@ store the interval.
 
 #include "RooDataSet.h"
 #include "RooDataHist.h"
+#include "RooMsgService.h"
 
 #include "RooStats/RooStatsUtils.h"
 
@@ -77,7 +78,7 @@ ConfidenceBelt::ConfidenceBelt(const char* name, const char* title, RooAbsData& 
 ////////////////////////////////////////////////////////////////////////////////
 
 double ConfidenceBelt::GetAcceptanceRegionMin(RooArgSet& parameterPoint, double cl, double leftside) {
-  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
+  if(cl>0 || leftside > 0) coutI(Eval) << "using default cl, leftside for now" << std::endl;
   AcceptanceRegion * region = GetAcceptanceRegion(parameterPoint, cl,leftside);
   return (region) ? region->GetLowerLimit() : TMath::QuietNaN();
 }
@@ -85,7 +86,7 @@ double ConfidenceBelt::GetAcceptanceRegionMin(RooArgSet& parameterPoint, double 
 ////////////////////////////////////////////////////////////////////////////////
 
 double ConfidenceBelt::GetAcceptanceRegionMax(RooArgSet& parameterPoint, double cl, double leftside) {
-  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
+  if(cl>0 || leftside > 0) coutI(Eval) << "using default cl, leftside for now" << std::endl;
   AcceptanceRegion * region = GetAcceptanceRegion(parameterPoint, cl,leftside);
   return (region) ? region->GetUpperLimit() : TMath::QuietNaN();
 }
@@ -102,7 +103,7 @@ vector<double> ConfidenceBelt::ConfidenceLevels() const {
 void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsIndex,
                 double lower, double upper,
                 double cl, double leftside){
-  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
+  if(cl>0 || leftside > 0) coutI(Eval) << "using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );
@@ -110,14 +111,14 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsInde
   //  std::cout << "add: " << tree << " " << hist << std::endl;
 
   if( !this->CheckParameters(parameterPoint) )
-    std::cout << "problem with parameters" << std::endl;
+    coutE(InputArguments) << "problem with parameters" << std::endl;
 
   Int_t luIndex = fSamplingSummaryLookup.GetLookupIndex(cl, leftside);
   //  std::cout << "lookup index = " << luIndex << std::endl;
   if(luIndex <0 ) {
     fSamplingSummaryLookup.Add(cl,leftside);
     luIndex = fSamplingSummaryLookup.GetLookupIndex(cl, leftside);
-    std::cout << "lookup index = " << luIndex << std::endl;
+    coutI(Eval) << "lookup index = " << luIndex << std::endl;
   }
   AcceptanceRegion* thisRegion = new AcceptanceRegion(luIndex, lower, upper);
 
@@ -159,13 +160,13 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, Int_t dsInde
 
 void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, AcceptanceRegion region,
                 double cl, double leftside){
-  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
+  if(cl>0 || leftside > 0) coutI(Eval) << "using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );
 
   if( !this->CheckParameters(parameterPoint) )
-    std::cout << "problem with parameters" << std::endl;
+    coutE(InputArguments) << "problem with parameters" << std::endl;
 
 
   if( hist ) {
@@ -198,13 +199,13 @@ void ConfidenceBelt::AddAcceptanceRegion(RooArgSet& parameterPoint, AcceptanceRe
 
 AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint, double cl, double leftside)
 {
-  if(cl>0 || leftside > 0) std::cout <<"using default cl, leftside for now" << std::endl;
+  if(cl>0 || leftside > 0) coutI(Eval) << "using default cl, leftside for now" << std::endl;
 
   RooDataSet*  tree = dynamic_cast<RooDataSet*>( fParameterPoints );
   RooDataHist* hist = dynamic_cast<RooDataHist*>(fParameterPoints );
 
   if( !this->CheckParameters(parameterPoint) ){
-    std::cout << "problem with parameters" << std::endl;
+    coutE(InputArguments) << "problem with parameters" << std::endl;
     return nullptr;
   }
 
@@ -244,7 +245,7 @@ AcceptanceRegion* ConfidenceBelt::GetAcceptanceRegion(RooArgSet &parameterPoint,
     return &(fSamplingSummaries[index].GetAcceptanceRegion());
   }
   else {
-      std::cout << "dataset is not initialized properly" << std::endl;
+      coutE(InputArguments) << "dataset is not initialized properly" << std::endl;
   }
 
   return nullptr;
@@ -264,11 +265,11 @@ RooArgSet* ConfidenceBelt::GetParameters() const
 bool ConfidenceBelt::CheckParameters(RooArgSet &parameterPoint) const
 {
    if (parameterPoint.size() != fParameterPoints->get()->size() ) {
-      std::cout << "size is wrong, parameters don't match" << std::endl;
+      coutE(InputArguments) << "size is wrong, parameters don't match" << std::endl;
       return false;
    }
    if ( ! parameterPoint.equals( *(fParameterPoints->get() ) ) ) {
-      std::cout << "size is ok, but parameters don't match" << std::endl;
+      coutE(InputArguments) << "size is ok, but parameters don't match" << std::endl;
       return false;
    }
    return true;

--- a/roofit/roostats/src/HybridPlot.cxx
+++ b/roofit/roostats/src/HybridPlot.cxx
@@ -18,6 +18,7 @@ http://www-ekp.physik.uni-karlsruhe.de/~schott/roostats/hybridplot_example.png
 #include <map>
 
 #include "RooStats/HybridPlot.h"
+#include "RooMsgService.h"
 #include "TStyle.h"
 #include "TF1.h"
 #include "TAxis.h"
@@ -262,7 +263,7 @@ double HybridPlot::GetHistoCenter(TH1* histo_orig, double n_rms, bool display_re
 
    delete gauss;
 
-   std::cout << "Center is 1st pass = " << mean << std::endl;
+   coutI(Eval) << "Center is 1st pass = " << mean << std::endl;
 
    double skewness = histo->GetSkewness();
 
@@ -300,7 +301,7 @@ double HybridPlot::GetHistoCenter(TH1* histo_orig, double n_rms, bool display_re
 double* HybridPlot::GetHistoPvals (TH1* histo, double percentage){
 
    if (percentage>1){
-      std::cerr << "Percentage greater or equal to 1!\n";
+      coutE(InputArguments) << "Percentage greater or equal to 1!\n";
       return nullptr;
    }
 

--- a/roofit/roostats/src/HybridResult.cxx
+++ b/roofit/roostats/src/HybridResult.cxx
@@ -32,6 +32,7 @@ TConfidenceLevel.
 #include "RooDataHist.h"
 #include "RooDataSet.h"
 #include "RooGlobalFunc.h" // for RooFit::Extended()
+#include "RooMsgService.h"
 #include "RooRealVar.h"
 #include "RooAbsData.h"
 
@@ -115,7 +116,7 @@ double HybridResult::NullPValue() const
    if (fComputationsNulDoneFlag==false) {
       int nToys = fTestStat_b.size();
       if (nToys==0) {
-         std::cout << "Error: no toy data present. Returning -1.\n";
+         coutE(Eval) << "Error: no toy data present. Returning -1.\n";
          return -1;
       }
 
@@ -128,7 +129,7 @@ double HybridResult::NullPValue() const
      if ( fTestStat_b[iToy] <= fTestStat_data ) ++larger_than_measured;
       }
 
-      if (larger_than_measured==0) std::cout << "Warning: CLb = 0 ... maybe more toys are needed!\n";
+      if (larger_than_measured==0) coutW(Eval) << "Warning: CLb = 0 ... maybe more toys are needed!\n";
 
       fComputationsNulDoneFlag = true;
       fNullPValue = 1-larger_than_measured/nToys;
@@ -145,7 +146,7 @@ double HybridResult::AlternatePValue() const
    if (fComputationsAltDoneFlag==false) {
       int nToys = fTestStat_b.size();
       if (nToys==0) {
-         std::cout << "Error: no toy data present. Returning -1.\n";
+         coutE(Eval) << "Error: no toy data present. Returning -1.\n";
          return -1;
       }
 
@@ -158,7 +159,7 @@ double HybridResult::AlternatePValue() const
      if ( fTestStat_sb[iToy] <= fTestStat_data ) ++larger_than_measured;
       }
 
-      if (larger_than_measured==0) std::cout << "Warning: CLsb = 0 ... maybe more toys are needed!\n";
+      if (larger_than_measured==0) coutW(Eval) << "Warning: CLsb = 0 ... maybe more toys are needed!\n";
 
       fComputationsAltDoneFlag = true;
       fAlternatePValue = larger_than_measured/nToys;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -559,7 +559,7 @@ HypoTestResult * HypoTestInverter::Eval(HypoTestCalculatorGeneric &hc, bool adap
       hcResult->Append(more.get());
       clsMid    = (fUseCLs ? hcResult->CLs()      : hcResult->CLsplusb());
       clsMidErr = (fUseCLs ? hcResult->CLsError() : hcResult->CLsplusbError());
-      if (fVerbose) std::cout << (fUseCLs ? "\tCLs = " : "\tCLsplusb = ") << clsMid << " +/- " << clsMidErr << std::endl;
+      if (fVerbose) oocoutP(nullptr,Eval) << (fUseCLs ? "\tCLs = " : "\tCLsplusb = ") << clsMid << " +/- " << clsMidErr << std::endl;
    }
 
    }
@@ -792,7 +792,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
 
   fLimitPlot = std::make_unique<TGraphErrors>();
 
-  if (fVerbose > 0) std::cout << "Search for upper limit to the limit" << std::endl;
+  if (fVerbose > 0) oocoutI(nullptr,Eval) << "Search for upper limit to the limit" << std::endl;
   for (int tries = 0; tries < 6; ++tries) {
      if (! RunOnePoint(rMax) ) {
         oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at upper limit of scan range: " << rMax << std::endl;
@@ -890,7 +890,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      clsMid = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
 
      if (clsMid.second == -1) {
-        std::cerr << "Hypotest failed" << std::endl;
+        oocoutE(nullptr,Eval) << "Hypotest failed" << std::endl;
         return false;
      }
 
@@ -902,7 +902,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
          rMin = limit; clsMin = clsMid;
        }
      } else {
-       if (fVerbose > 0) std::cout << "Trying to move the interval edges closer" << std::endl;
+       if (fVerbose > 0) oocoutI(nullptr,Eval) << "Trying to move the interval edges closer" << std::endl;
        double rMinBound = rMin;
        double rMaxBound = rMax;
        // try to reduce the size of the interval
@@ -934,7 +934,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
   if (!done) { // didn't reach accuracy with scan, now do fit
       if (fVerbose) {
          oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - Before fit   --- \n";
-         std::cout << "Limit: " << r->GetName() << " < " << limit << " +/- " << limitErr << " [" << rMin << ", " << rMax << "]\n";
+         oocoutI(nullptr,Eval) << "Limit: " << r->GetName() << " < " << limit << " +/- " << limitErr << " [" << rMin << ", " << rMax << "]\n";
       }
 
       expoFit.FixParameter(0,clsTarget);
@@ -1203,7 +1203,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
                                        << nToys << std::endl;
 
 
-      std::cout << "\n\nshnapshot of s+b model \n";
+      oocoutI(nullptr,Eval) << "\n\nsnapshot of s+b model \n";
       sbModel->GetSnapshot()->Print("v");
 
       // reset parameters to initial values to be sure in case they are not reset
@@ -1250,7 +1250,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       hL->Fill(r->LowerLimit() );
 
 
-      std::cout << "The computed upper limit for toy #" << itoy << " is " << value << std::endl;
+      oocoutI(nullptr,Eval) << "The computed upper limit for toy #" << itoy << " is " << value << std::endl;
 
       // write every 10 toys
       if (itoy%10 == 0 || itoy == nToys-1) {

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -579,7 +579,7 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
 
 //#define DO_DEBUG
 #ifdef DO_DEBUG
-   std::cout << "using graph for search " << lowSearch << " min " << axmin << " max " << axmax << std::endl;
+   ccoutD(Eval) << "using graph for search " << lowSearch << " min " << axmin << " max " << axmax << std::endl;
 #endif
 
 
@@ -618,7 +618,7 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
    if (axmin >= axmax ) {
 
 #ifdef DO_DEBUG
-      std::cout << "No range given - check if extrapolation is needed " << std::endl;
+      ccoutD(Eval) << "No range given - check if extrapolation is needed " << std::endl;
 #endif
 
       xmin = graph.GetX()[0];
@@ -649,8 +649,8 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
    brf.SetFunction(f1d,xmin,xmax);
    brf.SetNpx(std::max(graph.GetN()*2,100) );
 #ifdef DO_DEBUG
-   std::cout << "findind root for " << xmin << " ,  "<< xmax << "f(x) : " << graph.Eval(xmin) << " , " << graph.Eval(0.5*(xmax+xmin))
-             << " , " << graph.Eval(xmax) << " target " << y0 << std::endl;
+   ccoutD(Eval) << "findind root for " << xmin << " ,  "<< xmax << "f(x) : " << graph.Eval(xmin) << " , " << graph.Eval(0.5*(xmax+xmin))
+                << " , " << graph.Eval(xmax) << " target " << y0 << std::endl;
 #endif
 
    bool ret = brf.Solve(100, 1.E-16, 1.E-6);
@@ -664,10 +664,10 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
    double limit =  brf.Root();
 
 #ifdef DO_DEBUG
-   if (lowSearch) std::cout << "lower limit search : ";
-   else std::cout << "Upper limit search :  ";
-   std::cout << "interpolation done between " << xmin << "  and " << xmax
-             << "\n Found limit using RootFinder is " << limit << std::endl;
+   if (lowSearch) ccoutD(Eval) << "lower limit search : ";
+   else ccoutD(Eval) << "Upper limit search :  ";
+   ccoutD(Eval) << "interpolation done between " << xmin << "  and " << xmax
+                << "\n Found limit using RootFinder is " << limit << std::endl;
 
    TString fname = "graph_upper.root";
    if (lowSearch) fname = "graph_lower.root";
@@ -682,7 +682,7 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
    if (axmin >= axmax) {
       int index = TMath::BinarySearch(n, graph.GetX(), limit);
 #ifdef DO_DEBUG
-   std::cout << "do new interpolation dividing from " << index << "  and " << y[index] << std::endl;
+   ccoutD(Eval) << "do new interpolation dividing from " << index << "  and " << y[index] << std::endl;
 #endif
 
       if (lowSearch && index >= 1 && (y[0] - y0) * ( y[index]- y0) < 0) {
@@ -751,7 +751,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
       double xwithymax = graph.GetX()[iymax];
 
 #ifdef DO_DEBUG
-      std::cout << " max of y " << iymax << "  " << xwithymax << "  " << ymax << " target is " << target << std::endl;
+      ccoutD(Eval) << " max of y " << iymax << "  " << xwithymax << "  " << ymax << " target is " << target << std::endl;
 #endif
       // look if maximum is above/below target
       if (ymax > target) {
@@ -794,7 +794,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
       }
 
 #ifdef DO_DEBUG
-      std::cout << " found xmin, xmax  = " << xmin << "  " << xmax << " for search " << lowSearch << std::endl;
+      ccoutD(Eval) << " found xmin, xmax  = " << xmin << "  " << xmax << " for search " << lowSearch << std::endl;
 #endif
 
       // now come here if I have already found a lower/upper limit
@@ -819,7 +819,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
    }
 
 #ifdef DO_DEBUG
-   std::cout << "finding " << lowSearch << " limit between " << xmin << "  " << xmax << std::endl;
+   ccoutD(Eval) << "finding " << lowSearch << " limit between " << xmin << "  " << xmax << std::endl;
 #endif
 
    // compute now the limit using the TGraph interpolations routine
@@ -834,7 +834,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
       << "the computed " << limitType << " limit is " << limit << " +/- " << error << std::endl;
 
 #ifdef DO_DEBUG
-   std::cout << "Found limit is " << limit << " +/- " << error << std::endl;
+   ccoutD(Eval) << "Found limit is " << limit << " +/- " << error << std::endl;
 #endif
 
 
@@ -914,7 +914,7 @@ int HypoTestInverterResult::FindClosestPointIndex(double target, int mode, doubl
   int index1 = TMath::BinarySearch( n, &xsorted[0], xtarget);
 
 #ifdef DO_DEBUG
-  std::cout << "finding closest point to " << xtarget << " is " << index1 << "  " << indx[index1] << std::endl;
+  ccoutD(Eval) << "finding closest point to " << xtarget << " is " << index1 << "  " << indx[index1] << std::endl;
 #endif
 
    // case xtarget is outside the range (before or afterwards)
@@ -988,8 +988,8 @@ double HypoTestInverterResult::CalculateEstimatedError(double target, bool lower
   TString type = (!lower) ? "upper" : "lower";
 
 #ifdef DO_DEBUG
-  std::cout << "calculate estimate error " << type << " between " << xmin << " and " << xmax << std::endl;
-  std::cout << "computed limit is " << ( (lower) ? fLowerLimit : fUpperLimit ) << std::endl;
+  ccoutD(Eval) << "calculate estimate error " << type << " between " << xmin << " and " << xmax << std::endl;
+  ccoutD(Eval) << "computed limit is " << ( (lower) ? fLowerLimit : fUpperLimit ) << std::endl;
 #endif
 
     // make a TGraph Errors with the sorted points
@@ -1042,7 +1042,7 @@ double HypoTestInverterResult::CalculateEstimatedError(double target, bool lower
 
 #ifdef DO_DEBUG
   TCanvas * c1 = new TCanvas();
-  std::cout << "fitting for limit " << type << "between " << minX << " , " << maxX << " points considered " << graph.GetN() <<  std::endl;
+  ccoutD(Eval) << "fitting for limit " << type << "between " << minX << " , " << maxX << " points considered " << graph.GetN() <<  std::endl;
   int fitstat = graph.Fit(&fct," EX0");
   graph.SetMarkerStyle(20);
   graph.Draw("AP");
@@ -1073,7 +1073,7 @@ double HypoTestInverterResult::CalculateEstimatedError(double target, bool lower
   }
 
 #ifdef DO_DEBUG
-  std::cout << "closes point to the limit is " << index << "  " << GetXValue(index) << " and has error " << GetYError(index) << std::endl;
+  ccoutD(Eval) << "closes point to the limit is " << index << "  " << GetXValue(index) << " and has error " << GetYError(index) << std::endl;
 #endif
 
   return theError;

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -112,14 +112,14 @@ bool LikelihoodInterval::IsInInterval(const RooArgSet &parameterPoint) const
    RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
   // Method to determine if a parameter point is in the interval
   if( !this->CheckParameters(parameterPoint) ) {
-    std::cout << "parameters don't match" << std::endl;
+    coutE(InputArguments) << "parameters don't match" << std::endl;
     RooMsgService::instance().setGlobalKillBelow(msglevel);
     return false;
   }
 
   // make sure likelihood ratio is set
   if(!fLikelihoodRatio) {
-    std::cout << "likelihood ratio not set" << std::endl;
+    coutE(Eval) << "likelihood ratio not set" << std::endl;
     RooMsgService::instance().setGlobalKillBelow(msglevel);
     return false;
   }
@@ -132,7 +132,7 @@ bool LikelihoodInterval::IsInInterval(const RooArgSet &parameterPoint) const
 
   // evaluate likelihood ratio, see if it's bigger than threshold
   if (fLikelihoodRatio->getVal()<0){
-    std::cout << "The likelihood ratio is < 0, indicates a bad minimum or numerical precision problems.  Will return true" << std::endl;
+    coutW(Eval) << "The likelihood ratio is < 0, indicates a bad minimum or numerical precision problems.  Will return true" << std::endl;
     RooMsgService::instance().setGlobalKillBelow(msglevel);
     return true;
   }
@@ -165,11 +165,11 @@ RooArgSet* LikelihoodInterval::GetParameters() const
 bool LikelihoodInterval::CheckParameters(const RooArgSet &parameterPoint) const
 {
   if (parameterPoint.size() != fParameters.size() ) {
-    std::cout << "size is wrong, parameters don't match" << std::endl;
+    coutE(InputArguments) << "size is wrong, parameters don't match" << std::endl;
     return false;
   }
   if ( ! parameterPoint.equals( fParameters ) ) {
-    std::cout << "size is ok, but parameters don't match" << std::endl;
+    coutE(InputArguments) << "size is ok, but parameters don't match" << std::endl;
     return false;
   }
   return true;

--- a/roofit/roostats/src/LikelihoodIntervalPlot.cxx
+++ b/roofit/roostats/src/LikelihoodIntervalPlot.cxx
@@ -499,7 +499,7 @@ void LikelihoodIntervalPlot::Draw(const Option_t *options)
          int ncp = fInterval->GetContourPoints(*myparam, *myparamY, gr->GetX(), gr->GetY(),nPoints);
 
          if (int(ncp) < nPoints) {
-            std::cout << "Warning - Less points calculated in contours np = " << ncp << " / " << nPoints << std::endl;
+            coutW(Eval) << "Warning - Less points calculated in contours np = " << ncp << " / " << nPoints << std::endl;
             for (int i = ncp; i < nPoints; ++i) gr->RemovePoint(i);
          }
          // add last point to same as first one to close the contour

--- a/roofit/roostats/src/PointSetInterval.cxx
+++ b/roofit/roostats/src/PointSetInterval.cxx
@@ -36,6 +36,7 @@ store the interval.
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooDataHist.h"
+#include "RooMsgService.h"
 
 
 
@@ -97,7 +98,7 @@ bool PointSetInterval::IsInInterval(const RooArgSet &parameterPoint) const
     return false; // didn't find a good point
   }
   else {
-      std::cout << "dataset is not initialized properly" << std::endl;
+      coutE(InputArguments) << "dataset is not initialized properly" << std::endl;
   }
 
    return true;
@@ -117,12 +118,12 @@ RooArgSet* PointSetInterval::GetParameters() const
 bool PointSetInterval::CheckParameters(const RooArgSet &parameterPoint) const
 {
    if (parameterPoint.size() != fParameterPointsInInterval->get()->size() ) {
-     std::cout << "PointSetInterval: argument size is wrong, parameters don't match: arg=" << parameterPoint
+     coutE(InputArguments) << "PointSetInterval: argument size is wrong, parameters don't match: arg=" << parameterPoint
           << " interval=" << (*fParameterPointsInInterval->get()) << std::endl;
       return false;
    }
    if ( ! parameterPoint.equals( *(fParameterPointsInInterval->get() ) ) ) {
-      std::cout << "PointSetInterval: size is ok, but parameters don't match" << std::endl;
+      coutE(InputArguments) << "PointSetInterval: size is ok, but parameters don't match" << std::endl;
       return false;
    }
    return true;

--- a/roofit/roostats/src/ProfileInspector.cxx
+++ b/roofit/roostats/src/ProfileInspector.cxx
@@ -29,6 +29,7 @@ Utility class to plot conditional MLE of nuisance parameters vs. Parameters of I
 #include "RooArgSet.h"
 #include "RooAbsPdf.h"
 #include "RooCurve.h"
+#include "RooMsgService.h"
 #include "TAxis.h"
 
 
@@ -71,24 +72,24 @@ TList* ProfileInspector::GetListOfProfilePlots( RooAbsData& data, RooStats::Mode
 
 
   if(!poi_set){
-    std::cout << "no parameters of interest" << std::endl;
+    oocoutE(nullptr,InputArguments) << "no parameters of interest" << std::endl;
     return nullptr;
   }
 
   if(poi_set->size()!=1){
-    std::cout << "only one parameter of interest is supported currently" << std::endl;
+    oocoutE(nullptr,InputArguments) << "only one parameter of interest is supported currently" << std::endl;
     return nullptr;
   }
   RooRealVar* poi = static_cast<RooRealVar*>(poi_set->first());
 
 
   if(!nuis_params){
-    std::cout << "no nuisance parameters" << std::endl;
+    oocoutE(nullptr,InputArguments) << "no nuisance parameters" << std::endl;
     return nullptr;
   }
 
   if(!pdf){
-    std::cout << "pdf not set" << std::endl;
+    oocoutE(nullptr,InputArguments) << "pdf not set" << std::endl;
     return nullptr;
   }
 

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -181,18 +181,18 @@ RooFit::OwningPtr<RooFitResult> ProfileLikelihoodCalculator::DoMinimizeNLL(RooAb
       if (status%1000 == 0) {  // ignore errors from Improve
          break;
       } else if (tries < maxtries) {
-         std::cout << "    ----> Doing a re-scan first" << std::endl;
+         oocoutW(nullptr,Minimization) << "    ----> Doing a re-scan first" << std::endl;
          minim.minimize(minimType,"Scan");
          if (tries == 2) {
             if (strategy == 0 ) {
-               std::cout << "    ----> trying with strategy = 1" << std::endl;
+               oocoutW(nullptr,Minimization) << "    ----> trying with strategy = 1" << std::endl;
                minim.setStrategy(1);
             }
             else
                tries++; // skip this trial if strategy is already 1
          }
          if (tries == 3) {
-            std::cout << "    ----> trying with improve" << std::endl;
+            oocoutW(nullptr,Minimization) << "    ----> trying with improve" << std::endl;
             minimType = "Minuit";
             minimAlgo = "migradimproved";
          }

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -96,7 +96,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        if (firstPOI) initial_mu_value = firstPOI->getVal();
        //paramsOfInterest.getRealValue(firstPOI->GetName());
        if (fPrintLevel > 1) {
-            std::cout << "POIs: " << std::endl;
+            oocoutI(nullptr,Eval) << "POIs: " << std::endl;
             paramsOfInterest.Print("v");
        }
 
@@ -116,21 +116,21 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
                                  RooFit::GlobalObservables(fGlobalObs), RooFit::ConditionalObservables(fConditionalObs), RooFit::Offset(fLOffset))};
 
           if (fPrintLevel > 0) {
-             std::cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset mode \""
-                 << fLOffset << "\" in creating NLL" << std::endl;
+             oocoutI(nullptr,Eval) << "ProfileLikelihoodTestStat::Evaluate - Use Offset mode \""
+                         << fLOffset << "\" in creating NLL" << std::endl;
           }
 
           created = true ;
-          if (fPrintLevel > 1) std::cout << "creating NLL " << &*fNll << " with data = " << &data << std::endl ;
+          if (fPrintLevel > 1) oocoutI(nullptr,Eval) << "creating NLL " << &*fNll << " with data = " << &data << std::endl ;
        }
        if (reuse && !created) {
-         if (fPrintLevel > 1) std::cout << "reusing NLL " << &*fNll << " new data = " << &data << std::endl ;
+         if (fPrintLevel > 1) oocoutI(nullptr,Eval) << "reusing NLL " << &*fNll << " new data = " << &data << std::endl ;
          fNll->setData(data,false) ;
        }
        // print data in case of number counting (simple data sets)
        if (fPrintLevel > 1 && data.numEntries() == 1) {
-          std::cout << "Data set used is:  ";
-          RooStats::PrintListContent(*data.get(0), std::cout);
+          oocoutI(nullptr,Eval) << "Data set used is:  ";
+          RooStats::PrintListContent(*data.get(0), ooccoutI(nullptr,Eval));
        }
 
 
@@ -161,7 +161,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           if (!minimizationNeeded(*attachedSet)) {
              uncondML = fNll->getVal();
           } else {
-             if (fPrintLevel>1) std::cout << "Do unconditional fit" << std::endl;
+             if (fPrintLevel>1) oocoutI(nullptr,Eval) << "Do unconditional fit" << std::endl;
              std::tie(uncondML, statusD) = minimizeNLL("fitUncond_");
           }
 
@@ -189,7 +189,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
        if (doConditionalFit) {
 
-          if (fPrintLevel>1) std::cout << "Do conditional fit " << std::endl;
+          if (fPrintLevel>1) oocoutI(nullptr,Eval) << "Do conditional fit " << std::endl;
 
 
           //       std::cout <<" reestablish snapshot"<< std::endl;
@@ -242,7 +242,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
 
          if (fSigned) {
             if (pll<0.0) {
-               if (fPrintLevel > 0) std::cout << "pll is negative - setting it to zero " << std::endl;
+               if (fPrintLevel > 0) oocoutW(nullptr,Eval) << "pll is negative - setting it to zero " << std::endl;
                pll = 0.0;   // bad fit
             }
            if (fLimitType==oneSidedDiscovery ? (fit_favored_mu < initial_mu_value)
@@ -252,15 +252,15 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
        }
 
        if (fPrintLevel > 0) {
-          std::cout << "EvaluateProfileLikelihood - ";
+          oocoutP(nullptr,Eval) << "EvaluateProfileLikelihood - ";
           if (type <= 1)
-             std::cout << "mu hat = " << fit_favored_mu  <<  ", uncond ML = " << uncondML;
+             ooccoutP(nullptr,Eval) << "mu hat = " << fit_favored_mu  <<  ", uncond ML = " << uncondML;
           if (type != 1)
-             std::cout << ", cond ML = " << condML;
+             ooccoutP(nullptr,Eval) << ", cond ML = " << condML;
           if (type == 0)
-             std::cout << " pll = " << pll;
-          std::cout << " time (create/fit1/2) " << createTime << " , " << fitTime1 << " , " << fitTime2
-                    << std::endl;
+             ooccoutP(nullptr,Eval) << " pll = " << pll;
+          ooccoutP(nullptr,Eval) << " time (create/fit1/2) " << createTime << " , " << fitTime1 << " , " << fitTime2
+                                 << std::endl;
        }
 
 

--- a/roofit/roostats/src/ProposalHelper.cxx
+++ b/roofit/roostats/src/ProposalHelper.cxx
@@ -65,7 +65,7 @@ ProposalFunction* ProposalHelper::GetProposalFunction()
       if (fCluesFrac < 0) {
          fCluesFrac = DEFAULT_CLUES_FRAC;
       }
-      std::cout << "added clues from dataset " << fClues->GetName() << " with fraction " << fCluesFrac << std::endl;
+      oocoutI(nullptr,InputArguments) << "added clues from dataset " << fClues->GetName() << " with fraction " << fCluesFrac << std::endl;
       components.add(*fCluesPdf);
       coeffs.add(RooConst(fCluesFrac));
    }

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -227,7 +227,7 @@ void SamplingDistPlot::addObject(TObject *obj, Option_t *drawOptions)
 {
 
   if(nullptr == obj) {
-    std::cerr << fName << "::addObject: called with a null pointer" << std::endl;
+    coutE(InputArguments) << fName << "::addObject: called with a null pointer" << std::endl;
     return;
   }
 
@@ -561,7 +561,7 @@ void SamplingDistPlot::DumpToFile(const char* RootFileName, Option_t *option, co
    // All the objects are written to rootfile
 
    if(!fRooPlot) {
-      std::cout << "Plot was not drawn yet. Dump can only be saved after it was drawn with Draw()." << std::endl;
+      coutW(Plotting) << "Plot was not drawn yet. Dump can only be saved after it was drawn with Draw()." << std::endl;
       return;
    }
 

--- a/roofit/roostats/src/SamplingDistribution.cxx
+++ b/roofit/roostats/src/SamplingDistribution.cxx
@@ -380,7 +380,7 @@ double SamplingDistribution::InverseCDF(double pvalue,
     return fSamplingDist[nominal+1];
   }
   else{
-    std::cout << "problem in SamplingDistribution::InverseCDF" << std::endl;
+    coutE(Eval) << "problem in SamplingDistribution::InverseCDF" << std::endl;
   }
   inverseWithVariation = RooNumber::infinity();
   return RooNumber::infinity();

--- a/roofit/roostats/src/SimpleInterval.cxx
+++ b/roofit/roostats/src/SimpleInterval.cxx
@@ -27,6 +27,7 @@ In addition, you can ask it for the upper- or lower-bound.
 
 #include "RooStats/SimpleInterval.h"
 #include "RooAbsReal.h"
+#include "RooMsgService.h"
 #include "RooRealVar.h"
 #include <string>
 
@@ -121,11 +122,11 @@ RooArgSet* SimpleInterval::GetParameters() const
 bool SimpleInterval::CheckParameters(const RooArgSet &parameterPoint) const
 {
    if (parameterPoint.size() != fParameters.size() ) {
-      std::cout << "size is wrong, parameters don't match" << std::endl;
+      coutE(InputArguments) << "size is wrong, parameters don't match" << std::endl;
       return false;
    }
    if ( ! parameterPoint.equals( fParameters ) ) {
-      std::cout << "size is ok, but parameters don't match" << std::endl;
+      coutE(InputArguments) << "size is ok, but parameters don't match" << std::endl;
       return false;
    }
    return true;

--- a/roofit/roostats/src/UpperLimitMCSModule.cxx
+++ b/roofit/roostats/src/UpperLimitMCSModule.cxx
@@ -39,8 +39,8 @@ UpperLimitMCSModule::UpperLimitMCSModule(const RooArgSet* poi, double CL) :
   _parName(poi->first()->GetName()),
   _plc(nullptr),_ul(nullptr),_poi(nullptr), _data(nullptr),_cl(CL), _model(nullptr)
 {
-  std::cout<<"RooUpperLimitConstructor ParName:"<<_parName<<std::endl;
-  std::cout<<"RooUpperLimitConstructor CL:"<<_cl<<std::endl;
+  coutI(InputArguments)<<"RooUpperLimitConstructor ParName:"<<_parName<<std::endl;
+  coutI(InputArguments)<<"RooUpperLimitConstructor CL:"<<_cl<<std::endl;
   // Constructor of module with parameter to be interpreted as nSignal and the value of the
   // null hypothesis for nSignal (usually zero)
 }
@@ -93,9 +93,9 @@ bool UpperLimitMCSModule::initializeInstance()
 
   //Construct the ProfileLikelihoodCalculator
   _poi=new RooArgSet(*(fitParams()->find(_parName.c_str())));
-  std::cout<<"RooUpperLimit Initialize Instance: POI Set:"<<std::endl;
+  coutI(Eval)<<"RooUpperLimit Initialize Instance: POI Set:"<<std::endl;
   _poi->Print("v");
-  std::cout<<"RooUpperLimit Initialize Instance: End:"<<std::endl;
+  coutI(Eval)<<"RooUpperLimit Initialize Instance: End:"<<std::endl;
 
 
 
@@ -161,7 +161,7 @@ RooDataSet* UpperLimitMCSModule::finalizeRun()
 ////////////////////////////////////////////////////////////////////////////////
 
 bool UpperLimitMCSModule::processBetweenGenAndFit(Int_t /*sampleNum*/) {
-  std::cout<<"after generation Test"<<std::endl;
+  coutI(Eval)<<"after generation Test"<<std::endl;
 
   if (!fitInitParams() || !genSample() || !fitParams() || !fitModel() ) return false;
 
@@ -171,7 +171,7 @@ bool UpperLimitMCSModule::processBetweenGenAndFit(Int_t /*sampleNum*/) {
   static_cast<RooRealVar*>(_poi->first())->setBins(1000);
   //fitModel()->Print("v");
 
-  std::cout<<"generated Entries:"<<genSample()->numEntries()<<std::endl;
+  coutI(Eval)<<"generated Entries:"<<genSample()->numEntries()<<std::endl;
 
   RooStats::ProfileLikelihoodCalculator plc( *(genSample()), *(fitModel()), *_poi);
 
@@ -181,9 +181,9 @@ bool UpperLimitMCSModule::processBetweenGenAndFit(Int_t /*sampleNum*/) {
 
   if (!pllint) return false;
 
-  std::cout<<"poi value: "<<(static_cast<RooRealVar*>(_poi->first()))->getVal()<<std::endl;
-  std::cout<<(static_cast<RooRealVar*>((fitParams()->find(_parName.c_str()))))->getVal()<<std::endl;
-  std::cout<<(static_cast<RooStats::LikelihoodInterval*>(pllint))->UpperLimit(static_cast<RooRealVar&>(*(_poi->first())))<<std::endl;
+  coutI(Eval)<<"poi value: "<<(static_cast<RooRealVar*>(_poi->first()))->getVal()<<std::endl;
+  coutI(Eval)<<(static_cast<RooRealVar*>((fitParams()->find(_parName.c_str()))))->getVal()<<std::endl;
+  coutI(Eval)<<(static_cast<RooStats::LikelihoodInterval*>(pllint))->UpperLimit(static_cast<RooRealVar&>(*(_poi->first())))<<std::endl;
 
 
   //Go to the fit Value for zour POI to make sure upper limit works correct.
@@ -194,7 +194,7 @@ bool UpperLimitMCSModule::processBetweenGenAndFit(Int_t /*sampleNum*/) {
   _ul->setVal((static_cast<RooStats::LikelihoodInterval*>(pllint))->UpperLimit(static_cast<RooRealVar&>(*(fitParams()->find(_parName.c_str())))));
 
   _data->add(RooArgSet(*_ul));
-  std::cout<<"UL:"<<_ul->getVal()<<std::endl;
+  coutI(Eval)<<"UL:"<<_ul->getVal()<<std::endl;
 //   if (_ul->getVal()<1){
 
 //   RooStats::LikelihoodIntervalPlot plotpll((RooStats::LikelihoodInterval*) pllint);


### PR DESCRIPTION
Several RooStats classes were mixing three printing mechanisms: `std::cout`, `printf`, and the RooFit message logger (`oocoutX` and `coutX` macros). Because only the last route honours RooMsgService, users could not control the verbosity of RooStats output consistently. This is fixed by this commit.

Closes https://github.com/root-project/root/issues/17429