### PR TITLE
[ntuple] Support multiple column representations in the merger

### DIFF
--- a/tree/ntuple/doc/Merging.md
+++ b/tree/ntuple/doc/Merging.md
@@ -15,11 +15,13 @@ Please note that the RNTupleMerger is currently experimental and the content of 
 
 Currently there is no guarantee for the user about which mode will be used to generate the merged RNTuple.
 At the moment, this is how it works:
-- if both compression and encoding of the target column match those of the source column, L1 is used;
-- otherwise, if compression matches but encoding doesn't, L2 is used;
-- otherwise L3 is used.
+- if the compression of the target column match that of the source column, L1 is used;
+- otherwise, L2 is used.
 
-Note that L0 and L4 are currently never used.
+L0, L3 and L4 are currently never used.
+
+**NOTE**: prior to ROOT 6.42, if two columns had the same compression but different encoding they would undergo L3 merging (implying a recompression and resealing);
+from 6.42 onwards the RNTupleMerger will instead attach a new column to the parent field as a new representation and L1-merge them.
 
 ## Goal
 The goal of the RNTuple merging process is producing one output RNTuple from *N* input RNTuples that can be used as if it were produced directly in the merged state. This means that:
@@ -44,15 +46,16 @@ Consequences of R3 and R4:
 The following properties are currently true but they are subject to change:
 
 * P1: all output pages have the **same compression** (which may be different from the input pages' compression);
-* P2: all pages in the same output column have the **same encoding** (which may be different from the inputs' encoding);
-* P3: the output clusters are **the same as the input clusters**;
-* P4: the output RNTuple **always has 1 cluster group**
+* P2: the output clusters are **the same as the input clusters**;
+* P3: the output RNTuple **always has 1 cluster group**
 
-Note that these properties influence and are influenced by the level of merging used.
-E.g. P1 and P2 are currently true because we only support L1 merging of pages with identical compressions. This is a limitation that we intend to lift at some point (both for L1 and L0 if we ever support it).
-P3 and P4 would not necessarily be true with L4 support (which might be desirable in some cases, e.g. to group pages into smaller/larger clusters).
+Note that these properties influence and are influenced by the level of merging used. 
+E.g. P1 is currently true because we only support L1 merging of pages with identical compressions. This is a limitation that we intend to lift at some point (both for L1 and L0 if we ever support it).
+P2 and P3 would not necessarily be true with L4 support (which might be desirable in some cases, e.g. to group pages into smaller/larger clusters).
 
-Therefore we *will* want to drop these properties at some point, in order to improve the capabilities of the Merger.
+Also note that the output pages coming from matching columns of a field may use mixed encodings.
+
+Therefore we *will* want to drop at least some of these properties at some point, in order to improve the capabilities of the Merger.
 
 ## High-level description
 The merging process requires at least 1 input, in the form of an `RPageSource`.
@@ -64,14 +67,15 @@ In `Union` mode only, we allow any subsequent input RNTuple to define new fields
 ## Descriptor compatibility and validation
 Whenever a new input is processed, we compare its descriptor with the output descriptor to verify that merging is possible.
 
-The comparison function does 3 main things:
+The comparison function does 4 main things:
 - collect all "extra destination fields" (i.e. fields that exist in the output but not in this input RNTuple)
 - collect all "extra source fields" from the input RNTuple
-- collect and validate all common fields.
+- collect and validate all common fields
+- collect all columns that need to be extended with additional representations.
 
-If the Merging Mode is set to **Filter** we require the "extra destination fields" list to be empty.
-If the Merging Mode is set to **Strict** we require both the "extra destination fields" and "extra source fields" lists to be empty.
-If the Merging Mode is set to **Union**, the "extra source fields" list is used to late model extend the destination model.
+If the merging mode is set to **Filter** we require the "extra destination fields" list to be empty.
+If the merging mode is set to **Strict** we require both the "extra destination fields" and "extra source fields" lists to be empty.
+If the merging mode is set to **Union**, the "extra source fields" list is used to late model extend the destination model.
 
 As for common fields, they are matched by name and validated as follows:
 - any field that is projected in the destination must be also projected in the source and must be projected to the same field;
@@ -90,3 +94,27 @@ As for common fields, they are matched by name and validated as follows:
 
 
 <sup>1</sup>: these restrictions will likely not be required for L4 merging.
+
+## Column representation extension
+In all merging modes, we allow new column representations to be attached to the source fields. This is done to allow for L1 merging of columns with different encodings, which would otherwise require recompressing.
+These new column representations are added to the output RNTuple's footer and become part of its Schema Extension section. Note that in general these columns will be added as deferred *and* suppressed.
+
+**Technical note**: this is *not* done via the regular late model extension API, but uses internal functionality.
+
+We add new (physical) column representations in the following cases:
+
+- when one or more columns of a field has a different type than its matching counterpart in the destination RNTuple;
+- when one or more columns of a field has the same type but different metadata than its matching counterpart in the destination RNTuple (e.g. in case of a Real32Quant column, different bit width or value range).
+
+Whenever we extend a physical column that is referred to by one or more alias columns in some projected fields, we also add a corresponding new alias column in those fields.
+
+#### Example
+Suppose we merge source RNTuples **S1** and **S2**, each with the following fields:
+
+1. `foo` of type `int`
+1. `fooProj` projecting onto field `foo`
+
+Suppose that S1 is compressed and thus its `foo` field is represented by a column of type `kSplitInt32`, whereas S2 is uncompressed and its `foo` field is represented by a column `kInt32`.
+When merging S1 and S2 we collate those two representations under the same field `foo`, so that it will now have representatives: `{kSplitInt32, kInt32}`.
+At the same time, we add a second alias column to the field `fooProj`, which will now have its first column aliasing the `kSplitInt32` column (column 0 of field `foo`) and its second one aliasing the `kInt32` one (column 1 of field `foo`).
+

--- a/tree/ntuple/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/inc/ROOT/RColumnElementBase.hxx
@@ -17,6 +17,7 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RFloat16.hxx>
 #include <ROOT/RNTupleTypes.hxx>
+#include <ROOT/RNTupleDescriptor.hxx>
 
 #include <Byteswap.h>
 #include <TError.h>
@@ -146,6 +147,13 @@ std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate(ROOT::ENTupleCo
 
 template <>
 std::unique_ptr<RColumnElementBase> RColumnElementBase::Generate<void>(ROOT::ENTupleColumnType onDiskType);
+
+struct RColumnFormat {
+   ENTupleColumnType fType = ENTupleColumnType::kUnknown;
+   // 0 means "use default". Only valid for fixed-bitwidth column types.
+   std::uint16_t fBitWidth = 0;
+   std::optional<RColumnDescriptor::RValueRange> fValueRange = std::nullopt;
+};
 
 } // namespace ROOT::Internal
 

--- a/tree/ntuple/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/inc/ROOT/RNTuple.hxx
@@ -76,8 +76,8 @@ class RNTuple final {
 
 public:
    static constexpr std::uint16_t kVersionEpoch = 1;
-   static constexpr std::uint16_t kVersionMajor = 0;
-   static constexpr std::uint16_t kVersionMinor = 2;
+   static constexpr std::uint16_t kVersionMajor = 1;
+   static constexpr std::uint16_t kVersionMinor = 0;
    static constexpr std::uint16_t kVersionPatch = 0;
 
    /// Returns the RNTuple version in the following form:

--- a/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
@@ -120,7 +120,7 @@ class RNTupleMerger final {
    ROOT::RResult<void>
    MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool, const ROOT::RClusterDescriptor &clusterDesc,
                       std::span<RColumnMergeInfo> commonColumns,
-                      const ROOT::Internal::RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
+                      const ROOT::Internal::RCluster::ColumnSet_t &commonColumnSet,
                       RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData,
                       ROOT::Internal::RPageAllocator &pageAlloc);
 

--- a/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
@@ -117,16 +117,16 @@ class RNTupleMerger final {
    std::unique_ptr<ROOT::RNTupleModel> fModel;
 
    [[nodiscard]]
-   ROOT::RResult<void> MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
-                                          const ROOT::RClusterDescriptor &clusterDesc,
-                                          std::span<const RColumnMergeInfo> commonColumns,
-                                          const ROOT::Internal::RCluster::ColumnSet_t &commonColumnSet,
-                                          std::size_t nCommonColumnsInCluster, RSealedPageMergeData &sealedPageData,
-                                          const RNTupleMergeData &mergeData, ROOT::Internal::RPageAllocator &pageAlloc);
+   ROOT::RResult<void>
+   MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool, const ROOT::RClusterDescriptor &clusterDesc,
+                      std::span<RColumnMergeInfo> commonColumns,
+                      const ROOT::Internal::RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
+                      RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData,
+                      ROOT::Internal::RPageAllocator &pageAlloc);
 
    [[nodiscard]]
    ROOT::RResult<void>
-   MergeSourceClusters(ROOT::Internal::RPageSource &source, std::span<const RColumnMergeInfo> commonColumns,
+   MergeSourceClusters(ROOT::Internal::RPageSource &source, std::span<RColumnMergeInfo> commonColumns,
                        std::span<const RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData);
 
    /// Creates a RNTupleMerger with the given destination.

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -546,6 +546,21 @@ public:
    [[nodiscard]] std::unique_ptr<RNTupleModel>
    InitFromDescriptor(const ROOT::RNTupleDescriptor &descriptor, bool copyClusters);
 
+   /// Adds a new column representation to the given field. It is NOT marked as suppressed.
+   /// This can only be legally done at cluster boundary (i.e. immediately after committing a cluster or before
+   /// writing any entry). This is NOT checked for you.
+   /// `newRepresentation` must have a number of elements equal to the field's cardinality and must contain
+   /// compatible column types.
+   /// NOTE: this function was designed for use by the Merger and it's not fit as-is for use with the higher level
+   /// API layers. In other words, you cannot use this with a Writer and write data through the regular Entry/Field
+   /// API, as this function only modifies the descriptor.
+   void
+   AddColumnRepresentation(const ROOT::RFieldDescriptor &field, std::span<const ENTupleColumnType> newRepresentation);
+
+   /// Adds a new alias column pointing to an existing column with the given physical id to the given field.
+   void AddAliasColumn(const ROOT::RNTupleDescriptor &desc, const ROOT::RFieldDescriptor &field,
+                       ROOT::DescriptorId_t physicalId);
+
    void CommitSuppressedColumn(ColumnHandle_t columnHandle) final;
    void CommitPage(ColumnHandle_t columnHandle, const ROOT::Internal::RPage &page) final;
    void CommitSealedPage(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -555,8 +555,8 @@ public:
    /// API layers. In other words, you cannot use this with a Writer and write data through the regular Entry/Field
    /// API, as this function only modifies the descriptor.
    /// \return The physical id of the first newly added column.
-   ROOT::DescriptorId_t
-   AddColumnRepresentation(const ROOT::RFieldDescriptor &field, std::span<const ENTupleColumnType> newRepresentation);
+   ROOT::DescriptorId_t AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
+                                                std::span<const ROOT::Internal::RColumnFormat> newRepresentation);
 
    /// Adds a new alias column pointing to an existing column with the given physical id to the given field.
    void AddAliasColumn(const ROOT::RNTupleDescriptor &desc, const ROOT::RFieldDescriptor &field,

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -554,7 +554,8 @@ public:
    /// NOTE: this function was designed for use by the Merger and it's not fit as-is for use with the higher level
    /// API layers. In other words, you cannot use this with a Writer and write data through the regular Entry/Field
    /// API, as this function only modifies the descriptor.
-   void
+   /// \return The physical id of the first newly added column.
+   ROOT::DescriptorId_t
    AddColumnRepresentation(const ROOT::RFieldDescriptor &field, std::span<const ENTupleColumnType> newRepresentation);
 
    /// Adds a new alias column pointing to an existing column with the given physical id to the given field.

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -547,6 +547,8 @@ public:
    InitFromDescriptor(const ROOT::RNTupleDescriptor &descriptor, bool copyClusters);
 
    /// Adds a new column representation to the given field. It is NOT marked as suppressed.
+   /// The first element index of the added column will be computed as the sum of the first element index of the
+   /// 0th representation's column range plus `addedFirstElementIndex` (which must be non-negative).
    /// This can only be legally done at cluster boundary (i.e. immediately after committing a cluster or before
    /// writing any entry). This is NOT checked for you.
    /// `newRepresentation` must have a number of elements equal to the field's cardinality and must contain
@@ -556,7 +558,8 @@ public:
    /// API, as this function only modifies the descriptor.
    /// \return The physical id of the first newly added column.
    ROOT::DescriptorId_t AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
-                                                std::span<const ROOT::Internal::RColumnFormat> newRepresentation);
+                                                std::span<const ROOT::Internal::RColumnFormat> newRepresentation,
+                                                std::uint64_t clusterOffset);
 
    /// Adds a new alias column pointing to an existing column with the given physical id to the given field.
    void AddAliasColumn(const ROOT::RNTupleDescriptor &desc, const ROOT::RFieldDescriptor &field,

--- a/tree/ntuple/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/src/RNTupleDescriptor.cxx
@@ -925,11 +925,12 @@ ROOT::Internal::RClusterDescriptorBuilder::AddExtendedColumnRanges(const RNTuple
                // Fixup the RColumnRange and RPageRange in deferred columns. We know what the first element index and
                // number of elements should have been if the column was not deferred; fix those and let
                // `ExtendToFitColumnRange()` synthesize RPageInfos accordingly.
-               // Note that a deferred column (i.e, whose first element index is > 0) already met the criteria of
-               // `ROOT::RFieldBase::EntryToColumnElementIndex()`, i.e. it is a principal column reachable from the
-               // field zero excluding subfields of collection and variant fields.
                if (c.IsDeferredColumn()) {
                   if (c.GetRepresentationIndex() == 0) {
+                     // Note that a deferred column (i.e, whose first element index is > 0) for the 0th representation
+                     // index already met the criteria of `ROOT::RFieldBase::EntryToColumnElementIndex()`, i.e. it is a
+                     // principal column reachable from the field zero excluding subfields of collection and variant
+                     // fields.
                      columnRange.SetFirstElementIndex(fCluster.GetFirstEntryIndex() * nRepetitions);
                      columnRange.SetNElements(fCluster.GetNEntries() * nRepetitions);
                   } else {

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -431,16 +431,6 @@ struct RSealedPageMergeData {
    std::vector<std::unique_ptr<std::byte[]>> fBuffers;
 };
 
-static std::ostream &operator<<(std::ostream &os, const std::optional<ROOT::RColumnDescriptor::RValueRange> &x)
-{
-   if (x) {
-      os << '(' << x->fMin << ", " << x->fMax << ')';
-   } else {
-      os << "(null)";
-   }
-   return os;
-}
-
 } // namespace ROOT::Experimental::Internal
 
 // Subprocedure of CompareDescriptorStructure, extracted for readability.
@@ -500,26 +490,18 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
                const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
                const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
                const auto &dstCol = dstDesc.GetColumnDescriptor(dstColId);
-               if (srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage() ||
+               if (srcCol.GetType() != dstCol.GetType() || srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage() ||
                    srcCol.GetValueRange() != dstCol.GetValueRange()) {
-                  std::stringstream ss;
-                  ss << "Source field `" << srcField.GetFieldName()
-                     << "` has a matching column representation as its destination field, however one or "
-                        "more "
-                        "of its columns have different column metadata (bit width and/or value range). "
-                        "Merging variable-sized columns is currently only supported if all metadata is "
-                        "identical between source and destination columns."
-                     << "\n   bit width src: " << srcCol.GetBitsOnStorage() << ", dst: " << dstCol.GetBitsOnStorage()
-                     << ""
-                     << "\n   value range src: " << srcCol.GetValueRange() << ", dst: " << dstCol.GetValueRange();
-                  errors.push_back(ss.str());
+                  matches = false;
                   break;
                }
             }
 
-            // We found a valid matching representation: break the loop on the dst column representations.
-            matchingRepr = dstReprIdx;
-            break;
+            if (matches) {
+               // We found a valid matching representation.
+               matchingRepr = dstReprIdx;
+               break;
+            }
          }
       }
 
@@ -799,7 +781,7 @@ ExtendDestinationModel(RDescriptorsComparison &descCmp, ROOT::RNTupleModel &dstM
    //
    // Since we call ExtendDestinationModel (this function) *before* adding the new column representations,
    // the dst descriptor always gets updated with the new column descriptors coming from the extended fields before
-   //it gets updated with the extended column representations.
+   // it gets updated with the extended column representations.
    //
    // However, in GatherColumnInfos, the new column output ids are added sequentially in *field* order and the fields
    // containing the new column representations are already in that list from earlier! So, to make sure the new output
@@ -1059,7 +1041,7 @@ ROOT::RResult<void> RNTupleMerger::MergeSourceClusters(RPageSource &source, std:
       // Note that some suppressed columns may not be in commonColumns because they might not appear at all in the
       // current source.
       FieldCollectionMap_t<ROOT::DescriptorId_t> columnsInCluster;
-      using ColumnHandle_t = ROOT::Internal::RPageSource::ColumnHandle_t;
+      using ColumnHandle_t = ROOT::Internal::RPageStorage::ColumnHandle_t;
 
       // NOTE: `commonColumns` contains all columns that appear *somewhere* both in the src and in the dst.
       // Just because a column is in `commonColumns` it doesn't mean that each cluster in the source contains
@@ -1080,7 +1062,6 @@ ROOT::RResult<void> RNTupleMerger::MergeSourceClusters(RPageSource &source, std:
             columnsInCluster[column.fParentFieldDescriptor].push_back(column.fOutputId);
             if (!colRange.IsSuppressed()) {
                commonColumnSet.emplace(column.fInputId);
-               columnsInCluster[column.fParentFieldDescriptor].push_back(column.fOutputId);
                return true;
             }
             mergeData.fDestination.CommitSuppressedColumn(ColumnHandle_t{column.fOutputId});
@@ -1109,7 +1090,7 @@ ROOT::RResult<void> RNTupleMerger::MergeSourceClusters(RPageSource &source, std:
             assert(colIt != mergeData.fColumnIdMap.end());
             const auto colOutId = colIt->second.fColumnId;
             if (std::find(columnIds.begin(), columnIds.end(), colOutId) == columnIds.end()) {
-               mergeData.fDestination.CommitSuppressedColumn(ROOT::Internal::RPageStorage::ColumnHandle_t{colOutId});
+               mergeData.fDestination.CommitSuppressedColumn(ColumnHandle_t{colOutId});
             }
          }
       }

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -443,6 +443,121 @@ static std::ostream &operator<<(std::ostream &os, const std::optional<ROOT::RCol
 
 } // namespace ROOT::Experimental::Internal
 
+// Subprocedure of CompareDescriptorStructure, extracted for readability.
+// Given two fields, attempts to match their column representations and schedules column extensions if necessary.
+static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, const ROOT::RNTupleDescriptor &dstDesc,
+                                       const ROOT::RFieldDescriptor &srcField, const ROOT::RFieldDescriptor &dstField,
+                                       RDescriptorsComparison &result, std::vector<std::string> &errors)
+{
+   const auto &srcColumns = srcField.GetLogicalColumnIds();
+   const auto &dstColumns = dstField.GetLogicalColumnIds();
+
+   // Fields must have the same number of columns
+   const auto srcNCols = srcColumns.size();
+   const auto dstNCols = dstColumns.size();
+   if (srcNCols != dstNCols) {
+      std::stringstream ss;
+      ss << "Field `" << srcField.GetFieldName()
+         << "` has a different number of columns than previously-seen field with the same name (old: " << dstNCols
+         << ", new: " << srcNCols << ")";
+      errors.push_back(ss.str());
+      return;
+   }
+
+   // Fields must have the same cardinality
+   const std::uint32_t srcColCardinality = srcField.GetColumnCardinality();
+   const std::uint32_t dstColCardinality = dstField.GetColumnCardinality();
+   if (srcColCardinality != dstColCardinality) {
+      std::stringstream ss;
+      ss << "Field `" << srcField.GetFieldName()
+         << "` has a different column cardinality than previously-seen field with the same name (old: "
+         << dstColCardinality << ", new: " << srcColCardinality << ")";
+      errors.push_back(ss.str());
+      return;
+   }
+
+   if (srcColCardinality == 0)
+      return; // no columns to match
+
+   const auto srcNColReprs = srcNCols / srcColCardinality;
+   const auto dstNColReprs = dstNCols / dstColCardinality;
+
+   // For each column representation of the source, check if it matches one in the descriptor.
+   // If so, and if it doesn't match the destination's repr index, add a mapping for it.
+   // If nothing matches, schedule the column representation to be added later.
+   // NOTE: this has quadratic complexity but the numbers involved are small so it's fine.
+   for (auto srcReprIdx = 0u; srcReprIdx < srcNColReprs; ++srcReprIdx) {
+      std::int64_t matchingRepr = -1;
+      for (auto dstReprIdx = 0u; dstReprIdx < dstNColReprs; ++dstReprIdx) {
+         bool matches = true;
+         for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+            const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+            const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
+            const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
+            const auto &dstCol = dstDesc.GetColumnDescriptor(dstColId);
+            if (srcCol.GetType() != dstCol.GetType()) {
+               matches = false;
+               break;
+            }
+         }
+
+         if (matches) {
+            // If this column representation matches by column type, we need to make sure that it also has
+            // matching column metadata. Since we currently do not support multiple column representations
+            // that only differ by such metadata, we forbid merging such columns (e.g. we cannot merge two
+            // Real32Trunc columns with different bit widths). This could technically be supported, but it
+            // would require significant effort, so we currently don't.
+            for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+               const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+               const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
+               const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
+               const auto &dstCol = dstDesc.GetColumnDescriptor(dstColId);
+               if (srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage() ||
+                   srcCol.GetValueRange() != dstCol.GetValueRange()) {
+                  std::stringstream ss;
+                  ss << "Source field `" << srcField.GetFieldName()
+                     << "` has a matching column representation as its destination field, however one or "
+                        "more "
+                        "of its columns have different column metadata (bit width and/or value range). "
+                        "Merging variable-sized columns is currently only supported if all metadata is "
+                        "identical between source and destination columns."
+                     << "\n   bit width src: " << srcCol.GetBitsOnStorage() << ", dst: " << dstCol.GetBitsOnStorage()
+                     << ""
+                     << "\n   value range src: " << srcCol.GetValueRange() << ", dst: " << dstCol.GetValueRange();
+                  errors.push_back(ss.str());
+                  break;
+               }
+            }
+
+            // We found a valid matching representation: break the loop on the dst column representations.
+            matchingRepr = dstReprIdx;
+            break;
+         }
+      }
+
+      if (errors.empty()) {
+         if (matchingRepr >= 0 && matchingRepr != srcReprIdx) {
+            // a different matching representation was found
+            assert(matchingRepr < std::numeric_limits<std::uint32_t>::max());
+            result.fColReprMappings[&dstField].push_back(
+               RColReprMapping{srcReprIdx, static_cast<std::uint32_t>(matchingRepr)});
+         } else if (matchingRepr < 0) {
+            // this representation was not found in the destination
+            assert(dstNColReprs < std::numeric_limits<std::uint32_t>::max());
+            ROOT::RFieldBase::ColumnRepresentation_t newRepr;
+            for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+               const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+               const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
+               newRepr.push_back(srcCol.GetType());
+            }
+            RColReprExtension extension{{srcReprIdx, static_cast<std::uint32_t>(dstNColReprs)}, newRepr};
+            result.fColReprExtensions[&dstField].push_back(extension);
+            result.fColReprMappings[&dstField].push_back(extension);
+         }
+      }
+   }
+}
+
 /// Compares the top level fields of `dst` and `src` and determines whether they can be merged or not.
 /// In addition, returns the differences between `dst` and `src`'s structures
 static ROOT::RResult<RDescriptorsComparison>
@@ -560,104 +675,7 @@ CompareDescriptorStructure(const ROOT::RNTupleDescriptor &dst, const ROOT::RNTup
 
       // Require that column representations match
       if (!field.fSrc->IsProjectedField()) {
-         const auto &srcColumns = field.fSrc->GetLogicalColumnIds();
-         const auto &dstColumns = field.fDst->GetLogicalColumnIds();
-         const auto srcNCols = srcColumns.size();
-         const auto dstNCols = dstColumns.size();
-         if (srcNCols != dstNCols) {
-            std::stringstream ss;
-            ss << "Field `" << field.fSrc->GetFieldName()
-               << "` has a different number of columns than previously-seen field with the same name (old: " << dstNCols
-               << ", new: " << srcNCols << ")";
-            errors.push_back(ss.str());
-         } else {
-            const std::uint32_t srcColCardinality = field.fSrc->GetColumnCardinality();
-            const std::uint32_t dstColCardinality = field.fDst->GetColumnCardinality();
-            if (srcColCardinality != dstColCardinality) {
-               std::stringstream ss;
-               ss << "Field `" << field.fSrc->GetFieldName()
-                  << "` has a different column cardinality than previously-seen field with the same name (old: "
-                  << dstColCardinality << ", new: " << srcColCardinality << ")";
-               errors.push_back(ss.str());
-            } else if (srcColCardinality > 0) {
-               const auto srcNColReprs = srcNCols / srcColCardinality;
-               const auto dstNColReprs = dstNCols / dstColCardinality;
-
-               // For each column representation of the source, check if it matches one in the descriptor.
-               // If so, and if it doesn't match the destination's repr index, add a mapping for it.
-               // If nothing matches, schedule the column representation to be added later.
-               // NOTE: this has quadratic complexity but the numbers involved are small so it's fine.
-               for (auto srcReprIdx = 0u; srcReprIdx < srcNColReprs; ++srcReprIdx) {
-                  std::int64_t matchingRepr = -1;
-                  for (auto dstReprIdx = 0u; dstReprIdx < dstNColReprs; ++dstReprIdx) {
-                     bool matches = true;
-                     for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
-                        const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
-                        const auto &srcCol = src.GetColumnDescriptor(srcColId);
-                        const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
-                        const auto &dstCol = dst.GetColumnDescriptor(dstColId);
-                        if (srcCol.GetType() != dstCol.GetType()) {
-                           matches = false;
-                           break;
-                        }
-                     }
-
-                     if (matches) {
-                        // If this column representation matches by column type, we need to make sure that it also has
-                        // matching column metadata. Since we currently do not support multiple column representations
-                        // that only differ by such metadata, we forbid merging such columns (e.g. we cannot merge two
-                        // Real32Trunc columns with different bit widths). This could technically be supported, but it
-                        // would require significant effort, so we currently don't.
-                        for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
-                           const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
-                           const auto &srcCol = src.GetColumnDescriptor(srcColId);
-                           const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
-                           const auto &dstCol = dst.GetColumnDescriptor(dstColId);
-                           if (srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage() ||
-                               srcCol.GetValueRange() != dstCol.GetValueRange()) {
-                              std::stringstream ss;
-                              ss << "Source field `" << field.fSrc->GetFieldName()
-                                 << "` has a matching column representation as its destination field, however one or "
-                                    "more "
-                                    "of its columns have different column metadata (bit width and/or value range). "
-                                    "Merging variable-sized columns is currently only supported if all metadata is "
-                                    "identical between source and destination columns."
-                                 << "\n   bit width src: " << srcCol.GetBitsOnStorage()
-                                 << ", dst: " << dstCol.GetBitsOnStorage() << ""
-                                 << "\n   value range src: " << srcCol.GetValueRange()
-                                 << ", dst: " << dstCol.GetValueRange();
-                              errors.push_back(ss.str());
-                              break;
-                           }
-                        }
-                        matchingRepr = dstReprIdx;
-                        break;
-                     }
-                  }
-
-                  if (errors.empty()) {
-                     if (matchingRepr >= 0 && matchingRepr != srcReprIdx) {
-                        // a different matching representation was found
-                        assert(matchingRepr < std::numeric_limits<std::uint32_t>::max());
-                        res.fColReprMappings[field.fDst].push_back(
-                           RColReprMapping{srcReprIdx, static_cast<std::uint32_t>(matchingRepr)});
-                     } else if (matchingRepr < 0) {
-                        // this representation was not found in the destination
-                        assert(dstNColReprs < std::numeric_limits<std::uint32_t>::max());
-                        ROOT::RFieldBase::ColumnRepresentation_t newRepr;
-                        for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
-                           const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
-                           const auto &srcCol = src.GetColumnDescriptor(srcColId);
-                           newRepr.push_back(srcCol.GetType());
-                        }
-                        RColReprExtension extension{{srcReprIdx, static_cast<std::uint32_t>(dstNColReprs)}, newRepr};
-                        res.fColReprExtensions[field.fDst].push_back(extension);
-                        res.fColReprMappings[field.fDst].push_back(extension);
-                     }
-                  }
-               }
-            }
-         }
+         MatchColumnRepresentations(src, dst, *field.fSrc, *field.fDst, res, errors);
       }
 
       // Require that subfields are compatible

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -342,10 +342,10 @@ struct RColReprMapping {
 };
 
 /// A column extension that needs to be added to an output field.
