### PR TITLE
[cmake] Look for static libxxhash first therewith restoring the symmetry with the builtin provided xxhash library

### DIFF
--- a/cmake/modules/FindxxHash.cmake
+++ b/cmake/modules/FindxxHash.cmake
@@ -34,7 +34,11 @@
 #   xxHash_VERSION_PATCH  - The patch version of xxHash
 
 find_path(xxHash_INCLUDE_DIR NAME xxhash.h PATH_SUFFIXES include)
-find_library(xxHash_LIBRARY NAMES xxhash xxHash PATH_SUFFIXES lib)
+# Each library name given to the NAMES option is first considered as is, if it contains a library suffix, 
+# and then considered with platform-specific prefixes (e.g. lib) and suffixes (e.g. .so), as defined by 
+# the variables CMAKE_FIND_LIBRARY_PREFIXES and CMAKE_FIND_LIBRARY_SUFFIXES. Therefore one may specify 
+# library file names such as libfoo.a directly. This can be used to locate static libraries on UNIX-like systems.
+find_library(xxHash_LIBRARY NAMES libxxhash.${CMAKE_STATIC_LIBRARY_SUFFIX} libxxHash.${CMAKE_STATIC_LIBRARY_SUFFIX} xxhash xxHash PATH_SUFFIXES lib)
 
 mark_as_advanced(xxHash_INCLUDE_DIR)
 


### PR DESCRIPTION
This PR fixes #21991

