### PR TITLE
Enable fitpanel and stressgui tests with xvfb utitlity

### DIFF
--- a/gui/fitpanel/test/CMakeLists.txt
+++ b/gui/fitpanel/test/CMakeLists.txt
@@ -4,18 +4,17 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-# @author Danilo Piparo CERN
+# @author Sergey Linev
 
 ROOT_EXECUTABLE(fitPanelUnitTesting UnitTesting.cxx LIBRARIES FitPanel Gui Tree Hist MathCore)
 
-# batch usage is instable - need more investigations
-#ROOT_ADD_TEST(test-fitpanel-UnitTesting-batch COMMAND fitPanelUnitTesting -b FAILREGEX "FAILED|Error in")
+# batch mode is unstable, it still crashed on some CI platforms
+# ROOT_ADD_TEST(test-fitpanel-UnitTesting-batch COMMAND fitPanelUnitTesting -b FAILREGEX "FAILED|Error in")
 
 find_program(XVFB_RUN_EXECUTABLE NAMES xvfb-run)
 
 if(XVFB_RUN_EXECUTABLE)
    ROOT_ADD_TEST(test-fitpanel-UnitTesting-xvfb
-                 COMMAND ${XVFB_RUN_EXECUTABLE} --auto-servernum --server-args="-screen 0 1024x768x24" ./fitPanelUnitTesting
-                 PASSRC 1
+                 COMMAND ${XVFB_RUN_EXECUTABLE} -a -s "-ac -screen 0 1024x768x24" ./fitPanelUnitTesting
                  FAILREGEX "FAILED|Error in")
 endif()

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -10,6 +10,7 @@
 #include "TError.h"
 
 #include "TGComboBox.h"
+#include "TVirtualX.h"
 
 #include "TF2.h"
 #include "TMath.h"
@@ -26,6 +27,17 @@
 
 #include "../src/CommonDefs.h"
 
+class TTestVirtualX : public TVirtualX {
+   Long_t fCounter = 1;
+   public:
+
+      TTestVirtualX(const char *name, const char *title) : TVirtualX(name, title) {}
+
+      GContext_t   CreateGC(Drawable_t, GCValues_t *) override
+      {
+         return (GContext_t) fCounter++;
+      }
+};
 
 TString gTmpfilename;
 
