### PR TITLE
[asimage] fix seg fault when negative coordinate specified [6.38]

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -6723,5 +6723,5 @@ Bool_t TASImage::SetJpegDpi(const char *name, UInt_t set)
 Int_t TASImage::Idx(Int_t idx)
 {
    // The size of arrays like fImage->alt.argb32 is fImage->width*fImage->height
-   return TMath::Min(idx,(Int_t)(fImage->width*fImage->height));
+   return TMath::Max(0, TMath::Min(idx,(Int_t)(fImage->width*fImage->height)));
 }


### PR DESCRIPTION
Index was checked on max value, but not on negative value

