### PR TITLE
[RF] Fix RooMCStudy module dataset size mismatch on failed fits

### DIFF
--- a/roofit/roofit/inc/RooChi2MCSModule.h
+++ b/roofit/roofit/inc/RooChi2MCSModule.h
@@ -31,7 +31,7 @@ public:
   bool initializeInstance() override ;
   bool initializeRun(Int_t numSamples) override ;
   RooDataSet* finalizeRun() override ;
-  bool processAfterFit(Int_t sampleNum, bool fitOk) override  ;
+  bool processAfterFit(bool fitOk) override  ;
 
 private:
    std::unique_ptr<RooDataSet> _data;    // Summary dataset to store results

--- a/roofit/roofit/inc/RooChi2MCSModule.h
+++ b/roofit/roofit/inc/RooChi2MCSModule.h
@@ -29,9 +29,9 @@ public:
   ~RooChi2MCSModule() override ;
 
   bool initializeInstance() override ;
-  bool initializeRun(Int_t /*numSamples*/) override ;
+  bool initializeRun(Int_t numSamples) override ;
   RooDataSet* finalizeRun() override ;
-  bool processAfterFit(Int_t /*sampleNum*/) override  ;
+  bool processAfterFit(Int_t sampleNum, bool fitOk) override  ;
 
 private:
    std::unique_ptr<RooDataSet> _data;    // Summary dataset to store results

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -91,7 +91,7 @@ RooDataSet *RooChi2MCSModule::finalizeRun()
 ////////////////////////////////////////////////////////////////////////////////
 /// Bin dataset and calculate chi2 of p.d.f w.r.t binned dataset
 
-bool RooChi2MCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+bool RooChi2MCSModule::processAfterFit(bool fitOk)
 {
   if(!fitOk)
      return true;

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -91,8 +91,11 @@ RooDataSet *RooChi2MCSModule::finalizeRun()
 ////////////////////////////////////////////////////////////////////////////////
 /// Bin dataset and calculate chi2 of p.d.f w.r.t binned dataset
 
-bool RooChi2MCSModule::processAfterFit(Int_t /*sampleNum*/)
+bool RooChi2MCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
 {
+  if(!fitOk)
+     return true;
+
   RooAbsData* data = genSample() ;
   std::unique_ptr<RooDataHist> binnedDataOwned;
   RooDataHist* binnedData = dynamic_cast<RooDataHist*>(data) ;

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -65,10 +65,11 @@ public:
     return true ;
   }
 
-  /// Method called after fit has been performed.
-  virtual bool processAfterFit(Int_t /*sampleNum*/) {
-    return true ;
-  }
+  /// Method called after fit has been performed. It's crucial that this is
+  /// implemented, because it's the responsability of this method to ensure
+  /// that this MC study module will not have added an element to its internal
+  /// RooDataSet if the fit has failed.
+  virtual bool processAfterFit(Int_t sampleNum, bool fitOk) = 0;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -69,7 +69,7 @@ public:
   /// implemented, because it's the responsability of this method to ensure
   /// that this MC study module will not have added an element to its internal
   /// RooDataSet if the fit has failed.
-  virtual bool processAfterFit(Int_t sampleNum, bool fitOk) = 0;
+  virtual bool processAfterFit(bool fitOk) = 0;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
+++ b/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
@@ -30,10 +30,10 @@ public:
 
   bool initializeInstance() override ;
 
-  bool initializeRun(Int_t /*numSamples*/) override ;
+  bool initializeRun(Int_t numSamples) override ;
   RooDataSet* finalizeRun() override ;
 
-  bool processAfterFit(Int_t /*sampleNum*/) override  ;
+  bool processAfterFit(Int_t sampleNum, bool fitOk) override  ;
 
 private:
 

--- a/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
+++ b/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
@@ -33,7 +33,7 @@ public:
   bool initializeRun(Int_t numSamples) override ;
   RooDataSet* finalizeRun() override ;
 
-  bool processAfterFit(Int_t sampleNum, bool fitOk) override  ;
+  bool processAfterFit(bool fitOk) override  ;
 
 private:
 

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -37,6 +37,11 @@ public:
              const RooCmdArg& arg3={}, const RooCmdArg& arg4={}, const RooCmdArg& arg5={},
              const RooCmdArg& arg6={}, const RooCmdArg& arg7={}, const RooCmdArg& arg8={}) ;
 