@@ -482,6 +494,9 @@ public:
 // tests
 int UnitTesting()
 {
+   if (gROOT->IsBatch())
+      gVirtualX = new TTestVirtualX("BatchTest", "ROOT Interface to batch graphics");
+
    gROOT->SetWebDisplay("off");
 
    gTmpfilename = "UnitTesting.log";

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -174,6 +174,12 @@ public:
    int CompareFuncPars(std::vector<TFitEditor::FuncParamData_t>& pars)
    {
       int status = 0;
+
+      if (f->fFuncPars.size() != pars.size()) {
+         fprintf(stderr, "ERROR: mismatch of parameters size  fitpanel: %u refs: %u\n",  (unsigned) f->fFuncPars.size(), (unsigned) pars.size());
+         return 111;
+      }
+
       for ( unsigned int i = 0; i < f->fFuncPars.size(); ++i ) {
          for ( unsigned int j = 0; j < 3; ++j) {
             int internalStatus = equals(pars[i][j], f->fFuncPars[i][j]);

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -39,8 +39,6 @@ class TTestVirtualX : public TVirtualX {
       }
 };
 
-TString gTmpfilename;
-
 // Function that compares to doubles up to an error limit
 int equals(Double_t n1, Double_t n2, double ERRORLIMIT = 1.E-4)
 {
@@ -124,7 +122,8 @@ public:
    };
 
    // Constructor: Receives the instance of the TFitEditor
-   FitEditorUnitTesting() {
+   FitEditorUnitTesting()
+   {
 
       // Execute the initial script
       TString scriptLine = TString(".x ") + TROOT::GetTutorialDir() + "/math/fit/FittingDemo.C+";
@@ -151,7 +150,8 @@ public:
    // trying to retrieve the TFitEditor singleton. If the user wants
    // to play a bit with the fitpanel once the tests have finised,
    // then they should comment this method.
-   ~FitEditorUnitTesting() {
+   ~FitEditorUnitTesting()
+   {
       f->DoClose();
    }
 
@@ -191,7 +191,8 @@ public:
    // of the test should be enough to know what they are testing, as
    // these tests are meant to be as simple as possible.
 
-   int TestHistogramFit() {
+   int TestHistogramFit()
+   {
       f->fTypeFit->Select(kFP_UFUNC, kTRUE);
       f->fFuncList->Select(kFP_ALTFUNC, kTRUE);
       f->DoFit();
@@ -207,7 +208,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestGSLFit() {
+   int TestGSLFit()
+   {
       f->fTypeFit->Select(kFP_PREVFIT, kTRUE);
       f->fLibGSL->Toggled(kTRUE);
       f->fMinMethodList->Select(kFP_BFGS2, kTRUE);
@@ -224,7 +226,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestUpdate() {
+   int TestUpdate()
+   {
       TString scriptLine = TString(".x ") + TROOT::GetTutorialsDir() + "/math/fit/ConfidenceIntervals.C+";
       gROOT->ProcessLine(scriptLine.Data());
       f->DoUpdate();
@@ -232,7 +235,8 @@ public:
       return 0;
    }
 
-   int TestGraph() {
+   int TestGraph()
+   {
       SelectEntry(f->fDataSet, "TGraph::GraphNoError");
 
       f->fLibMinuit2->Toggled(kTRUE);
@@ -249,7 +253,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-    int TestGraphError() {
+    int TestGraphError()
+    {
       SelectEntry(f->fDataSet, "TGraphErrors::Graph");
 
       f->fLibMinuit2->Toggled(kTRUE);
@@ -266,7 +271,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestGraph2D() {
+   int TestGraph2D()
+   {
       SelectEntry(f->fDataSet, "TGraph2D::Graph2DNoError");
 
       f->fLibMinuit2->Toggled(kTRUE);
@@ -290,7 +296,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestGraph2DError() {
+   int TestGraph2DError()
+   {
       SelectEntry(f->fDataSet, "TGraph2DErrors::Graph2D");
 
       f->fLibMinuit2->Toggled(kTRUE);
@@ -314,13 +321,15 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestUpdateTree() {
+   int TestUpdateTree()
+   {
       createTree();
       f->DoUpdate();
       return 0;
    }
 
-   int TestTree1D() {
+   int TestTree1D()
+   {
       TObject* objSelected = gROOT->FindObject("tree");
       if ( !objSelected )
          throw InvalidPointer("In TestUpdateTree");
@@ -345,7 +354,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestTree2D() {
+   int TestTree2D()
+   {
       TObject* objSelected = gROOT->FindObject("tree");
       if ( !objSelected )
          throw InvalidPointer("In TestUpdateTree");
@@ -374,7 +384,8 @@ public:
       return CompareFuncPars(pars);
    }
 
-   int TestTreeND() {
+   int TestTreeND()
+   {
       TObject* objSelected = gROOT->FindObject("tree");
       if ( !objSelected )
          throw InvalidPointer("In TestUpdateTree");
@@ -421,7 +432,7 @@ public:
       return CompareFuncPars(pars);
    }
 
-      // This is a generic method to make the output of all the tests
+   // This is a generic method to make the output of all the tests
    // consistent. T is a function pointer to one of the tests
    // function. It has been implemented through templates to permit
    // more test types than the originally designed.
@@ -429,11 +440,11 @@ public:
    // @ func : Member function pointer to the real implementation of
    // the test.
    template <typename T>
-   int MakeTest(const char* str,  T func)
+   int MakeTest(const char *str,  T func, Bool_t first = kFALSE)
    {
       RedirectHandle_t gRH;
 
-      gSystem->RedirectOutput(gTmpfilename.Data(), "w", &gRH);
+      gSystem->RedirectOutput("outputUnitTesting.txt", first ? "w" : "a", &gRH);
 
       fprintf(stdout, "\n***** %s *****\n", str);
 
@@ -455,7 +466,7 @@ public:
 
       fprintf(stdout, "\n**STARTING TFitEditor Unit Tests**\n\n");
 
-      result += MakeTest("TestHistogramFit...", &FitEditorUnitTesting::TestHistogramFit);
+      result += MakeTest("TestHistogramFit...", &FitEditorUnitTesting::TestHistogramFit, kTRUE);
 
       result += MakeTest("TestGSLFit.........", &FitEditorUnitTesting::TestGSLFit);
 
@@ -471,9 +482,7 @@ public:
 
       result += MakeTest("TestUpdateTree.....", &FitEditorUnitTesting::TestUpdateTree);
 
-      // TODO: reenable in batch once stack smashing issue is fixed
-      if (!gROOT->IsBatch())
-         result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D);
+      result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D);
 
       // TODO: reenable once fit results are fixed
       // result += MakeTest("TestTree2D.........", &FitEditorUnitTesting::TestTree2D);
@@ -482,7 +491,7 @@ public:
       // result += MakeTest("TestTreeND.........", &FitEditorUnitTesting::TestTreeND);
 
       fprintf(stdout, "\nRemember to also check outputUnitTesting.txt for "
-              "more detailed information\n\n");
+                      "more detailed information\n\n");
 
       return result;
    }
@@ -499,17 +508,9 @@ int UnitTesting()
 
    gROOT->SetWebDisplay("off");
 
-   gTmpfilename = "UnitTesting.log";
-   auto f = gSystem->TempFileName(gTmpfilename);
-   fclose(f);
-
    FitEditorUnitTesting fUT;
 
-   auto res = fUT.UnitTesting();
-
-   gSystem->Unlink(gTmpfilename.Data());
-
-   return res;
+   return fUT.UnitTesting();
 }
 
 #ifndef __ROOTCLING__

--- a/gui/fitpanel/test/UnitTesting.cxx
+++ b/gui/fitpanel/test/UnitTesting.cxx
@@ -2,12 +2,11 @@
 
 #include "TApplication.h"
 #include "TROOT.h"
-#include "TBenchmark.h"
+#include "TSystem.h"
 
 #include "TCanvas.h"
 #include "TH1.h"
 
-#include "TPluginManager.h"
 #include "TError.h"
 
 #include "TGComboBox.h"
@@ -27,11 +26,8 @@
 
 #include "../src/CommonDefs.h"
 
-#ifdef WIN32
-#include "io.h"
-#else
-#include "unistd.h"
-#endif
+
+TString gTmpfilename;
 
 // Function that compares to doubles up to an error limit
 int equals(Double_t n1, Double_t n2, double ERRORLIMIT = 1.E-4)
@@ -102,10 +98,6 @@ private:
    // Pointer to the current (and only one) TFitEditor opened.
    TFitEditor* f;
 
-   // These two variables are here to redirect the standard output to
-   // a file.
-   int old_stdout;
-   FILE *out;
 public:
 
    // Exception thrown when any of the pointers managed by the
@@ -121,21 +113,6 @@ public:
 
    // Constructor: Receives the instance of the TFitEditor
    FitEditorUnitTesting() {
-      // Redirect the stdout to a file outputUnitTesting.txt
-      #ifdef WIN32
-      old_stdout = _dup (_fileno (stdout));
-      #else
-      old_stdout = dup (fileno (stdout));
-      #endif
-      auto res = freopen ("outputUnitTesting.txt", "w", stdout);
-      if (!res) {
-          throw InvalidPointer("In FitEditorUnitTesting constructor cannot freopen");
-      }
-      #ifdef WIN32
-      out = _fdopen (old_stdout, "w");
-      #else
-      out = fdopen (old_stdout, "w");
-      #endif
 
       // Execute the initial script
       TString scriptLine = TString(".x ") + TROOT::GetTutorialDir() + "/math/fit/FittingDemo.C+";
@@ -164,73 +141,6 @@ public:
    // then they should comment this method.
    ~FitEditorUnitTesting() {
       f->DoClose();
-      gApplication->Terminate();
-   }
-
-   // This is a generic method to make the output of all the tests
-   // consistent. T is a function pointer to one of the tests
-   // function. It has been implemented through templates to permit
-   // more test types than the originally designed.
-   // @ str : Name of the test
-   // @ func : Member function pointer to the real implementation of
-   // the test.
-   template <typename T>
-   int MakeTest(const char* str,  T func )
-   {
-      fprintf(stdout, "\n***** %s *****\n", str);
-      int status = (this->*func)();
-
-      fprintf(stdout, "%s..........", str);
-      fprintf(out, "%s..........", str);
-      if ( status == 0 ) {
-         fprintf(stdout, "OK\n");
-         fprintf(out, "OK\n");
-      }
-      else {
-         fprintf(stdout, "FAILED\n");
-         fprintf(out, "FAILED\n");
-      }
-      return status;
-   }
-
-   // This is where all the tests are called. If the user wants to add
-   // new tests or avoid executing one of the existing ones, it is
-   // here where they should do it.
-   int UnitTesting() {
-      int result = 0;
-
-      fprintf(out, "\n**STARTING TFitEditor Unit Tests**\n\n");
-
-      result += MakeTest("TestHistogramFit...", &FitEditorUnitTesting::TestHistogramFit);
-
-      result += MakeTest("TestGSLFit.........", &FitEditorUnitTesting::TestGSLFit);
-
-      result += MakeTest("TestUpdate.........", &FitEditorUnitTesting::TestUpdate);
-
-      result += MakeTest("TestGraph..........", &FitEditorUnitTesting::TestGraph);
-
-      result += MakeTest("TestGraphError.....", &FitEditorUnitTesting::TestGraphError);
-
-      result += MakeTest("TestGraph2D........", &FitEditorUnitTesting::TestGraph2D);
-
-      result += MakeTest("TestGraph2DError...", &FitEditorUnitTesting::TestGraph2DError);
-
-      result += MakeTest("TestUpdateTree.....", &FitEditorUnitTesting::TestUpdateTree);
-
-      // TODO: reenable in batch once stack smashing issue is fixed
-      if (!gROOT->IsBatch())
-         result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D);
-
-      // TODO: reenable once fit results are fixed
-      // result += MakeTest("TestTree2D.........", &FitEditorUnitTesting::TestTree2D);
-
-      // TODO: reenable once fit results are fixed
-      // result += MakeTest("TestTreeND.........", &FitEditorUnitTesting::TestTreeND);
-
-      fprintf(out, "\nRemember to also check outputUnitTesting.txt for "
-              "more detailed information\n\n");
-
-      return result;
    }
 
    // This is a debuggin method used to print the parameter values
@@ -239,9 +149,9 @@ public:
    void PrintFuncPars()
    {
       static int counter = 0;
-      fprintf(out, "Printing the Func Pars (%d)\n", ++counter);
-      for ( unsigned int i = 0; i < f->fFuncPars.size(); ++i ) {
-         fprintf(out, "%30.20f %30.20f %30.20f\n", f->fFuncPars[i][0], f->fFuncPars[i][1], f->fFuncPars[i][2]);
+      fprintf(stdout, "Printing the Func Pars (%d)\n", ++counter);
+      for (unsigned int i = 0; i < f->fFuncPars.size(); ++i ) {
+         fprintf(stdout, "%30.20f %30.20f %30.20f\n", f->fFuncPars[i][0], f->fFuncPars[i][1], f->fFuncPars[i][2]);
       }
    }
 
@@ -256,7 +166,7 @@ public:
          for ( unsigned int j = 0; j < 3; ++j) {
             int internalStatus = equals(pars[i][j], f->fFuncPars[i][j]);
             if (internalStatus != 0) {
-                fprintf(out, "i: %d, j: %d, e: %d, diff %g\n", i, j, internalStatus, (pars[i][j] - f->fFuncPars[i][j]));
+                fprintf(stdout, "i: %d, j: %d, e: %d, diff %g\n", i, j, internalStatus, (pars[i][j] - f->fFuncPars[i][j]));
             }
             status += internalStatus;
          }
@@ -498,6 +408,73 @@ public:
 
       return CompareFuncPars(pars);
    }
+
+      // This is a generic method to make the output of all the tests
+   // consistent. T is a function pointer to one of the tests
+   // function. It has been implemented through templates to permit
+   // more test types than the originally designed.
+   // @ str : Name of the test
+   // @ func : Member function pointer to the real implementation of
+   // the test.
+   template <typename T>
+   int MakeTest(const char* str,  T func)
+   {
+      RedirectHandle_t gRH;
+
+      gSystem->RedirectOutput(gTmpfilename.Data(), "w", &gRH);
+
+      fprintf(stdout, "\n***** %s *****\n", str);
+
+      int status = (this->*func)();
+
+      gSystem->RedirectOutput(0, 0, &gRH);
+
+      fprintf(stdout, "%s..........%s\n", str, status == 0 ? "OK" : "FAILED");
+
+      return status;
+   }
+
+   // This is where all the tests are called. If the user wants to add
+   // new tests or avoid executing one of the existing ones, it is
+   // here where they should do it.
+   int UnitTesting()
+   {
+      int result = 0;
+
+      fprintf(stdout, "\n**STARTING TFitEditor Unit Tests**\n\n");
+
+      result += MakeTest("TestHistogramFit...", &FitEditorUnitTesting::TestHistogramFit);
+
+      result += MakeTest("TestGSLFit.........", &FitEditorUnitTesting::TestGSLFit);
+
+      result += MakeTest("TestUpdate.........", &FitEditorUnitTesting::TestUpdate);
+
+      result += MakeTest("TestGraph..........", &FitEditorUnitTesting::TestGraph);
+
+      result += MakeTest("TestGraphError.....", &FitEditorUnitTesting::TestGraphError);
+
+      result += MakeTest("TestGraph2D........", &FitEditorUnitTesting::TestGraph2D);
+
+      result += MakeTest("TestGraph2DError...", &FitEditorUnitTesting::TestGraph2DError);
+
+      result += MakeTest("TestUpdateTree.....", &FitEditorUnitTesting::TestUpdateTree);
+
+      // TODO: reenable in batch once stack smashing issue is fixed
+      if (!gROOT->IsBatch())
+         result += MakeTest("TestTree1D.........", &FitEditorUnitTesting::TestTree1D);
+
+      // TODO: reenable once fit results are fixed
+      // result += MakeTest("TestTree2D.........", &FitEditorUnitTesting::TestTree2D);
+
+      // TODO: reenable once fit results are fixed
+      // result += MakeTest("TestTreeND.........", &FitEditorUnitTesting::TestTreeND);
+
+      fprintf(stdout, "\nRemember to also check outputUnitTesting.txt for "
+              "more detailed information\n\n");
+
+      return result;
+   }
+
 };
 
 // Runs the  basic script  and pops  out the fit  panel. Then  it will
@@ -507,10 +484,20 @@ int UnitTesting()
 {
    gROOT->SetWebDisplay("off");
 
+   gTmpfilename = "UnitTesting.log";
+   auto f = gSystem->TempFileName(gTmpfilename);
+   fclose(f);
+
    FitEditorUnitTesting fUT;
 
-   return fUT.UnitTesting();
+   auto res = fUT.UnitTesting();
+
+   gSystem->Unlink(gTmpfilename.Data());
+
+   return res;
 }
+
+#ifndef __ROOTCLING__
 
 // The main function. It is VERY important that it is run using the
 // TApplication.
@@ -528,3 +515,5 @@ int main(int argc, char** argv)
 
    return ret;
 }
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,6 +196,21 @@ ROOT_ADD_TEST(test-stresshistogram-interpreted COMMAND ${root_exe} -b -q ${CMAKE
 #--stressGUI---------------------------------------------------------------------------------------
 if(asimage)
   ROOT_EXECUTABLE(stressGUI stressGUI.cxx LIBRARIES Gui Recorder GuiHtml ASImageGui)
+
+  find_program(XVFB_RUN_EXECUTABLE NAMES xvfb-run)
+
+  if(XVFB_RUN_EXECUTABLE)
+    ROOT_ADD_TEST(test-stressgui-ref
+                  COMMAND ${XVFB_RUN_EXECUTABLE} -a -s "-ac -screen 0 1024x768x24" ./stressGUI -ref
+                  FIXTURES_SETUP fixtures-test-stressgui
+                  FAILREGEX "FAILED|Error in"
+                  LABELS longtest)
+    ROOT_ADD_TEST(test-stressgui-xvfb
+                  COMMAND ${XVFB_RUN_EXECUTABLE} -a -s "-ac -screen 0 1024x768x24" ./stressGUI
+                  FIXTURES_REQUIRED fixtures-test-stressgui
+                  FAILREGEX "FAILED|Error in"
+                  LABELS longtest)
+  endif()
 endif()
 
 #--stressSpectrum----------------------------------------------------------------------------------

--- a/test/stressGUI.cxx
+++ b/test/stressGUI.cxx
@@ -132,25 +132,27 @@ Bool_t VerifySize(const char *filename, const char *title)
          success = kFALSE;
       else
          success = kTRUE;
-
-      snprintf(gLine,80,"Test %2d: %s", gTestNum, title);
-      const Int_t nch = strlen(gLine);
-      if (success) {
-         std::cout << gLine;
-         for (Int_t i = nch; i < 67; i++) std::cout << ".";
-         std::cout << " OK" << std::endl;
-      } else {
-         std::cout << gLine;
-         for (Int_t i = nch; i < 63; i++) std::cout << ".";
-         std::cout << " FAILED" << std::endl;
-         std::cout << "         File Size = "  << fsize << std::endl;
-         std::cout << "          Ref Size = "  << sizes[gTestNum] << std::endl;
-      }
    } else {
       fprintf(sgref, "%5d%10d\n", gTestNum, fsize);
       success = kTRUE;
    }
-   if (!gOptionKeep && success) gSystem->Unlink(filename);
+
+   snprintf(gLine,80,"Test %2d: %s", gTestNum, title);
+   const Int_t nch = strlen(gLine);
+   if (success) {
+      std::cout << gLine;
+      for (Int_t i = nch; i < 67; i++) std::cout << ".";
+      std::cout << (gOptionRef ? " REF" : " OK") << std::endl;
+   } else {
+      std::cout << gLine;
+      for (Int_t i = nch; i < 63; i++) std::cout << ".";
+      std::cout << " FAILED" << std::endl;
+      std::cout << "         File Size = "  << fsize << std::endl;
+      std::cout << "          Ref Size = "  << sizes[gTestNum] << std::endl;
+   }
+
+   if (!gOptionKeep && success)
+      gSystem->Unlink(filename);
    return success;
 }
 


### PR DESCRIPTION
Enable fitpanel and stressgui tests with `xvfb-run` utility.
It emulates X server and allows to run GUI tests on batch machines.

Also modernize fitpanel test to prepare for pure batch tests.

GUI classes requires that `gVirtualX->CreateGC()` returns unique value. This id value identify `TGGC` instance and used to cleanup these instances at the end. If returned value always 0 - cleanup does not work correctly and may crash ROOT during teardown. In fitpanel `UnitTesting` provide special subclass of `TVirtualX` which returns unique ids. Maybe such workaround can be directly add to base `TVirtualX` class.

Modernize `UnitTesting` in fitpanel - use `gSystem->RedirectOutput` to redirect standard output to the file.