### PR TITLE
Provide new fonts handling routines in TVirtualX/TPadPainter classes

### DIFF
--- a/core/base/inc/TAttText.h
+++ b/core/base/inc/TAttText.h
@@ -37,7 +37,8 @@ public:
    virtual Color_t  GetTextColor() const {return fTextColor;} ///< Return the text color
    virtual Font_t   GetTextFont()  const {return fTextFont;}  ///< Return the text font
    virtual Float_t  GetTextSize()  const {return fTextSize;}  ///< Return the text size
-   virtual Float_t  GetTextSizePercent(Float_t size);         ///< Return the text in percent of the pad size
+   virtual Float_t  GetTextSizePercent(Float_t size);   ///< Return the text in percent of the pad size
+   virtual Float_t  GetTextSizePixels(TVirtualPad &pad) const; ///< Return the text size in pixels for specified pad
    virtual void     Modify();
    virtual void     ModifyOn(TVirtualPad &pad);
    virtual void     ResetAttText(Option_t *toption="");

--- a/core/base/inc/TAttText.h
+++ b/core/base/inc/TAttText.h
@@ -39,6 +39,7 @@ public:
    virtual Float_t  GetTextSize()  const {return fTextSize;}  ///< Return the text size
    virtual Float_t  GetTextSizePercent(Float_t size);   ///< Return the text in percent of the pad size
    virtual Float_t  GetTextSizePixels(TVirtualPad &pad) const; ///< Return the text size in pixels for specified pad
+   virtual Float_t  GetTextSizeRelative(TVirtualPad &pad) const; ///< Return the text size in relative units
    virtual void     Modify();
    virtual void     ModifyOn(TVirtualPad &pad);
    virtual void     ResetAttText(Option_t *toption="");

--- a/core/base/inc/TVirtualPadPainter.h
+++ b/core/base/inc/TVirtualPadPainter.h
@@ -115,6 +115,15 @@ public:
    virtual void     LockPainter();
    virtual void     NewPage() {}
 
+   //Methods for text dimensions handling
+   virtual Bool_t    HasTTFonts() const;
+   virtual void      GetTextExtent(Font_t /* font */, Double_t /* size */, UInt_t & /* w */, UInt_t & /* h */, const char * /* mess */) {}
+   virtual void      GetTextExtent(Font_t /* font */, Double_t /* size */, UInt_t & /* w */, UInt_t & /* h */, const wchar_t * /* mess */) {}
+   virtual void      GetTextAscentDescent(Font_t /* font */, Double_t /* size */, UInt_t & /* w */, UInt_t & /* h */, const char * /* mess */) {}
+   virtual void      GetTextAscentDescent(Font_t /* font */, Double_t /* size */, UInt_t & /* w */, UInt_t & /* h */, const wchar_t * /* mess */) {}
+   virtual UInt_t    GetTextAdvance(Font_t /* font */, Double_t /* size */, const char * /* text */, Bool_t /* kern */ ) { return 0; }
+
+
    //Now, drawing primitives.
    virtual void     DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2) = 0;
    virtual void     DrawLineNDC(Double_t u1, Double_t v1, Double_t u2, Double_t v2) = 0;

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -102,6 +102,13 @@ public:
    virtual void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const wchar_t *text,
                               ETextMode mode);
 
+   virtual void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess);
+   virtual void      GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess);
+   virtual Int_t     GetFontAscent() const;
+   virtual Int_t     GetFontAscent(const char *mess) const;
+   virtual Int_t     GetFontDescent() const;
+   virtual Int_t     GetFontDescent(const char *mess) const;
+
 
    //---- New graphics interface -----
 
@@ -127,6 +134,10 @@ public:
    virtual void      DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn, const wchar_t *text, ETextMode mode);
    virtual Int_t     WriteGIFW(WinContext_t wctxt, const char *name);
 
+   virtual Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess);
+   virtual Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess);
+   virtual Bool_t    GetFontAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess);
+
 
    //---- OpenGL related stuff, required only with R__HAS_COCOA ----
    virtual Double_t  GetOpenGLScalingFactor();
@@ -146,12 +157,6 @@ public:
    virtual ULong_t   GetPixel(Color_t cindex);
    virtual void      GetPlanes(Int_t &nplanes);
    virtual void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b);
-   virtual void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess);
-   virtual void      GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess);
-   virtual Int_t     GetFontAscent() const;
-   virtual Int_t     GetFontAscent(const char *mess) const;
-   virtual Int_t     GetFontDescent() const;
-   virtual Int_t     GetFontDescent(const char *mess) const;
    virtual Float_t   GetTextMagnitude();
    virtual Window_t  GetWindowID(Int_t wid);
    virtual Bool_t    HasTTFonts() const;

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -63,12 +63,13 @@ public:
    virtual void      ClearWindow();
    virtual void      ClosePixmap();
    virtual void      CloseWindow();
-   virtual void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos);
    virtual void      CreateOpenGLContext(Int_t wid=0);
    virtual void      DeleteOpenGLContext(Int_t wid=0);
 
 
-   //---- Old graphics interface -----
+   //---- Old, no longer used graphics interface -----
+
+   virtual void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos);
 
            void      SetFillColor(Color_t cindex) override;
            void      SetFillStyle(Style_t style) override;
@@ -100,6 +101,7 @@ public:
                               ETextMode mode);
    virtual void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const wchar_t *text,
                               ETextMode mode);
+
 
    //---- New graphics interface -----
 

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -148,13 +148,20 @@ If the text precision (see next paragraph) is smaller than 3, the text
 size (`textsize`) is a fraction of the current pad size. Therefore the
 same `textsize` value can generate text outputs with different absolute
 sizes in two different pads.
-The text size in pixels (`charheight`) is computed the following way:
+The text size in pixels (`charheight`) computed in the following way:
 
 ~~~ {.cpp}
    pad_width  = gPad->XtoPixel(gPad->GetX2());
    pad_height = gPad->YtoPixel(gPad->GetY1());
    if (pad_width < pad_height)  charheight = textsize*pad_width;
    else                         charheight = textsize*pad_height;
+~~~
+
+This value can be obtained using GetTextSizePixels() method:
+
+~~~ {.cpp}
+   TText txt;
+   auto charheight = text.GetTextSizePixels(*gPad);
 ~~~
 
 If the text precision is equal to 3, the text size doesn't depend on the pad's