-/// Note that this also adds a mapping for the new representation, which is why this inherits RColReprMapping.
+/// Note that this also adds a mapping for each new representation, which is why it inherits RColReprMapping.
 struct RColReprExtension : RColReprMapping {
-   /// The new representation to be added
-   ROOT::RFieldBase::ColumnRepresentation_t fSourceRepr;
+   /// The new representations to be added
+   std::vector<ROOT::Internal::RColumnFormat> fSourceRepr;
 };
 
 static std::optional<std::uint32_t>
@@ -532,11 +532,15 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
          } else if (matchingRepr < 0) {
             // this representation was not found in the destination
             assert(dstNColReprs < std::numeric_limits<std::uint32_t>::max());
-            ROOT::RFieldBase::ColumnRepresentation_t newRepr;
+            std::vector<ROOT::Internal::RColumnFormat> newRepr;
+            newRepr.reserve(srcColCardinality);
             for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
                const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
                const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
-               newRepr.push_back(srcCol.GetType());
+               auto &reprElement = newRepr.emplace_back();
+               reprElement.fType = srcCol.GetType();
+               reprElement.fBitWidth = srcCol.GetBitsOnStorage();
+               reprElement.fValueRange = srcCol.GetValueRange();
             }
             RColReprExtension extension{{srcReprIdx, static_cast<std::uint32_t>(dstNColReprs)}, newRepr};
             result.fColReprExtensions[&dstField].push_back(extension);

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -269,12 +269,10 @@ try {
 }
 
 namespace {
-// Functor used to change the compression of a page to `options.fCompressionSettings`.
+// Functor used to change the compression of a page to `fCompressionSettings`.
 struct RChangeCompressionFunc {
    const RColumnElementBase &fSrcColElement;
-   const RColumnElementBase &fDstColElement;
-   const RNTupleMergeOptions &fMergeOptions;
-
+   std::uint32_t fCompressionSettings;
    RPageStorage::RSealedPage &fSealedPage;
    ROOT::Internal::RPageAllocator &fPageAlloc;
    std::byte *fBuffer;
@@ -283,16 +281,13 @@ struct RChangeCompressionFunc {
 
    void operator()() const
    {
-      assert(fSrcColElement.GetIdentifier() == fDstColElement.GetIdentifier());
-
       fSealedPage.VerifyChecksumIfEnabled().ThrowOnError();
 
       const auto bytesPacked = fSrcColElement.GetPackedSize(fSealedPage.GetNElements());
-      const auto compression = fMergeOptions.fCompressionSettings.value_or(0);
       // TODO: this buffer could be kept and reused across pages
       std::unique_ptr<std::byte[]> unzipBufOwned;
       std::byte *unzipBuf;
-      if (compression != 0) {
+      if (fCompressionSettings != 0) {
          unzipBufOwned = MakeUninitArray<std::byte>(bytesPacked);
          unzipBuf = unzipBufOwned.get();
       } else {
@@ -303,42 +298,15 @@ struct RChangeCompressionFunc {
 
       const auto checksumSize = fWriteOpts.GetEnablePageChecksums() * sizeof(std::uint64_t);
       std::size_t nBytesZipped;
-      if (compression != 0) {
+      if (fCompressionSettings != 0) {
          assert(fBuffer != unzipBuf);
          assert(fBufSize >= bytesPacked + checksumSize);
-         nBytesZipped = ROOT::Internal::RNTupleCompressor::Zip(unzipBuf, bytesPacked, compression, fBuffer);
+         nBytesZipped = ROOT::Internal::RNTupleCompressor::Zip(unzipBuf, bytesPacked, fCompressionSettings, fBuffer);
       } else {
          nBytesZipped = bytesPacked;
       }
-
       fSealedPage = {fBuffer, nBytesZipped + checksumSize, fSealedPage.GetNElements(), fSealedPage.GetHasChecksum()};
       fSealedPage.ChecksumIfEnabled();
-   }
-};
-
-struct RResealFunc {
-   const RColumnElementBase &fSrcColElement;
-   const RColumnElementBase &fDstColElement;
-   const RNTupleMergeOptions &fMergeOptions;
-
-   RPageStorage::RSealedPage &fSealedPage;
-   ROOT::Internal::RPageAllocator &fPageAlloc;
-   std::byte *fBuffer;
-   std::size_t fBufSize;
-   const ROOT::RNTupleWriteOptions &fWriteOpts;
-
-   void operator()() const
-   {
-      auto page = RPageSource::UnsealPage(fSealedPage, fSrcColElement, fPageAlloc).Unwrap();
-      RPageSink::RSealPageConfig sealConf;
-      sealConf.fElement = &fDstColElement;
-      sealConf.fPage = &page;
-      sealConf.fBuffer = fBuffer;
-      sealConf.fCompressionSettings = *fMergeOptions.fCompressionSettings;
-      sealConf.fWriteChecksum = fWriteOpts.GetEnablePageChecksums();
-      assert(fBufSize >= fSealedPage.GetDataSize() + fSealedPage.GetHasChecksum() * sizeof(std::uint64_t));
-      auto refSealedPage = RPageSink::SealPage(sealConf);
-      fSealedPage = refSealedPage;
    }
 };
 
@@ -362,23 +330,56 @@ struct RCommonField {
    RCommonField(const ROOT::RFieldDescriptor &src, const ROOT::RFieldDescriptor &dst) : fSrc(&src), fDst(&dst) {}
 };
 
+/// Maps a column representation from a source to a destination RNTuple.
+/// fSource and fDest are the representation indices of a specific column.
+///
+/// When we merge fields from different RNTuples, two compatible fields may use different column
+/// representations. When merging their columns we need to make sure that we keep the output
+/// representation coherent, which is what this mapping is here for.
+struct RColReprMapping {
+   std::uint32_t fSource;
+   std::uint32_t fDest;
+};
+
+/// A column extension that needs to be added to an output field.
+/// Note that this also adds a mapping for the new representation, which is why this inherits RColReprMapping.
+struct RColReprExtension : RColReprMapping {
+   /// The new representation to be added
+   ROOT::RFieldBase::ColumnRepresentation_t fSourceRepr;
+};
+
+static std::optional<std::uint32_t>
+FindColumnReprMapping(const std::vector<RColReprMapping> &mappings, std::uint32_t sourceReprIndex)
+{
+   for (const auto [src, dst] : mappings)
+      if (src == sourceReprIndex)
+         return dst;
+   return std::nullopt;
+}
+
+template <typename T>
+using FieldCollectionMap_t = std::unordered_map<const ROOT::RFieldDescriptor *, std::vector<T>>;
+
 struct RDescriptorsComparison {
    std::vector<const ROOT::RFieldDescriptor *> fExtraDstFields;
    std::vector<const ROOT::RFieldDescriptor *> fExtraSrcFields;
    std::vector<RCommonField> fCommonFields;
+   // For each field that has more than 1 column representation in the output model,
+   // maps the column representatives of the source field with those of the destination.
+   // The key is the destination field.
+   FieldCollectionMap_t<RColReprMapping> fColReprMappings;
+   FieldCollectionMap_t<RColReprExtension> fColReprExtensions;
 };
 
 struct RColumnOutInfo {
-   ROOT::DescriptorId_t fColumnId;
-   ENTupleColumnType fColumnType;
+   ROOT::DescriptorId_t fColumnId = ROOT::kInvalidDescriptorId;
 };
 
-// { fully.qualified.fieldName.colInputId => colOutputInfo }
+// { ".fully.qualified.fieldName.colInputIndex.colOutputReprIndex" => colOutputInfo }
 using ColumnIdMap_t = std::unordered_map<std::string, RColumnOutInfo>;
 
 struct RColumnInfoGroup {
    std::vector<RColumnMergeInfo> fExtraDstColumns;
-   // These are sorted by InputId
    std::vector<RColumnMergeInfo> fCommonColumns;
 };
 
@@ -392,14 +393,14 @@ struct RColumnMergeInfo {
    // e.g. "Muon.pt.x._0"
    std::string fColumnName;
    // The column id in the source RNTuple
-   ROOT::DescriptorId_t fInputId;
+   ROOT::DescriptorId_t fInputId = kInvalidDescriptorId;
    // The corresponding column id in the destination RNTuple (the mapping happens in AddColumnsFromField())
-   ROOT::DescriptorId_t fOutputId;
-   ENTupleColumnType fColumnType;
+   ROOT::DescriptorId_t fOutputId = kInvalidDescriptorId;
+   std::uint16_t fOutputReprIndex = 0;
    // If nullopt, use the default in-memory type
    std::optional<std::type_index> fInMemoryType;
-   const ROOT::RFieldDescriptor *fParentFieldDescriptor;
-   const ROOT::RNTupleDescriptor *fParentNTupleDescriptor;
+   const ROOT::RFieldDescriptor *fParentFieldDescriptor = nullptr;
+   const ROOT::RNTupleDescriptor *fParentNTupleDescriptor = nullptr;
 };
 
 // Data related to a single call of RNTupleMerger::Merge()
@@ -411,6 +412,7 @@ struct RNTupleMergeData {
    const ROOT::RNTupleDescriptor *fSrcDescriptor = nullptr;
 
    std::vector<RColumnMergeInfo> fColumns;
+   // Maps input column IDs to output IDs
    ColumnIdMap_t fColumnIdMap;
 
    ROOT::NTupleSize_t fNumDstEntries = 0;
@@ -441,33 +443,6 @@ static std::ostream &operator<<(std::ostream &os, const std::optional<ROOT::RCol
 
 } // namespace ROOT::Experimental::Internal
 
-static bool IsSplitOrUnsplitVersionOf(ENTupleColumnType a, ENTupleColumnType b)
-{
-   // clang-format off
-   if (a == ENTupleColumnType::kInt16 && b == ENTupleColumnType::kSplitInt16) return true;
-   if (a == ENTupleColumnType::kSplitInt16 && b == ENTupleColumnType::kInt16) return true;
-   if (a == ENTupleColumnType::kInt32 && b == ENTupleColumnType::kSplitInt32) return true;
-   if (a == ENTupleColumnType::kSplitInt32 && b == ENTupleColumnType::kInt32) return true;
-   if (a == ENTupleColumnType::kInt64 && b == ENTupleColumnType::kSplitInt64) return true;
-   if (a == ENTupleColumnType::kSplitInt64 && b == ENTupleColumnType::kInt64) return true;
-   if (a == ENTupleColumnType::kUInt16 && b == ENTupleColumnType::kSplitUInt16) return true;
-   if (a == ENTupleColumnType::kSplitUInt16 && b == ENTupleColumnType::kUInt16) return true;
-   if (a == ENTupleColumnType::kUInt32 && b == ENTupleColumnType::kSplitUInt32) return true;
-   if (a == ENTupleColumnType::kSplitUInt32 && b == ENTupleColumnType::kUInt32) return true;
-   if (a == ENTupleColumnType::kUInt64 && b == ENTupleColumnType::kSplitUInt64) return true;
-   if (a == ENTupleColumnType::kSplitUInt64 && b == ENTupleColumnType::kUInt64) return true;
-   if (a == ENTupleColumnType::kIndex32 && b == ENTupleColumnType::kSplitIndex32) return true;
-   if (a == ENTupleColumnType::kSplitIndex32 && b == ENTupleColumnType::kIndex32) return true;
-   if (a == ENTupleColumnType::kIndex64 && b == ENTupleColumnType::kSplitIndex64) return true;
-   if (a == ENTupleColumnType::kSplitIndex64 && b == ENTupleColumnType::kIndex64) return true;
-   if (a == ENTupleColumnType::kReal32 && b == ENTupleColumnType::kSplitReal32) return true;
-   if (a == ENTupleColumnType::kSplitReal32 && b == ENTupleColumnType::kReal32) return true;
-   if (a == ENTupleColumnType::kReal64 && b == ENTupleColumnType::kSplitReal64) return true;
-   if (a == ENTupleColumnType::kSplitReal64 && b == ENTupleColumnType::kReal64) return true;
-   // clang-format on
-   return false;
-}
-
 /// Compares the top level fields of `dst` and `src` and determines whether they can be merged or not.
 /// In addition, returns the differences between `dst` and `src`'s structures
 static ROOT::RResult<RDescriptorsComparison>
@@ -495,8 +470,9 @@ CompareDescriptorStructure(const ROOT::RNTupleDescriptor &dst, const ROOT::RNTup
    }
    for (const auto &srcField : src.GetTopLevelFields()) {
       const auto dstFieldId = dst.FindFieldId(srcField.GetFieldName());
-      if (dstFieldId == ROOT::kInvalidDescriptorId)
+      if (dstFieldId == ROOT::kInvalidDescriptorId) {
          res.fExtraSrcFields.push_back(&srcField);
+      }
    }
 
    // Check compatibility of common fields
@@ -583,55 +559,103 @@ CompareDescriptorStructure(const ROOT::RNTupleDescriptor &dst, const ROOT::RNTup
       }
 
       // Require that column representations match
-      const auto srcNCols = field.fSrc->GetLogicalColumnIds().size();
-      const auto dstNCols = field.fDst->GetLogicalColumnIds().size();
-      if (srcNCols != dstNCols) {
-         std::stringstream ss;
-         ss << "Field `" << field.fSrc->GetFieldName()
-            << "` has a different number of columns than previously-seen field with the same name (old: " << dstNCols
-            << ", new: " << srcNCols << ")";
-         errors.push_back(ss.str());
-      } else {
-         for (auto i = 0u; i < srcNCols; ++i) {
-            const auto srcColId = field.fSrc->GetLogicalColumnIds()[i];
-            const auto dstColId = field.fDst->GetLogicalColumnIds()[i];
-            const auto &srcCol = src.GetColumnDescriptor(srcColId);
-            const auto &dstCol = dst.GetColumnDescriptor(dstColId);
-            // TODO(gparolini): currently we refuse to merge columns of different types unless they are Split/non-Split
-            // version of the same type, because we know how to treat that specific case. We should also properly handle
-            // different but compatible types.
-            if (srcCol.GetType() != dstCol.GetType() &&
-                !IsSplitOrUnsplitVersionOf(srcCol.GetType(), dstCol.GetType())) {
+      if (!field.fSrc->IsProjectedField()) {
+         const auto &srcColumns = field.fSrc->GetLogicalColumnIds();
+         const auto &dstColumns = field.fDst->GetLogicalColumnIds();
+         const auto srcNCols = srcColumns.size();
+         const auto dstNCols = dstColumns.size();
+         if (srcNCols != dstNCols) {
+            std::stringstream ss;
+            ss << "Field `" << field.fSrc->GetFieldName()
+               << "` has a different number of columns than previously-seen field with the same name (old: " << dstNCols
+               << ", new: " << srcNCols << ")";
+            errors.push_back(ss.str());
+         } else {
+            const std::uint32_t srcColCardinality = field.fSrc->GetColumnCardinality();
+            const std::uint32_t dstColCardinality = field.fDst->GetColumnCardinality();
+            if (srcColCardinality != dstColCardinality) {
                std::stringstream ss;
-               ss << i << "-th column of field `" << field.fSrc->GetFieldName()
-                  << "` has a different column type of the same column on the previously-seen field with the same name "
-                     "(old: "
-                  << RColumnElementBase::GetColumnTypeName(srcCol.GetType())
-                  << ", new: " << RColumnElementBase::GetColumnTypeName(dstCol.GetType()) << ")";
+               ss << "Field `" << field.fSrc->GetFieldName()
+                  << "` has a different column cardinality than previously-seen field with the same name (old: "
+                  << dstColCardinality << ", new: " << srcColCardinality << ")";
                errors.push_back(ss.str());
-            }
-            if (srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage()) {
-               std::stringstream ss;
-               ss << i << "-th column of field `" << field.fSrc->GetFieldName()
-                  << "` has a different number of bits of the same column on the previously-seen field with the same "
-                     "name "
-                     "(old: "
-                  << srcCol.GetBitsOnStorage() << ", new: " << dstCol.GetBitsOnStorage() << ")";
-               errors.push_back(ss.str());
-            }
-            if (srcCol.GetValueRange() != dstCol.GetValueRange()) {
-               std::stringstream ss;
-               ss << i << "-th column of field `" << field.fSrc->GetFieldName()
-                  << "` has a different value range of the same column on the previously-seen field with the same name "
-                     "(old: "
-                  << srcCol.GetValueRange() << ", new: " << dstCol.GetValueRange() << ")";
-               errors.push_back(ss.str());
-            }
-            if (srcCol.GetRepresentationIndex() > 0) {
-               std::stringstream ss;
-               ss << i << "-th column of field `" << field.fSrc->GetFieldName()
-                  << "` has a representation index higher than 0. This is not supported yet by the merger.";
-               errors.push_back(ss.str());
+            } else if (srcColCardinality > 0) {
+               const auto srcNColReprs = srcNCols / srcColCardinality;
+               const auto dstNColReprs = dstNCols / dstColCardinality;
+
+               // For each column representation of the source, check if it matches one in the descriptor.
+               // If so, and if it doesn't match the destination's repr index, add a mapping for it.
+               // If nothing matches, schedule the column representation to be added later.
+               // NOTE: this has quadratic complexity but the numbers involved are small so it's fine.
+               for (auto srcReprIdx = 0u; srcReprIdx < srcNColReprs; ++srcReprIdx) {
+                  std::int64_t matchingRepr = -1;
+                  for (auto dstReprIdx = 0u; dstReprIdx < dstNColReprs; ++dstReprIdx) {
+                     bool matches = true;
+                     for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+                        const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+                        const auto &srcCol = src.GetColumnDescriptor(srcColId);
+                        const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
+                        const auto &dstCol = dst.GetColumnDescriptor(dstColId);
+                        if (srcCol.GetType() != dstCol.GetType()) {
+                           matches = false;
+                           break;
+                        }
+                     }
+
+                     if (matches) {
+                        // If this column representation matches by column type, we need to make sure that it also has
+                        // matching column metadata. Since we currently do not support multiple column representations
+                        // that only differ by such metadata, we forbid merging such columns (e.g. we cannot merge two
+                        // Real32Trunc columns with different bit widths). This could technically be supported, but it
+                        // would require significant effort, so we currently don't.
+                        for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+                           const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+                           const auto &srcCol = src.GetColumnDescriptor(srcColId);
+                           const auto dstColId = dstColumns[dstReprIdx * dstColCardinality + reprColIdx];
+                           const auto &dstCol = dst.GetColumnDescriptor(dstColId);
+                           if (srcCol.GetBitsOnStorage() != dstCol.GetBitsOnStorage() ||
+                               srcCol.GetValueRange() != dstCol.GetValueRange()) {
+                              std::stringstream ss;
+                              ss << "Source field `" << field.fSrc->GetFieldName()
+                                 << "` has a matching column representation as its destination field, however one or "
+                                    "more "
+                                    "of its columns have different column metadata (bit width and/or value range). "
+                                    "Merging variable-sized columns is currently only supported if all metadata is "
+                                    "identical between source and destination columns."
+                                 << "\n   bit width src: " << srcCol.GetBitsOnStorage()
+                                 << ", dst: " << dstCol.GetBitsOnStorage() << ""
+                                 << "\n   value range src: " << srcCol.GetValueRange()
+                                 << ", dst: " << dstCol.GetValueRange();
+                              errors.push_back(ss.str());
+                              break;
+                           }
+                        }
+                        matchingRepr = dstReprIdx;
+                        break;
+                     }
+                  }
+
+                  if (errors.empty()) {
+                     if (matchingRepr >= 0 && matchingRepr != srcReprIdx) {
+                        // a different matching representation was found
+                        assert(matchingRepr < std::numeric_limits<std::uint32_t>::max());
+                        res.fColReprMappings[field.fDst].push_back(
+                           RColReprMapping{srcReprIdx, static_cast<std::uint32_t>(matchingRepr)});
+                     } else if (matchingRepr < 0) {
+                        // this representation was not found in the destination
+                        assert(dstNColReprs < std::numeric_limits<std::uint32_t>::max());
+                        ROOT::RFieldBase::ColumnRepresentation_t newRepr;
+                        for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
+                           const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
+                           const auto &srcCol = src.GetColumnDescriptor(srcColId);
+                           newRepr.push_back(srcCol.GetType());
+                        }
+                        RColReprExtension extension{{srcReprIdx, static_cast<std::uint32_t>(dstNColReprs)}, newRepr};
+                        res.fColReprExtensions[field.fDst].push_back(extension);
+                        res.fColReprMappings[field.fDst].push_back(extension);
+                     }
+                  }
+               }
             }
          }
       }
@@ -669,13 +693,13 @@ CompareDescriptorStructure(const ROOT::RNTupleDescriptor &dst, const ROOT::RNTup
    return ROOT::RResult(res);
 }
 
-// Applies late model extension to `destination`, adding all `newFields` to it.
+// Applies late model extension to `mergeData.fDestination`, adding all `descCmp.fExtraSrcFields` to it.
 [[nodiscard]]
 static ROOT::RResult<void>
-ExtendDestinationModel(std::span<const ROOT::RFieldDescriptor *> newFields, ROOT::RNTupleModel &dstModel,
-                       RNTupleMergeData &mergeData, std::vector<RCommonField> &commonFields)
+ExtendDestinationModel(RDescriptorsComparison &descCmp, ROOT::RNTupleModel &dstModel, RNTupleMergeData &mergeData)
 {
-   assert(newFields.size() > 0); // no point in calling this with 0 new cols
+   const auto &newFields = descCmp.fExtraSrcFields;
+   auto &commonFields = descCmp.fCommonFields;
 
    dstModel.Unfreeze();
    ROOT::Internal::RNTupleModelChangeset changeset{dstModel};
@@ -695,10 +719,19 @@ ExtendDestinationModel(std::span<const ROOT::RFieldDescriptor *> newFields, ROOT
    changeset.fAddedFields.reserve(newFields.size());
    // First add all non-projected fields...
    for (const auto *fieldDesc : newFields) {
-      if (!fieldDesc->IsProjectedField()) {
-         auto field = fieldDesc->CreateField(*mergeData.fSrcDescriptor);
-         changeset.AddField(std::move(field));
+      if (fieldDesc->IsProjectedField())
+         continue;
+
+      auto field = fieldDesc->CreateField(*mergeData.fSrcDescriptor);
+      // Explicitly set the field representatives. This prevents UpdateSchema() from changing our column
+      // representations via AutoAdjustColumnTypes.
+      ROOT::RFieldBase::ColumnRepresentation_t representatives;
+      for (const auto &colId : fieldDesc->GetLogicalColumnIds()) {
+         const auto &column = mergeData.fSrcDescriptor->GetColumnDescriptor(colId);
+         representatives.push_back(column.GetType());
       }
+      field->SetColumnRepresentatives({representatives});
+      changeset.AddField(std::move(field));
    }
    // ...then add all projected fields.
    for (const auto *fieldDesc : newFields) {
@@ -723,16 +756,49 @@ ExtendDestinationModel(std::span<const ROOT::RFieldDescriptor *> newFields, ROOT
    }
    dstModel.Freeze();
    try {
+      // FIXME: here we are connecting the new fields/columns to the sink!
+      // We should avoid doing that, as all other non-extended fields never get connected (and we don't
+      // need to connect these either in principle).
+      // NOTE: this calls AutoAdjustColumnTypes, but we have set the column representations of all fields
+      // explicitly, so it will not change it under the hood.
       mergeData.fDestination.UpdateSchema(changeset, mergeData.fNumDstEntries);
    } catch (const ROOT::RException &ex) {
       return R__FAIL(ex.what());
    }
 
    commonFields.reserve(commonFields.size() + newFields.size());
-   for (const auto *field : newFields) {
+   // NOTE(gparolini): Insert the new fields at the beginning of `commonFields`.
+   // We need to make sure the extended fields appear before all other common fields for the following reason:
+   // in general, when we GatherColumnInfos we (potentially) assign new column output ids in field order; this
+   // assignment happens whenever we find new columns, which happens in 3 cases:
+   //   1. we are in the first source and we're adding the first set of (common) fields;
+   //   2. we are adding a new set of extended common fields (this is done in this function);
+   //   3. we are adding new column representations for fields that we already had before processing this source.
+   //
+   // It's important that the output id assigned to the new columns is coherent with the order of the column descriptors
+   // as they appear in the header and footer of the destination RNTuple.
+   // This is in turn determined by the order by which we append new columns to the dst descriptor during the merging
+   // process.
+   //
+   // Now let's consider the three cases listed above.
+   // Ignoring the trivial case (1), the order of operations for each source is:
+   //   - call ExtendDestinationModel (case 2)
+   //       (this adds both new fields and column descriptors; see the UpdateSchema call above)
+   //   - add new column representations (case 3)
+   //       (this only adds column descriptors, see the call to AddColumnRepresentation)
+   //
+   // Since we call ExtendDestinationModel (this function) *before* adding the new column representations,
+   // the dst descriptor always gets updated with the new column descriptors coming from the extended fields before
+   //it gets updated with the extended column representations.
+   //
+   // However, in GatherColumnInfos, the new column output ids are added sequentially in *field* order and the fields
+   // containing the new column representations are already in that list from earlier! So, to make sure the new output
+   // ids are assigned to our extended fields first, we push them in from on the list so they are visited first.
+   for (auto it = newFields.rbegin(); it != newFields.rend(); ++it) {
+      const auto *field = *it;
       const auto newFieldInDstId = mergeData.fDstDescriptor.FindFieldId(field->GetFieldName());
       const auto &newFieldInDst = mergeData.fDstDescriptor.GetFieldDescriptor(newFieldInDstId);
-      commonFields.emplace_back(*field, newFieldInDst);
+      commonFields.insert(commonFields.begin(), RCommonField{*field, newFieldInDst});
    }
 
    return ROOT::RResult<void>::Success();
@@ -776,10 +842,10 @@ GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<const RColumnMe
       const auto structure = field->GetStructure();
 
       if (structure == ROOT::ENTupleStructure::kStreamer) {
-         return R__FAIL(
-            "Destination RNTuple contains a streamer field (" + field->GetFieldName() +
-            ") that is not present in one of the sources. "
-            "Creating a default value for a streamer field is ill-defined, therefore the merging process will abort.");
+         return R__FAIL("Destination RNTuple contains a streamer field (" + field->GetFieldName() +
+                        ") that is not present in one of the sources. "
+                        "Creating a default value for a streamer field is ill-defined, therefore the merging "
+                        "process will abort.");
       }
 
       // NOTE: we cannot have a Record here because it has no associated columns.
@@ -826,7 +892,7 @@ GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<const RColumnMe
 ROOT::RResult<void>
 RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
                                   const ROOT::RClusterDescriptor &clusterDesc,
-                                  std::span<const RColumnMergeInfo> commonColumns,
+                                  std::span<RColumnMergeInfo> commonColumns,
                                   const RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
                                   RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData,
                                   ROOT::Internal::RPageAllocator &pageAlloc)
@@ -838,8 +904,10 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
 
    const RCluster *cluster = clusterPool.GetCluster(clusterDesc.GetId(), commonColumnSet);
    // we expect the cluster pool to contain the requested set of columns, since they were
-   // validated by CompareDescriptorStructure().
+   // validated by CompareDescriptorStructure() and MergeSourceClusters().
    assert(cluster);
+
+   const std::uint32_t outCompression = mergeData.fMergeOpts.fCompressionSettings.value();
 
    for (size_t colIdx = 0; colIdx < nCommonColumnsInCluster; ++colIdx) {
       const auto &column = commonColumns[colIdx];
@@ -850,9 +918,6 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
       const auto srcColElement = column.fInMemoryType
                                     ? ROOT::Internal::GenerateColumnElement(*column.fInMemoryType, columnDesc.GetType())
                                     : RColumnElementBase::Generate(columnDesc.GetType());
-      const auto dstColElement = column.fInMemoryType
-                                    ? ROOT::Internal::GenerateColumnElement(*column.fInMemoryType, column.fColumnType)
-                                    : RColumnElementBase::Generate(column.fColumnType);
 
       // Now get the pages for this column in this cluster
       const auto &pages = clusterDesc.GetPageRange(columnId);
@@ -861,30 +926,27 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
       sealedPages.resize(pages.GetPageInfos().size());
 
       // Each column range potentially has a distinct compression settings
-      const auto colRangeCompressionSettings = clusterDesc.GetColumnRange(columnId).GetCompressionSettings().value();
+      const auto &columnRange = clusterDesc.GetColumnRange(columnId);
+      assert(!columnRange.IsSuppressed());
+      const auto colRangeCompressionSettings = columnRange.GetCompressionSettings().value();
 
-      // Select "merging level". There are 3 levels, from fastest to slowest, depending on the case:
+      // Select "merging level". There are 2 levels, from fastest to slowest, depending on the case:
       // L1: compression and encoding of src and dest both match: we can simply copy the page
-      // L2: compression of dest doesn't match the src but encoding does: we must recompress the page but can avoid
-      //     resealing it.
-      // L3: on-disk encoding doesn't match: we need to reseal the page, which implies decompressing and recompressing
-      //     it.
-      const bool compressionIsDifferent =
-         colRangeCompressionSettings != mergeData.fMergeOpts.fCompressionSettings.value();
-      const bool needsResealing =
-         srcColElement->GetIdentifier().fOnDiskType != dstColElement->GetIdentifier().fOnDiskType;
-      const bool needsRecompressing = compressionIsDifferent || needsResealing;
+      // L2: compression of dest doesn't match the src we must recompress the page.
+      // Note that in no case do we need to re-encode the page, as if the encoding differs we simply
+      // append a new column representation to the field.
+      const bool needsRecompressing = colRangeCompressionSettings != outCompression;
 
       if (needsRecompressing && mergeData.fMergeOpts.fExtraVerbose) {
-         R__LOG_INFO(NTupleMergeLog())
-            << (needsResealing ? "Resealing" : "Recompressing") << " column " << column.fColumnName
-            << ": { compression: " << colRangeCompressionSettings << " => "
-            << mergeData.fMergeOpts.fCompressionSettings.value()
-            << ", onDiskType: " << RColumnElementBase::GetColumnTypeName(srcColElement->GetIdentifier().fOnDiskType)
-            << " => " << RColumnElementBase::GetColumnTypeName(dstColElement->GetIdentifier().fOnDiskType);
+         R__LOG_INFO(NTupleMergeLog()) << "Recompressing column " << column.fColumnName
+                                       << ": { compression: " << colRangeCompressionSettings << " => "
+                                       << mergeData.fMergeOpts.fCompressionSettings.value() << ", onDiskType: "
+                                       << RColumnElementBase::GetColumnTypeName(
+                                             srcColElement->GetIdentifier().fOnDiskType)
+                                       << "}";
       }
 
-      size_t pageBufferBaseIdx = sealedPageData.fBuffers.size();
+      const size_t pageBufferBaseIdx = sealedPageData.fBuffers.size();
       // If the column range already has the right compression we don't need to allocate any new buffer, so we don't
       // bother reserving memory for them.
       if (needsRecompressing)
@@ -933,29 +995,15 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
             buffer = MakeUninitArray<std::byte>(bufSize);
 
             // clang-format off
-            if (needsResealing) {
-               RTaskVisitor{fTaskGroup}(RResealFunc{
-                  *srcColElement,
-                  *dstColElement,
-                  mergeData.fMergeOpts,
-                  sealedPage,
-                  *fPageAlloc,
-                  buffer.get(),
-                  bufSize,
-                  mergeData.fDestination.GetWriteOptions()
-               });
-            } else {
-               RTaskVisitor{fTaskGroup}(RChangeCompressionFunc{
-                  *srcColElement,
-                  *dstColElement,
-                  mergeData.fMergeOpts,
-                  sealedPage,
-                  *fPageAlloc,
-                  buffer.get(),
-                  bufSize,
-                  mergeData.fDestination.GetWriteOptions()
-               });
-            }
+            RTaskVisitor{fTaskGroup}(RChangeCompressionFunc{
+               *srcColElement,
+               outCompression,
+               sealedPage,
+               *fPageAlloc,
+               buffer.get(),
+               bufSize,
+               mergeData.fDestination.GetWriteOptions()
+            });
             // clang-format on
          }
 
@@ -979,9 +1027,9 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
 // the destination's schemas.
 // The pages may be "fast-merged" (i.e. simply copied with no decompression/recompression) if the target
 // compression is unspecified or matches the original compression settings.
-ROOT::RResult<void>
-RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<const RColumnMergeInfo> commonColumns,
-                                   std::span<const RColumnMergeInfo> extraDstColumns, RNTupleMergeData &mergeData)
+ROOT::RResult<void> RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<RColumnMergeInfo> commonColumns,
+                                                       std::span<const RColumnMergeInfo> extraDstColumns,
+                                                       RNTupleMergeData &mergeData)
 {
    ROOT::Internal::RClusterPool clusterPool{source};
 
@@ -996,37 +1044,79 @@ RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<const RColumnM
       const auto nClusterEntries = clusterDesc.GetNEntries();
       R__ASSERT(nClusterEntries > 0);
 
-      // NOTE: just because a column is in `commonColumns` it doesn't mean that each cluster in the source contains it,
-      // as it may be a deferred column that only has real data in a future cluster.
-      // We need to figure out which columns are actually present in this cluster so we only merge their pages (the
-      // missing columns are handled by synthesizing zero pages - see below).
-      size_t nCommonColumnsInCluster = commonColumns.size();
-      while (nCommonColumnsInCluster > 0) {
-         // Since `commonColumns` is sorted by column input id, we can simply traverse it from the back and stop as
-         // soon as we find a common column that appears in this cluster: we know that in that case all previous
-         // columns must appear as well.
-         if (clusterDesc.ContainsColumn(commonColumns[nCommonColumnsInCluster - 1].fInputId))
-            break;
-         --nCommonColumnsInCluster;
-      }
+      // Deduce which columns are suppressed (cluster by cluster) by exclusion, as:
+      // (columns in the columnIdMap) - (columns in commonColumns which are not suppressed).
+      // Note that some suppressed columns may not be in commonColumns because they might not appear at all in the
+      // current source.
+      FieldCollectionMap_t<ROOT::DescriptorId_t> columnsInCluster;
+      using ColumnHandle_t = ROOT::Internal::RPageSource::ColumnHandle_t;
+
+      // NOTE: `commonColumns` contains all columns that appear *somewhere* both in the src and in the dst.
+      // Just because a column is in `commonColumns` it doesn't mean that each cluster in the source contains
+      // it, as it may be a deferred column that only has real data in a future cluster. We need to figure out which
+      // columns are actually present in this cluster so we only merge their pages (the missing columns are handled
+      // by synthesizing zero pages - see below).
 
       // Convert columns to a ColumnSet for the ClusterPool query
       RCluster::ColumnSet_t commonColumnSet;
-      commonColumnSet.reserve(nCommonColumnsInCluster);
-      for (size_t i = 0; i < nCommonColumnsInCluster; ++i)
-         commonColumnSet.emplace(commonColumns[i].fInputId);
+      // Collect all common columns appearing in this cluster into commonColumnSet and reorganize commonColumns so
+      // that those columns are at the start of it (whereas missing columns are at its end).
+      // NOTE: it's fine if this scrambles the order of columns: the RNTupleSerializer will sort them by physical ID.
+      int nCommonColumnsInCluster = 0;
+      std::partition(commonColumns.begin(), commonColumns.end(), [&](const auto &column) {
+         if (clusterDesc.ContainsColumn(column.fInputId)) {
+            const auto &colRange = clusterDesc.GetColumnRange(column.fInputId);
+            ++nCommonColumnsInCluster;
+            columnsInCluster[column.fParentFieldDescriptor].push_back(column.fOutputId);
+            if (!colRange.IsSuppressed()) {
+               commonColumnSet.emplace(column.fInputId);
+               columnsInCluster[column.fParentFieldDescriptor].push_back(column.fOutputId);
+               return true;
+            }
+            mergeData.fDestination.CommitSuppressedColumn(ColumnHandle_t{column.fOutputId});
+         }
+         return false;
+      });
 
-      // For each cluster, the "missing columns" are the union of the extraDstColumns and the common columns
-      // that are not present in the cluster. We generate zero pages for all of them.
-      missingColumns.resize(extraDstColumns.size()); // NOTE: this clears all common columns of the previous cluster
-      for (size_t i = nCommonColumnsInCluster; i < commonColumns.size(); ++i)
-         missingColumns.push_back(commonColumns[i]);
+      // Commit all suppressed columns.
+      // This is a fairly involved operation, as we need to commit all known columns that:
+      // a) do not appear in extraDstColumns (those are "missing", not suppressed), and
+      // b) do not appear in commonColumnSet (those are the active columns).
+      // Not that these may or may not appear in commonColumns as suppressed columns, since they may or may not be
+      // present in the current source.
+      // The only way to find all the columns is to go and get them from fColumnIdMap, which keeps track of every
+      // column we added to the destination so far. However, since it also contains the extraDstColumns, we need to
+      // specifically only query those columns that belong to a field that has at least 1 column in commonColumns
+      // (remember that commonColumns contains all columns associated to the common fields for this source).
+      for (const auto &[fieldDesc, columnIds] : columnsInCluster) {
+         const auto &fieldFQName = mergeData.fSrcDescriptor->GetQualifiedFieldName(fieldDesc->GetId());
+         const auto cardinality = fieldDesc->GetColumnCardinality();
+         for (auto i = 0u; i < fieldDesc->GetLogicalColumnIds().size(); ++i) {
+            const auto colIndex = i % cardinality;
+            const auto reprIndex = i / cardinality;
+            const auto colName = "." + fieldFQName + '.' + std::to_string(colIndex) + '.' + std::to_string(reprIndex);
+            const auto colIt = mergeData.fColumnIdMap.find(colName);
+            assert(colIt != mergeData.fColumnIdMap.end());
+            const auto colOutId = colIt->second.fColumnId;
+            if (std::find(columnIds.begin(), columnIds.end(), colOutId) == columnIds.end()) {
+               mergeData.fDestination.CommitSuppressedColumn(ROOT::Internal::RPageStorage::ColumnHandle_t{colOutId});
+            }
+         }
+      }
 
       RSealedPageMergeData sealedPageData;
       auto res = MergeCommonColumns(clusterPool, clusterDesc, commonColumns, commonColumnSet, nCommonColumnsInCluster,
                                     sealedPageData, mergeData, *fPageAlloc);
       if (!res)
          return R__FORWARD_ERROR(res);
+
+      // Generate zero pages for the missing columns.
+      // For each cluster, the "missing columns" are the union of the extraDstColumns and the common columns
+      // that are not present in the cluster.
+      // Note that this does NOT include suppressed columns, for which no pages are synthesized.
+      missingColumns.resize(extraDstColumns.size()); // NOTE: this clears all common columns of the previous cluster
+      for (size_t i = nCommonColumnsInCluster; i < commonColumns.size(); ++i)
+         missingColumns.push_back(commonColumns[i]);
 
       res = GenerateZeroPagesForColumns(nClusterEntries, missingColumns, sealedPageData, *fPageAlloc,
                                         mergeData.fDstDescriptor, mergeData);
@@ -1080,13 +1170,15 @@ static std::optional<std::type_index> ColumnInMemoryType(std::string_view fieldT
    return std::nullopt;
 }
 
-// Given a field, fill `columns` and `mergeData.fColumnIdMap` with information about all columns belonging to it and its
-// subfields. `mergeData.fColumnIdMap` is used to map matching columns from different sources to the same output column
-// in the destination. We match columns by their "fully qualified name", which is the concatenation of their ancestor
-// fields' names and the column index. By this point, since we called `CompareDescriptorStructure()` earlier, we should
-// be guaranteed that two matching columns will have at least compatible representations. NOTE: srcFieldDesc and
-// dstFieldDesc may alias.
+// Given a field, fill `columns` and `mergeData.fColumnIdMap` with information about all columns belonging to it and
+// its subfields. `mergeData.fColumnIdMap` is used to map matching columns from different sources to the same output
+// column in the destination. We match columns by their "fully qualified name", which is the concatenation of their
+// ancestor fields' names and the column index. By this point, since we called `CompareDescriptorStructure()`
+// earlier, we should be guaranteed that two matching columns will have at least compatible representations.
+// This function is recursive as it needs to call itself on the entire subfield hierarchy of the source field.
+// NOTE: srcFieldDesc and dstFieldDesc may alias.
 static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const ROOT::RNTupleDescriptor &srcDesc,
+                                const FieldCollectionMap_t<RColReprMapping> &colReprMappings,
                                 RNTupleMergeData &mergeData, const ROOT::RFieldDescriptor &srcFieldDesc,
                                 const ROOT::RFieldDescriptor &dstFieldDesc, const std::string &prefix = "")
 {
@@ -1099,21 +1191,19 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RO
 
    const auto &columnIds = srcFieldDesc.GetLogicalColumnIds();
    columns.reserve(columns.size() + columnIds.size());
-   // NOTE: here we can match the src and dst columns by column index because we forbid merging fields with
-   // different column representations.
+
    for (auto i = 0u; i < srcFieldDesc.GetLogicalColumnIds().size(); ++i) {
       auto srcColumnId = srcFieldDesc.GetLogicalColumnIds()[i];
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
 
       RColumnMergeInfo info{};
-      info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex());
       info.fInputId = srcColumn.GetPhysicalId();
       // NOTE(gparolini): the parent field is used when synthesizing zero pages, which happens in 2 situations:
       // 1. when adding extra dst columns (in which case we need to synthesize zero pages for the incoming src), and
       // 2. when merging a deferred column into an existing column (in which case we need to fill the "hole" with
-      // zeroes). For the first case srcFieldDesc and dstFieldDesc are the same (see the calling site of this function),
-      // but for the second case they're not, and we need to pick the source field because we will then check the
-      // column's *input* id inside fParentFieldDescriptor to see if it's a suppressed column (see
+      // zeroes). For the first case srcFieldDesc and dstFieldDesc are the same (see the calling site of this
+      // function), but for the second case they're not, and we need to pick the source field because we will then
+      // check the column's *input* id inside fParentFieldDescriptor to see if it's a suppressed column (see
       // GenerateZeroPagesForColumns()).
       info.fParentFieldDescriptor = &srcFieldDesc;
       // Save the parent field descriptor since this may be either the source or destination descriptor depending on
@@ -1121,22 +1211,34 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RO
       // properly walk up the field hierarchy.
       info.fParentNTupleDescriptor = &srcDesc;
 
+      const auto mappingsIt = colReprMappings.find(&dstFieldDesc);
+      std::uint16_t reprIndex = srcColumn.GetRepresentationIndex();
+      if (mappingsIt != colReprMappings.end()) {
+         if (auto outReprIdx = FindColumnReprMapping(mappingsIt->second, reprIndex); outReprIdx)
+            reprIndex = *outReprIdx;
+      }
+
+      info.fColumnName = name + '.' + std::to_string(srcColumn.GetIndex()) + '.' + std::to_string(reprIndex);
+
+      ENTupleColumnType columnType = ENTupleColumnType::kUnknown;
+
       if (auto it = mergeData.fColumnIdMap.find(info.fColumnName); it != mergeData.fColumnIdMap.end()) {
+         // We had already added this column to the column id map: just copy its data.
          info.fOutputId = it->second.fColumnId;
-         info.fColumnType = it->second.fColumnType;
+         info.fOutputReprIndex = reprIndex;
       } else {
+         // New column: assign it the next ouput id.
          info.fOutputId = mergeData.fColumnIdMap.size();
-         // NOTE(gparolini): map the type of src column to the type of dst column.
-         // This mapping is only relevant for common columns and it's done to ensure we keep a consistent
-         // on-disk representation of the same column.
-         // This is also important to do for first source when it is used to generate the destination sink,
-         // because even in that case their column representations may differ.
-         // e.g. if the destination has a different compression than the source, an integer column might be
-         // zigzag-encoded in the source but not in the destination.
-         auto dstColumnId = dstFieldDesc.GetLogicalColumnIds()[i];
+         // NOTE(gparolini): map the representation index of src column to that of dst column.
+         // This mapping is only relevant for common columns and it's done to ensure we have the correct representation
+         // index in the output column metadata.
+         assert(dstFieldDesc.GetColumnCardinality() == srcFieldDesc.GetColumnCardinality());
+         const auto dstColumnIndex = reprIndex * dstFieldDesc.GetColumnCardinality() + srcColumn.GetIndex();
+         const auto dstColumnId = dstFieldDesc.GetLogicalColumnIds()[dstColumnIndex];
          const auto &dstColumn = mergeData.fDstDescriptor.GetColumnDescriptor(dstColumnId);
-         info.fColumnType = dstColumn.GetType();
-         mergeData.fColumnIdMap[info.fColumnName] = {info.fOutputId, info.fColumnType};
+         columnType = dstColumn.GetType();
+         info.fOutputReprIndex = reprIndex;
+         mergeData.fColumnIdMap[info.fColumnName] = RColumnOutInfo{info.fOutputId};
       }
 
       if (mergeData.fMergeOpts.fExtraVerbose) {
@@ -1144,12 +1246,12 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RO
                                        << ", phys.id " << srcColumn.GetPhysicalId() << ", type "
                                        << RColumnElementBase::GetColumnTypeName(srcColumn.GetType()) << " -> log.id "
                                        << info.fOutputId << ", type "
-                                       << RColumnElementBase::GetColumnTypeName(info.fColumnType);
+                                       << RColumnElementBase::GetColumnTypeName(columnType);
       }
 
       // Since we disallow merging fields of different types, src and dstFieldDesc must have the same type name.
       assert(srcFieldDesc.GetTypeName() == dstFieldDesc.GetTypeName());
-      info.fInMemoryType = ColumnInMemoryType(srcFieldDesc.GetTypeName(), info.fColumnType);
+      info.fInMemoryType = ColumnInMemoryType(srcFieldDesc.GetTypeName(), columnType);
       columns.emplace_back(info);
    }
 
@@ -1159,7 +1261,7 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RO
    for (auto i = 0u; i < srcChildrenIds.size(); ++i) {
       const auto &srcChild = srcDesc.GetFieldDescriptor(srcChildrenIds[i]);
       const auto &dstChild = mergeData.fDstDescriptor.GetFieldDescriptor(dstChildrenIds[i]);
-      AddColumnsFromField(columns, srcDesc, mergeData, srcChild, dstChild, name);
+      AddColumnsFromField(columns, srcDesc, colReprMappings, mergeData, srcChild, dstChild, name);
    }
 }
 
@@ -1171,17 +1273,12 @@ static RColumnInfoGroup GatherColumnInfos(const RDescriptorsComparison &descCmp,
 {
    RColumnInfoGroup res;
    for (const ROOT::RFieldDescriptor *field : descCmp.fExtraDstFields) {
-      AddColumnsFromField(res.fExtraDstColumns, mergeData.fDstDescriptor, mergeData, *field, *field);
+      AddColumnsFromField(res.fExtraDstColumns, mergeData.fDstDescriptor, descCmp.fColReprMappings, mergeData, *field,
+                          *field);
    }
    for (const auto &[srcField, dstField] : descCmp.fCommonFields) {
-      AddColumnsFromField(res.fCommonColumns, srcDesc, mergeData, *srcField, *dstField);
+      AddColumnsFromField(res.fCommonColumns, srcDesc, descCmp.fColReprMappings, mergeData, *srcField, *dstField);
    }
-
-   // Sort the commonColumns by ID so we can more easily tell how many common columns each cluster has
-   // (since each cluster must contain all columns of the previous cluster plus potentially some new ones)
-   std::sort(res.fCommonColumns.begin(), res.fCommonColumns.end(),
-             [](const auto &a, const auto &b) { return a.fInputId < b.fInputId; });
-
    return res;
 }
 
@@ -1192,15 +1289,34 @@ static void PrefillColumnMap(const ROOT::RNTupleDescriptor &desc, const ROOT::RF
    for (const auto &colId : fieldDesc.GetLogicalColumnIds()) {
       const auto &colDesc = desc.GetColumnDescriptor(colId);
       RColumnOutInfo info{};
-      const auto colName = name + '.' + std::to_string(colDesc.GetIndex());
       info.fColumnId = colDesc.GetLogicalId();
-      info.fColumnType = colDesc.GetType();
+      const auto colName =
+         name + '.' + std::to_string(colDesc.GetIndex()) + '.' + std::to_string(colDesc.GetRepresentationIndex());
       colIdMap[colName] = info;
    }
 
    for (const auto &subId : fieldDesc.GetLinkIds()) {
       const auto &subfield = desc.GetFieldDescriptor(subId);
       PrefillColumnMap(desc, subfield, colIdMap, name);
+   }
+}
+
+static void AddColumnExtensionsInFieldOrder(
+   const ROOT::RFieldDescriptor &field, const ROOT::RNTupleDescriptor &desc,
+   const FieldCollectionMap_t<RColReprExtension> &extensions,
+   std::vector<std::pair<const ROOT::RFieldDescriptor *, std::vector<RColReprExtension>>> &outExtensions,
+   std::unordered_map<ROOT::DescriptorId_t, std::vector<const ROOT::RFieldDescriptor *>> &outProjectionPointees)
+{
+   const auto it = extensions.find(&field);
+   if (it != extensions.end())
+      outExtensions.emplace_back(it->first, it->second);
+
+   if (field.IsProjectedField())
+      outProjectionPointees[field.GetProjectionSourceId()].push_back(&field);
+
+   for (auto childId : field.GetLinkIds()) {
+      const auto &child = desc.GetFieldDescriptor(childId);
+      AddColumnExtensionsInFieldOrder(child, desc, extensions, outExtensions, outProjectionPointees);
    }
 }
 
@@ -1243,6 +1359,9 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
                         ") This is currently unsupported.");
       }
    }
+
+   // Maps projection source fields to all their projections.
+   std::unordered_map<ROOT::DescriptorId_t, std::vector<const ROOT::RFieldDescriptor *>> projectionPointees;
 
    // we should have a model if and only if the destination is initialized.
    if (!!fModel != fDestination->IsInitialized()) {
@@ -1295,7 +1414,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
          }
       }
 
-      // Create sink from the input model if not initialized
+      // Create sink and model from the input descriptor if not initialized
       if (!fModel) {
          fModel = fDestination->InitFromDescriptor(srcDescriptor.GetRef(), false /* copyClusters */);
       }
@@ -1321,10 +1440,10 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       }
 
       // handle extra src fields
-      if (descCmp.fExtraSrcFields.size()) {
+      if (!descCmp.fExtraSrcFields.empty()) {
          if (mergeOpts.fMergingMode == ENTupleMergingMode::kUnion) {
             // late model extension for all fExtraSrcFields in Union mode
-            auto res = ExtendDestinationModel(descCmp.fExtraSrcFields, *fModel, mergeData, descCmp.fCommonFields);
+            auto res = ExtendDestinationModel(descCmp, *fModel, mergeData);
             if (!res)
                return R__FORWARD_ERROR(res);
          } else if (mergeOpts.fMergingMode == ENTupleMergingMode::kStrict) {
@@ -1334,6 +1453,50 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
                msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }
             SKIP_OR_ABORT(msg);
+         }
+      }
+
+      //// Extend columns if needed
+      if (!descCmp.fColReprExtensions.empty()) {
+         for (const auto &field : descCmp.fExtraDstFields) {
+            if (field->IsProjectedField())
+               projectionPointees[field->GetProjectionSourceId()].push_back(field);
+         }
+
+         // We need to extend the columns in the proper order, i.e. so that they appear in the same order as
+         // their first representation. This is to ensure that the pages we write to the cluster are in a consistent
+         // order as their column descriptors. The page creation order is determined by the order of
+         // columnInfos.fCommonColumns, which in turn depends on the common fields order (see GatherColumnInfos).
+         // XXX: do we need this separate sort step? Why not just create this vector directly in
+         // CompareDescriptorStructure?
+         std::vector<std::pair<const RFieldDescriptor *, std::vector<RColReprExtension>>> colExtensions;
+         colExtensions.reserve(descCmp.fColReprExtensions.size());
+         for (const auto &commonField : descCmp.fCommonFields) {
+            const auto *field = commonField.fDst;
+            AddColumnExtensionsInFieldOrder(*field, mergeData.fDstDescriptor, descCmp.fColReprExtensions, colExtensions,
+                                            projectionPointees);
+         }
+         for (const auto &field : descCmp.fExtraSrcFields) {
+            if (field->IsProjectedField())
+               projectionPointees[field->GetProjectionSourceId()].push_back(field);
+         }
+
+         for (const auto &[fieldDesc, extensions] : colExtensions) {
+            auto &mappings = descCmp.fColReprMappings[fieldDesc];
+            for (const auto &extension : extensions) {
+               const auto firstColumnId = fDestination->AddColumnRepresentation(*fieldDesc, extension.fSourceRepr);
+
+               // When adding new column representations to an existing field which is the source of some projected
+               // fields, we need to also add new alias columns to those fields so that they can point to the proper
+               // representation.
+               if (auto it = projectionPointees.find(fieldDesc->GetId()); it != projectionPointees.end()) {
+                  for (const auto &projection : it->second) {
+                     for (auto colIdx = 0u; colIdx < extension.fSourceRepr.size(); ++colIdx)
+                        fDestination->AddAliasColumn(mergeData.fDstDescriptor, *projection, firstColumnId + colIdx);
+                  }
+               }
+               mappings.push_back(extension);
+            }
          }
       }
 

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -452,18 +452,6 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
    const auto &srcColumns = srcField.GetLogicalColumnIds();
    const auto &dstColumns = dstField.GetLogicalColumnIds();
 
-   // Fields must have the same number of columns
-   const auto srcNCols = srcColumns.size();
-   const auto dstNCols = dstColumns.size();
-   if (srcNCols != dstNCols) {
-      std::stringstream ss;
-      ss << "Field `" << srcField.GetFieldName()
-         << "` has a different number of columns than previously-seen field with the same name (old: " << dstNCols
-         << ", new: " << srcNCols << ")";
-      errors.push_back(ss.str());
-      return;
-   }
-
    // Fields must have the same cardinality
    const std::uint32_t srcColCardinality = srcField.GetColumnCardinality();
    const std::uint32_t dstColCardinality = dstField.GetColumnCardinality();
@@ -479,8 +467,8 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
    if (srcColCardinality == 0)
       return; // no columns to match
 
-   const auto srcNColReprs = srcNCols / srcColCardinality;
-   const auto dstNColReprs = dstNCols / dstColCardinality;
+   const auto srcNColReprs = srcColumns.size() / srcColCardinality;
+   const auto dstNColReprs = dstColumns.size() / dstColCardinality;
 
    // For each column representation of the source, check if it matches one in the descriptor.
    // If so, and if it doesn't match the destination's repr index, add a mapping for it.

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -331,7 +331,7 @@ struct RCommonField {
 };
 
 /// Maps a column representation from a source to a destination RNTuple.
-/// fSource and fDest are the representation indices of a specific column.
+/// fSource and fDest are the first representation indices of a specific column.
 ///
 /// When we merge fields from different RNTuples, two compatible fields may use different column
 /// representations. When merging their columns we need to make sure that we keep the output
@@ -346,6 +346,10 @@ struct RColReprMapping {
 struct RColReprExtension : RColReprMapping {
    /// The new representations to be added
    std::vector<ROOT::Internal::RColumnFormat> fSourceRepr;
+   /// The first element index that this column had in its source. When adding this representation to the destination,
+   /// the new column will add this amount to the first element index of the 0th-representation column in the
+   /// destination's current cluster.
+   std::uint32_t fOrigFirstElementIndex = 0;
 };
 
 static std::optional<std::uint32_t>
@@ -459,6 +463,7 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
 
    const auto srcNColReprs = srcColumns.size() / srcColCardinality;
    const auto dstNColReprs = dstColumns.size() / dstColCardinality;
+   std::uint32_t nextDstReprIndex = dstNColReprs;
 
    // For each column representation of the source, check if it matches one in the descriptor.
    // If so, and if it doesn't match the destination's repr index, add a mapping for it.
@@ -512,19 +517,23 @@ static void MatchColumnRepresentations(const ROOT::RNTupleDescriptor &srcDesc, c
             result.fColReprMappings[&dstField].push_back(
                RColReprMapping{srcReprIdx, static_cast<std::uint32_t>(matchingRepr)});
          } else if (matchingRepr < 0) {
-            // this representation was not found in the destination
-            assert(dstNColReprs < std::numeric_limits<std::uint32_t>::max());
+            // this representation was not found in the destination: add it
             std::vector<ROOT::Internal::RColumnFormat> newRepr;
             newRepr.reserve(srcColCardinality);
+            std::uint32_t firstElemIdx = 0;
             for (auto reprColIdx = 0u; reprColIdx < srcColCardinality; ++reprColIdx) {
                const auto srcColId = srcColumns[srcReprIdx * srcColCardinality + reprColIdx];
                const auto &srcCol = srcDesc.GetColumnDescriptor(srcColId);
+               // All added columns are supposed to have the same firstElementIndex
+               assert(firstElemIdx == 0 || firstElemIdx == srcCol.GetFirstElementIndex());
+               firstElemIdx = srcCol.GetFirstElementIndex();
                auto &reprElement = newRepr.emplace_back();
                reprElement.fType = srcCol.GetType();
                reprElement.fBitWidth = srcCol.GetBitsOnStorage();
                reprElement.fValueRange = srcCol.GetValueRange();
             }
-            RColReprExtension extension{{srcReprIdx, static_cast<std::uint32_t>(dstNColReprs)}, newRepr};
+            RColReprExtension extension{{srcReprIdx, nextDstReprIndex}, newRepr, firstElemIdx};
+            nextDstReprIndex += newRepr.size();
             result.fColReprExtensions[&dstField].push_back(extension);
             result.fColReprMappings[&dstField].push_back(extension);
          }
@@ -1475,7 +1484,8 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
          for (const auto &[fieldDesc, extensions] : colExtensions) {
             auto &mappings = descCmp.fColReprMappings[fieldDesc];
             for (const auto &extension : extensions) {
-               const auto firstColumnId = fDestination->AddColumnRepresentation(*fieldDesc, extension.fSourceRepr);
+               const auto firstColumnId = fDestination->AddColumnRepresentation(*fieldDesc, extension.fSourceRepr,
+                                                                                extension.fOrigFirstElementIndex);
 
                // When adding new column representations to an existing field which is the source of some projected
                // fields, we need to also add new alias columns to those fields so that they can point to the proper

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -885,12 +885,12 @@ ROOT::RResult<void>
 RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
                                   const ROOT::RClusterDescriptor &clusterDesc,
                                   std::span<RColumnMergeInfo> commonColumns,
-                                  const RCluster::ColumnSet_t &commonColumnSet, std::size_t nCommonColumnsInCluster,
-                                  RSealedPageMergeData &sealedPageData, const RNTupleMergeData &mergeData,
-                                  ROOT::Internal::RPageAllocator &pageAlloc)
+                                  const RCluster::ColumnSet_t &commonColumnSet, RSealedPageMergeData &sealedPageData,
+                                  const RNTupleMergeData &mergeData, ROOT::Internal::RPageAllocator &pageAlloc)
 {
-   assert(nCommonColumnsInCluster == commonColumnSet.size());
+   const auto nCommonColumnsInCluster = commonColumnSet.size();
    assert(nCommonColumnsInCluster <= commonColumns.size());
+
    if (nCommonColumnsInCluster == 0)
       return ROOT::RResult<void>::Success();
 
@@ -1096,8 +1096,8 @@ ROOT::RResult<void> RNTupleMerger::MergeSourceClusters(RPageSource &source, std:
       }
 
       RSealedPageMergeData sealedPageData;
-      auto res = MergeCommonColumns(clusterPool, clusterDesc, commonColumns, commonColumnSet, nCommonColumnsInCluster,
-                                    sealedPageData, mergeData, *fPageAlloc);
+      auto res = MergeCommonColumns(clusterPool, clusterDesc, commonColumns, commonColumnSet, sealedPageData, mergeData,
+                                    *fPageAlloc);
       if (!res)
          return R__FORWARD_ERROR(res);
 

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -1018,7 +1018,7 @@ RNTupleMerger::MergeSourceClusters(RPageSource &source, std::span<const RColumnM
 
       // For each cluster, the "missing columns" are the union of the extraDstColumns and the common columns
       // that are not present in the cluster. We generate zero pages for all of them.
-      missingColumns.resize(extraDstColumns.size());
+      missingColumns.resize(extraDstColumns.size()); // NOTE: this clears all common columns of the previous cluster
       for (size_t i = nCommonColumnsInCluster; i < commonColumns.size(); ++i)
          missingColumns.push_back(commonColumns[i]);
 
@@ -1092,15 +1092,16 @@ static void AddColumnsFromField(std::vector<RColumnMergeInfo> &columns, const RO
 {
    std::string name = prefix + '.' + srcFieldDesc.GetFieldName();
 
+   // We don't want to try and merge alias columns. Note that subfields of projected fields
+   // must also be projected, so we don't need to check them.
+   if (srcFieldDesc.IsProjectedField())
+      return;
+
    const auto &columnIds = srcFieldDesc.GetLogicalColumnIds();
    columns.reserve(columns.size() + columnIds.size());
    // NOTE: here we can match the src and dst columns by column index because we forbid merging fields with
    // different column representations.
    for (auto i = 0u; i < srcFieldDesc.GetLogicalColumnIds().size(); ++i) {
-      // We don't want to try and merge alias columns
-      if (srcFieldDesc.IsProjectedField())
-         continue;
-
       auto srcColumnId = srcFieldDesc.GetLogicalColumnIds()[i];
       const auto &srcColumn = srcDesc.GetColumnDescriptor(srcColumnId);
 

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -291,6 +291,7 @@ ROOT::RResult<std::uint32_t> SerializeColumnsOfFields(const ROOT::RNTupleDescrip
 
    const auto *xHeader = !forHeaderExtension ? desc.GetHeaderExtension() : nullptr;
 
+   std::vector<const ROOT::RColumnDescriptor *> columnsToSerialize;
    for (auto parentId : fieldList) {
       // If we're serializing the non-extended header and we already have a header extension (which may happen if
       // we load an RNTuple for incremental merging), we need to skip all the extended fields, as they need to be
@@ -301,12 +302,22 @@ ROOT::RResult<std::uint32_t> SerializeColumnsOfFields(const ROOT::RNTupleDescrip
       for (const auto &c : desc.GetColumnIterable(parentId)) {
          if (c.IsAliasColumn() || (xHeader && xHeader->ContainsExtendedColumnRepresentation(c.GetLogicalId())))
             continue;
+         columnsToSerialize.push_back(&c);
+      }
+   }
 
-         if (auto res = SerializePhysicalColumn(c, context, *where)) {
-            pos += res.Unwrap();
-         } else {
-            return R__FORWARD_ERROR(res);
-         }
+   // Make sure the columns are sorted by physical ID.
+   // This is usually the case already, but it may not be true if we have a late-model-extended column in one
+   // of the fields.
+   std::sort(columnsToSerialize.begin(), columnsToSerialize.end(), [&context](const auto *a, const auto *b) {
+      return context.GetOnDiskColumnId(a->GetPhysicalId()) < context.GetOnDiskColumnId(b->GetPhysicalId());
+   });
+
+   for (const auto *c : columnsToSerialize) {
+      if (auto res = SerializePhysicalColumn(*c, context, *where)) {
+         pos += res.Unwrap();
+      } else {
+         return R__FORWARD_ERROR(res);
       }
    }
 

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1176,8 +1176,9 @@ ROOT::Internal::RPagePersistentSink::InitFromDescriptor(const ROOT::RNTupleDescr
    return model;
 }
 
-void ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
-                                                                  std::span<const ENTupleColumnType> newRepresentation)
+ROOT::DescriptorId_t
+ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
+                                                             std::span<const ENTupleColumnType> newRepresentation)
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
@@ -1243,6 +1244,8 @@ void ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RF
 
       ++columnIndex;
    }
+
+   return firstPhysicalIndex;
 }
 
 void ROOT::Internal::RPagePersistentSink::AddAliasColumn(const ROOT::RNTupleDescriptor &desc,

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1178,7 +1178,7 @@ ROOT::Internal::RPagePersistentSink::InitFromDescriptor(const ROOT::RNTupleDescr
 
 ROOT::DescriptorId_t
 ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
-                                                             std::span<const ENTupleColumnType> newRepresentation)
+                                                             std::span<const RColumnFormat> newRepresentation)
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
@@ -1194,10 +1194,15 @@ ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldD
    fDescriptorBuilder.ShiftAliasColumns(newRepresentation.size());
 
    std::uint16_t columnIndex = 0; // index into the representation
-   for (auto columnType : newRepresentation) {
-      // Extending columns with variable bit width is currently unsupported.
-      const auto [rangeMin, rangeMax] = ROOT::Internal::RColumnElementBase::GetValidBitRange(columnType);
-      R__ASSERT(rangeMin == rangeMax);
+   for (auto columnRepr : newRepresentation) {
+      std::size_t bitsOnStorage = columnRepr.fBitWidth;
+      if (!bitsOnStorage) {
+         const auto [rangeMin, rangeMax] = ROOT::Internal::RColumnElementBase::GetValidBitRange(columnRepr.fType);
+         if (rangeMin != rangeMax) {
+            throw ROOT::RException(R__FAIL("bit width must be given for columns of variable bit width"));
+         }
+         bitsOnStorage = rangeMin;
+      }
 
       const ROOT::DescriptorId_t firstReprColumnId = field.GetLogicalColumnIds()[columnIndex];
       const auto &firstReprColumnRange = fOpenColumnRanges.at(firstReprColumnId);
@@ -1208,11 +1213,12 @@ ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldD
       columnBuilder.LogicalColumnId(columnId)
          .PhysicalColumnId(columnId)
          .FieldId(field.GetId())
-         .BitsOnStorage(rangeMax)
-         .Type(columnType)
+         .BitsOnStorage(bitsOnStorage)
+         .Type(columnRepr.fType)
          .Index(columnIndex)
          .FirstElementIndex(newReprFirstElemIndex)
-         .RepresentationIndex(reprIndex);
+         .RepresentationIndex(reprIndex)
+         .ValueRange(columnRepr.fValueRange);
       if (newReprFirstElemIndex)
          columnBuilder.SetSuppressedDeferred();
       fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1079,6 +1079,7 @@ void ROOT::Internal::RPagePersistentSink::UpdateExtraTypeInfo(const ROOT::RExtra
 void ROOT::Internal::RPagePersistentSink::InitImpl(ROOT::RNTupleModel &model)
 {
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
+   fDescriptorBuilder.SetVersionForWriting();
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
    auto &fieldZero = ROOT::Internal::GetFieldZeroOfModel(model);
@@ -1109,6 +1110,7 @@ ROOT::Internal::RPagePersistentSink::InitFromDescriptor(const ROOT::RNTupleDescr
 {
    // Create new descriptor
    fDescriptorBuilder.SetSchemaFromExisting(srcDescriptor);
+   fDescriptorBuilder.SetVersionForWriting();
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
    // Create column/page ranges
@@ -1251,6 +1253,8 @@ ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldD
       ++columnIndex;
    }
 
+   fDescriptorBuilder.EnsureValidDescriptor().ThrowOnError();
+
    return firstPhysicalIndex;
 }
 
@@ -1274,6 +1278,8 @@ void ROOT::Internal::RPagePersistentSink::AddAliasColumn(const ROOT::RNTupleDesc
       .FirstElementIndex(pointedColumn.GetFirstElementIndex())
       .RepresentationIndex(pointedColumn.GetRepresentationIndex());
    fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
+
+   fDescriptorBuilder.EnsureValidDescriptor().ThrowOnError();
 }
 
 void ROOT::Internal::RPagePersistentSink::CommitSuppressedColumn(ColumnHandle_t columnHandle)

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1180,7 +1180,8 @@ ROOT::Internal::RPagePersistentSink::InitFromDescriptor(const ROOT::RNTupleDescr
 
 ROOT::DescriptorId_t
 ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
-                                                             std::span<const RColumnFormat> newRepresentation)
+                                                             std::span<const RColumnFormat> newRepresentation,
+                                                             std::uint64_t clusterOffset)
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
@@ -1209,7 +1210,8 @@ ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldD
       const ROOT::DescriptorId_t firstReprColumnId = field.GetLogicalColumnIds()[columnIndex];
       const auto &firstReprColumnRange = fOpenColumnRanges.at(firstReprColumnId);
       const ROOT::DescriptorId_t columnId = firstPhysicalIndex + columnIndex;
-      const std::uint64_t newReprFirstElemIndex = firstReprColumnRange.GetFirstElementIndex();
+      // NOTE: this is always non-negative because it's the sum of two unsigned integers.
+      const std::uint64_t newReprFirstElemIndex = firstReprColumnRange.GetFirstElementIndex() + clusterOffset;
 
       RColumnDescriptorBuilder columnBuilder;
       columnBuilder.LogicalColumnId(columnId)

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1176,6 +1176,97 @@ ROOT::Internal::RPagePersistentSink::InitFromDescriptor(const ROOT::RNTupleDescr
    return model;
 }
 
+void ROOT::Internal::RPagePersistentSink::AddColumnRepresentation(const ROOT::RFieldDescriptor &field,
+                                                                  std::span<const ENTupleColumnType> newRepresentation)
+{
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+
+   assert(&descriptor.GetFieldDescriptor(field.GetId()) == &field);
+   assert(!field.IsProjectedField());
+   assert(field.GetColumnCardinality() > 0);
+   assert(!field.GetLogicalColumnIds().empty());
+   assert(newRepresentation.size() == field.GetColumnCardinality());
+
+   const std::size_t firstPhysicalIndex = fDescriptorBuilder.GetDescriptor().GetNPhysicalColumns();
+   const std::uint16_t reprIndex = field.GetLogicalColumnIds().size() / field.GetColumnCardinality();
+
+   fDescriptorBuilder.ShiftAliasColumns(newRepresentation.size());
+
+   std::uint16_t columnIndex = 0; // index into the representation
+   for (auto columnType : newRepresentation) {
+      // Extending columns with variable bit width is currently unsupported.
+      const auto [rangeMin, rangeMax] = ROOT::Internal::RColumnElementBase::GetValidBitRange(columnType);
+      R__ASSERT(rangeMin == rangeMax);
+
+      const ROOT::DescriptorId_t firstReprColumnId = field.GetLogicalColumnIds()[columnIndex];
+      const auto &firstReprColumnRange = fOpenColumnRanges.at(firstReprColumnId);
+      const ROOT::DescriptorId_t columnId = firstPhysicalIndex + columnIndex;
+      const std::uint64_t newReprFirstElemIndex = firstReprColumnRange.GetFirstElementIndex();
+
+      RColumnDescriptorBuilder columnBuilder;
+      columnBuilder.LogicalColumnId(columnId)
+         .PhysicalColumnId(columnId)
+         .FieldId(field.GetId())
+         .BitsOnStorage(rangeMax)
+         .Type(columnType)
+         .Index(columnIndex)
+         .FirstElementIndex(newReprFirstElemIndex)
+         .RepresentationIndex(reprIndex);
+      if (newReprFirstElemIndex)
+         columnBuilder.SetSuppressedDeferred();
+      fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
+
+      if (newReprFirstElemIndex != 0) {
+         for (auto parentId = field.GetParentId(); parentId != ROOT::kInvalidDescriptorId;) {
+            const ROOT::RFieldDescriptor &parent = descriptor.GetFieldDescriptor(parentId);
+            if (parent.GetStructure() == ROOT::ENTupleStructure::kCollection ||
+                parent.GetStructure() == ROOT::ENTupleStructure::kVariant) {
+               fDescriptorBuilder.SetFeature(RNTupleDescriptor::kFeatureFlag_NestedDeferredColumns);
+               break;
+            }
+            parentId = parent.GetParentId();
+         }
+      }
+
+      ROOT::RClusterDescriptor::RColumnRange columnRange;
+      columnRange.SetPhysicalColumnId(columnId);
+      columnRange.SetFirstElementIndex(firstReprColumnRange.GetFirstElementIndex());
+      columnRange.SetNElements(0);
+      columnRange.SetCompressionSettings(GetWriteOptions().GetCompression());
+      fOpenColumnRanges.emplace_back(columnRange);
+
+      ROOT::RClusterDescriptor::RPageRange pageRange;
+      pageRange.SetPhysicalColumnId(columnId);
+      fOpenPageRanges.emplace_back(std::move(pageRange));
+
+      fSerializationContext.MapPhysicalColumnId(columnId);
+
+      ++columnIndex;
+   }
+}
+
+void ROOT::Internal::RPagePersistentSink::AddAliasColumn(const ROOT::RNTupleDescriptor &desc,
+                                                         const ROOT::RFieldDescriptor &field,
+                                                         ROOT::DescriptorId_t physicalId)
+{
+   const auto &pointedColumn = desc.GetColumnDescriptor(physicalId);
+   assert(!pointedColumn.IsAliasColumn());
+   assert(field.IsProjectedField());
+
+   const auto columnId = fDescriptorBuilder.GetDescriptor().GetNLogicalColumns();
+   RColumnDescriptorBuilder columnBuilder;
+   columnBuilder.LogicalColumnId(columnId)
+      .PhysicalColumnId(physicalId)
+      .FieldId(field.GetId())
+      .Type(pointedColumn.GetType())
+      .Index(pointedColumn.GetIndex())
+      .BitsOnStorage(pointedColumn.GetBitsOnStorage())
+      .ValueRange(pointedColumn.GetValueRange())
+      .FirstElementIndex(pointedColumn.GetFirstElementIndex())
+      .RepresentationIndex(pointedColumn.GetRepresentationIndex());
+   fDescriptorBuilder.AddColumn(columnBuilder.MakeDescriptor().Unwrap());
+}
+
 void ROOT::Internal::RPagePersistentSink::CommitSuppressedColumn(ColumnHandle_t columnHandle)
 {
    fOpenColumnRanges.at(columnHandle.fPhysicalId).SetIsSuppressed(true);

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -1011,7 +1011,7 @@ TEST(RNTupleMerger, MergeLateModelExtension)
 {
    // Write two test ntuples to be merged, with different models.
    // Use EMergingMode::kUnion so the output ntuple has all the fields of its inputs.
-   FileRaii fileGuard1("test_ntuple_merge_in_1.root");
+   FileRaii fileGuard1("test_ntuple_merge_lmext_in_1.root");
    {
       auto model = RNTupleModel::Create();
       auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo");
@@ -1027,11 +1027,12 @@ TEST(RNTupleMerger, MergeLateModelExtension)
       }
    }
 
-   FileRaii fileGuard2("test_ntuple_merge_in_2.root");
+   FileRaii fileGuard2("test_ntuple_merge_lmext_in_2.root");
    {
       auto model = RNTupleModel::Create();
       auto fieldBaz = model->MakeField<int>("baz");
       auto fieldFoo = model->MakeField<std::unordered_map<std::string, int>>("foo");
+      auto fieldQux = model->MakeField<int>("qux");
       auto fieldVfoo = model->MakeField<std::vector<int>[3]>("vfoo");
       auto wopts = RNTupleWriteOptions();
       wopts.SetCompression(0);
@@ -1041,12 +1042,13 @@ TEST(RNTupleMerger, MergeLateModelExtension)
          fieldFoo->insert(std::make_pair(std::to_string(i), i * 765));
          fieldVfoo[0] = {(int)i * 765};
          fieldVfoo[2] = {(int)i * 987};
+         *fieldQux = i * 777;
          ntuple->Fill();
       }
    }
 
    // Now merge the inputs
-   FileRaii fileGuard3("test_ntuple_merge_out.root");
+   FileRaii fileGuard3("test_ntuple_merge_lmext_out.root");
    {
       // Gather the input sources
       std::vector<std::unique_ptr<RPageSource>> sources;
@@ -1077,6 +1079,7 @@ TEST(RNTupleMerger, MergeLateModelExtension)
       auto vfoo = ntuple->GetModel().GetDefaultEntry().GetPtr<std::vector<int>[3]>("vfoo");
       auto bar = ntuple->GetModel().GetDefaultEntry().GetPtr<int>("bar");
       auto baz = ntuple->GetModel().GetDefaultEntry().GetPtr<int>("baz");
+      auto qux = ntuple->GetModel().GetDefaultEntry().GetPtr<int>("qux");
 
       for (int i = 0; i < 10; ++i) {
          ntuple->LoadEntry(i);
@@ -1086,6 +1089,7 @@ TEST(RNTupleMerger, MergeLateModelExtension)
          ASSERT_TRUE(vfoo[1].empty());
          ASSERT_EQ(*bar, i * 321);
          ASSERT_EQ(*baz, 0);
+         ASSERT_EQ(*qux, 0);
       }
       for (int i = 10; i < 20; ++i) {
          ntuple->LoadEntry(i);
@@ -1095,6 +1099,7 @@ TEST(RNTupleMerger, MergeLateModelExtension)
          ASSERT_TRUE(vfoo[1].empty());
          ASSERT_EQ(*bar, 0);
          ASSERT_EQ(*baz, (i - 10) * 567);
+         ASSERT_EQ(*qux, (i - 10) * 777);
       }
    }
 }
@@ -1182,8 +1187,10 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
    auto model = RNTupleModel::Create();
    auto pFoo = model->MakeField<double>("foo");
    auto clonedModel = model->Clone();
+   auto wopts = RNTupleWriteOptions();
+   wopts.SetCompression(0);
    {
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath(), wopts);
       for (size_t i = 0; i < 10; ++i) {
          *pFoo = i * 123;
          ntuple->Fill();
@@ -1195,12 +1202,12 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
    {
       auto &fieldFooDbl = clonedModel->GetMutableField("foo");
       fieldFooDbl.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
-      auto ntuple = RNTupleWriter::Recreate(std::move(clonedModel), "ntuple", fileGuard2.GetPath());
+      auto ntuple = RNTupleWriter::Recreate(std::move(clonedModel), "ntuple", fileGuard2.GetPath(), wopts);
       auto e = ntuple->CreateEntry();
       auto pFoo2 = e->GetPtr<double>("foo");
       for (size_t i = 0; i < 10; ++i) {
          *pFoo2 = i * 567;
-         ntuple->Fill();
+         ntuple->Fill(*e);
       }
    }
 
@@ -1220,30 +1227,18 @@ TEST(RNTupleMerger, DifferentCompatibleRepresentations)
       auto sourcePtrs2 = sourcePtrs;
 
       {
-         auto wopts = RNTupleWriteOptions();
-         wopts.SetCompression(0);
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), wopts);
          auto opts = RNTupleMergeOptions();
          opts.fCompressionSettings = 0;
          RNTupleMerger merger{std::move(destination)};
          auto res = merger.Merge(sourcePtrs, opts);
-         // TODO(gparolini): we want to support this in the future
-         EXPECT_FALSE(bool(res));
-         if (res.GetError()) {
-            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("different column type"));
-         }
-         // EXPECT_TRUE(bool(res));
+         EXPECT_TRUE(bool(res));
       }
       {
          auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard4.GetPath(), RNTupleWriteOptions());
          RNTupleMerger merger{std::move(destination)};
          auto res = merger.Merge(sourcePtrs);
-         // TODO(gparolini): we want to support this in the future
-         EXPECT_FALSE(bool(res));
-         if (res.GetError()) {
-            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("different column type"));
-         }
-         // EXPECT_TRUE(bool(res));
+         EXPECT_TRUE(bool(res));
       }
    }
 }
@@ -1513,6 +1508,113 @@ TEST(RNTupleMerger, MergeProjectedFieldsMultiple)
    }
 }
 
+TEST(RNTupleMerger, MergeProjectedFieldsDifferentCompression)
+{
+   // Verify that we correctly handle projected fields with different compressions
+   FileRaii fileGuard1("test_ntuple_merge_proj_diff_comp_in_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldInt = model->MakeField<int>("int");
+      auto fieldFlt = model->MakeField<float>("flt");
+      auto projIntProj = std::make_unique<RField<int>>("intProj");
+      model->AddProjectedField(std::move(projIntProj), [](const std::string &) { return "int"; });
+      auto projFltProj = std::make_unique<RField<float>>("fltProj");
+      model->AddProjectedField(std::move(projFltProj), [](const std::string &) { return "flt"; });
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      for (size_t i = 0; i < 10; ++i) {
+         *fieldInt = i * 123;
+         *fieldFlt = i * 456;
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_merge_proj_diff_comp_in_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldInt = model->MakeField<int>("int");
+      auto fieldFlt = model->MakeField<float>("flt");
+      auto projIntProj = std::make_unique<RField<int>>("intProj");
+      model->AddProjectedField(std::move(projIntProj), [](const std::string &) { return "int"; });
+      auto projFltProj = std::make_unique<RField<float>>("fltProj");
+      model->AddProjectedField(std::move(projFltProj), [](const std::string &) { return "flt"; });
+      auto wopts = RNTupleWriteOptions();
+      wopts.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath(), wopts);
+      for (size_t i = 0; i < 10; ++i) {
+         *fieldInt = (i + 10) * 123;
+         *fieldFlt = (i + 10) * 456;
+         ntuple->Fill();
+      }
+   }
+
+   FileRaii fileGuard3("test_ntuple_merge_proj_diff_comp_out.root");
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Now merge the inputs
+      auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard3.GetPath(), RNTupleWriteOptions());
+      RNTupleMerger merger{std::move(destination)};
+      auto res = merger.Merge(sourcePtrs);
+      EXPECT_TRUE(bool(res));
+   }
+   {
+      auto ntuple1 = RNTupleReader::Open("ntuple", fileGuard1.GetPath());
+      auto ntuple2 = RNTupleReader::Open("ntuple", fileGuard2.GetPath());
+      auto ntuple3 = RNTupleReader::Open("ntuple", fileGuard3.GetPath());
+      EXPECT_EQ(ntuple1->GetNEntries() + ntuple2->GetNEntries(), ntuple3->GetNEntries());
+      const auto &desc1 = ntuple1->GetDescriptor();
+      const auto nAliasColumns1 = desc1.GetNLogicalColumns() - desc1.GetNPhysicalColumns();
+      EXPECT_EQ(nAliasColumns1, 2);
+      const auto &desc2 = ntuple2->GetDescriptor();
+      const auto nAliasColumns2 = desc2.GetNLogicalColumns() - desc2.GetNPhysicalColumns();
+      EXPECT_EQ(nAliasColumns2, 2);
+      const auto &desc3 = ntuple3->GetDescriptor();
+      const auto nAliasColumns3 = desc3.GetNLogicalColumns() - desc3.GetNPhysicalColumns();
+      EXPECT_EQ(nAliasColumns3, 4);
+
+      auto int1 = ntuple1->GetModel().GetDefaultEntry().GetPtr<int>("int");
+      auto int2 = ntuple2->GetModel().GetDefaultEntry().GetPtr<int>("int");
+      auto int3 = ntuple3->GetModel().GetDefaultEntry().GetPtr<int>("int");
+      auto intProj1 = ntuple1->GetModel().GetDefaultEntry().GetPtr<int>("intProj");
+      auto intProj2 = ntuple2->GetModel().GetDefaultEntry().GetPtr<int>("intProj");
+      auto intProj3 = ntuple3->GetModel().GetDefaultEntry().GetPtr<int>("intProj");
+
+      auto flt1 = ntuple1->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      auto flt2 = ntuple2->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      auto flt3 = ntuple3->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      auto fltProj1 = ntuple1->GetModel().GetDefaultEntry().GetPtr<float>("fltProj");
+      auto fltProj2 = ntuple2->GetModel().GetDefaultEntry().GetPtr<float>("fltProj");
+      auto fltProj3 = ntuple3->GetModel().GetDefaultEntry().GetPtr<float>("fltProj");
+
+      for (auto i = 0u; i < ntuple1->GetNEntries(); ++i) {
+         ntuple1->LoadEntry(i);
+         ntuple3->LoadEntry(i);
+         EXPECT_EQ(*int1, *int3);
+         EXPECT_EQ(*intProj1, *intProj3);
+         EXPECT_FLOAT_EQ(*flt1, *flt3);
+         EXPECT_FLOAT_EQ(*fltProj1, *fltProj3);
+         EXPECT_FLOAT_EQ(*fltProj1, *flt1);
+         EXPECT_FLOAT_EQ(*fltProj3, *flt3);
+      }
+      for (auto i = 0u; i < ntuple2->GetNEntries(); ++i) {
+         ntuple2->LoadEntry(i);
+         ntuple3->LoadEntry(ntuple1->GetNEntries() + i);
+         EXPECT_EQ(*int2, *int3);
+         EXPECT_EQ(*intProj2, *intProj3);
+         EXPECT_FLOAT_EQ(*flt2, *flt3);
+         EXPECT_FLOAT_EQ(*fltProj2, *fltProj3);
+         EXPECT_FLOAT_EQ(*fltProj2, *flt2);
+         EXPECT_FLOAT_EQ(*fltProj3, *flt3);
+      }
+   }
+}
+
 TEST(RNTupleMerger, MergeProjectedFieldsOnlyFirst)
 {
    // Merge two files where the first has a projection and the second doesn't, and verify that we can
@@ -1533,7 +1635,9 @@ TEST(RNTupleMerger, MergeProjectedFieldsOnlyFirst)
    {
       auto model = RNTupleModel::Create();
       auto fieldFoo = model->MakeField<int>("foo");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto wopts = RNTupleWriteOptions();
+      wopts.SetCompression(0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath(), wopts);
       for (size_t i = 0; i < 10; ++i) {
          *fieldFoo = i * 123;
          ntuple->Fill();
@@ -1567,16 +1671,18 @@ TEST(RNTupleMerger, MergeProjectedFieldsOnlyFirst)
          auto ntuple1 = RNTupleReader::Open("ntuple", fileGuard1.GetPath());
          auto ntuple2 = RNTupleReader::Open("ntuple", fileGuard2.GetPath());
          auto ntuple3 = RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
-         ASSERT_EQ(ntuple1->GetNEntries() + ntuple2->GetNEntries(), ntuple3->GetNEntries());
+         EXPECT_EQ(ntuple1->GetNEntries() + ntuple2->GetNEntries(), ntuple3->GetNEntries());
          const auto &desc1 = ntuple1->GetDescriptor();
          const auto &desc2 = ntuple2->GetDescriptor();
          const auto &desc3 = ntuple3->GetDescriptor();
          const auto nAliasColumns1 = desc1.GetNLogicalColumns() - desc1.GetNPhysicalColumns();
          const auto nAliasColumns2 = desc2.GetNLogicalColumns() - desc2.GetNPhysicalColumns();
          const auto nAliasColumns3 = desc3.GetNLogicalColumns() - desc3.GetNPhysicalColumns();
-         ASSERT_EQ(nAliasColumns1, 1);
-         ASSERT_EQ(nAliasColumns2, 0);
-         ASSERT_EQ(nAliasColumns3, 1);
+         EXPECT_EQ(nAliasColumns1, 1);
+         EXPECT_EQ(nAliasColumns2, 0);
+         // The output RNTuple has 2 alias columns because one was created by the merger to point to the extended
+         // column that was added to field "foo" (since source 2 had a different encoding than source 1).
+         EXPECT_EQ(nAliasColumns3, 2);
 
          auto foo1 = ntuple1->GetModel().GetDefaultEntry().GetPtr<int>("foo");
          auto foo2 = ntuple2->GetModel().GetDefaultEntry().GetPtr<int>("foo");
@@ -1588,16 +1694,16 @@ TEST(RNTupleMerger, MergeProjectedFieldsOnlyFirst)
          for (auto i = 0u; i < ntuple1->GetNEntries(); ++i) {
             ntuple1->LoadEntry(i);
             ntuple3->LoadEntry(i);
-            ASSERT_EQ(*foo1, *foo3);
-            ASSERT_EQ(*bar1, *foo3);
-            ASSERT_EQ(*bar1, *bar3);
+            EXPECT_EQ(*foo1, *foo3);
+            EXPECT_EQ(*bar1, *foo3);
+            EXPECT_EQ(*bar1, *bar3);
          }
          for (auto i = 0u; i < ntuple2->GetNEntries(); ++i) {
             ntuple2->LoadEntry(i);
             ntuple3->LoadEntry(ntuple1->GetNEntries() + i);
-            ASSERT_EQ(*foo2, *foo3);
+            EXPECT_EQ(*foo2, *foo3);
             // we should be able to read the data from the second ntuple using the projection defined in the first.
-            ASSERT_EQ(*foo2, *bar3);
+            EXPECT_EQ(*foo2, *bar3);
          }
       }
    }
@@ -2540,7 +2646,8 @@ TEST(RNTupleMerger, MergeDeferredAdvanced)
       auto model1 = RNTupleModel::Create();
       auto wopts = RNTupleWriteOptions();
       wopts.SetCompression(0);
-      auto writer1 = RNTupleWriter::Recreate(std::move(model1), "ntuple", fileGuard1.GetPath(), wopts);
+      auto tfile = TFile::Open(fileGuard1.GetPath().c_str(), "RECREATE");
+      auto writer1 = RNTupleWriter::Append(std::move(model1), "ntuple", *tfile, wopts);
       auto updater = writer1->CreateModelUpdater();
       updater->BeginUpdate();
       updater->AddField(RFieldBase::Create("flt", "float").Unwrap());
@@ -2613,7 +2720,7 @@ TEST(RNTupleMerger, MergeDeferredAdvanced)
 
    auto pInt = reader->GetModel().GetDefaultEntry().GetPtr<int>("int");
    auto pFlt = reader->GetModel().GetDefaultEntry().GetPtr<float>("flt");
-   for (auto i = 0u; i < reader->GetNEntries(); ++i) {
+   for (auto i : reader->GetEntryRange()) {
       reader->LoadEntry(i);
       float expectedFlt = (i >= 10 && i < 15) ? 0 : i;
       EXPECT_FLOAT_EQ(*pFlt, expectedFlt);

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -2729,6 +2729,93 @@ TEST(RNTupleMerger, MergeDeferredAdvanced)
    }
 }
 
+TEST(RNTupleMerger, MergeDeferredAdvanced2)
+{
+   // Like MergeDeferredAdvanced, but make sure the fields have different column types so that the merging produces
+   // a late-extended column.
+   FileRaii fileGuard1("test_ntuple_merge_deferred_adv2_in_1.root");
+   FileRaii fileGuard2("test_ntuple_merge_deferred_adv2_in_2.root");
+
+   // First RNTuple with late model extended field "flt" (column is not deferred because it's still entry 0)
+   {
+      auto model1 = RNTupleModel::Create();
+      auto wopts = RNTupleWriteOptions();
+      wopts.SetCompression(0);
+      auto tfile = TFile::Open(fileGuard1.GetPath().c_str(), "RECREATE");
+      auto writer1 = RNTupleWriter::Append(std::move(model1), "ntuple", *tfile, wopts);
+      auto updater = writer1->CreateModelUpdater();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetHalfPrecision();
+      updater->BeginUpdate();
+      updater->AddField(std::move(field));
+      updater->CommitUpdate();
+      auto pFlt1 = writer1->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *pFlt1 = i;
+         writer1->Fill();
+      }
+   }
+
+   // Second RNTuple with late model extended field "flt"
+   {
+      auto model2 = RNTupleModel::Create();
+      // Add a non-late model extended field so we can write some entries before we extend the model and obtain
+      // actual deferred columns in the extension header.
+      auto pInt = model2->MakeField<int>("int");
+      auto wopts = RNTupleWriteOptions();
+      wopts.SetCompression(0);
+      auto writer2 = RNTupleWriter::Recreate(std::move(model2), "ntuple", fileGuard2.GetPath(), wopts);
+      for (int i = 0; i < 5; ++i) {
+         *pInt = 10 + i;
+         writer2->Fill();
+      }
+      auto updater = writer2->CreateModelUpdater();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
+      updater->BeginUpdate();
+      updater->AddField(std::move(field));
+      updater->CommitUpdate();
+      auto pFlt2 = writer2->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 5; i < 10; ++i) {
+         *pInt = 10 + i;
+         *pFlt2 = 10 + i;
+         writer2->Fill();
+      }
+   }
+
+   // Now merge them
+   std::vector<std::unique_ptr<RPageSource>> sources;
+   sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+   sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+   std::vector<RPageSource *> sourcePtrs;
+   for (const auto &s : sources) {
+      sourcePtrs.push_back(s.get());
+   }
+
+   FileRaii fileGuardOut("test_ntuple_merge_deferred_adv2_out.root");
+   auto wopts = RNTupleWriteOptions();
+   wopts.SetCompression(0);
+   auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), wopts);
+   RNTupleMerger merger{std::move(destination)};
+   auto opts = RNTupleMergeOptions();
+   opts.fMergingMode = ENTupleMergingMode::kUnion;
+   auto res = merger.Merge(sourcePtrs, opts);
+   ASSERT_TRUE(bool(res));
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+   EXPECT_EQ(reader->GetNEntries(), 20);
+
+   auto pInt = reader->GetModel().GetDefaultEntry().GetPtr<int>("int");
+   auto pFlt = reader->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+   for (auto i : reader->GetEntryRange()) {
+      reader->LoadEntry(i);
+      float expectedFlt = (i >= 10 && i < 15) ? 0 : i;
+      EXPECT_FLOAT_EQ(*pFlt, expectedFlt);
+      int expectedInt = (i >= 10 && i < 20) * i;
+      EXPECT_EQ(*pInt, expectedInt);
+   }
+}
+
 TEST(RNTupleMerger, MergeIncrementalLMExt)
 {
    // Create the input files:

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -4275,10 +4275,17 @@ TEST(RNTupleMerger, MergeReal32Trunc)
             RNTupleMergeOptions opts;
             opts.fMergingMode = mmode;
             auto res = merger.Merge(sourcePtrs, opts);
-            // Currently we're not supporting merging columns with the same type but different metadata.
-            // TODO: support this.
-            EXPECT_FALSE(bool(res));
-            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("have different column metadata"));
+            EXPECT_TRUE(bool(res));
+         }
+         {
+            auto reader = ROOT::RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+            EXPECT_EQ(reader->GetNEntries(), 20);
+            EXPECT_EQ(reader->GetDescriptor().GetNPhysicalColumns(), 2);
+            auto pFlt = reader->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+            for (auto i : reader->GetEntryRange()) {
+               reader->LoadEntry(i);
+               EXPECT_NEAR(*pFlt, i, 0.01f);
+            }
          }
       }
    }
