### PR TITLE
[tmva] Fix a warning on Windows

### DIFF
--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -2313,7 +2313,7 @@ TH1F *TMVA::Factory::EvaluateImportanceAll(DataLoader *loader, Types::EMVA theMe
       SROC = ROC[x];
       for (uint32_t i = 0; i < VIBITS; ++i) {
          if (x & (uint64_t(1) << i)) {
-            y = x & ~(1 << i);
+            y = x & ~(uint64_t(1) << i);
             std::bitset<VIBITS> ybitset(y);
             // need at least one variable
             // NOTE: if sub-seed is zero then is the special case
@@ -2412,7 +2412,7 @@ TH1F *TMVA::Factory::EvaluateImportanceShort(DataLoader *loader, Types::EMVA the
    // removing global result because it is requiring a lot of RAM for all seeds
 
    for (uint32_t i = 0; i < VIBITS; ++i) {
-      if (x & (1 << i)) {
+      if (x & (uint64_t(1) << i)) {
          y = x & ~(uint64_t(1) << i);
          std::bitset<VIBITS> ybitset(y);
          // need at least one variable
@@ -2527,7 +2527,7 @@ TH1F *TMVA::Factory::EvaluateImportanceRandom(DataLoader *loader, UInt_t nseeds,
 
       for (uint32_t i = 0; i < 32; ++i) {
          if (x & (uint64_t(1) << i)) {
-            y = x & ~(1 << i);
+            y = x & ~(uint64_t(1) << i);
             std::bitset<32> ybitset(y);
             // need at least one variable
             // NOTE: if sub-seed is zero then is the special case


### PR DESCRIPTION
Fix warning for the result of 32-bit shift implicitly converted to 64 bit. Since the result is intended to be in 64 bits, explicitly add the conversion. However there were no issue since there was no overflow happening ( i is < 32)

