### PR TITLE
[meta] Change type of `TDataType::fAlignOf` to `UInt_t`

### DIFF
--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -46,7 +46,7 @@ class TDataType : public TDictionary {
 private:
    TypedefInfo_t    *fInfo;     ///<!pointer to CINT typedef info
    Int_t             fSize;     // size of type
-   std::size_t       fAlignOf;  // alignment of type (0 if unknown)
+   UInt_t            fAlignOf;  // alignment of type (0 if unknown)
    EDataType         fType;     //type id
    Long_t            fProperty; //The property information for the (potential) underlying class
    TString           fTrueName; //Qualified name of the (potential) underlying class, e.g. "MyClass*const*"

--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -79,7 +79,7 @@ public:
    static EDataType GetType(const std::type_info &typeinfo);
    static void AddBuiltins(TCollection* types);
 
-   ClassDefOverride(TDataType,2)  //Basic data type descriptor
+   ClassDefOverride(TDataType,3)  //Basic data type descriptor
 };
 
 #endif


### PR DESCRIPTION
In contrast to `std::size_t`, this is stable across platforms and between 32 and 64 bits.

Also bump the class version for the added data member.