### PR TITLE
[fitpanel test] switch to testing with `xvfb`, disable TestTree1D only in batch

### DIFF
--- a/gui/fitpanel/test/CMakeLists.txt
+++ b/gui/fitpanel/test/CMakeLists.txt
@@ -8,4 +8,3 @@
 
 ROOT_EXECUTABLE(fitPanelUnitTesting UnitTesting.cxx LIBRARIES FitPanel Gui Tree Hist MathCore)
 ROOT_ADD_TEST(test-fitpanel-UnitTesting COMMAND fitPanelUnitTesting -b FAILREGEX "FAILED|Error in")
-target_include_directories(fitPanelUnitTesting PRIVATE ../src/)

--- a/gui/fitpanel/test/CMakeLists.txt
+++ b/gui/fitpanel/test/CMakeLists.txt
@@ -7,4 +7,15 @@
 # @author Danilo Piparo CERN
 
 ROOT_EXECUTABLE(fitPanelUnitTesting UnitTesting.cxx LIBRARIES FitPanel Gui Tree Hist MathCore)
-ROOT_ADD_TEST(test-fitpanel-UnitTesting COMMAND fitPanelUnitTesting -b FAILREGEX "FAILED|Error in")
+
+# batch usage is instable - need more investigations
+#ROOT_ADD_TEST(test-fitpanel-UnitTesting-batch COMMAND fitPanelUnitTesting -b FAILREGEX "FAILED|Error in")
+
+find_program(XVFB_RUN_EXECUTABLE NAMES xvfb-run)
+
+if(XVFB_RUN_EXECUTABLE)
+   ROOT_ADD_TEST(test-fitpanel-UnitTesting-xvfb
+                 COMMAND ${XVFB_RUN_EXECUTABLE} --auto-servernum --server-args="-screen 0 1024x768x24" ./fitPanelUnitTesting
+                 PASSRC 1
+                 FAILREGEX "FAILED|Error in")
+endif()

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -25,7 +25,7 @@
 #include <cmath>
 #include <cstdio>
 
-#include "CommonDefs.h"
+#include "../src/CommonDefs.h"
 
 #ifdef WIN32
 #include "io.h"
@@ -217,11 +217,15 @@ public:
 
       result += MakeTest("TestUpdateTree.....", &FitEditorUnitTesting::TestUpdateTree);
 
-      // result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D); // TODO reenable once stack smashing issue is fixed
+      // TODO: reenable in batch once stack smashing issue is fixed
+      if (!gROOT->IsBatch())
+         result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D);
 
-      // result += MakeTest("TestTree2D.........", &FitEditorUnitTesting::TestTree2D); // TODO reenable once fit results are fixed
+      // TODO: reenable once fit results are fixed
+      // result += MakeTest("TestTree2D.........", &FitEditorUnitTesting::TestTree2D);
 
-      // result += MakeTest("TestTreeND.........", &FitEditorUnitTesting::TestTreeND); // TODO reenable once fit results are fixed
+      // TODO: reenable once fit results are fixed
+      // result += MakeTest("TestTreeND.........", &FitEditorUnitTesting::TestTreeND);
 
       fprintf(out, "\nRemember to also check outputUnitTesting.txt for "
               "more detailed information\n\n");


### PR DESCRIPTION
Provide full include path to let run macro directly

TestTree1D works in interactive mode so let run it in interactive mode

Switch testing into `xvfb-run` - if it found

Pure batch is unstable therefore disable it for the time been again.