@@ -4333,10 +4340,17 @@ TEST(RNTupleMerger, MergeReal32Quant)
             RNTupleMergeOptions opts;
             opts.fMergingMode = mmode;
             auto res = merger.Merge(sourcePtrs, opts);
-            // Currently we're not supporting merging columns with the same type but different metadata.
-            // TODO: support this.
-            ASSERT_FALSE(bool(res));
-            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("have different column metadata"));
+            EXPECT_TRUE(bool(res));
+         }
+         {
+            auto reader = ROOT::RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+            EXPECT_EQ(reader->GetNEntries(), 20);
+            EXPECT_EQ(reader->GetDescriptor().GetNPhysicalColumns(), 2);
+            auto pFlt = reader->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+            for (auto i : reader->GetEntryRange()) {
+               reader->LoadEntry(i);
+               EXPECT_NEAR(*pFlt, i, 0.01f);
+            }
          }
       }
    }
@@ -4401,6 +4415,71 @@ TEST(RNTupleMerger, MergeReal32TruncQuantMixed)
             for (auto i : reader->GetEntryRange()) {
                reader->LoadEntry(i);
                EXPECT_NEAR(*pFlt, i, 0.01f);
+            }
+         }
+      }
+   }
+}
+
+TEST(RNTupleMerger, MergeRealRegularQuantMixed)
+{
+   // Merge two files, both containing the same field, but with the first being a SplitReal64 and the second Real32Quant
+   FileRaii fileGuard1("test_ntuple_merge_realregquant_in_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldDbl = model->MakeField<double>("dbl");
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      for (int i = 0; i < 10; ++i) {
+         *fieldDbl = i;
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_merge_realregquant_in_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<double>>("dbl");
+      field->SetQuantized(29, {0., 20.});
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto fieldDbl = ntuple->GetModel().GetDefaultEntry().GetPtr<double>("dbl");
+      for (int i = 0; i < 10; ++i) {
+         *fieldDbl = 10 + i;
+         ntuple->Fill();
+      }
+   }
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Now merge the inputs
+      for (const auto mmode : {ENTupleMergingMode::kFilter, ENTupleMergingMode::kStrict, ENTupleMergingMode::kUnion}) {
+         SCOPED_TRACE(std::string("with merging mode = ") + ToString(mmode));
+         FileRaii fileGuardOut("test_ntuple_merge_realregquant_out.root");
+         {
+            auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
+            RNTupleMerger merger{std::move(destination)};
+            RNTupleMergeOptions opts;
+            opts.fMergingMode = mmode;
+            auto res = merger.Merge(sourcePtrs, opts);
+            EXPECT_TRUE(bool(res));
+         }
+         {
+            auto reader = ROOT::RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+            EXPECT_EQ(reader->GetNEntries(), 20);
+            EXPECT_EQ(reader->GetDescriptor().GetNPhysicalColumns(), 2);
+            auto pDbl = reader->GetModel().GetDefaultEntry().GetPtr<double>("dbl");
+            for (auto i : reader->GetEntryRange()) {
+               reader->LoadEntry(i);
+               if (i < 10)
+                  EXPECT_DOUBLE_EQ(*pDbl, i);
+               else
+                  EXPECT_NEAR(*pDbl, i, 0.01f);
             }
          }
       }

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -1247,10 +1247,11 @@ TEST(RNTupleMerger, MultipleRepresentations)
 {
    // verify that we properly handle ntuples with multiple column representations
    FileRaii fileGuard1("test_ntuple_merge_multirep_in_1.root");
+   FileRaii fileGuard2("test_ntuple_merge_multirep_in_2.root");
 
    {
       auto model = RNTupleModel::Create();
-      auto fldPx = RFieldBase::Create("px", "float").Unwrap();
+      auto fldPx = std::make_unique<RField<float>>("px");
       fldPx->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}, {ROOT::ENTupleColumnType::kReal16}});
       model->AddField(std::move(fldPx));
       auto ptrPx = model->GetDefaultEntry().GetPtr<float>("px");
@@ -1263,14 +1264,29 @@ TEST(RNTupleMerger, MultipleRepresentations)
       *ptrPx = 2.0;
       writer->Fill();
    }
