### PR TITLE
Fix windows warnings

### DIFF
--- a/graf2d/asimage/src/libAfterImage/CMakeLists.txt
+++ b/graf2d/asimage/src/libAfterImage/CMakeLists.txt
@@ -80,6 +80,7 @@ target_compile_definitions(
           HAVE_PROTOTYPES
           HAVE_STDARG_H
           HAVE_STDDEF_H
+          HAVE_STDLIB_H
           HAVE_STRING_H
           HAVE_SYS_STAT_H
           HAVE_SYS_TYPES_H

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -172,7 +172,7 @@ struct RTFString {
       // The length of strings with 255 characters and longer are encoded with a 32-bit integer following the first
       // byte. This is currently not handled.
       R__ASSERT(str.length() < 255);
-      fLName = str.length();
+      fLName = static_cast<unsigned char>(str.length());
       memcpy(fData, str.data(), fLName);
    }
    std::size_t GetSize() const
@@ -228,7 +228,7 @@ struct RTFKey {
       // For writing, we alywas produce "big" keys with 64-bit SeekKey and SeekPdir.
       fVersion = fVersion + kBigKeyVersion;
       fObjLen = szObjInMem;
-      fKeyLen = GetHeaderSize() + clName.GetSize() + objName.GetSize() + titleName.GetSize();
+      fKeyLen = static_cast<RUInt16BE>(GetHeaderSize() + clName.GetSize() + objName.GetSize() + titleName.GetSize());
       fInfoLong.fSeekKey = seekKey;
       fInfoLong.fSeekPdir = seekPdir;
       // Depends on fKeyLen being set


### PR DESCRIPTION
1. Add missing define in libAfterImage
2. Provide strict casting in RMiniFile
