### PR TITLE
Introduce GetPadWidth() and GetPadHeight() methods

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -118,6 +118,8 @@ public:
    virtual Double_t GetHNDC() const = 0;
    virtual UInt_t   GetWw() const = 0;
    virtual UInt_t   GetWh() const = 0;
+   virtual UInt_t   GetPadWidth() const = 0;
+   virtual UInt_t   GetPadHeight() const = 0;
    virtual Double_t GetAbsXlowNDC() const = 0;
    virtual Double_t GetAbsYlowNDC() const = 0;
    virtual Double_t GetAbsWNDC() const = 0;

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -151,10 +151,9 @@ sizes in two different pads.
 The text size in pixels (`charheight`) computed in the following way:
 
 ~~~ {.cpp}
-   pad_width  = gPad->XtoPixel(gPad->GetX2());
-   pad_height = gPad->YtoPixel(gPad->GetY1());
-   if (pad_width < pad_height)  charheight = textsize*pad_width;
-   else                         charheight = textsize*pad_height;
+   UInt_t pad_width  = gPad->GetPadWidth();
+   UInt_t pad_height = gPad->GetPadHeight();
+   Float_t charheight = textsize*TMath::Min(pad_width, pad_height);
 ~~~
 
 This value can be obtained using GetTextSizePixels() method:
@@ -336,9 +335,9 @@ Float_t TAttText::GetTextSizeRelative(TVirtualPad &pad) const
 {
    Float_t rsize = GetTextSize();
    if (GetTextFont() % 10 > 2) {
-      auto wh = pad.XtoPixel(pad.GetX2());
-      auto hh = pad.YtoPixel(pad.GetY1());
-      rsize = rsize / TMath::Max(1, TMath::Min(wh, hh));
+      UInt_t padw = pad.GetPadWidth();
+      UInt_t padh = pad.GetPadHeight();
+      rsize /= TMath::Max((UInt_t) 1, TMath::Min(padw, padh));
    }
    return rsize;
 }