+   {
+      auto model = RNTupleModel::Create();
+      auto fldPx = std::make_unique<RField<float>>("px");
+      fldPx->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kSplitReal32}, {ROOT::ENTupleColumnType::kReal32}});
+      model->AddField(std::move(fldPx));
+      auto ptrPx = model->GetDefaultEntry().GetPtr<float>("px");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      *ptrPx = 1.0;
+      writer->Fill();
+      writer->CommitCluster();
+      ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(
+         const_cast<RFieldBase &>(writer->GetModel().GetConstField("px")), 1);
+      *ptrPx = 2.0;
+      writer->Fill();
+   }
 
    // Now merge the inputs
-   FileRaii fileGuard2("test_ntuple_merge_multirep_out.root");
+   FileRaii fileGuardOut("test_ntuple_merge_multirep_out.root");
    {
       // Gather the input sources
       std::vector<std::unique_ptr<RPageSource>> sources;
       sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath()));
-      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath()));
       std::vector<RPageSource *> sourcePtrs;
       for (const auto &s : sources) {
          sourcePtrs.push_back(s.get());
@@ -1279,19 +1295,95 @@ TEST(RNTupleMerger, MultipleRepresentations)
       auto sourcePtrs2 = sourcePtrs;
 
       {
-         auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuard2.GetPath(), RNTupleWriteOptions());
+         auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
          auto opts = RNTupleMergeOptions();
-         opts.fCompressionSettings = 0;
          RNTupleMerger merger{std::move(destination)};
          auto res = merger.Merge(sourcePtrs, opts);
-         // TODO(gparolini): we want to support this in the future
-         // XXX: this currently fails because of a mismatch in the number of columns of dst vs src.
-         // Is this correct? Anyway the situation will likely change once we properly support different representation
-         // indices...
-         EXPECT_FALSE(bool(res));
-         // EXPECT_TRUE(bool(res));
+         EXPECT_TRUE(bool(res));
       }
    }
