### PR TITLE
Backport graphics fixes to 6.40

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -2231,8 +2231,6 @@ Bool_t TASImage::InitVisual()
    if (fgVisual && (noX == fgBatch))
       return kTRUE;
 
-   if (fgVisual)
-      destroy_asvisual(fgVisual, kFALSE);
    fgVisual = nullptr;
    fgBatch = false;
 
@@ -2244,16 +2242,27 @@ Bool_t TASImage::InitVisual()
    Visual *vis   = (Visual*) gVirtualX->GetVisual();
    Colormap cmap = (Colormap) gVirtualX->GetColormap();
 
-   if (vis && cmap)
-      fgVisual = create_asvisual_for_id(disp, screen, depth,
+   static ASVisual *vis_x = nullptr;
+
+   if (vis && cmap && !noX) {
+      if (!vis_x)
+         vis_x = create_asvisual_for_id(disp, screen, depth,
                                         XVisualIDFromVisual(vis), cmap, nullptr);
+      fgVisual = vis_x;
+   }
 #endif
 #endif
 
+   static ASVisual *vis_batch = nullptr;
+
    if (!fgVisual) {
-      // create dummy fgVisual for batch mode
-      fgVisual = create_asvisual(nullptr, 0, 0, nullptr);
-      fgVisual->dpy = nullptr; // fake (not used)
+      if (!vis_batch) {
+         // create dummy visual for batch mode
+         vis_batch = create_asvisual(nullptr, 0, 0, nullptr);
+         vis_batch->dpy = nullptr; // fake (not used)
+      }
+
+      fgVisual = vis_batch;
       fgBatch = true;
    }
 

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -6749,5 +6749,5 @@ Bool_t TASImage::SetJpegDpi(const char *name, UInt_t set)
 Int_t TASImage::Idx(Int_t idx)
 {
    // The size of arrays like fImage->alt.argb32 is fImage->width*fImage->height
-   return TMath::Min(idx,(Int_t)(fImage->width*fImage->height));
+   return TMath::Max(0, TMath::Min(idx,(Int_t)(fImage->width*fImage->height)));
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3626,8 +3626,10 @@ void TPad::Paint(Option_t * /*option*/)
          lnk = lnk->Next();
       }
 
-      if (fCanvas && (fCanvas->fHilightPadBorder == this))
-         PaintBorder(-GetHighLightColor(), kTRUE);
+      if (fCanvas && (fCanvas->fHilightPadBorder == this)) {
+         auto col = GetHighLightColor();
+         if (col > 0) PaintBorder(-col, kTRUE);
+      }
    }
 
    fPadPaint = 0;


### PR DESCRIPTION
1. Paint highlight `TPad` border only if highlight color is positive.
2. Create two ASVisual objects in `TASImage` to avoid multiple recreation
3. Fix crash in TASImage when negative coordinates provided