### PR TITLE
[roottest] fix typo in variable name

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2749,7 +2749,7 @@ macro(ROOTTEST_GENERATE_REFLEX_DICTIONARY dictionary)
     set(CMAKE_ROOTTEST_NOROOTMAP OFF)
   endif()
 
-  set(ROOT_genreflex_cmd ${ROOT_BINDIR}/genreflex)
+  set(ROOT_genreflex_CMD ${ROOT_BINDIR}/genreflex)
 
   ROOTTEST_TARGETNAME_FROM_FILE(targetname ${dictionary})
 


### PR DESCRIPTION
ROOT_genreflex_CMD is used everywhere
not ROOT_genreflex_cmd

Found out while investigating failures in  https://github.com/root-project/root/pull/21890/