### PR TITLE
[RF] Remove remnant setOperMode() in the RooFit::Evaluator constructor

### DIFF
--- a/roofit/roofitcore/src/RooFit/Evaluator.cxx
+++ b/roofit/roofitcore/src/RooFit/Evaluator.cxx
@@ -326,17 +326,6 @@ void Evaluator::updateOutputSizes()
    for (auto &info : _nodes) {
       info.outputSize = outputSizeMap.at(info.absArg);
       info.isDirty = true;
-      // We don't need dirty flag propagation because the evaluator takes care
-      // of deciding what needs to be re-evaluated. We can disable the regular
-      // dirty state propagation. However, fundamental variables like
-      // RooRealVars and RooCategories are usually shared with other
-      // computation graphs outside the evaluator, so they can't be mutated.
-      // See also the code of the RooMinimizer, which ensures that dirty state
-      // propagation is temporarily disabled during minimization to really
-      // eliminate any overhead from the dirty flag propagation.
-      if (!info.absArg->isFundamental()) {
-         setOperMode(info.absArg, RooAbsArg::ADirty);
-      }
    }
 
    if (_useGPU) {


### PR DESCRIPTION
Follows up on fa977749042b74, which ensures that the mutation of the computation graphs operation mode is is only happening during minimization. There was a remnant `setOperMode(RooAbsArg::ADirty)` in the evaluator constructor that can now be removed.

This also fixes slowdowns in some tutorials that happened becuause some `setOperMode(RooAbsArg::ADirty)` "leaked" to RooAbsArgs that were shared with other computation graphs, e.g. for plotting.