### PR TITLE
[ci] use problem-matcher also for Windows

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -281,6 +281,10 @@ jobs:
         with:
           ref: ${{ inputs.ref_name }}
 
+      - uses: root-project/gcc-problem-matcher-improved@main
+        with:
+          build-directory: C:\ROOT-CI\src\
+
       - name: Pull Request Build
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
depends on https://github.com/root-project/gcc-problem-matcher-improved/pull/10

could be a msvc-problem-matcher if you do not want to reuse the gcc part