+}
+
+TEST(RNTupleMerger, MultipleRepresentations2)
+{
+   // Like MultipleRepresentations but using fields with increased cardinality
+   FileRaii fileGuard1("test_ntuple_merge_multirep2_in_1.root");
+   FileRaii fileGuard2("test_ntuple_merge_multirep2_in_2.root");
+
+   using Tuple_t = std::tuple<std::int32_t, std::int64_t, std::int8_t>;
+   {
+      auto model = RNTupleModel::Create();
+      auto fldStr = std::make_unique<RField<std::string>>("str");
+      auto fldTuple = std::make_unique<RField<Tuple_t>>("tuple");
+      fldStr->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kIndex64, ROOT::ENTupleColumnType::kChar}});
+      model->AddField(std::move(fldStr));
+      model->AddField(std::move(fldTuple));
+      auto ptrStr = model->GetDefaultEntry().GetPtr<std::string>("str");
+      auto ptrTuple = model->GetDefaultEntry().GetPtr<Tuple_t>("tuple");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      *ptrStr = "1";
+      *ptrTuple = {32, 64, 8};
+      writer->Fill();
+      writer->CommitCluster();
+      *ptrStr = "2";
+      *ptrTuple = {64, 128, 16};
+      writer->Fill();
+   }
+   {
+      auto model = RNTupleModel::Create();
+      auto fldStr = std::make_unique<RField<std::string>>("str");
+      auto fldTuple = std::make_unique<RField<Tuple_t>>("tuple");
+      fldStr->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kSplitIndex64, ROOT::ENTupleColumnType::kChar}});
+      model->AddField(std::move(fldStr));
+      model->AddField(std::move(fldTuple));
+      auto ptrStr = model->GetDefaultEntry().GetPtr<std::string>("str");
+      auto ptrTuple = model->GetDefaultEntry().GetPtr<Tuple_t>("tuple");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      *ptrStr = "3";
+      *ptrTuple = {96, 192, 24};
+      writer->Fill();
+      writer->CommitCluster();
+      *ptrStr = "4";
+      *ptrTuple = {128, 256, 32};
+      writer->Fill();
+   }
+
+   // Now merge the inputs
+   FileRaii fileGuardOut("test_ntuple_merge_multirep2_out.root");
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      auto sourcePtrs2 = sourcePtrs;
+
+      {
+         auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
+         auto opts = RNTupleMergeOptions();
+         RNTupleMerger merger{std::move(destination)};
+         auto res = merger.Merge(sourcePtrs, opts);
+         EXPECT_TRUE(bool(res));
+      }
+   }
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+   EXPECT_EQ(reader->GetNEntries(), 4);
+   auto viewStr = reader->GetView<std::string>("str");
+   auto viewTuple = reader->GetView<Tuple_t>("tuple");
+   EXPECT_EQ(viewStr(0), "1");
+   EXPECT_EQ(viewStr(1), "2");
+   EXPECT_EQ(viewStr(2), "3");
+   EXPECT_EQ(viewStr(3), "4");
+   auto t = [](auto a, auto b, auto c) { return std::make_tuple(a, b, c); };
+   EXPECT_EQ(viewTuple(0), t(32, 64, 8));
+   EXPECT_EQ(viewTuple(1), t(64, 128, 16));
+   EXPECT_EQ(viewTuple(2), t(96, 192, 24));
+   EXPECT_EQ(viewTuple(3), t(128, 256, 32));
 }
 
 TEST(RNTupleMerger, Double32)
