### PR TITLE
Allow TNetXNGFile to use the http protocol

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -172,7 +172,7 @@ TNetXNGFile::TNetXNGFile(const char *url, const char *lurl, Option_t *mode, cons
 
    fFile        = new File();
    fInitCondVar = new XrdSysCondVar();
-   fUrl->SetProtocol(std::string("root"));
+
    fQueryReadVParams = 1;
    fReadvIorMax = 2097136;
    fReadvIovMax = 1024;


### PR DESCRIPTION
TNetXNGFile was not working correctly when given http URLs. This PR fixes that and unlocks progress on those http/s3 matters