+  RooMCStudy(const RooMCStudy&) = delete;
+  RooMCStudy(RooMCStudy &&) = delete;
+  RooMCStudy& operator=(const RooMCStudy&) = delete;
+  RooMCStudy& operator=(RooMCStudy &&) = delete;
+
   ~RooMCStudy() override ;
 
   // Method to add study modules
@@ -144,10 +149,6 @@ protected:
   RooFit::OwningPtr<RooFitResult> refit(RooAbsData* genSample=nullptr) ;
   void resetFitParams() ;
   void RecursiveRemove(TObject *obj) override;
-
-private:
-
-  RooMCStudy(const RooMCStudy&) ;
 
   ClassDefOverride(RooMCStudy,0) // A general purpose toy Monte Carlo study manager
 } ;

--- a/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
+++ b/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
@@ -41,7 +41,7 @@ public:
 
   bool processBeforeGen(Int_t /*sampleNum*/) override ;
 
-  bool processAfterFit(Int_t sampleNum, bool fitOk) override;
+  bool processAfterFit(bool fitOk) override;
 
 private:
 

--- a/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
+++ b/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
@@ -41,6 +41,8 @@ public:
 
   bool processBeforeGen(Int_t /*sampleNum*/) override ;
 
+  bool processAfterFit(Int_t sampleNum, bool fitOk) override;
+
 private:
 
   struct UniParam {

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -145,7 +145,7 @@ RooDataSet* RooDLLSignificanceMCSModule::finalizeRun()
 /// null hypothesis value and rerun fit Save difference in likelihood
 /// and associated Gaussian significance in auxiliary dataset
 
-bool RooDLLSignificanceMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+bool RooDLLSignificanceMCSModule::processAfterFit(bool fitOk)
 {
   if(!fitOk)
      return true;

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -145,8 +145,11 @@ RooDataSet* RooDLLSignificanceMCSModule::finalizeRun()
 /// null hypothesis value and rerun fit Save difference in likelihood
 /// and associated Gaussian significance in auxiliary dataset
 
-bool RooDLLSignificanceMCSModule::processAfterFit(Int_t /*sampleNum*/)
+bool RooDLLSignificanceMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
 {
+  if(!fitOk)
+     return true;
+
   RooRealVar* par = static_cast<RooRealVar*>(fitParams()->find(_parName.c_str())) ;
   par->setVal(_nullValue) ;
   par->setConstant(true) ;

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -438,7 +438,7 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
 
     // Call module between generation and fitting hook
     for (RooAbsMCStudyModule *mod : _modList) {
-      mod->processAfterFit(nSamples, fitOk) ;
+      mod->processAfterFit(fitOk) ;
     }
 
     // Optionally write to ascii file

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -433,11 +433,12 @@ bool RooMCStudy::run(bool doGenerate, bool DoFit, Int_t nSamples, Int_t nEvtPerS
       mod->processBetweenGenAndFit(nSamples) ;
     }
 
-    if (DoFit) fitSample(_genSample) ;
+    bool fitOk = true;
+    if (DoFit) fitOk = !fitSample(_genSample) ;
 
     // Call module between generation and fitting hook
     for (RooAbsMCStudyModule *mod : _modList) {
-      mod->processAfterFit(nSamples) ;
+      mod->processAfterFit(nSamples, fitOk) ;
     }
 
     // Optionally write to ascii file

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -404,7 +404,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
 }
 
 
-bool RooRandomizeParamMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+bool RooRandomizeParamMCSModule::processAfterFit(bool fitOk)
 {
    if (!fitOk)
       return true;

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -398,12 +398,20 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
     }
   }
 
-  // Store generator values for all modified parameters
-  _data->add(_genParSet) ;
+  // Store generator values later in processAfterFit if fit succeeded.
 
   return true ;
 }
 