@@ -2771,7 +2863,7 @@ TEST(RNTupleMerger, MergeDeferredAdvanced2)
       }
       auto updater = writer2->CreateModelUpdater();
       auto field = std::make_unique<RField<float>>("flt");
-      field->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
+      field->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}, {ROOT::ENTupleColumnType::kSplitReal32}});
       updater->BeginUpdate();
       updater->AddField(std::move(field));
       updater->CommitUpdate();
@@ -2780,6 +2872,11 @@ TEST(RNTupleMerger, MergeDeferredAdvanced2)
          *pInt = 10 + i;
          *pFlt2 = 10 + i;
          writer2->Fill();
+         if (i == 7) {
+            writer2->CommitCluster();
+            auto &fld = const_cast<ROOT::RFieldBase &>(writer2->GetModel().GetConstField("flt"));
+            ROOT::Internal::RFieldRepresentationModifier::SetPrimaryColumnRepresentation(fld, 1);
+         }
       }
    }
 

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -4225,3 +4225,184 @@ TEST(RNTupleMerger, MergeNewerVersion)
       }
    }
 }
+
+TEST(RNTupleMerger, MergeReal32Trunc)
+{
+   // Merge two files, both containing the same Real32Trunc-encoded field, but with different bit widths.
+   FileRaii fileGuard1("test_ntuple_merge_real32trunc_in_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetTruncated(14);
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = i;
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_merge_real32trunc_in_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetTruncated(24);
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = 10 + i;
+         ntuple->Fill();
+      }
+   }
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Now merge the inputs
+      for (const auto mmode : {ENTupleMergingMode::kFilter, ENTupleMergingMode::kStrict, ENTupleMergingMode::kUnion}) {
+         SCOPED_TRACE(std::string("with merging mode = ") + ToString(mmode));
+         FileRaii fileGuardOut("test_ntuple_merge_real32trunc_out.root");
+         {
+            auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
+            RNTupleMerger merger{std::move(destination)};
+            RNTupleMergeOptions opts;
+            opts.fMergingMode = mmode;
+            auto res = merger.Merge(sourcePtrs, opts);
+            // Currently we're not supporting merging columns with the same type but different metadata.
+            // TODO: support this.
+            EXPECT_FALSE(bool(res));
+            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("have different column metadata"));
+         }
+      }
+   }
+}
+
+TEST(RNTupleMerger, MergeReal32Quant)
+{
+   // Merge two files, both containing the same Real32Quant-encoded field, but with different value ranges.
+   FileRaii fileGuard1("test_ntuple_merge_real32quant_in_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetQuantized(20, {0., 100.});
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = i;
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_merge_real32quant_in_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetQuantized(20, {-100., 100.});
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = 10 + i;
+         ntuple->Fill();
+      }
+   }
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Now merge the inputs
+      for (const auto mmode : {ENTupleMergingMode::kFilter, ENTupleMergingMode::kStrict, ENTupleMergingMode::kUnion}) {
+         SCOPED_TRACE(std::string("with merging mode = ") + ToString(mmode));
+         FileRaii fileGuardOut("test_ntuple_merge_real32quant_out.root");
+         {
+            auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
+            RNTupleMerger merger{std::move(destination)};
+            RNTupleMergeOptions opts;
+            opts.fMergingMode = mmode;
+            auto res = merger.Merge(sourcePtrs, opts);
+            // Currently we're not supporting merging columns with the same type but different metadata.
+            // TODO: support this.
+            ASSERT_FALSE(bool(res));
+            EXPECT_THAT(res.GetError()->GetReport(), testing::HasSubstr("have different column metadata"));
+         }
+      }
+   }
+}
+
+TEST(RNTupleMerger, MergeReal32TruncQuantMixed)
+{
+   // Merge two files, both containing the same field, but with the first being Real32Trunc and the second Real32Quant
+   FileRaii fileGuard1("test_ntuple_merge_real32truncquant_in_1.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetTruncated(24);
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = i;
+         ntuple->Fill();
+      }
+   }
+   FileRaii fileGuard2("test_ntuple_merge_real32truncquant_in_2.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto field = std::make_unique<RField<float>>("flt");
+      field->SetQuantized(20, {-1., 100.});
+      model->AddField(std::move(field));
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+      auto fieldFlt = ntuple->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+      for (int i = 0; i < 10; ++i) {
+         *fieldFlt = 10 + i;
+         ntuple->Fill();
+      }
+   }
+   {
+      // Gather the input sources
+      std::vector<std::unique_ptr<RPageSource>> sources;
+      sources.push_back(RPageSource::Create("ntuple", fileGuard1.GetPath(), RNTupleReadOptions()));
+      sources.push_back(RPageSource::Create("ntuple", fileGuard2.GetPath(), RNTupleReadOptions()));
+      std::vector<RPageSource *> sourcePtrs;
+      for (const auto &s : sources) {
+         sourcePtrs.push_back(s.get());
+      }
+
+      // Now merge the inputs
+      for (const auto mmode : {ENTupleMergingMode::kFilter, ENTupleMergingMode::kStrict, ENTupleMergingMode::kUnion}) {
+         SCOPED_TRACE(std::string("with merging mode = ") + ToString(mmode));
+         FileRaii fileGuardOut("test_ntuple_merge_real32truncquant_out.root");
+         {
+            auto destination = std::make_unique<RPageSinkFile>("ntuple", fileGuardOut.GetPath(), RNTupleWriteOptions());
+            RNTupleMerger merger{std::move(destination)};
+            RNTupleMergeOptions opts;
+            opts.fMergingMode = mmode;
+            auto res = merger.Merge(sourcePtrs, opts);
+            EXPECT_TRUE(bool(res));
+         }
+         {
+            auto reader = ROOT::RNTupleReader::Open("ntuple", fileGuardOut.GetPath());
+            EXPECT_EQ(reader->GetNEntries(), 20);
+            EXPECT_EQ(reader->GetDescriptor().GetNPhysicalColumns(), 2);
+            auto pFlt = reader->GetModel().GetDefaultEntry().GetPtr<float>("flt");
+            for (auto i : reader->GetEntryRange()) {
+               reader->LoadEntry(i);
+               EXPECT_NEAR(*pFlt, i, 0.01f);
+            }
+         }
+      }
+   }
+}

