### PR TITLE
[cmake] rm duplicated afterimage flag

### DIFF
--- a/graf2d/asimage/src/libAfterImage/CMakeLists.txt
+++ b/graf2d/asimage/src/libAfterImage/CMakeLists.txt
@@ -129,7 +129,6 @@ else()
             HAVE_DIRENT_H
             HAVE_LONG_LONG
             HAVE_STDINT_H
-            HAVE_STDLIB_H
             HAVE_UNISTD_H
             HAVE_STRINGS_H
             SHAPE


### PR DESCRIPTION
shared flags for all platforms are listed first in a common list.
OS-specific flags are listed later in an if-else

STDLIB_H is both in the common list as well as in the Linux specific list. Remove it from the specific branch.

Follow-up of https://github.com/root-project/root/pull/21965