+
+bool RooRandomizeParamMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+{
+   if (!fitOk)
+      return true;
+   // Store generator values for all modified parameters
+   _data->add(_genParSet);
+   return true;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
+++ b/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
@@ -37,7 +37,7 @@ public:
    bool initializeRun(Int_t numSamples) override ;
    RooDataSet* finalizeRun() override ;
 
-   bool processAfterFit(Int_t sampleNum, bool fitOk) override;
+   bool processAfterFit(bool fitOk) override;
    bool processBetweenGenAndFit(Int_t sampleNum) override ;
 
 private:

--- a/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
+++ b/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
@@ -34,11 +34,11 @@ public:
 
    bool initializeInstance() override ;
 
-   bool initializeRun(Int_t /*numSamples*/) override ;
+   bool initializeRun(Int_t numSamples) override ;
    RooDataSet* finalizeRun() override ;
 
-   //bool processAfterFit(Int_t /*sampleNum*/)  ;
-   bool processBetweenGenAndFit(Int_t /*sampleNum*/) override ;
+   bool processAfterFit(Int_t sampleNum, bool fitOk) override;
+   bool processBetweenGenAndFit(Int_t sampleNum) override ;
 
 private:
 

--- a/roofit/roostats/src/UpperLimitMCSModule.cxx
+++ b/roofit/roostats/src/UpperLimitMCSModule.cxx
@@ -131,7 +131,7 @@ RooDataSet* UpperLimitMCSModule::finalizeRun()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool UpperLimitMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+bool UpperLimitMCSModule::processAfterFit(bool fitOk)
 {
    if (!fitOk)
       return true;

--- a/roofit/roostats/src/UpperLimitMCSModule.cxx
+++ b/roofit/roostats/src/UpperLimitMCSModule.cxx
@@ -131,8 +131,23 @@ RooDataSet* UpperLimitMCSModule::finalizeRun()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// bool UpperLimitMCSModule::processAfterFit(Int_t /*sampleNum*/)
-// {
+bool UpperLimitMCSModule::processAfterFit(Int_t /*sampleNum*/, bool fitOk)
+{
+   if (!fitOk)
+      return true;
+   _data->add(RooArgSet(*_ul));
+   coutI(Eval)<<"UL:"<<_ul->getVal()<<std::endl;
+//   if (_ul->getVal()<1){
+
+//   RooStats::LikelihoodIntervalPlot plotpll((RooStats::LikelihoodInterval*) pllint);
+//   TCanvas c1;
+//   plotpll.Draw();
+//   c1.Print("test.ps");
+//   std::cout<<" UL<1 whats going on here?"<<std::endl;
+//   abort();
+//   }
+
+
 //   // Save likelihood from nominal fit, fix chosen parameter to its
 //   // null hypothesis value and rerun fit Save difference in likelihood
 //   // and associated Gaussian significance in auxiliary dataset
@@ -154,9 +169,8 @@ RooDataSet* UpperLimitMCSModule::finalizeRun()
 //   _data->add(RooArgSet(*_nll0h,*_dll0h,*_sig0h)) ;
 
 //   delete frnull ;
-//   return true ;
-
-// }
+   return true ;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -192,18 +206,6 @@ bool UpperLimitMCSModule::processBetweenGenAndFit(Int_t /*sampleNum*/) {
 
 
   _ul->setVal((static_cast<RooStats::LikelihoodInterval*>(pllint))->UpperLimit(static_cast<RooRealVar&>(*(fitParams()->find(_parName.c_str())))));
-
-  _data->add(RooArgSet(*_ul));
-  coutI(Eval)<<"UL:"<<_ul->getVal()<<std::endl;
-//   if (_ul->getVal()<1){
-
-//   RooStats::LikelihoodIntervalPlot plotpll((RooStats::LikelihoodInterval*) pllint);
-//   TCanvas c1;
-//   plotpll.Draw();
-//   c1.Print("test.ps");
-//   std::cout<<" UL<1 whats going on here?"<<std::endl;
-//   abort();
-//   }
 
   delete pllint;
 


### PR DESCRIPTION
RooMCStudy stores fit results only for successful fits in the internal
`_fitParData` dataset. However, RooAbsMCStudyModule implementations had
no way to detect whether a fit succeeded, while `finalizeRun()` requires
modules to return datasets with the same number of entries as the
fit parameter dataset.

This mismatch could lead to merge errors:
```
  RooDataSet::merge(...) ERROR: datasets have different size
```

This fix suggests to propagate fit success status to study modules via
`RooAbsMCStudyModule::processAfterFit`, making it also pure virtual to
enforce correct handling in all modules. It is then correctly
implemented in all RooAbsMCStudyModule-derived classes.

Closes https://github.com/root-project/root/issues/6949.