@@ -310,20 +317,36 @@ void TAttText::Copy(TAttText &atttext) const
 
 Float_t TAttText::GetTextSizePercent(Float_t size)
 {
-   Float_t rsize = size;
-   if (fTextFont%10 > 2 && gPad) {
-      auto ww = gPad->WtoAbsPixel(gPad->GetX1(), gPad->GetX2());
-      auto hh = gPad->HtoAbsPixel(gPad->GetY1(), gPad->GetY2());
-      rsize = rsize / TMath::Max(1, TMath::Min(ww, hh));
+   if ((GetTextFont() % 2 < 3) || !gPad)
+      return size;
+
+   auto size0 = fTextSize;
+   fTextSize = size;
+   size = GetTextSizeRelative(*gPad);
+   fTextSize = size0;
+   return size;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the text size in relative units
+///
+/// If the font precision grater then 2 use pad dimensions to get value
+
+Float_t TAttText::GetTextSizeRelative(TVirtualPad &pad) const
+{
+   Float_t rsize = GetTextSize();
+   if (GetTextFont() % 10 > 2) {
+      auto wh = pad.XtoPixel(pad.GetX2());
+      auto hh = pad.YtoPixel(pad.GetY1());
+      rsize = rsize / TMath::Max(1, TMath::Min(wh, hh));
    }
    return rsize;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the text size in pixels for the specified pad
 ///
-/// If the font precision less than 2 size defined as percent of pad size and
+/// If the font precision less than 3 size defined as percent of pad size and
 /// scaled to minimal pad size
 
 Float_t TAttText::GetTextSizePixels(TVirtualPad &pad) const
@@ -356,24 +379,9 @@ void TAttText::ModifyOn(TVirtualPad &pad)
       return;
 
    Float_t tsize0 = fTextSize;
-   Float_t tsize = fTextSize;
 
-   // there was difference in text size handling, keep it in one place
-   if (pp->IsNative()) {
-      tsize = GetTextSizePixels(pad);
-   } else {
-      if (fTextFont % 10 > 2) {
-         Float_t wh = pad.XtoPixel(pad.GetX2());
-         Float_t hh = pad.YtoPixel(pad.GetY1());
-         if (wh < hh)  {
-            Float_t dy = pad.AbsPixeltoX(Int_t(tsize)) - pad.AbsPixeltoX(0);
-            tsize = dy/(pad.GetX2() - pad.GetX1());
-         } else {
-            Float_t dy = pad.AbsPixeltoY(0) - pad.AbsPixeltoY(Int_t(tsize));
-            tsize = dy/(pad.GetY2() - pad.GetY1());
-         }
-      }
-   }
+   // PS-based painter uses relative size, gVirtualX - pixels
+   Float_t tsize = pp->GetPS() ? GetTextSizeRelative(pad) : GetTextSizePixels(pad);
 
    fTextSize = tsize;
 
@@ -381,7 +389,6 @@ void TAttText::ModifyOn(TVirtualPad &pad)
 
    fTextSize = tsize0;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Reset this text attributes to default values.

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -16,6 +16,7 @@
 #include "TVirtualPad.h"
 #include "TVirtualPadPainter.h"
 #include "TVirtualPadEditor.h"
+#include "TMathBase.h"
 #include "TStyle.h"
 #include "TError.h"
 #include "TColor.h"
@@ -301,7 +302,7 @@ void TAttText::Copy(TAttText &atttext) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the text in percent of the pad size.
+/// Return the text size in percent of the pad size.
 ///
 /// If the font precision is greater than 2, the text size returned is the size in pixel
 /// converted into percent of the pad size, otherwise the size returned is the same as the
@@ -311,14 +312,29 @@ Float_t TAttText::GetTextSizePercent(Float_t size)
 {
    Float_t rsize = size;
    if (fTextFont%10 > 2 && gPad) {
-      UInt_t w = gPad->WtoAbsPixel(gPad->GetX1(), gPad->GetX2());
-      UInt_t h = gPad->HtoAbsPixel(gPad->GetY1(), gPad->GetY2());
-      if (w < h)
-         rsize = rsize/w;
-      else
-         rsize = rsize/h;
+      auto ww = gPad->WtoAbsPixel(gPad->GetX1(), gPad->GetX2());
+      auto hh = gPad->HtoAbsPixel(gPad->GetY1(), gPad->GetY2());
+      rsize = rsize / TMath::Max(1, TMath::Min(ww, hh));
    }
    return rsize;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the text size in pixels for the specified pad
+///
+/// If the font precision less than 2 size defined as percent of pad size and
+/// scaled to minimal pad size
+
+Float_t TAttText::GetTextSizePixels(TVirtualPad &pad) const
+{
+   Float_t tsize = GetTextSize();
+   if (GetTextFont() % 10 <= 2) {
+      auto wh = pad.XtoPixel(pad.GetX2());
+      auto hh = pad.YtoPixel(pad.GetY1());
+      tsize *= TMath::Min(wh, hh);
+   }
+   return tsize;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -344,12 +360,7 @@ void TAttText::ModifyOn(TVirtualPad &pad)
 
    // there was difference in text size handling, keep it in one place
    if (pp->IsNative()) {
-      if (fTextFont % 10 <= 2) {
-         auto  wh = pad.XtoPixel(pad.GetX2());
-         auto  hh = pad.YtoPixel(pad.GetY1());
-         if (wh < hh)  tsize *= wh;
-         else          tsize *= hh;
-      }
+      tsize = GetTextSizePixels(pad);
    } else {
       if (fTextFont % 10 > 2) {
          Float_t wh = pad.XtoPixel(pad.GetX2());

--- a/core/base/src/TVirtualPadPainter.cxx
+++ b/core/base/src/TVirtualPadPainter.cxx
@@ -211,3 +211,11 @@ void TVirtualPadPainter::SetCursor(Int_t device, ECursor cursor)
    if (gVirtualX)
       gVirtualX->SetCursor(device, cursor);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return true if TTF font can be used
+
+Bool_t TVirtualPadPainter::HasTTFonts() const
+{
+   return gVirtualX ? gVirtualX->HasTTFonts() : kFALSE;
+}

--- a/core/base/src/TVirtualX.cxx
+++ b/core/base/src/TVirtualX.cxx
@@ -652,6 +652,34 @@ void TVirtualX::GetTextExtent(UInt_t &w, UInt_t &h, wchar_t * /*mess*/)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns the size of the specified character string "mess" for font and size.
+
+Bool_t TVirtualX::GetTextExtentA(Font_t, Double_t, UInt_t &w, UInt_t &h, const char *)
+{
+   w = h = 0;
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the size of the specified character string "mess" for font and size.
+
+Bool_t TVirtualX::GetTextExtentA(Font_t, Double_t, UInt_t &w, UInt_t &h, const wchar_t *)
+{
+   w = h = 0;
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns ascent/descent for specified character string "mess" with font and size.
+
+
+Bool_t TVirtualX::GetFontAscentDescent(Font_t, Double_t, UInt_t &a, UInt_t &d, const char *)
+{
+   a = d = 0;
+   return kFALSE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Returns the ascent of the current font (in pixels).
 /// The ascent of a font is the distance from the baseline
 /// to the highest position characters extend to

--- a/graf2d/cocoa/inc/FontCache.h
+++ b/graf2d/cocoa/inc/FontCache.h
@@ -58,15 +58,15 @@ public:
 
    //Typographical bounds (whatever it means),
    //for the current selected font and text.
-   void GetTextBounds(UInt_t &w, UInt_t &h, const char *text)const;
-   void GetTextBounds(UInt_t &w, UInt_t &h, const std::vector<UniChar> & unichars)const;
+   void GetTextBounds(CTFontRef fontref, UInt_t &w, UInt_t &h, const char *text)const;
+   void GetTextBounds(CTFontRef fontref, UInt_t &w, UInt_t &h, const std::vector<UniChar> & unichars)const;
    //
-   double GetAscent()const;
-   double GetAscent(const char *text)const;
-   double GetAscent(const std::vector<UniChar> & unichars)const;
-   double GetDescent()const;
-   double GetDescent(const char *text)const;
-   double GetDescent(const std::vector<UniChar> & unichars)const;
+   double GetAscent(CTFontRef fontref) const;
+   double GetAscent(CTFontRef fontref, const char *text) const;
+   double GetAscent(CTFontRef fontref, const std::vector<UniChar> &unichars) const;
+   double GetDescent(CTFontRef fontref) const;
+   double GetDescent(CTFontRef fontref, const char *text) const;
+   double GetDescent(CTFontRef fontref, const std::vector<UniChar> &unichars) const;
    double GetLeading()const;
 
 private:

--- a/graf2d/cocoa/inc/TGQuartz.h
+++ b/graf2d/cocoa/inc/TGQuartz.h
@@ -73,6 +73,7 @@ public:
    Int_t     GetFontAscent(const char *text) const override;
    Int_t     GetFontDescent() const override;
    Int_t     GetFontDescent(const char *text) const override;
+
    Float_t   GetTextMagnitude() override;
 
    //---- Methods used for new graphics -----
@@ -91,6 +92,9 @@ public:
    void      DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn, const char *text, ETextMode mode) override;
    void      DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn, const wchar_t *text, ETextMode mode) override;
 
+   Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess) override;
+   Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess) override;
+   Bool_t    GetFontAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess) override;
 
 private:
 

--- a/graf2d/cocoa/src/FontCache.mm
+++ b/graf2d/cocoa/src/FontCache.mm
@@ -537,12 +537,12 @@ CTFontRef FontCache::SelectSymbolFont(Float_t fontSize, unsigned fontIndex)
 }
 
 //_________________________________________________________________
-void FontCache::GetTextBounds(UInt_t &w, UInt_t &h, const char *text)const
+void FontCache::GetTextBounds(CTFontRef fontref, UInt_t &w, UInt_t &h, const char *text)const
 {
-   assert(fSelectedFont != 0 && "GetTextBounds: no font was selected");
+   assert(fontref != 0 && "GetTextBounds: no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(text, fSelectedFont);
+      const Quartz::TextLine ctLine(text, fontref);
       ctLine.GetBounds(w, h);
       h += 2;
    } catch (const std::exception &) {
@@ -551,12 +551,12 @@ void FontCache::GetTextBounds(UInt_t &w, UInt_t &h, const char *text)const
 }
 
 //_________________________________________________________________
-void FontCache::GetTextBounds(UInt_t &w, UInt_t &h, const std::vector<UniChar> &unichars)const
+void FontCache::GetTextBounds(CTFontRef fontref, UInt_t &w, UInt_t &h, const std::vector<UniChar> &unichars)const
 {
-   assert(fSelectedFont != 0 && "GetTextBounds: no font was selected");
+   assert(fontref != 0 && "GetTextBounds: no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(unichars, fSelectedFont);
+      const Quartz::TextLine ctLine(unichars, fontref);
       ctLine.GetBounds(w, h);
       h += 2;
    } catch (const std::exception &) {
@@ -565,20 +565,20 @@ void FontCache::GetTextBounds(UInt_t &w, UInt_t &h, const std::vector<UniChar> &
 }
 
 //_________________________________________________________________
-double FontCache::GetAscent()const
+double FontCache::GetAscent(CTFontRef fontref) const
 {
-   assert(fSelectedFont != 0 && "GetAscent, no font was selected");
-   return CTFontGetAscent(fSelectedFont) + 1;
+   assert(fontref != 0 && "GetAscent, no font was selected");
+   return CTFontGetAscent(fontref) + 1;
 }
 
 //_________________________________________________________________
-double FontCache::GetAscent(const char *text)const
+double FontCache::GetAscent(CTFontRef fontref, const char *text) const
 {
    assert(text != 0 && "GetAscent, parameter 'text' is null");
-   assert(fSelectedFont != 0 && "GetAscent, no font was selected");
+   assert(fontref != 0 && "GetAscent, no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(text, fSelectedFont);
+      const Quartz::TextLine ctLine(text, fontref);
       Int_t ascent = 0, descent = 0;
       ctLine.GetAscentDescent(ascent, descent);
       return ascent;
@@ -588,12 +588,12 @@ double FontCache::GetAscent(const char *text)const
 }
 
 //_________________________________________________________________
-double FontCache::GetAscent(const std::vector<UniChar> &unichars)const
+double FontCache::GetAscent(CTFontRef fontref, const std::vector<UniChar> &unichars) const
 {
-   assert(fSelectedFont != 0 && "GetAscent, no font was selected");
+   assert(fontref != 0 && "GetAscent, no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(unichars, fSelectedFont);
+      const Quartz::TextLine ctLine(unichars, fontref);
       Int_t ascent = 0, descent = 0;
       ctLine.GetAscentDescent(ascent, descent);
       return ascent;
@@ -603,20 +603,20 @@ double FontCache::GetAscent(const std::vector<UniChar> &unichars)const
 }
 
 //_________________________________________________________________
-double FontCache::GetDescent()const
+double FontCache::GetDescent(CTFontRef fontref) const
 {
-   assert(fSelectedFont != 0 && "GetDescent, no font was selected");
-   return CTFontGetDescent(fSelectedFont) + 1;
+   assert(fontref != 0 && "GetDescent, no font was selected");
+   return CTFontGetDescent(fontref) + 1;
 }
 
 //_________________________________________________________________
-double FontCache::GetDescent(const char *text)const
+double FontCache::GetDescent(CTFontRef fontref, const char *text) const
 {
    assert(text != 0 && "GetDescent, parameter 'text' is null");
-   assert(fSelectedFont != 0 && "GetDescent, no font was selected");
+   assert(fontref != 0 && "GetDescent, no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(text, fSelectedFont);
+      const Quartz::TextLine ctLine(text, fontref);
       Int_t ascent = 0, descent = 0;
       ctLine.GetAscentDescent(ascent, descent);
       return descent;
@@ -626,12 +626,12 @@ double FontCache::GetDescent(const char *text)const
 }
 
 //_________________________________________________________________
-double FontCache::GetDescent(const std::vector<UniChar> &unichars)const
+double FontCache::GetDescent(CTFontRef fontref, const std::vector<UniChar> &unichars) const
 {
-   assert(fSelectedFont != 0 && "GetDescent, no font was selected");
+   assert(fontref != 0 && "GetDescent, no font was selected");
 
    try {
-      const Quartz::TextLine ctLine(unichars, fSelectedFont);
+      const Quartz::TextLine ctLine(unichars, fontref);
       Int_t ascent = 0, descent = 0;
       ctLine.GetAscentDescent(ascent, descent);
       return descent;

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -452,6 +452,21 @@ void TGQuartz::DrawPolyMarker(Int_t n, TPoint *xy)
 
 
 //______________________________________________________________________________
+
+std::vector<UniChar> quartz_get_greek_unicars(const char *text)
+{
+   //This is a hack. Correct way is to extract glyphs from symbol.ttf,
+   //find correct mapping, place this glyphs. This requires manual layout though (?),
+   //and as usually, I have to many things to do, may be, one day I'll fix text rendering also.
+   //This hack work only on MacOSX 10.7.3, does not work on iOS and I'm not sure about future/previous
+   //versions of MacOSX.
+   std::vector<UniChar> unichars(std::strlen(text));
+   for (std::size_t i = 0; i < unichars.size(); ++i)
+      unichars[i] = 0xF000 + (unsigned char)text[i];
+   return unichars;
+}
+
+//______________________________________________________________________________
 void TGQuartz::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t /* angle */ , Float_t /* mgn */,
                          const char *text, ETextMode /* mode */)
 {
@@ -483,18 +498,9 @@ void TGQuartz::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t /* angle 
    try {
       if (CTFontRef currentFont = fPimpl->fFontManager.SelectFont(atttext.GetTextFont(), kScale * atttext.GetTextSize())) {
          const unsigned fontIndex = atttext.GetTextFont() / 10;
-         if (fontIndex == 12 || fontIndex == 15) {//Greek and math symbols.
-            //This is a hack. Correct way is to extract glyphs from symbol.ttf,
-            //find correct mapping, place this glyphs. This requires manual layout though (?),
-            //and as usually, I have to many things to do, may be, one day I'll fix text rendering also.
-            //This hack work only on MacOSX 10.7.3, does not work on iOS and I'm not sure about future/previous
-            //versions of MacOSX.
-            typedef std::vector<UniChar>::size_type size_type;
-
-            std::vector<UniChar> unichars(std::strlen(text));
-            for (size_type i = 0, len = unichars.size(); i < len; ++i)
-               unichars[i] = 0xF000 + (unsigned char)text[i];
-
+         if (fontIndex == 12 || fontIndex == 15) {
+            //Greek and math symbols.
+            auto unichars = quartz_get_greek_unicars(text);
             Quartz::TextLine ctLine(unichars, currentFont, atttext.GetTextColor());
             ctLine.DrawLine(ctx, x, X11::LocalYROOTToCocoa(drawable, y), atttext);
          } else {
@@ -553,27 +559,56 @@ void TGQuartz::GetTextExtent(UInt_t &w, UInt_t &h, char *text)
    // h    - the text height
    // text - the string
 
-   if (!text || !text[0]) {
-      w = 0;
-      h = 0;
+   w = h = 0;
+
+   if (!text || !*text)
       return;
-   }
 
-   if (fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize())) {
-      const unsigned fontIndex = GetTextFont() / 10;
-      if (fontIndex == 12 || fontIndex == 15) {//Greek and math symbols.
-         typedef std::vector<UniChar>::size_type size_type;
-
-         std::vector<UniChar> unichars(std::strlen(text));
-         for (size_type i = 0, len = unichars.size(); i < len; ++i)
-            unichars[i] = 0xF000 + (unsigned char)text[i];
-
-         fPimpl->fFontManager.GetTextBounds(w, h, unichars);
-      } else {
-         fPimpl->fFontManager.GetTextBounds(w, h, text);
-      }
+   auto fontref = fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize());
+   if (!fontref)
+      return;
+   const unsigned fontIndex = GetTextFont() / 10;
+   if (fontIndex == 12 || fontIndex == 15) {
+      //Greek and math symbols.
+      auto unichars = quartz_get_greek_unicars(text);
+      fPimpl->fFontManager.GetTextBounds(fontref, w, h, unichars);
+   } else {
+      fPimpl->fFontManager.GetTextBounds(fontref, w, h, text);
    }
 }
+
+//______________________________________________________________________________
+Bool_t TGQuartz::GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *text)
+{
+   if (!text || !*text) {
+      w = h = 0;
+      return kTRUE;
+   }
+
+   auto fontref = fPimpl->fFontManager.SelectFont(font, kScale * size);
+   if (!fontref)
+      return kFALSE;
+
+   const unsigned fontIndex = font / 10;
+   if (fontIndex == 12 || fontIndex == 15) {
+      //Greek and math symbols.
+      auto unichars = quartz_get_greek_unicars(text);
+      fPimpl->fFontManager.GetTextBounds(fontref, w, h, unichars);
+   } else {
+      fPimpl->fFontManager.GetTextBounds(fontref, w, h, text);
+   }
+
+   return kTRUE;
+}
+
+//______________________________________________________________________________
+Bool_t TGQuartz::GetTextExtentA(Font_t, Double_t, UInt_t &w, UInt_t &h, const wchar_t *)
+{
+   // do not handle wchar, pad painter will switch to TTF
+   w = h = 0;
+   return kFALSE;
+}
+
 
 //______________________________________________________________________________
 Int_t TGQuartz::GetFontAscent() const
@@ -581,8 +616,8 @@ Int_t TGQuartz::GetFontAscent() const
    // Returns the ascent of the current font (in pixels).
    // The ascent of a font is the distance from the baseline
    // to the highest position characters extend to.
-   if (fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize()))
-      return Int_t(fPimpl->fFontManager.GetAscent());
+   if (auto fontref = fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize()))
+      return Int_t(fPimpl->fFontManager.GetAscent(fontref));
 
    return 0;
 }
@@ -595,22 +630,17 @@ Int_t TGQuartz::GetFontAscent(const char *text) const
    // to the highest position characters extend to.
 
    //In case of any problem we can always resort to the old version:
-   if (!text || !text[0])//How it's usually tested in ROOT
+   if (!text || !*text)
       return GetFontAscent();
 
-   if (fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize())) {
+   if (auto fontref = fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize())) {
       const unsigned fontIndex = GetTextFont() / 10;
-      if (fontIndex == 12 || fontIndex == 15) {//Greek and math symbols.
-         //That's an ugly hack :)
-         typedef std::vector<UniChar>::size_type size_type;
-
-         std::vector<UniChar> unichars(std::strlen(text));
-         for (size_type i = 0, len = unichars.size(); i < len; ++i)
-            unichars[i] = 0xF000 + (unsigned char)text[i];
-
-         return Int_t(fPimpl->fFontManager.GetAscent(unichars));
+      if (fontIndex == 12 || fontIndex == 15) {
+         //Greek and math symbols.
+         auto unichars = quartz_get_greek_unicars(text);
+         return Int_t(fPimpl->fFontManager.GetAscent(fontref, unichars));
       } else
-         return Int_t(fPimpl->fFontManager.GetAscent(text));
+         return Int_t(fPimpl->fFontManager.GetAscent(fontref, text));
    }
 
    return 0;
@@ -622,8 +652,8 @@ Int_t TGQuartz::GetFontDescent() const
    // Returns the descent of the current font (in pixels.
    // The descent is the distance from the base line
    // to the lowest point characters extend to.
-   if (fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize()))
-      return Int_t(fPimpl->fFontManager.GetDescent());
+   if (auto fontref = fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize()))
+      return Int_t(fPimpl->fFontManager.GetDescent(fontref));
 
    return 0;
 }
@@ -636,25 +666,46 @@ Int_t TGQuartz::GetFontDescent(const char *text) const
    // to the lowest point characters extend to.
 
    //That's how it's tested in ROOT:
-   if (!text || !text[0])
+   if (!text || !*text)
       return GetFontDescent();
 
-   if (fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize())) {
+   if (auto fontref = fPimpl->fFontManager.SelectFont(GetTextFont(), kScale*GetTextSize())) {
       const unsigned fontIndex = GetTextFont() / 10;
-      if (fontIndex == 12 || fontIndex == 15) {//Greek and math symbols.
-         //That's an ugly hack :)
-         typedef std::vector<UniChar>::size_type size_type;
-
-         std::vector<UniChar> unichars(std::strlen(text));
-         for (size_type i = 0, len = unichars.size(); i < len; ++i)
-            unichars[i] = 0xF000 + (unsigned char)text[i];
-
-         return Int_t(fPimpl->fFontManager.GetDescent(unichars));
+      if (fontIndex == 12 || fontIndex == 15) {
+         //Greek and math symbols.
+         auto unichars = quartz_get_greek_unicars(text);
+         return Int_t(fPimpl->fFontManager.GetDescent(fontref, unichars));
       } else
-         return Int_t(fPimpl->fFontManager.GetDescent(text));
+         return Int_t(fPimpl->fFontManager.GetDescent(fontref, text));
    }
 
    return 0;
+}
+
+//______________________________________________________________________________
+Bool_t TGQuartz::GetFontAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *text)
+{
+   a = d = 0;
+
+   auto fontref = fPimpl->fFontManager.SelectFont(font, kScale * size);
+   if (!fontref)
+      return kFALSE;
+
+   const unsigned fontIndex = font / 10;
+   if (!text || !*text) {
+      a = fPimpl->fFontManager.GetAscent(fontref);
+      d = fPimpl->fFontManager.GetDescent(fontref);
+   } else if (fontIndex == 12 || fontIndex == 15) {
+      //Greek and math symbols.
+      auto unichars = quartz_get_greek_unicars(text);
+      a = fPimpl->fFontManager.GetAscent(fontref, unichars);
+      a = fPimpl->fFontManager.GetDescent(fontref, unichars);
+   } else {
+      a = fPimpl->fFontManager.GetAscent(fontref, text);
+      d = fPimpl->fFontManager.GetDescent(fontref, text);
+   }
+
+   return kTRUE;
 }
 
 

--- a/graf2d/gpad/inc/TPadPainterBase.h
+++ b/graf2d/gpad/inc/TPadPainterBase.h
@@ -105,6 +105,12 @@ public:
          att.Copy(fAttText);
    }
 
+   void GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess) override;
+   void GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess) override;
+   void GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess) override;
+   void GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *mess) override;
+   UInt_t GetTextAdvance(Font_t font, Double_t size, const char *text, Bool_t kern) override;
+
    ClassDefOverride(TPadPainterBase, 0)//Pad painter with attributes handling
 };
 

--- a/graf2d/gpad/inc/TPadPainterPS.h
+++ b/graf2d/gpad/inc/TPadPainterPS.h
@@ -48,6 +48,9 @@ public:
    void     DestroyDrawable(Int_t device) override;
    void     SelectDrawable(Int_t device) override;
 
+
+   Bool_t   HasTTFonts() const override { return kTRUE; }
+
    void     NewPage() override;
 
    //TASImage support (noop for a non-gl pad).

--- a/graf2d/gpad/src/TPadPainterBase.cxx
+++ b/graf2d/gpad/src/TPadPainterBase.cxx
@@ -12,11 +12,16 @@
 #include "TPadPainterBase.h"
 #include "TColor.h"
 
+#include "TTF.h"
+#include "TVirtualX.h"
+#include "TMathBase.h"
 
 /** \class TPadPainterBase
 \ingroup gpad
 
 Extends TVirtualPadPainter interface to simplify work with graphical attributes
+
+Plus for now central place for TTF handling
 */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -38,4 +43,106 @@ TAttFill TPadPainterBase::GetAttFillInternal(Bool_t with_transparency)
    }
 
    return { color, style };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns text extend
+
+void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess)
+{
+   Bool_t res = kFALSE;
+
+   if (!HasTTFonts() && gVirtualX)
+      res = gVirtualX->GetTextExtentA(font, size, w, h, mess);
+
+   if (!res) {
+      TTF::SetTextFont(font);
+      TTF::SetTextSize(size);
+      TTF::GetTextExtent(w, h, mess);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns text extend
+
+void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess)
+{
+   Bool_t res = kFALSE;
+
+   if (!HasTTFonts() && gVirtualX)
+      res = gVirtualX->GetTextExtentA(font, size, w, h, mess);
+
+   if (!res) {
+      TTF::SetTextFont(font);
+      TTF::SetTextSize(size);
+      TTF::GetTextExtent(w, h, mess);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns text accent / descent
+
+void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess)
+{
+   Bool_t res = kFALSE;
+
+   if (!HasTTFonts() && gVirtualX) {
+      res = gVirtualX->GetFontAscentDescent(font, size, a, d, mess);
+      if (res & !a) {
+         UInt_t w = 0;
+         gVirtualX->GetTextExtentA(font, size, w, a, mess);
+      }
+   }
+
+   if (!res) {
+      TTF::SetTextFont(font);
+      TTF::SetTextSize(size);
+      a = TTF::GetBox().yMax;
+      d = TMath::Abs(TTF::GetBox().yMin);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns text accent / descent
+
+void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *mess)
+{
+   Bool_t res = kFALSE;
+
+   // special use case for MacOS - directly use TTF
+   if (!HasTTFonts() && !IsCocoa() && gVirtualX) {
+      res = gVirtualX->GetFontAscentDescent(font, size, a, d, "");
+      if (res & !a) {
+         UInt_t w = 0;
+         gVirtualX->GetTextExtentA(font, size, w, a, mess);
+      }
+   }
+
+   if (!res) {
+      TTF::SetTextFont(font);
+      TTF::SetTextSize(size);
+      a = TTF::GetBox().yMax;
+      d = TMath::Abs(TTF::GetBox().yMin);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns text advance
+
+UInt_t TPadPainterBase::GetTextAdvance(Font_t font, Double_t size, const char *mess, Bool_t kern)
+{
+   if (!HasTTFonts() && gVirtualX) {
+      UInt_t a = 0, h;
+      if (gVirtualX->GetTextExtentA(font, size, a, h, mess))
+         return a;
+   }
+
+   Bool_t kernsave = TTF::GetKerning();
+   TTF::SetKerning(kern);
+   TTF::SetTextFont(font);
+   TTF::SetTextSize(size);
+   UInt_t a = 0;
+   TTF::GetTextAdvance(a, mess);
+   TTF::SetKerning(kernsave);
+   return a;
 }

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -119,9 +119,9 @@ public:
    static void           SetHinting(Bool_t state);
    static void           SetKerning(Bool_t state);
    static void           SetSmoothing(Bool_t state);
-   static void           GetTextExtent(UInt_t &w, UInt_t &h, char *text);
-   static void           GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *text);
-   static void           GetTextAdvance(UInt_t &a, char *text);
+   static void           GetTextExtent(UInt_t &w, UInt_t &h, const char *text);
+   static void           GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text);
+   static void           GetTextAdvance(UInt_t &a, const char *text);
    static void           SetTextFont(Font_t fontnumber);
    static Int_t          SetTextFont(const char *fontname, Int_t italic=0);
    static void           SetTextSize(Float_t textsize);

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -161,7 +161,7 @@ void TTF::ComputeTrailingBlanksWidth(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Get width (w) and height (h) when text is horizontal.
 
-void TTF::GetTextExtent(UInt_t &w, UInt_t &h, char *text)
+void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const char *text)
 {
    Init();
 
@@ -178,7 +178,7 @@ void TTF::GetTextExtent(UInt_t &w, UInt_t &h, char *text)
 ////////////////////////////////////////////////////////////////////////////////
 /// Get advance (a) when text is horizontal.
 
-void TTF::GetTextAdvance(UInt_t &a, char *text)
+void TTF::GetTextAdvance(UInt_t &a, const char *text)
 {
    Init();
 
@@ -192,7 +192,7 @@ void TTF::GetTextAdvance(UInt_t &a, char *text)
 ////////////////////////////////////////////////////////////////////////////////
 /// Get width (w) and height (h) when text is horizontal.
 
-void TTF::GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *text)
+void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text)
 {
    Init();
 

--- a/graf2d/graf/src/TText.cxx
+++ b/graf2d/graf/src/TText.cxx
@@ -14,10 +14,7 @@
 #include "TROOT.h"
 #include "TBuffer.h"
 #include "TVirtualPad.h"
-#include <ft2build.h>
-#include FT_FREETYPE_H
-#include FT_GLYPH_H
-#include "TTF.h"
+#include "TVirtualPadPainter.h"
 #include "TVirtualX.h"
 #include "TMath.h"
 #include "TPoint.h"
@@ -478,7 +475,8 @@ void TText::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
       return;
    }
 
-   if (!gPad) return;
+   if (!gPad)
+      return;
    if (angle) {
       Int_t cBoxX[4], cBoxY[4];
       Int_t ptx, pty;
@@ -503,16 +501,10 @@ void TText::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
       w = x2-x1;
       h = y2-y1;
    } else {
-      if ((gVirtualX->HasTTFonts() && TTF::IsInitialized()) || gPad->IsBatch()) {
-         TTF::GetTextExtent(w, h, (char*)GetTitle());
-      } else {
-         const Font_t oldFont = gVirtualX->GetTextFont();
-         if (gVirtualX->InheritsFrom("TGCocoa"))
-            gVirtualX->SetTextFont(fTextFont);
-         gVirtualX->GetTextExtent(w, h, (char*)GetTitle());
-         if (gVirtualX->InheritsFrom("TGCocoa"))
-            gVirtualX->SetTextFont(oldFont);
-      }
+      Double_t tsize = GetTextSizePixels(*gPad);
+      auto pp = gPad->GetPainter();
+      if (pp)
+         pp->GetTextExtent(GetTextFont(), tsize, w, h, GetTitle());
    }
 }
 
@@ -523,32 +515,14 @@ void TText::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
 
 void TText::GetTextAscentDescent(UInt_t &a, UInt_t &d, const char *text) const
 {
-   if (!gPad) return;
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
-   Double_t tsize;
-   if (wh < hh)  tsize = fTextSize*wh;
-   else          tsize = fTextSize*hh;
+   if (!gPad)
+      return;
 
-   if (gVirtualX->HasTTFonts() || gPad->IsBatch()) {
-      TTF::SetTextFont(fTextFont);
-      TTF::SetTextSize(tsize);
-      a = TTF::GetBox().yMax;
-      d = TMath::Abs(TTF::GetBox().yMin);
-   } else {
-      const Font_t oldFont = gVirtualX->GetTextFont();
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(fTextFont);
-      gVirtualX->SetTextSize(tsize);
-      a = gVirtualX->GetFontAscent(text);
-      if (!a) {
-         UInt_t w;
-         gVirtualX->GetTextExtent(w, a, (char*)text);
-      }
-      d = gVirtualX->GetFontDescent(text);
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(oldFont);
-   }
+   Double_t tsize = GetTextSizePixels(*gPad);
+
+   auto pp = gPad->GetPainter();
+   if (pp)
+      pp->GetTextAscentDescent(GetTextFont(), tsize, a, d, text);
 }
 
 
@@ -559,27 +533,14 @@ void TText::GetTextAscentDescent(UInt_t &a, UInt_t &d, const char *text) const
 
 void TText::GetTextAscentDescent(UInt_t &a, UInt_t &d, const wchar_t *text) const
 {
-   if (!gPad) return;
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
-   Double_t tsize;
-   if (wh < hh)  tsize = fTextSize*wh;
-   else          tsize = fTextSize*hh;
+   if (!gPad)
+      return;
 
-   if (gVirtualX->HasTTFonts() || gPad->IsBatch() || gVirtualX->InheritsFrom("TGCocoa")) {
-      TTF::SetTextFont(fTextFont);
-      TTF::SetTextSize(tsize);
-      a = TTF::GetBox().yMax;
-      d = TMath::Abs(TTF::GetBox().yMin);
-   } else {
-      gVirtualX->SetTextSize(tsize);
-      a = gVirtualX->GetFontAscent();
-      if (!a) {
-         UInt_t w;
-         gVirtualX->GetTextExtent(w, a, (wchar_t*)text);
-      }
-      d = gVirtualX->GetFontDescent();
-   }
+   Double_t tsize = GetTextSizePixels(*gPad);
+
+   auto pp = gPad->GetPainter();
+   if (pp)
+      pp->GetTextAscentDescent(GetTextFont(), tsize, a, d, text);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -589,26 +550,14 @@ void TText::GetTextAscentDescent(UInt_t &a, UInt_t &d, const wchar_t *text) cons
 
 void TText::GetTextExtent(UInt_t &w, UInt_t &h, const char *text) const
 {
-   if (!gPad) return;
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
-   Double_t tsize;
-   if (wh < hh)  tsize = fTextSize*wh;
-   else          tsize = fTextSize*hh;
+   if (!gPad)
+      return;
 
-   if (gVirtualX->HasTTFonts() || gPad->IsBatch()) {
-      TTF::SetTextFont(fTextFont);
-      TTF::SetTextSize(tsize);
-      TTF::GetTextExtent(w, h, (char*)text);
-   } else {
-      const Font_t oldFont = gVirtualX->GetTextFont();
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(fTextFont);
-      gVirtualX->SetTextSize(tsize);
-      gVirtualX->GetTextExtent(w, h, (char*)text);
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(oldFont);
-   }
+   Double_t tsize = GetTextSizePixels(*gPad);
+
+   auto pp = gPad->GetPainter();
+   if (pp)
+      pp->GetTextExtent(GetTextFont(), tsize, w, h, text);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -618,33 +567,14 @@ void TText::GetTextExtent(UInt_t &w, UInt_t &h, const char *text) const
 
 void TText::GetTextAdvance(UInt_t &a, const char *text, const Bool_t kern) const
 {
-   if (!gPad) return;
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
-   Double_t tsize;
-   if (wh < hh)  tsize = fTextSize*wh;
-   else          tsize = fTextSize*hh;
+   if (!gPad)
+      return;
 
-   if (gVirtualX->HasTTFonts() || gPad->IsBatch()) {
-      Bool_t kernsave = TTF::GetKerning();
-      TTF::SetKerning(kern);
-      TTF::SetTextFont(fTextFont);
-      TTF::SetTextSize(tsize);
-      TTF::GetTextAdvance(a, (char*)text);
-      TTF::SetKerning(kernsave);
-   } else {
-      UInt_t h;
-      const Font_t oldFont = gVirtualX->GetTextFont();
-      //how do I know what to calculate without a font???
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(fTextFont);
+   Double_t tsize = GetTextSizePixels(*gPad);
 
-      gVirtualX->SetTextSize(tsize);
-      gVirtualX->GetTextExtent(a, h, (char*)text);
-
-      if (gVirtualX->InheritsFrom("TGCocoa"))
-         gVirtualX->SetTextFont(oldFont);
-   }
+   auto pp = gPad->GetPainter();
+   if (pp)
+      a = pp->GetTextAdvance(GetTextFont(), tsize, text, kern);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -654,21 +584,14 @@ void TText::GetTextAdvance(UInt_t &a, const char *text, const Bool_t kern) const
 
 void TText::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text) const
 {
-   if (!gPad) return;
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
-   Double_t tsize;
-   if (wh < hh)  tsize = fTextSize*wh;
-   else          tsize = fTextSize*hh;
+   if (!gPad)
+      return;
 
-   if (gVirtualX->HasTTFonts() || gPad->IsBatch() || gVirtualX->InheritsFrom("TGCocoa")) {
-      TTF::SetTextFont(fTextFont);
-      TTF::SetTextSize(tsize);
-      TTF::GetTextExtent(w, h, (wchar_t*)text);
-   } else {
-      gVirtualX->SetTextSize(tsize);
-      gVirtualX->GetTextExtent(w, h, (wchar_t*)text);
-   }
+   Double_t tsize = GetTextSizePixels(*gPad);
+
+   auto pp = gPad->GetPainter();
+   if (pp)
+      pp->GetTextExtent(GetTextFont(), tsize, w, h, text);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/win32gdk/inc/TGWin32.h
+++ b/graf2d/win32gdk/inc/TGWin32.h
@@ -155,8 +155,6 @@ public:
    ULong_t   GetPixel(Color_t cindex) override;
    void      GetPlanes(Int_t &nplanes) override;
    void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b) override;
-   virtual void GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
-   virtual void GetTextExtent(UInt_t &, UInt_t &, wchar_t *) override {}
    Float_t   GetTextMagnitude() override {return fTextMagnitude;}
    Window_t  GetWindowID(Int_t wid) override;
    Bool_t    HasTTFonts() const override { return fHasTTFonts; }
@@ -204,6 +202,8 @@ public:
    Int_t     WriteGIF(char *name) override;
    void      WritePixmap(Int_t wid, UInt_t w, UInt_t h, char *pxname) override;
    Window_t  GetCurrentWindow() const override;
+   void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
+   void      GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess) override;
 
    //---- Methods used for new graphics -----
    WinContext_t GetWindowContext(Int_t wid) override;

--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -2056,6 +2056,16 @@ void TGWin32::GetTextExtent(UInt_t &w, UInt_t &h, char *mess)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the size of a wcharacter string - use TTF
+
+void TGWin32::GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess)
+{
+   TTF::SetTextFont(gTextFont);
+   TTF::SetTextSize(fTextSize);
+   TTF::GetTextExtent(w, h, mess);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return the X11 window identifier.
 /// wid      : Workstation identifier (input)
 

--- a/graf2d/x11/inc/TGX11.h
+++ b/graf2d/x11/inc/TGX11.h
@@ -157,8 +157,6 @@ public:
    ULong_t   GetPixel(Color_t cindex) override;
    void      GetPlanes(Int_t &nplanes) override;
    void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b) override;
-   void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
-   void      GetTextExtent(UInt_t &, UInt_t &, wchar_t *) override {}
    Float_t   GetTextMagnitude() override { return fTextMagnitude; }
    Window_t  GetWindowID(Int_t wid) override;
    Bool_t    HasTTFonts() const override { return fHasTTFonts; }
@@ -224,6 +222,8 @@ public:
    void      DrawPolyMarker(Int_t n, TPoint *xy) override;
    void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const char *text, ETextMode mode) override;
    void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const wchar_t *text, ETextMode mode) override;
+   void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
+   void      GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess) override;
 
    //---- Methods used for new graphics -----
    WinContext_t GetWindowContext(Int_t wid) override;
@@ -239,7 +239,6 @@ public:
    void      CopyPixmapW(WinContext_t wctxt, Int_t wid, Int_t xpos, Int_t ypos) override;
    Int_t     WriteGIFW(WinContext_t wctxt, const char *name) override;
 
-
    void      DrawBoxW(WinContext_t wctxt, Int_t x1, Int_t y1, Int_t x2, Int_t y2, EBoxMode mode) override;
    void      DrawFillAreaW(WinContext_t wctxt, Int_t n, TPoint *xy) override;
    void      DrawLineW(WinContext_t wctxt, Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
@@ -248,6 +247,10 @@ public:
    void      DrawPolyMarkerW(WinContext_t wctxt, Int_t n, TPoint *xy) override;
    void      DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn, const char *text, ETextMode mode) override;
    void      DrawTextW(WinContext_t, Int_t, Int_t, Float_t, Float_t, const wchar_t *, ETextMode) override {}
+
+   Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess) override;
+   Bool_t    GetTextExtentA(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess) override;
+
 
    //---- Methods used for GUI -----
    void         GetWindowAttributes(Window_t id, WindowAttributes_t &attr) override;

--- a/graf2d/x11/inc/TGX11.h
+++ b/graf2d/x11/inc/TGX11.h
@@ -126,12 +126,15 @@ protected:
 
    Bool_t     AllocColor(Colormap cmap, RXColor *color);
    void       QueryColors(Colormap cmap, RXColor *colors, Int_t ncolors);
-   void      *GetGC(Int_t which) const;
    Window_t  GetWindow(WinContext_t wctxt) const;
    void      *GetGCW(WinContext_t wctxt, Int_t which) const;
    EAlign     GetTextAlignW(WinContext_t wctxt) const;
 
    XColor_t  &GetColor(Int_t cid);
+
+   //---- Methods used for old graphics -----
+   void      *GetGC(Int_t which) const;
+
 
    TGX11(TGX11 &&org);
    TGX11(const TGX11 &org) = delete;

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -1181,17 +1181,45 @@ void TGX11::GetRGB(int index, float &r, float &g, float &b)
 
 void TGX11::GetTextExtent(UInt_t &w, UInt_t &h, char *mess)
 {
-   w=0; h=0;
-   if (strlen(mess)==0) return;
+   w = h = 0;
+   if (!mess || !*mess)
+      return;
 
-   XPoint *cBox;
    XRotSetMagnification(fTextMagnitude);
-   cBox = XRotTextExtents((Display*)fDisplay, gTextFont, 0., 0, 0, mess, 0);
+   XPoint *cBox = XRotTextExtents((Display*)fDisplay, gTextFont, 0., 0, 0, mess, 0);
    if (cBox) {
       w    = cBox[2].x;
       h    = -cBox[2].y;
-      free((char *)cBox);
+      free(cBox);
    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the size of a wcharacter string - not implemented
+
+void TGX11::GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *)
+{
+   w = h = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the size of a character string for specified font and size
+/// On plain X11 font and size is ignored - just some default font is used
+
+Bool_t TGX11::GetTextExtentA(Font_t, Double_t, UInt_t &w, UInt_t &h, const char *mess)
+{
+   GetTextExtent(w, h, (char *)mess);
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return the size of a wcharacter string - not implemented
+/// On plain X11 font and size is ignored - just some default font is used
+
+Bool_t TGX11::GetTextExtentA(Font_t, Double_t, UInt_t &w, UInt_t &h, const wchar_t *)
+{
+   w = h = 0;
+   return kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/webgui6/inc/TWebPadPainter.h
+++ b/gui/webgui6/inc/TWebPadPainter.h
@@ -37,6 +37,7 @@ public:
 
    void SetPainting(TWebPainting *p) { fPainting = p; }
 
+   Bool_t   HasTTFonts() const override { return kTRUE; }
 
    void     SetOpacity(Int_t percent) override;
 


### PR DESCRIPTION
1. When render text basic functions like text extent/ascent/descent are required. These values handled normally by TTF, but for Cocoa it is done differently. Also plain X11 uses simplified text rendering with own methods. Provide several new methods in `TVirtualX` interface which gives text metrics for specified font/size. 
2. Implement these methods in TGQuartz class, extend internal interfaces to avoid dependency on selected font.
3. Provide in TVirtualPadPainter similar methods.
4. In TPadPainterBase implement these methods with FFT support when it is desired. It will be central place where difference between `TTF` and `not-TTF` platform will be handled.
5. Implement `TAttText::GetTextSizePixels(TVirtualPad &pad)` and `TAttText::GetTextSizeRelative(TVirtualPad &pad)`. These methods uses pad attributes to correctly scale font size depending from font precision. One can see that pixel size used by TVirtualX and relative size used by TVirtualPS output
6. Finally adjust all TText methods to get metrics via pad painter. In this respect text rendering now mostly do not depend from gVirtualX.

Really missing is functionality to get pad pixel width and height. All kind of workarounds are really annoying. 
Using equation: `pad_height = pad.YtoPixel(pad.GetY1());` is not that one expects.