### PR TITLE
[core,RF,misc,interpreter] fix windows warning

### DIFF
--- a/cmake/win/w32pragma.h
+++ b/cmake/win/w32pragma.h
@@ -49,7 +49,7 @@
 #pragma warning (disable: 4503)
 
 /* function is hidden */
-#pragma warning (3: 4266)
+#pragma warning (disable: 4266)
 /* loop control variable is used outside the for-loop scope */
 #pragma warning (3: 4289)
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -340,6 +340,7 @@ namespace {
             try {
                desiredValue = std::stoi(env);
             } catch (std::invalid_argument &e) {
+               (void)e;
                Error("TROOT", "%s should be 0 or 1", envName);
             }
             if (desiredValue == 0) {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -340,8 +340,7 @@ namespace {
             try {
                desiredValue = std::stoi(env);
             } catch (std::invalid_argument &e) {
-               (void)e;
-               Error("TROOT", "%s should be 0 or 1", envName);
+               Error("TROOT", "%s should be 0 or 1, exception message: '%s'", envName, e.what());
             }
             if (desiredValue == 0) {
                autoReg = AutoReg::kOff;

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -202,9 +202,7 @@ if(builtin_llvm)
     set(LLVM_CXX_FLAGS ${CMAKE_CXX_FLAGS_${LLVM_BUILD_TYPE}})
     # On Windows, use the same compiler flags than ROOT and not
     # the other way around
-    if(MSVC)
-      set(LLVM_CXX_FLAGS "${LLVM_CXX_FLAGS} /wd4266 /wd4005") # no override available for virtual member function, 'WINVER': macro redefinition
-    else()
+    if(NOT MSVC)
       foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
         string(TOUPPER ${CONFIG} CONFIG)
         set(CMAKE_C_FLAGS_${CONFIG} ${LLVM_C_FLAGS})

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -202,7 +202,9 @@ if(builtin_llvm)
     set(LLVM_CXX_FLAGS ${CMAKE_CXX_FLAGS_${LLVM_BUILD_TYPE}})
     # On Windows, use the same compiler flags than ROOT and not
     # the other way around
-    if(NOT MSVC)
+    if(MSVC)
+      set(LLVM_CXX_FLAGS "${LLVM_CXX_FLAGS} /wd4266 /wd4005") # no override available for virtual member function, 'WINVER': macro redefinition
+    else()
       foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
         string(TOUPPER ${CONFIG} CONFIG)
         set(CMAKE_C_FLAGS_${CONFIG} ${LLVM_C_FLAGS})

--- a/io/io/test/TBufferJSONTests.cxx
+++ b/io/io/test/TBufferJSONTests.cxx
@@ -119,7 +119,14 @@ TEST(TBufferJSON, SpecialNumbersFloat)
    p = nullptr;
 
    auto maxVal = std::numeric_limits<float>::max(); // 3.40282e+38f
+   #ifdef WIN32
+   #pragma warning( push )
+   #pragma warning( disable : 4756 ) // overflow in constant arithmetic
+   #endif
    auto ovfVal = std::numeric_limits<float>::max() * static_cast<float>(1 + 1e-7);
+   #ifdef WIN32
+   #pragma warning( pop )
+   #endif
    auto infVal = std::numeric_limits<float>::infinity();
    EXPECT_EQ(ovfVal, infVal);
    auto nanVal = std::numeric_limits<float>::quiet_NaN();

--- a/misc/win/bindexplib/bindexplib.cxx
+++ b/misc/win/bindexplib/bindexplib.cxx
@@ -470,7 +470,7 @@ void bindexplib::WriteFile(FILE *file)
 }
 
 
-void
+int
 main(int argc, char **argv)
 {
    std::string cmdline;
@@ -484,7 +484,7 @@ main(int argc, char **argv)
    if (argc < 3) {
 Usage:
       fprintf(stderr, "Usage: %s ?-o outfile? ?-f(ull)? <dllname> <object filenames> ..\n", argv[0]);
-      exit(1);
+      return EXIT_FAILURE;
    }
 
    arg = 1;
@@ -515,7 +515,7 @@ Usage:
          fprintf(stderr, "Unable to open \'%s\' for writing:\n",
                  argv[arg]);
          perror("");
-         exit(1);
+         return EXIT_FAILURE;
       }
    } else {
       fout = stdout;
@@ -543,7 +543,7 @@ Usage:
             fprintf(stderr, "Unable to open \'%s\' for reading:\n",
                     argv[arg]);
             perror("");
-            exit(1);
+            return EXIT_FAILURE;
          }
          char *fargv[1000];
          for (i = 0; i < arg; i++) {
@@ -566,7 +566,7 @@ Usage:
       if (SearchFile == INVALID_HANDLE_VALUE) {
          fprintf(stderr, "Unable to find \'%s\' for reading:\n",
                  argv[arg]);
-         exit(1);
+         return EXIT_FAILURE;
       } else {
          /*
          *  Since WIN32_FIND_DATA has no path information one has to extract it oneself.
@@ -588,5 +588,5 @@ Usage:
          deffile.WriteFile(fout);
       }
    }
-   exit(0);
+   return EXIT_SUCCESS;
 }

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -399,7 +399,7 @@ __rooglobal__ void computeGamma(Batches &batches)
    double gamma = -std::lgamma(G[0]);
    for (size_t i = BEGIN; i < batches.nEvents; i += STEP) {
       if (X[i] == M[i]) {
-         batches.output[i] = (G[i] == 1.0) / B[i];
+         batches.output[i] = int(G[i] == 1.0) / B[i];
       } else if (G._isVector) {
          batches.output[i] = -std::lgamma(G[i]);
       } else {

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -648,12 +648,12 @@ int FitUsingRooFit2(TTree *tree)
          pdf[N - 1]->fitTo(data, RooFit::Minos(0), RooFit::Hesse(1), RooFit::PrintLevel(level), RooFit::Save(save))};
 
 #ifdef DEBUG
-      assert(result != nullptr);
-      std::cout << " Roofit status " << result->status() << std::endl;
-      result->Print();
+      assert(result == nullptr);
+//std::cout << " Roofit status " << result->status() << std::endl;
+//result->Print();
 #endif
 
-      iret |= int(result == nullptr);
+      iret |= int(result != nullptr);
 
       if (iret != 0)
          return iret;

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -648,12 +648,12 @@ int FitUsingRooFit2(TTree *tree)
          pdf[N - 1]->fitTo(data, RooFit::Minos(0), RooFit::Hesse(1), RooFit::PrintLevel(level), RooFit::Save(save))};
 
 #ifdef DEBUG
-      assert(result != 0);
+      assert(result != nullptr);
       std::cout << " Roofit status " << result->status() << std::endl;
       result->Print();
 #endif
 
-      iret |= (result != 0);
+      iret |= int(result == nullptr);
 
       if (iret != 0)
          return iret;

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -563,12 +563,12 @@ int FitUsingRooFit(TTree *tree, TF1 *func)
 #ifdef DEBUG
       mean.Print();
       sigma.Print();
-      assert(result != 0);
+      assert(result != nullptr);
       std::cout << " Roofit status " << result->status() << std::endl;
       result->Print();
 #endif
       if (save)
-         iret |= int(result != 0);
+         iret |= int(result == nullptr);
 
       if (iret != 0) {
          std::cout << "Fit failed " << std::endl;

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -568,7 +568,7 @@ int FitUsingRooFit(TTree *tree, TF1 *func)
       result->Print();
 #endif
       if (save)
-         iret |= (result == 0);
+         iret |= int(result != 0);
 
       if (iret != 0) {
          std::cout << "Fit failed " << std::endl;

--- a/roofit/roofit/test/testRooFit.cxx
+++ b/roofit/roofit/test/testRooFit.cxx
@@ -209,7 +209,7 @@ int FitUsingRooFit(TTree &tree, RooAbsPdf &pdf, RooArgSet &xvars)
       std::cout << " Roofit status " << result->status() << std::endl;
       result->Print();
 #endif
-      iret |= (result == nullptr);
+      iret |= int(result == nullptr);
    }
 
    w.Stop();

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -68,7 +68,7 @@ namespace RooLinkedListImplDetails {
       ~Chunk() { delete[] _chunk; }
       /// chunk capacity
       Int_t capacity() const
-      { return (1L << _sz) / sizeof(RooLinkedListElem); }
+      { return (1ULL << _sz) / sizeof(RooLinkedListElem); }
       /// chunk free elements
       Int_t free() const { return _free; }
       /// chunk occupied elements

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -68,7 +68,7 @@ namespace RooLinkedListImplDetails {
       ~Chunk() { delete[] _chunk; }
       /// chunk capacity
       Int_t capacity() const
-      { return (1 << _sz) / sizeof(RooLinkedListElem); }
+      { return (1L << _sz) / sizeof(RooLinkedListElem); }
       /// chunk free elements
       Int_t free() const { return _free; }
       /// chunk occupied elements

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1549,7 +1549,7 @@ void RModel::ReadInitializedTensorsFromFile(long pos) {
                fGC += "      fTensor_" + i.first + " = *reinterpret_cast<std::vector<int64_t>*>(rootFile->Get(\"";
                fGC += dirName + "/" + tensor_name + "\"));\n";
             } else {
-               std::runtime_error("tmva-sofie tensor " + tensor_name + " with type " + ConvertTypeToString(i.second.type()) + " cannot be read from a ROOT file");
+               throw std::runtime_error("tmva-sofie tensor " + tensor_name + " with type " + ConvertTypeToString(i.second.type()) + " cannot be read from a ROOT file");
             }
             fGC += "  }\n";
         }
@@ -1617,7 +1617,7 @@ long RModel::WriteInitializedTensorsToFile(std::string filename) {
                outputDir->WriteObjectAny(&tensorDataVector, "std::vector<int64_t>", tensorName.c_str());
             }
             else {
-               std::runtime_error("tmva-sofie tensor " + tensorName + " with type " + ConvertTypeToString(item.second.type()) +
+               throw std::runtime_error("tmva-sofie tensor " + tensorName + " with type " + ConvertTypeToString(item.second.type()) +
                                   " cannot be written to a ROOT file");
             }
         }
@@ -1668,7 +1668,7 @@ long RModel::WriteInitializedTensorsToFile(std::string filename) {
                throw std::runtime_error("tmva-sofie tensor " + tensor_name + " with type " + ConvertTypeToString(i.second.type()) + " cannot be written to a file");
             }
             if (f.fail())
-               std::runtime_error("tmva-sofie failed to write tensor data to file for  " + tensor_name);
+               throw std::runtime_error("tmva-sofie failed to write tensor data to file for  " + tensor_name);
         }
         long curr_pos = f.tellp();
         f.close();


### PR DESCRIPTION
C:\ROOT-CI\src\roofit\roofitcore\src\RooLinkedList.cxx(71,19): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?) [C:\ROOT-CI\build\roofit\roofitcore\RooFitCore.vcxproj]

also warning about unused e var in TROOT

and several more.

Related: https://github.com/root-project/root/pull/22069