### PR TITLE
[tasimage] fix copy constructor, optimize GetMask

### DIFF
--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -51,6 +51,7 @@ private:
    void SetDefaults();
    void CreateThumbnail();
    void DestroyImage();
+   void DestroyScaledImage();
    const char *TypeFromMagicNumber(const char *file);
 
 protected:

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -2368,32 +2368,25 @@ Pixmap_t TASImage::GetMask()
    UInt_t ow = img->width%8;
    UInt_t ww = img->width - ow + (ow ? 8 : 0);
 
-   UInt_t bit = 0;
-   int i = 0;
-   UInt_t y = 0;
-   UInt_t x = 0;
-
-   char *bits = new char[ww*hh]; //an array of bits
-
    ASImageDecoder *imdec = start_image_decoding(fgVisual, img, SCL_DO_ALPHA,
                                                 0, 0, ww, 0, nullptr);
-   if (!imdec) {
-      delete [] bits;
-      return 0;
-   }
+   if (!imdec)
+      return pxmap;
 
-   for (y = 0; y < hh; y++) {
+   std::vector<char> bits(ww * hh / 8); //an array of bits
+
+   UInt_t bit = 0, i = 0;
+   for (UInt_t y = 0; y < hh; y++) {
       imdec->decode_image_scanline(imdec);
       CARD32 *a = imdec->buffer.alpha;
 
-      for (x = 0; x < ww; x++) {
+      for (UInt_t x = 0; x < ww; x++) {
          if (a[x]) {
             SETBIT(bits[i], bit);
          } else {
             CLRBIT(bits[i], bit);
          }
-         bit++;
-         if (bit == 8) {
+         if (++bit == 8) {
             bit = 0;
             i++;
          }
@@ -2401,9 +2394,7 @@ Pixmap_t TASImage::GetMask()
    }
 
    stop_image_decoding(&imdec);
-   pxmap = gVirtualX->CreateBitmap(gVirtualX->GetDefaultRootWindow(), (const char *)bits,
-                                   ww, hh);
-   delete [] bits;
+   pxmap = gVirtualX->CreateBitmap(gVirtualX->GetDefaultRootWindow(), bits.data(), ww, hh);
    return pxmap;
 }
 

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -297,8 +297,8 @@ TASImage::TASImage(const TASImage &img) : TImage(img)
 
    if (img.IsValid()) {
       fImage = clone_asimage(img.fImage, SCL_DO_ALL);
-      fScaledImage   = fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
-      fGrayImage     = fGrayImage ? clone_asimage(img.fGrayImage, SCL_DO_ALL) : nullptr;
+      fScaledImage   = img.fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
+      fGrayImage     = img.fGrayImage ? clone_asimage(img.fGrayImage, SCL_DO_ALL) : nullptr;
 
       if (img.fImage->alt.vector) {
          Int_t size = img.fImage->width * img.fImage->height * sizeof(double);
@@ -327,8 +327,8 @@ TASImage &TASImage::operator=(const TASImage &img)
       DestroyImage();
       delete fScaledImage;
       fImage = clone_asimage(img.fImage, SCL_DO_ALL);
-      fScaledImage = fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
-      fGrayImage = fGrayImage ? clone_asimage(img.fGrayImage, SCL_DO_ALL) : nullptr;
+      fScaledImage = img.fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
+      fGrayImage = img.fGrayImage ? clone_asimage(img.fGrayImage, SCL_DO_ALL) : nullptr;
 
       if (img.fImage->alt.vector) {
          Int_t size = img.fImage->width * img.fImage->height * sizeof(double);
@@ -336,7 +336,6 @@ TASImage &TASImage::operator=(const TASImage &img)
          memcpy(fImage->alt.vector, img.fImage->alt.vector, size);
       }
 
-      fScaledImage = img.fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
       fZoomUpdate = kNoZoom;
       fZoomOffX   = img.fZoomOffX;
       fZoomOffY   = img.fZoomOffY;

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -173,7 +173,6 @@ typedef struct {
 }\
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Destroy image.
 
@@ -190,6 +189,18 @@ void TASImage::DestroyImage()
    fIsGray     = kFALSE;
    fGrayImage  = nullptr;
    fImage      = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Destroy scaled image.
+
+void TASImage::DestroyScaledImage()
+{
+   if (fScaledImage) {
+      delete fScaledImage;
+      fScaledImage = nullptr;
+   }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -325,7 +336,8 @@ TASImage &TASImage::operator=(const TASImage &img)
       TImage::operator=(img);
 
       DestroyImage();
-      delete fScaledImage;
+      DestroyScaledImage();
+
       fImage = clone_asimage(img.fImage, SCL_DO_ALL);
       fScaledImage = img.fScaledImage ? static_cast<TASImage *>(img.fScaledImage->Clone()) : nullptr;
       fGrayImage = img.fGrayImage ? clone_asimage(img.fGrayImage, SCL_DO_ALL) : nullptr;
@@ -355,8 +367,7 @@ TASImage &TASImage::operator=(const TASImage &img)
 TASImage::~TASImage()
 {
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -585,8 +596,7 @@ end:
    fName.Form("%s.", gSystem->BaseName(fname.Data()));
 
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    fImage      = image;
    fZoomUpdate = kNoZoom;
@@ -998,8 +1008,7 @@ void TASImage::SetImage(const Double_t *imageData, UInt_t width, UInt_t height,
    }
 
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    // get min and max value of image
    fMinValue = fMaxValue = *imageData;
@@ -1089,8 +1098,7 @@ void TASImage::FromPad(TVirtualPad *pad, Int_t x, Int_t y, UInt_t w, UInt_t h)
    SetName(pad->GetName());
 
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    if (gROOT->IsBatch()) { // in batch mode
       TVirtualPS *psave = gVirtualPS;
@@ -1471,8 +1479,8 @@ void TASImage::Paint(Option_t *option)
    }
 
    if (tile) {
-      delete fScaledImage;
-      fScaledImage = (TASImage*)TImage::Create();
+      DestroyScaledImage();
+      fScaledImage = (TASImage*) TImage::Create();
       if (!fScaledImage) return;
       fScaledImage->fImage = tile_asimage(fgVisual, fImage, tile_x, tile_y,
                                           to_w, to_h, tile_tint, ASA_ASImage,
@@ -1491,8 +1499,7 @@ void TASImage::Paint(Option_t *option)
                 Int_t(fScaledImage->GetHeight()) != to_h ||
                 fZoomUpdate)) {
 
-            delete fScaledImage;
-            fScaledImage = nullptr;
+            DestroyScaledImage();
          }
 
          if (!fScaledImage) {
@@ -1925,9 +1932,7 @@ void TASImage::SetPalette(const TImagePalette *palette)
    for (Int_t col = 0; col < 4; col++)
       delete [] asPalette.channels[col];
 
-
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2083,8 +2088,7 @@ void TASImage::UnZoom()
    fZoomWidth  = fImage->width;
    fZoomHeight = fImage->height;
 
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2408,8 +2412,7 @@ void TASImage::SetImage(Pixmap_t pxm, Pixmap_t mask)
    }
 
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    Int_t xy;
    UInt_t w, h;
@@ -6452,8 +6455,7 @@ void TASImage::Gray(Bool_t on)
       return;
    }
    ASImage *sav = nullptr;
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    if (fGrayImage)  {
       sav = fImage;
@@ -6501,8 +6503,7 @@ void TASImage::Gray(Bool_t on)
                                                 GetImageCompression(), GetImageQuality());
       if (!imout) {
          Warning("ToGray", "Failed to start image output");
-         delete fScaledImage;
-         fScaledImage = nullptr;
+         DestroyScaledImage();
          delete [] imdec;
          return;
       }
@@ -6576,8 +6577,7 @@ void TASImage::FromWindow(Drawable_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h)
    }
 
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    static int x11 = -1;
    if (x11 < 0) x11 = gVirtualX->InheritsFrom("TGX11");
@@ -6601,8 +6601,7 @@ void TASImage::FromWindow(Drawable_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h)
 void TASImage::FromGLBuffer(UChar_t* buf, UInt_t w, UInt_t h)
 {
    DestroyImage();
-   delete fScaledImage;
-   fScaledImage = nullptr;
+   DestroyScaledImage();
 
    UChar_t* xx = new UChar_t[4*w];
    for (UInt_t i = 0; i < h/2; ++i) {


### PR DESCRIPTION
1. Copy constructor and assign operator implemented wrongly.
One should check source img to clone fScaledImage or fGreyImage

2. Fix memory leak in assign operator - fScaledImage was cloned twice

3. Optimize GetMask() method - required buffer size is 8 times smaller

4. Provide `DestroyScaledImage()` method to unify way how image is destroyed