### PR TITLE
[RF] Use RooDataHist interfaces with index input arguments

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -48,7 +48,7 @@ public:
 
   RooDataHist const& dataHist() const { return _dataSet; }
 
-  double binVolume() const { return _dataSet.binVolume(); }
+  double binVolume(std::size_t i) const { return _dataSet.binVolume(i); }
 
   bool forceAnalyticalInt(const RooAbsArg&) const override { return true ; }
 

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -192,7 +192,7 @@ void RooStats::HistFactory::RooBarlowBeestonLL::initializeBarlowCache() {
       cache.bin_center = bin_center;
       cache.observables = obsSet;
 
-      cache.binVolume = param_func->binVolume();
+      cache.binVolume = param_func->binVolume(bin_index);
 
       // Delete this part, simply a comment
       RooArgList obs_list( *(cache.bin_center) );

--- a/roofit/roofit/src/RooHistConstraint.cxx
+++ b/roofit/roofit/src/RooHistConstraint.cxx
@@ -60,11 +60,11 @@ RooHistConstraint::RooHistConstraint(const char *name, const char *title,
 
     // Now populate nominal with parameters
     for (int i=0 ; i<phf->_dh.numEntries() ; i++) {
-      phf->_dh.get(i) ;
-      if (phf->_dh.weight()<threshold && phf->_dh.weight() != 0.) {
+      const double wi = phf->_dh.weight(i) ;
+      if (wi<threshold && wi != 0.) {
         const char* vname = Form("%s_nominal_bin_%i",GetName(),i) ;
         auto var = std::make_unique<RooRealVar>(vname,vname,0,1.E30);
-        var->setVal(phf->_dh.weight()) ;
+        var->setVal(wi) ;
         var->setConstant(true);
 
         auto gamma = static_cast<RooRealVar*>(phf->_p.at(i));

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -392,8 +392,8 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
   // Zero output histogram below lowest calculable X value
   for (int i=0; i<_yatXmin ; i++) {
     dIter->Next() ;
-    //_hist->get(i) ;
-    hist()->set(0) ;
+    const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
+    hist()->set(binIdx, 0, -1) ;
   }
 
   double x1 = _x->getMin("cache");
@@ -420,14 +420,16 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
     double fbarX = f1x1*f2x2 / ( _alpha->getVal()*f2x2 + (1-_alpha->getVal())*f1x1 ) ;
 
     dIter->Next() ;
-    //_hist->get(i) ;
-    hist()->set(fbarX) ;
+    {
+      const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
+      hist()->set(binIdx, fbarX, -1) ;
+    }
   }
   // Zero output histogram above highest calculable X value
   for (int i=_yatXmax+1 ; i<nbins ; i++) {
     dIter->Next() ;
-    //_hist->get(i) ;
-    hist()->set(0) ;
+    const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
+    hist()->set(binIdx, 0, -1) ;
   }
 
   pdf()->setUnitNorm(true) ;

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -2572,12 +2572,12 @@ TH1 *RooLagrangianMorphFunc::createTH1(const std::string &name, bool correlateEr
             continue;
          }
          const RooDataHist &dhist = hf->dataHist();
-         dhist.get(i);
          RooAbsReal *formula = dynamic_cast<RooAbsReal *>(prod->components().find(Form("w_%s", prod->GetName())));
          double weight = formula->getVal();
-         unc2 += dhist.weightSquared() * weight * weight;
-         unc += sqrt(dhist.weightSquared()) * weight;
-         val += dhist.weight() * weight;
+         const double w2 = dhist.weightSquared(i);
+         unc2 += w2 * weight * weight;
+         unc += sqrt(w2) * weight;
+         val += dhist.weight(i) * weight;
       }
       hist->SetBinContent(i + 1, val);
       hist->SetBinError(i + 1, correlateErrors ? unc : sqrt(unc2));
@@ -2827,8 +2827,7 @@ double RooLagrangianMorphFunc::expectedUncertainty() const
       if (hf) {
          const RooDataHist &hist = hf->dataHist();
          for (Int_t j = 0; j < observable->getBins(); ++j) {
-            hist.get(j);
-            newunc2 += hist.weightSquared();
+            newunc2 += hist.weightSquared(j);
          }
       } else if (rv) {
          newunc2 = pow(rv->getError(), 2);

--- a/roofit/roofit/src/RooParamHistFunc.cxx
+++ b/roofit/roofit/src/RooParamHistFunc.cxx
@@ -44,11 +44,11 @@ RooParamHistFunc::RooParamHistFunc(const char *name, const char *title, RooDataH
    // Now populate p with parameters
    RooArgSet allVars;
    for (Int_t i = 0; i < _dh.numEntries(); i++) {
-      _dh.get(i);
+      const double wi = _dh.weight(i);
       const char *vname = Form("%s_gamma_bin_%i", GetName(), i);
       RooRealVar *var = new RooRealVar(vname, vname, 0, 1000);
-      var->setVal(_relParam ? 1 : _dh.weight());
-      var->setError(_relParam ? 1 / sqrt(_dh.weight()) : sqrt(_dh.weight()));
+      var->setVal(_relParam ? 1 : wi);
+      var->setError(_relParam ? 1 / sqrt(wi) : sqrt(wi));
       var->setConstant(true);
       allVars.add(*var);
       _p.add(*var);
@@ -94,8 +94,7 @@ void RooParamHistFunc::setActual(Int_t ibin, double newVal)
 
 double RooParamHistFunc::getNominal(Int_t ibin) const
 {
-  _dh.get(ibin) ;
-  return _dh.weight() ;
+  return _dh.weight(ibin) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1703,26 +1703,27 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
   Int_t histOutSum(0) ;
   for (int i=0 ; i<hist->numEntries() ; i++) {
     hist->get(i) ;
+    const double wi = hist->weight(i) ;
     if (expectedData) {
 
       // Expected data, multiply p.d.f by nEvents
-      double w=hist->weight()*nEvents ;
+      double w=wi*nEvents ;
       hist->set(i, w, sqrt(w));
 
     } else if (extended) {
 
       // Extended mode, set contents to Poisson(pdf*nEvents)
-      double w = RooRandom::randomGenerator()->Poisson(hist->weight()*nEvents) ;
-      hist->set(w,sqrt(w)) ;
+      double w = RooRandom::randomGenerator()->Poisson(wi*nEvents) ;
+      hist->set(i, w, sqrt(w)) ;
 
     } else {
 
       // Regular mode, fill array of weights with Poisson(pdf*nEvents), but to not fill
       // histogram yet.
-      if (hist->weight()>histMax) {
-        histMax = hist->weight() ;
+      if (wi>histMax) {
+        histMax = wi ;
       }
-      histOut[i] = RooRandom::randomGenerator()->Poisson(hist->weight()*nEvents) ;
+      histOut[i] = RooRandom::randomGenerator()->Poisson(wi*nEvents) ;
       histOutSum += histOut[i] ;
     }
   }
@@ -1745,7 +1746,7 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
       hist->get(ibinRand) ;
       double ranY = RooRandom::randomGenerator()->Uniform(histMax) ;
 
-      if (ranY<hist->weight()) {
+      if (ranY<hist->weight(ibinRand)) {
         if (wgt==1) {
           histOut[ibinRand]++ ;
         } else {
@@ -1768,8 +1769,7 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
 
     // Transfer working array to histogram
     for (int i=0 ; i<hist->numEntries() ; i++) {
-      hist->get(i) ;
-      hist->set(histOut[i],sqrt(1.0*histOut[i])) ;
+      hist->set(i, histOut[i], sqrt(1.0*histOut[i])) ;
     }
 
   } else if (expectedData) {
@@ -1779,8 +1779,8 @@ RooFit::OwningPtr<RooDataHist> RooAbsPdf::generateBinned(const RooArgSet &whatVa
     // bin average and bin integral in sampling bins
     double corr = nEvents/hist->sumEntries() ;
     for (int i=0 ; i<hist->numEntries() ; i++) {
-      hist->get(i) ;
-      hist->set(hist->weight()*corr,sqrt(hist->weight()*corr)) ;
+      const double wnew = hist->weight(i)*corr ;
+      hist->set(i, wnew, sqrt(wnew)) ;
     }
 
   }

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1151,7 +1151,7 @@ RooDataHist* RooAbsReal::fillDataHist(RooDataHist *hist, const RooArgSet* normSe
     const RooArgSet* obs = hist->get(i) ;
     double binVal = theClone->getVal(normSet?normSet:obs)*scaleFactor ;
     if (correctForBinSize) {
-      binVal*= hist->binVolume() ;
+      binVal*= hist->binVolume(i) ;
     }
     hist->set(i, binVal, 0.);
   }

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -141,27 +141,28 @@ RooDataSet *RooBinnedGenContext::generate(double nEvt, bool /*skipInit*/, bool e
   double histMax(-1) ;
   Int_t histOutSum(0) ;
   for (int i=0 ; i<_hist->numEntries() ; i++) {
-    _hist->get(i) ;
+    const RooArgSet* coords = _hist->get(i) ;
+    const double wi = _hist->weight(i) ;
     if (_expectedData) {
 
       // Expected data, multiply p.d.f by nEvents
-      double w=_hist->weight()*nEvents ;
-      wudata->add(*_hist->get(),w) ;
+      double w=wi*nEvents ;
+      wudata->add(*coords,w) ;
 
     } else if (extended) {
 
       // Extended mode, set contents to Poisson(pdf*nEvents)
-      double w = RooRandom::randomGenerator()->Poisson(_hist->weight()*nEvents) ;
-      wudata->add(*_hist->get(),w) ;
+      double w = RooRandom::randomGenerator()->Poisson(wi*nEvents) ;
+      wudata->add(*coords,w) ;
 
     } else {
 
       // Regular mode, fill array of weights with Poisson(pdf*nEvents), but to not fill
       // histogram yet.
-      if (_hist->weight()>histMax) {
-   histMax = _hist->weight() ;
+      if (wi>histMax) {
+   histMax = wi ;
       }
-      histOut[i] = RooRandom::randomGenerator()->Poisson(_hist->weight()*nEvents) ;
+      histOut[i] = RooRandom::randomGenerator()->Poisson(wi*nEvents) ;
       histOutSum += histOut[i] ;
     }
   }
@@ -182,7 +183,7 @@ RooDataSet *RooBinnedGenContext::generate(double nEvt, bool /*skipInit*/, bool e
       _hist->get(ibinRand) ;
       double ranY = RooRandom::randomGenerator()->Uniform(histMax) ;
 
-      if (ranY<_hist->weight()) {
+      if (ranY<_hist->weight(ibinRand)) {
    if (wgt==1) {
      histOut[ibinRand]++ ;
    } else {

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -107,9 +107,9 @@ double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEve
     }
     if (!doSelect) continue ;
 
-    const double nData = hdata->weight() ;
+    const double nData = hdata->weight(i) ;
 
-    const double nPdf = _funcClone->getVal(_normSet) * normFactor * hdata->binVolume() ;
+    const double nPdf = _funcClone->getVal(_normSet) * normFactor * hdata->binVolume(i) ;
 
     const double eExt = nPdf-nData ;
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -660,7 +660,7 @@ void RooDataHist::importDHistSet(const RooArgList & /*vars*/, RooCategory &index
       // Transfer contents
       for (Int_t i = 0; i < dhist->numEntries(); i++) {
          _vars.assign(*dhist->get(i));
-         add(_vars, dhist->weight() * initWgt, pow(dhist->weightError(SumW2), 2));
+         add(_vars, dhist->weight(i) * initWgt, pow(dhist->weightError(SumW2), 2));
       }
    }
 }
@@ -955,7 +955,7 @@ std::unique_ptr<RooAbsData> RooDataHist::reduceEng(const RooArgSet& varSubset, c
 
     if (!cloneVar || cloneVar->getVal()) {
       weightError(lo,hi,SumW2) ;
-      rdh->add(*row,weight(),lo*lo) ;
+      rdh->add(*row,weight(i),lo*lo) ;
     }
   }
 
@@ -1572,7 +1572,7 @@ void RooDataHist::weightError(double& lo, double& hi, ErrorType etype) const
     throw std::invalid_argument("RooDataHist::weightError(" + std::string(GetName()) + ") error type Expected not allowed here");
     break ;
 
-  case Poisson:
+  case Poisson: {
     if (_errLo && _errLo[_curIndex] >= 0.0) {
       // Weight is preset or precalculated
       lo = _errLo[_curIndex];
@@ -1586,12 +1586,14 @@ void RooDataHist::weightError(double& lo, double& hi, ErrorType etype) const
     // Calculate poisson errors
     double ym;
     double yp;
-    RooHistError::instance().getPoissonInterval(Int_t(weight()+0.5),ym,yp,1) ;
-    _errLo[_curIndex] = weight()-ym;
-    _errHi[_curIndex] = yp-weight();
+    const double w = weight(_curIndex);
+    RooHistError::instance().getPoissonInterval(Int_t(w+0.5),ym,yp,1) ;
+    _errLo[_curIndex] = w-ym;
+    _errHi[_curIndex] = yp-w;
     lo = _errLo[_curIndex];
     hi = _errHi[_curIndex];
     return ;
+  }
 
   case SumW2:
     lo = std::sqrt(weightSquared(_curIndex));
@@ -2348,7 +2350,7 @@ void RooDataHist::printContents(std::ostream& os) const
 
         double lo, hi;
         weightError(lo, hi, RooAbsData::SumW2);
-        os << ", weight=" << weight() << " +/- [" << lo << "," << hi << "]"
+        os << ", weight=" << weight(i) << " +/- [" << lo << "," << hi << "]"
            << std::endl;
     }
 }

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -657,10 +657,11 @@ void RooFFTConvPdf::fillCacheSlice(FFTCacheElem& aux, const RooArgSet& slicePos)
     while (j>=N2) j-= N2 ;
 
     iter->Next() ;
+    const std::size_t binIdx = cacheHist.getIndex(*cacheHist.get(), /*fast=*/true);
 #ifndef ROOFIT_MATH_FFTW3
-    cacheHist.set(output[j]);
+    cacheHist.set(binIdx, output[j], -1.);
 #else
-    cacheHist.set(aux.fftc2r->GetPointReal(j));
+    cacheHist.set(binIdx, aux.fftc2r->GetPointReal(j), -1.);
 #endif
   }
 }

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -247,8 +247,7 @@ double RooHistFunc::maxVal(Int_t code) const
 
   double max(-1) ;
   for (Int_t i=0 ; i<_dataHist->numEntries() ; i++) {
-    _dataHist->get(i) ;
-    double wgt = _dataHist->weight() ;
+    double wgt = _dataHist->weight(i) ;
     if (wgt>max) max=wgt ;
   }
 
@@ -487,9 +486,7 @@ bool RooHistFunc::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
   if (std::abs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
   if (dh1.numEntries() != dh2.numEntries()) return false ;
   for (int i=0 ; i < dh1.numEntries() ; i++) {
-    dh1.get(i) ;
-    dh2.get(i) ;
-    if (std::abs(dh1.weight()-dh2.weight())>1e-8) return false ;
+    if (std::abs(dh1.weight(i)-dh2.weight(i))>1e-8) return false ;
   }
   using RooHelpers::getColonSeparatedNameString;
   if (getColonSeparatedNameString(*dh1.get()) != getColonSeparatedNameString(*dh2.get())) return false ;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -530,8 +530,7 @@ double RooHistPdf::maxVal(Int_t code) const
 
   double max(-1) ;
   for (Int_t i=0 ; i<_dataHist->numEntries() ; i++) {
-    _dataHist->get(i) ;
-    double wgt = _dataHist->weight() ;
+    double wgt = _dataHist->weight(i) ;
     if (wgt>max) max=wgt ;
   }
 
@@ -548,9 +547,7 @@ bool RooHistPdf::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
   if (std::abs(dh1.sumEntries()-dh2.sumEntries())>1e-8) return false ;
   if (dh1.numEntries() != dh2.numEntries()) return false ;
   for (int i=0 ; i < dh1.numEntries() ; i++) {
-    dh1.get(i) ;
-    dh2.get(i) ;
-    if (std::abs(dh1.weight()-dh2.weight())>1e-8) return false ;
+    if (std::abs(dh1.weight(i)-dh2.weight(i))>1e-8) return false ;
   }
   return true ;
 }

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -96,7 +96,7 @@ TEST(RooDataHist, UnWeightedEntries)
    EXPECT_EQ(static_cast<RooRealVar *>(coordsAtZero.find(x))->getVal(),
              static_cast<RooRealVar *>(coordsAtPoint9.find(x))->getVal());
 
-   const double weight = dataHist.weight();
+   const double weight = dataHist.weight(dataHist.getIndex(coordinates));
    EXPECT_EQ(weight, targetBinContent);
 
    EXPECT_NEAR(dataHist.weightError(RooAbsData::Poisson), sqrt(targetBinContent),
@@ -124,7 +124,7 @@ TEST(RooDataHist, UnWeightedEntries)
 
    RooArgSet coordsAt10;
    dataHist.get(10)->snapshot(coordsAt10);
-   const double weightBin10 = dataHist.weight();
+   const double weightBin10 = dataHist.weight(10);
 
    EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
    EXPECT_EQ(weight, weightBin10);
@@ -149,7 +149,7 @@ TEST(RooDataHist, WeightedEntries)
 
    x.setVal(0.);
    dataHist.get(coordinates);
-   const double weight = dataHist.weight();
+   const double weight = dataHist.weight(dataHist.getIndex(coordinates));
    ASSERT_EQ(weight, targetBinContent);
 
    const double targetError = sqrt(10 * 4.);
@@ -178,7 +178,7 @@ TEST(RooDataHist, WeightedEntries)
 
    RooArgSet coordsAt10;
    dataHist.get(10)->snapshot(coordsAt10);
-   const double weightBin10 = dataHist.weight();
+   const double weightBin10 = dataHist.weight(10);
 
    EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find(x))->getVal(), 0.5, 1.E-1);
    EXPECT_EQ(weight, weightBin10);
@@ -217,8 +217,7 @@ TEST_P(RooDataHistIO, ReadLegacy)
    EXPECT_EQ(dataHist.sumEntries(), 20 * targetBinContent);
 
    static_cast<RooRealVar *>(legacyVals.find("x"))->setVal(0.);
-   dataHist.get(legacyVals); // trigger side effect for weight below.
-   const double weight = dataHist.weight();
+   const double weight = dataHist.weight(dataHist.getIndex(legacyVals));
    ASSERT_EQ(weight, targetBinContent);
 
    const double targetError = sqrt(10 * 4.);
@@ -247,7 +246,7 @@ TEST_P(RooDataHistIO, ReadLegacy)
 
    RooArgSet coordsAt10;
    dataHist.get(10)->snapshot(coordsAt10);
-   const double weightBin10 = dataHist.weight();
+   const double weightBin10 = dataHist.weight(10);
 
    EXPECT_NEAR(static_cast<RooRealVar *>(coordsAt10.find("x"))->getVal(), 0.5, 1.E-1);
    EXPECT_EQ(weight, weightBin10);
@@ -804,11 +803,11 @@ TEST(RooDataHist, SplitDataHistWithSumW2)
 
    data1.get(0);
    data2.get(0);
-   EXPECT_DOUBLE_EQ(data2.weightSquared(), data1.weightSquared());
+   EXPECT_DOUBLE_EQ(data2.weightSquared(), data1.weightSquared(0));
    EXPECT_DOUBLE_EQ(data2.weightError(), data1.weightError());
 
    data1.get(1);
    data2.get(1);
-   EXPECT_DOUBLE_EQ(data2.weightSquared(), data1.weightSquared());
+   EXPECT_DOUBLE_EQ(data2.weightSquared(), data1.weightSquared(1));
    EXPECT_DOUBLE_EQ(data2.weightError(), data1.weightError());
 }

--- a/roofit/roofitcore/test/testRooDataSet.cxx
+++ b/roofit/roofitcore/test/testRooDataSet.cxx
@@ -374,10 +374,9 @@ TEST(RooDataSet, ImportDataHist)
    RooDataSet ds{"ds", "ds", x, RooFit::Import(dh)};
 
    for (int i = 0; i < x.numBins(); ++i) {
-      dh.get(i);
       ds.get(i);
-      EXPECT_FLOAT_EQ(ds.weight(), dh.weight()) << "weight() is off in bin " << i;
-      EXPECT_FLOAT_EQ(ds.weightSquared(), dh.weightSquared()) << "weightSquared() is off in bin " << i;
+      EXPECT_FLOAT_EQ(ds.weight(), dh.weight(i)) << "weight() is off in bin " << i;
+      EXPECT_FLOAT_EQ(ds.weightSquared(), dh.weightSquared(i)) << "weightSquared() is off in bin " << i;
    }
 }
 

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -111,10 +111,8 @@ MCMCInterval::~MCMCInterval() = default;
 struct CompareDataHistBins {
    CompareDataHistBins(RooDataHist* hist) : fDataHist(hist) {}
    bool operator() (Int_t bin1 , Int_t bin2) {
-      fDataHist->get(bin1);
-      double n1 = fDataHist->weight();
-      fDataHist->get(bin2);
-      double n2 = fDataHist->weight();
+      double n1 = fDataHist->weight(bin1);
+      double n2 = fDataHist->weight(bin2);
       return (n1 < n2);
    }
    RooDataHist* fDataHist;
@@ -185,8 +183,7 @@ bool MCMCInterval::IsInInterval(const RooArgSet& point) const
             // >= cutoff
             Int_t bin;
             bin = fDataHist->getIndex(point);
-            fDataHist->get(bin);
-            return (fDataHist->weight() >= (double)fHistCutoff);
+            return (fDataHist->weight(bin) >= (double)fHistCutoff);
          }
       }
    } else if (fIntervalType == kTailFraction) {
@@ -839,8 +836,7 @@ void MCMCInterval::DetermineByDataHist()
    double content;
    Int_t i;
    for (i = numBins - 1; i >= 0; i--) {
-      fDataHist->get(bins[i]);
-      content = fDataHist->weight();
+      content = fDataHist->weight(bins[i]);
       if ((sum + content) / nEntries >= fConfidenceLevel) {
          fHistCutoff = content;
          if (fIsHistStrict) {
@@ -858,8 +854,7 @@ void MCMCInterval::DetermineByDataHist()
    if (fIsHistStrict) {
       // keep going to find the sum
       for ( ; i >= 0; i--) {
-         fDataHist->get(bins[i]);
-         content = fDataHist->weight();
+         content = fDataHist->weight(bins[i]);
          if (content == fHistCutoff) {
             sum += content;
          } else {
@@ -869,8 +864,7 @@ void MCMCInterval::DetermineByDataHist()
    } else {
       // backtrack to find the cutoff and sum
       for ( ; i < numBins; i++) {
-         fDataHist->get(bins[i]);
-         content = fDataHist->weight();
+         content = fDataHist->weight(bins[i]);
          if (content > fHistCutoff) {
             fHistCutoff = content;
             break;
@@ -1070,9 +1064,8 @@ double MCMCInterval::LowerLimitByDataHist(RooRealVar& param)
          double lowerLimit = param.getMax();
          double val;
          for (Int_t i = 0; i < numBins; i++) {
-            fDataHist->get(i);
-            if (fDataHist->weight() >= fHistCutoff) {
-               val = fDataHist->get()->getRealValue(param.GetName());
+            if (fDataHist->weight(i) >= fHistCutoff) {
+               val = fDataHist->get(i)->getRealValue(param.GetName());
                if (val < lowerLimit)
                   lowerLimit = val;
             }
@@ -1147,9 +1140,8 @@ double MCMCInterval::UpperLimitByDataHist(RooRealVar& param)
          double upperLimit = param.getMin();
          double val;
          for (Int_t i = 0; i < numBins; i++) {
-            fDataHist->get(i);
-            if (fDataHist->weight() >= fHistCutoff) {
-               val = fDataHist->get()->getRealValue(param.GetName());
+            if (fDataHist->weight(i) >= fHistCutoff) {
+               val = fDataHist->get(i)->getRealValue(param.GetName());
                if (val > upperLimit)
                   upperLimit = val;
             }
@@ -1187,9 +1179,8 @@ double MCMCInterval::LowerLimitByKeys(RooRealVar& param)
          double lowerLimit = param.getMax();
          double val;
          for (Int_t i = 0; i < numBins; i++) {
-            fKeysDataHist->get(i);
-            if (fKeysDataHist->weight() >= fKeysCutoff) {
-               val = fKeysDataHist->get()->getRealValue(param.GetName());
+            if (fKeysDataHist->weight(i) >= fKeysCutoff) {
+               val = fKeysDataHist->get(i)->getRealValue(param.GetName());
                if (val < lowerLimit)
                   lowerLimit = val;
             }
@@ -1227,9 +1218,8 @@ double MCMCInterval::UpperLimitByKeys(RooRealVar& param)
          double upperLimit = param.getMin();
          double val;
          for (Int_t i = 0; i < numBins; i++) {
-            fKeysDataHist->get(i);
-            if (fKeysDataHist->weight() >= fKeysCutoff) {
-               val = fKeysDataHist->get()->getRealValue(param.GetName());
+            if (fKeysDataHist->weight(i) >= fKeysCutoff) {
+               val = fKeysDataHist->get(i)->getRealValue(param.GetName());
                if (val > upperLimit)
                   upperLimit = val;
             }
@@ -1264,8 +1254,7 @@ double MCMCInterval::GetKeysMax()
    double max = 0;
    double w;
    for (Int_t i = 0; i < numBins; i++) {
-      fKeysDataHist->get(i);
-      w = fKeysDataHist->weight();
+      w = fKeysDataHist->weight(i);
       if (w > max)
          max = w;
    }

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -2136,7 +2136,7 @@ xRooNode xRooNode::Add(const xRooNode &child, Option_t *opt)
             // need to divide by bin widths first
             for (int i = 0; i < _f->dataHist().numEntries(); i++) {
                auto bin_pars = _f->dataHist().get(i);
-               _f->dataHist().set(*bin_pars, _f->dataHist().weight() / _f->dataHist().binVolume(*bin_pars));
+               _f->dataHist().set(*bin_pars, _f->dataHist().weight(i) / _f->dataHist().binVolume(*bin_pars));
             }
             _f->setAttribute("autodensity", false);
             _f->setValueDirty();
@@ -3329,7 +3329,7 @@ xRooNode xRooNode::Multiply(const xRooNode &child, Option_t *opt)
             // need to divide by bin widths first
             for (int i = 0; i < _f->dataHist().numEntries(); i++) {
                auto bin_pars = _f->dataHist().get(i);
-               _f->dataHist().set(*bin_pars, _f->dataHist().weight() / _f->dataHist().binVolume(*bin_pars));
+               _f->dataHist().set(*bin_pars, _f->dataHist().weight(i) / _f->dataHist().binVolume(*bin_pars));
             }
             _f->setValueDirty();
 
@@ -4893,7 +4893,7 @@ bool xRooNode::SetBinError(int bin, double value)
          TString origName = (f->getStringAttribute("origName")) ? f->getStringAttribute("origName") : GetName();
          rrv->setStringAttribute(Form("sumw2_%s", origName.Data()), TString::Format("%f", pow(value, 2)));
          auto bin_pars = f->dataHist().get(bin - 1);
-         auto _binContent = f->dataHist().weight();
+         auto _binContent = f->dataHist().weight(bin - 1);
          if (f->getAttribute("density")) {
             _binContent *= f->dataHist().binVolume(*bin_pars);
          }


### PR DESCRIPTION
Use RooDataHist interfaces that take index input arguments, which is safer because they don't rely on the cached last index in the RooDataHist.

Addresses one bullet point in
https://github.com/root-project/root/issues/6557:

"Correct interface of RooAbsData and derived classes to use e.g. std::size_t for indexing events. int doesn't make sense."

As a followup, we could consider to deprecate the interfaces that use the last cached "current" index.