### PR TITLE
[RF] Enable all of `testGauss` and `testLandau` also on Windows

### DIFF
--- a/roofit/roofit/test/vectorisedPDFs/testGauss.cxx
+++ b/roofit/roofit/test/vectorisedPDFs/testGauss.cxx
@@ -52,8 +52,6 @@ FIT_TEST_SCALAR(TestGauss, RunScalar)
 FIT_TEST_BATCH(TestGauss, RunBatch)
 FIT_TEST_BATCH_VS_SCALAR(TestGauss, CompareBatchScalar)
 
-#if !defined(_MSC_VER) // TODO: make TestGaussWeighted work on Windows
-
 class TestGaussWeighted : public PDFTestWeightedData {
 protected:
    TestGaussWeighted() : PDFTestWeightedData("GaussWithWeights")
@@ -78,8 +76,6 @@ protected:
 FIT_TEST_BATCH(TestGaussWeighted,
                DISABLED_RunBatch) // Would need SumW2 or asymptotic error correction, but that's not in test macro.
 FIT_TEST_BATCH_VS_SCALAR(TestGaussWeighted, CompareBatchScalar)
-
-#endif // !defined(_MSC_VER)
 
 class TestGaussInMeanAndX : public PDFTest {
 protected:

--- a/roofit/roofit/test/vectorisedPDFs/testLandau.cxx
+++ b/roofit/roofit/test/vectorisedPDFs/testLandau.cxx
@@ -17,8 +17,6 @@
 #include "VectorisedPDFTests.h"
 #include "RooLandau.h"
 
-#if !defined(_MSC_VER) // TODO: make TestGaussWeighted work on Windows
-
 class TestLandauEvil : public PDFTest {
 protected:
    TestLandauEvil() : PDFTest("Landau_evil")
@@ -48,8 +46,6 @@ COMPARE_FIXED_VALUES_NORM(TestLandauEvil, CompareFixedValuesNorm)
 FIT_TEST_SCALAR(TestLandauEvil, DISABLED_RunScalar) // numerical integral presumably inaccurate
 FIT_TEST_BATCH(TestLandauEvil, DISABLED_RunBatch)   // numerical integral presumably inaccurate
 FIT_TEST_BATCH_VS_SCALAR(TestLandauEvil, CompareBatchScalar)
-
-#endif // !defined(_MSC_VER)
 
 class TestLandau : public PDFTest {
 protected:


### PR DESCRIPTION
These tests should also completely run on Windows nowadays.