@@ -353,9 +352,9 @@ Float_t TAttText::GetTextSizePixels(TVirtualPad &pad) const
 {
    Float_t tsize = GetTextSize();
    if (GetTextFont() % 10 <= 2) {
-      auto wh = pad.XtoPixel(pad.GetX2());
-      auto hh = pad.YtoPixel(pad.GetY1());
-      tsize *= TMath::Min(wh, hh);
+      UInt_t padw = pad.GetPadWidth();
+      UInt_t padh = pad.GetPadHeight();
+      tsize *= TMath::Min(padw, padh);
    }
    return tsize;
 }

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -5729,19 +5729,11 @@ void TASImage::DrawTextOnPad(TText *text, Int_t x, Int_t y, TVirtualPad *pad, In
    // set text font
    TTF::SetTextFont(text->GetTextFont());
 
-   Int_t wh = 100, hh = 100;
-   if (pad) {
-      wh = pad->XtoPixel(pad->GetX2());
-      hh = pad->YtoPixel(pad->GetY1());
-   }
+   UInt_t padw = pad ? pad->GetPadWidth() : 100;
+   UInt_t padh = pad ? pad->GetPadHeight() : 100;
 
    // set text size
-   Float_t ttfsize;
-   if (wh < hh) {
-      ttfsize = text->GetTextSize() * wh;
-   } else {
-      ttfsize = text->GetTextSize() * hh;
-   }
+   Float_t ttfsize = text->GetTextSize() * TMath::Min(padw, padh);
    TTF::SetTextSize(ttfsize*kScale);
 
    // set text angle

--- a/graf2d/gpad/inc/TCanvas.h
+++ b/graf2d/gpad/inc/TCanvas.h
@@ -166,6 +166,8 @@ public:
    UInt_t            GetWindowHeight() const { return fWindowHeight; }
    UInt_t            GetWw() const override { return fCw; }
    UInt_t            GetWh() const override { return fCh; }
+   UInt_t            GetPadWidth() const override { return fCw; }
+   UInt_t            GetPadHeight() const override { return fCh; }
    virtual void      GetCanvasPar(Int_t &wtopx, Int_t &wtopy, UInt_t &ww, UInt_t &wh)
                      {wtopx=GetWindowTopX(); wtopy=fWindowTopY; ww=fWindowWidth; wh=fWindowHeight;}
    virtual void      HandleInput(EEventType button, Int_t x, Int_t y);

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -217,6 +217,8 @@ public:
    Double_t          GetHNDC() const override { return fHNDC; }
    UInt_t            GetWw() const override;
    UInt_t            GetWh() const override;
+   UInt_t            GetPadWidth() const override;
+   UInt_t            GetPadHeight() const override;
    Double_t          GetAbsXlowNDC() const override { return fAbsXlowNDC; }
    Double_t          GetAbsYlowNDC() const override { return fAbsYlowNDC; }
    Double_t          GetAbsWNDC() const override { return fAbsWNDC; }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <locale>
 #include <memory>
+#include <cmath>
 
 #include "TROOT.h"
 #include "TBuffer.h"
@@ -2816,7 +2817,7 @@ TVirtualPad *TPad::GetPadSave() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get Wh.
+/// Get canvas height
 
 UInt_t TPad::GetWh() const
 {
@@ -2824,11 +2825,45 @@ UInt_t TPad::GetWh() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Get Ww.
+/// Get canvas width
 
 UInt_t TPad::GetWw() const
 {
    return  fCanvas ? fCanvas->GetWw() : 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get pad width
+
+UInt_t TPad::GetPadWidth() const
+{
+   // Very often pad width was calculated as XtoPixel(GetX2());
+   // But if coordinate system broken such trnasformation fail.
+   // Therefore use canvas width multiplied by absolute NDC width value
+   // Keep fallback solution only when canvas width cannot be defined
+
+   auto cw = GetWw();
+   if (!cw)
+      return XtoPixel(GetX2());
+
+   return static_cast<UInt_t>(std::lround(cw * GetAbsWNDC()));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get pad height
+
+UInt_t TPad::GetPadHeight() const
+{
+   // Very often pad height was calculated as YtoPixel(GetY1())
+   // But if coordinate system broken such trnasformation fail.
+   // Therefore use canvas height multiplied by absolute NDC height value
+   // Keep fallback solution only when canvas height cannot be defined
+
+   auto ch = GetWh();
+   if (!ch)
+      return YtoPixel(GetY1());
+
+   return static_cast<UInt_t>(std::lround(GetWh() * GetAbsHNDC()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveLabel.cxx
+++ b/graf2d/graf/src/TPaveLabel.cxx
@@ -142,8 +142,8 @@ void TPaveLabel::PaintPaveLabel(Double_t x1, Double_t y1,Double_t x2, Double_t  
    if (nch <= 0) return;
 
    // Draw label
-   Double_t wh   = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t hh   = (Double_t)gPad->YtoPixel(gPad->GetY1());
+   Double_t wh   = gPad->GetPadWidth();
+   Double_t hh   = gPad->GetPadHeight();
    if (wh==0||hh==0) return;
    Double_t labelsize, textsize = GetTextSize();
    Int_t automat = 0;

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -2675,8 +2675,10 @@ void TPostScript::Text(Double_t xx, Double_t yy, const char *chars)
    // Compute the font size. Exit if it is 0
    // The font size is computed from the TTF size to get exactly the same
    // size on the screen and in the PostScript file.
-   Double_t wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
+   Double_t wh = (Double_t) gPad->GetPadWidth();
+   Double_t hh = (Double_t) gPad->GetPadHeight();
+   if (wh <= 0 || hh <= 0)
+      return;
    Float_t tsize, ftsize;
 
    if (wh < hh) {

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1361,8 +1361,8 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
    Double_t txalv = fTextAlign%10;
    if (txalv <1) txalv = 1; else if (txalv > 3) txalv = 3;
 
-   Double_t     wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t     hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
+   Double_t     wh = (Double_t)gPad->GetPadWidth();
+   Double_t     hh = (Double_t)gPad->GetPadHeight();
    Float_t fontrap = 1.09; //scale down compared to X11
    Float_t ftsize;
 

--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -790,8 +790,8 @@ void TTeXDump::SetTextColor( Color_t cindex )
 
 void TTeXDump::Text(Double_t x, Double_t y, const char *chars)
 {
-   Double_t wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
+   Double_t wh = (Double_t)gPad->GetPadWidth();
+   Double_t hh = (Double_t)gPad->GetPadHeight();
    Float_t tsize, ftsize;
    if (wh < hh) {
       tsize = fTextSize*wh;

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -10360,9 +10360,9 @@ void THistPainter::PaintTitle()
 
    if (ht <= 0) {
       if (gStyle->GetTitleFont("")%10 == 3) {
-         Double_t hw = TMath::Max((Double_t)gPad->XtoPixel(gPad->GetX2()),
-                                  (Double_t)gPad->YtoPixel(gPad->GetY1()));
-         ht = 1.1*(gStyle->GetTitleSize("")/hw);
+         Double_t hw = (Double_t) TMath::Max(gPad->GetPadWidth(), gPad->GetPadHeight());
+         if (hw > 0)
+            ht = 1.1 * (gStyle->GetTitleSize("")/hw);
       } else {
          ht = 1.1*gStyle->GetTitleFontSize();
       }

--- a/test/Aclock.cxx
+++ b/test/Aclock.cxx
@@ -93,8 +93,8 @@ void ClockHand::Move(Float_t clock_angle)
   // ClockPoints used to rotate,scale and shift initial points
   static ClockPoints *points = new ClockPoints();
 
-  Float_t wh = (Float_t)fPad->XtoPixel(fPad->GetX2());
-  Float_t hh = (Float_t)fPad->YtoPixel(fPad->GetY1());
+  Float_t wh = (Float_t)fPad->GetPadWidth();
+  Float_t hh = (Float_t)fPad->GetPadHeight();
 
   for (int i = 0; i < n; i++) {
      points->SetXY(fX0[i],fY0[i]);

--- a/test/Tetris.cxx
+++ b/test/Tetris.cxx
@@ -68,7 +68,7 @@ void TetrisBox::SetY(Int_t y)
    // Set Y measured in boxes units
 
    // height in pixels of pad
-   Float_t height = (Float_t)fPad->YtoPixel(fPad->GetY1());
+   Float_t height = (Float_t)fPad->GetPadHeight();
 
    Coord_t y1 = ((Float_t)y)*gBoxPixelSize/height;
    Coord_t y2 = ((Float_t)y+1)*gBoxPixelSize/height;

--- a/test/Tetris.h
+++ b/test/Tetris.h
@@ -62,7 +62,9 @@ public:
 
    void    Erase();
    void    Paint(Option_t *option="") override;
-   void    ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
+   void    ExecuteEvent(Int_t, Int_t, Int_t) override  {}  // disable any actions on it
+
+   ClassDefOverride(TetrisBox, 0)
 };
 
 
@@ -174,7 +176,9 @@ public:
 
    void PaintModified() override;
    void   PieceDropped(TetrisPiece *piece, Int_t height);
-   void   ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
+   void   ExecuteEvent(Int_t, Int_t, Int_t) override  {}  // disable any actions on it
+
+   ClassDefOverride(TetrisBoard, 0)
 };
 
 
@@ -205,7 +209,9 @@ public:
    Bool_t  Notify() override;
    void    SetSpeed();
    void    Paint(Option_t *option="") override;
-   void    ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
+   void    ExecuteEvent(Int_t, Int_t, Int_t) override  { }  // disable any actions on it
+
+   ClassDefOverride(CurrentPiece, 0)
 };
 
 
@@ -228,7 +234,9 @@ public:
    void   Show()     { fPiece->Show(); Modified(kTRUE); }
 
    TetrisPiece  *GetPiece() { return fPiece; }
-   void ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
+   void ExecuteEvent(Int_t, Int_t, Int_t) override  { }  // disable any actions on it
+
+   ClassDefOverride(NextPiecePad, 0)
 };
 
 
@@ -244,6 +252,8 @@ public:
    ~QuitButton() override { }
 
    void ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+
+   ClassDefOverride(QuitButton, 0)
 };
 
 
@@ -269,6 +279,8 @@ public:
 
    Bool_t   IsPressed()               { return fPressed; }
    void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+
+   ClassDefOverride(PauseButton, 0)
 };
 
 
@@ -294,6 +306,8 @@ public:
 
    Bool_t   IsPressed()               { return fPressed; }
    void ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+
+   ClassDefOverride(NewGameButton, 0)
 };
 
 
@@ -315,7 +329,9 @@ public:
    virtual void AddValue(Int_t addValue=1) { fValue = fValue+addValue; Modified(kTRUE); }
 
    void PaintModified() override;
-   void ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
+   void ExecuteEvent(Int_t, Int_t, Int_t) override  { }  // disable any actions on it
+
+   ClassDefOverride(InfoPad, 0)
 };
 
 
@@ -331,6 +347,8 @@ public:
    ~KeyHandler() override;
 
    Bool_t HandleKey(Event_t *event) override;    // handler of the key events
+
+   ClassDefOverride(KeyHandler, 0)
 };
 
 
@@ -344,6 +362,8 @@ public:
    ~UpdateLevelTimer() override { }
 
    Bool_t Notify() override;
+
+   ClassDefOverride(UpdateLevelTimer, 0)
 };
 
 


### PR DESCRIPTION
For a long time `gPad->XtoPixel(gPad->GetX2());` and `gPad->YtoPixel(gPad->GetY1());` were used.
This is not very user-friendly.

Instead use canvas width and height multiplied by `GetAbsWNDC()` and `GetAbsHNDC()` respectively.

Adjust in several places in source code - especially around text size conversions.
