### PR TITLE
[core] Avoid a clang vectoriser bug in TColorGradient.

### DIFF
--- a/core/base/src/TColorGradient.cxx
+++ b/core/base/src/TColorGradient.cxx
@@ -111,6 +111,12 @@ void TColorGradient::ResetColor(UInt_t nPoints, const Double_t *points,
    fColors.assign(colors, colors + nPoints * 4);
 
    Double_t sum[4] = { 0., 0., 0., 0. };
+#ifdef __clang__
+   // Clang vectoriser bug (confirmed for clang 20 - 22)
+   // https://github.com/llvm/llvm-project/issues/194008
+   // The store in the loop can smash the stack with e.g. -O2 -mavx2.
+#pragma clang loop vectorize(disable)
+#endif
    for (unsigned n = 0; n < fColors.size(); ++n)
       sum[n % 4] += fColors[n];
 

--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -29,25 +29,6 @@ ROOT_ADD_GTEST(CoreSystemTests TSystemTests.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(CoreCryptoRandomTest CryptoRandomTest.cxx LIBRARIES Core)
 
 ROOT_ADD_GTEST(CoreColorTests TColorTests.cxx LIBRARIES Core)
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 25.4)
-  set_tests_properties(gtest-core-base-CoreColorTests PROPERTIES DISABLED True)
-  file(GENERATE
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/run_until_failure
-    CONTENT
-"import subprocess
-for _ in range(100):
-    try:
-        subprocess.run(['$<TARGET_FILE:CoreColorTests>'], check=True)
-    except subprocess.CalledProcessError as e:
-        print('This test is expected to fail with a stack corruption: ', e)
-        exit(123)
-print('This test was expected to fail with a stack corruption. Check if it got fixed.')
-exit(1)"
-    TARGET CoreColorTests)
-
-  add_test(NAME CoreColor_RunUntilFailure COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/run_until_failure)
-  set_tests_properties(CoreColor_RunUntilFailure PROPERTIES SKIP_RETURN_CODE 123)
-endif()
 
 configure_file(Foo.C Foo.C COPYONLY)
 ROOT_ADD_GTEST(IncludePathTest IncludePathTest.cxx LIBRARIES Core)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -739,13 +739,6 @@ foreach(t ${tutorials})
   if(${t} IN_LIST multithreaded)
     set_tests_properties(tutorial-${tname} PROPERTIES PROCESSORS ${NProcessors})
   endif()
-
-  if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 25.4 AND tname MATCHES "gl-.*grad")
-    # ROOT-21367
-    # On mac beta, there is a stack corruption (suspected to be a compiler bug) that may fail these tests
-    set_tests_properties(tutorial-${tname} PROPERTIES DISABLED True)
-    message(NOTICE "Disabling tutorial ${tname} for mac beta")
-  endif()
 endforeach()
 
 #---Loop over all MPI tutorials and define the corresponding test---------


### PR DESCRIPTION
The loop vectoriser in clang-20 to clang-22 can overflow the stack, which should explain the crashes observed when mac beta moved to clang-21.
Here, we instruct the vectoriser to leave the loop in the affected function untouched.

https://github.com/llvm/llvm-project/issues/194008

Fix #21367