### PR TITLE
[df] Register `Hist()` pythonization only if available

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdataframe.py
@@ -524,7 +524,8 @@ def pythonize_rdataframe(klass):
         getter = MethodTemplateGetter(getattr(klass, method_name), HistoProfileWrapper, model_class)
         setattr(klass, method_name, getter)
 
-    klass.Hist = MethodTemplateGetter(klass.Hist, HistWrapper)
+    if hasattr(klass, "Hist"):
+        klass.Hist = MethodTemplateGetter(klass.Hist, HistWrapper)
 
     klass._OriginalFilter = klass.Filter
     klass._OriginalDefine = klass.Define


### PR DESCRIPTION
If ROOT is built without the `root7` option, the method doesn't exist which leads to errors when registering the pythonization.

Fixes commit 295345ba1c ("[df] Pythonize Hist() with list of axes")