--- a/tree/ntuple/test/ntuple_minifile.cxx
+++ b/tree/ntuple/test/ntuple_minifile.cxx
@@ -16,8 +16,8 @@ namespace {
 // NOTE: these should be in sync with the version in RNTuple.hxx and are duplicated here
 // as a double check that we increment the version correctly.
 constexpr auto kVersionEpoch = 1;
-constexpr auto kVersionMajor = 0;
-constexpr auto kVersionMinor = 2;
+constexpr auto kVersionMajor = 1;
+constexpr auto kVersionMinor = 0;
 constexpr auto kVersionPatch = 0;
 
 bool IsEqual(const ROOT::RNTuple &a, const ROOT::RNTuple &b)

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1274,3 +1274,30 @@ TEST(RPageSink, AddColumnRepresentation)
    EXPECT_EQ(col1.GetType(), ROOT::ENTupleColumnType::kInt32);
    EXPECT_EQ(col2.GetType(), ROOT::ENTupleColumnType::kSplitInt32);
 }
+
+TEST(RPageSink, AddColumnRepresentationWithData)
+{
+   FileRaii fileGuard("test_ntuple_page_sink_add_colrep_data.root");
+
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto sink = std::make_unique<RPageSinkFile>("ntuple", *file, RNTupleWriteOptions());
+   auto model = RNTupleModel::Create();
+   auto fInt = std::make_unique<RField<int>>("int");
+   fInt->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
+   model->AddField(std::move(fInt));
+   sink->Init(*model);
+
+   const auto fId = sink->GetDescriptor().FindFieldId("int");
+   const auto &desc = sink->GetDescriptor();
+   const auto &fdesc = desc.GetFieldDescriptor(fId);
+   std::vector<ROOT::Internal::RColumnFormat> newRepr{{ROOT::ENTupleColumnType::kSplitInt32}};
+   sink->AddColumnRepresentation(fdesc, newRepr, 0);
+
+   EXPECT_EQ(fdesc.GetColumnCardinality(), 1);
+   EXPECT_EQ(fdesc.GetLogicalColumnIds().size(), 2);
+
+   const auto &col1 = desc.GetColumnDescriptor(0);
+   const auto &col2 = desc.GetColumnDescriptor(1);
+   EXPECT_EQ(col1.GetType(), ROOT::ENTupleColumnType::kInt32);
+   EXPECT_EQ(col2.GetType(), ROOT::ENTupleColumnType::kSplitInt32);
+}

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1247,3 +1247,29 @@ TEST(RPageSinkFile, CloneAsHidden)
    EXPECT_TRUE(found[0]);
    EXPECT_TRUE(found[1]);
 }
+
+TEST(RPageSink, AddColumnRepresentation)
+{
+   FileRaii fileGuard("test_ntuple_page_sink_add_colrep.root");
+
+   auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+   auto sink = std::make_unique<RPageSinkFile>("ntuple", *file, RNTupleWriteOptions());
+   auto model = RNTupleModel::Create();
+   auto fInt = std::make_unique<RField<int>>("int");
+   fInt->SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
+   model->AddField(std::move(fInt));
+   sink->Init(*model);
+
+   const auto fId = sink->GetDescriptor().FindFieldId("int");
+   const auto &desc = sink->GetDescriptor();
+   const auto &fdesc = desc.GetFieldDescriptor(fId);
+   sink->AddColumnRepresentation(fdesc, {ROOT::ENTupleColumnType::kSplitInt32});
+
+   EXPECT_EQ(fdesc.GetColumnCardinality(), 1);
+   EXPECT_EQ(fdesc.GetLogicalColumnIds().size(), 2);
+
+   const auto &col1 = desc.GetColumnDescriptor(0);
+   const auto &col2 = desc.GetColumnDescriptor(1);
+   EXPECT_EQ(col1.GetType(), ROOT::ENTupleColumnType::kInt32);
+   EXPECT_EQ(col2.GetType(), ROOT::ENTupleColumnType::kSplitInt32);
+}

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1263,7 +1263,8 @@ TEST(RPageSink, AddColumnRepresentation)
    const auto fId = sink->GetDescriptor().FindFieldId("int");
    const auto &desc = sink->GetDescriptor();
    const auto &fdesc = desc.GetFieldDescriptor(fId);
-   sink->AddColumnRepresentation(fdesc, {ROOT::ENTupleColumnType::kSplitInt32});
+   std::vector<ROOT::Internal::RColumnFormat> newRepr{{ROOT::ENTupleColumnType::kSplitInt32}};
+   sink->AddColumnRepresentation(fdesc, newRepr);
 
    EXPECT_EQ(fdesc.GetColumnCardinality(), 1);
    EXPECT_EQ(fdesc.GetLogicalColumnIds().size(), 2);

--- a/tree/ntuple/test/ntuple_storage.cxx
+++ b/tree/ntuple/test/ntuple_storage.cxx
@@ -1264,7 +1264,7 @@ TEST(RPageSink, AddColumnRepresentation)
    const auto &desc = sink->GetDescriptor();
    const auto &fdesc = desc.GetFieldDescriptor(fId);
    std::vector<ROOT::Internal::RColumnFormat> newRepr{{ROOT::ENTupleColumnType::kSplitInt32}};
-   sink->AddColumnRepresentation(fdesc, newRepr);
+   sink->AddColumnRepresentation(fdesc, newRepr, 0);
 
    EXPECT_EQ(fdesc.GetColumnCardinality(), 1);
    EXPECT_EQ(fdesc.GetLogicalColumnIds().size(), 2);


### PR DESCRIPTION
# This Pull request:
Significantly reworks the innards of the RNTupleMerger to support fast merging of fields with different but compatible column representations.
Basically it does two things:
* turns all [L3 merging](https://github.com/root-project/root/blob/master/tree/ntuple/doc/Merging.md#glossary) cases into L2/L1.
* no longer rejects merging fields with different column representations (previously this was only supported for representations that were the split/unsplit version of each other, and only via L3 merging).

A potentially negative consequence that we might want to revisit is that now the merger won't ever adapt the columns' splitness to the output compression (e.g. if merging changes the source compression from 0 to 505 it will still encode the columns as unsplit, and vice-versa). This will probably be readded in a future PR.

In order to achieve this, some new internal functionality had to be added, most notably `RPagePersistentSink::AddColumnRepresentation`.

Note that this PR is independent on #21740, which in fact might not be needed at all.

## IMPORTANT
This PR introduces our first feature flag and thus the first bump to the specs' major version (1.1.0.0). This means we can now start producing RNTuples which cannot be read by older ROOT versions.

## TODO
* [x] check if we need a feature flag for the changes in `AddExtendedColumnRanges`
* [x] add a test for merging of Real32Trunc/Quant columns with different bit width/value range
* [x] properly split the big merger commit
* [x] update Merging.md

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

