### PR TITLE
Restore modified flag after save TPad in ps/pdf/svg/tex file

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5086,7 +5086,7 @@ void TPad::Print(const char *filename, Option_t *option)
    if (!title && strstr(opt,"svg")) {
       gVirtualPS = (TVirtualPS*)gROOT->GetListOfSpecials()->FindObject(psname);
 
-      Bool_t noScreen = kFALSE;
+      Bool_t noScreen = kFALSE, wasModified = IsModified();
       if (!GetCanvas()->IsBatch() && GetCanvas()->GetCanvasID() == -1) {
          noScreen = kTRUE;
          GetCanvas()->SetBatch(kTRUE);
@@ -5114,6 +5114,8 @@ void TPad::Print(const char *filename, Option_t *option)
       Paint();
       if (noScreen)
          GetCanvas()->SetBatch(kFALSE);
+      if (wasModified && !IsBatch())
+         Modified(kTRUE);
 
       if (!gSystem->AccessPathName(psname))
          Info("Print", "SVG file %s has been created", psname.Data());
@@ -5128,7 +5130,7 @@ void TPad::Print(const char *filename, Option_t *option)
    if (!title && (strstr(opt,"tex") || strstr(opt,"Standalone"))) {
       gVirtualPS = (TVirtualPS*)gROOT->GetListOfSpecials()->FindObject(psname);
 
-      Bool_t noScreen = kFALSE;
+      Bool_t noScreen = kFALSE, wasModified = IsModified();
       if (!GetCanvas()->IsBatch() && GetCanvas()->GetCanvasID() == -1) {
          noScreen = kTRUE;
          GetCanvas()->SetBatch(kTRUE);
@@ -5157,7 +5159,10 @@ void TPad::Print(const char *filename, Option_t *option)
          gVirtualPS->NewPage();
       }
       Paint();
-      if (noScreen)  GetCanvas()->SetBatch(kFALSE);
+      if (noScreen)
+         GetCanvas()->SetBatch(kFALSE);
+      if (wasModified && !IsBatch())
+         Modified(kTRUE);
 
       if (!gSystem->AccessPathName(psname)) {
          if (standalone) {
@@ -5192,7 +5197,7 @@ void TPad::Print(const char *filename, Option_t *option)
    if (copen  || copenb)  mustClose = kFALSE;
    if (cclose || ccloseb) mustClose = kTRUE;
 
-   Bool_t noScreen = kFALSE;
+   Bool_t noScreen = kFALSE, wasModified = IsModified();
    if (!GetCanvas()->IsBatch() && GetCanvas()->GetCanvasID() == -1) {
       noScreen = kTRUE;
       GetCanvas()->SetBatch(kTRUE);
@@ -5282,6 +5287,9 @@ void TPad::Print(const char *filename, Option_t *option)
          gVirtualPS = nullptr;
       }
    }
+
+   if (wasModified && !IsBatch())
+      Modified(kTRUE);
 
    if (strstr(opt,"Preview"))
       gSystem->Exec(TString::Format("epstool --quiet -t6p %s %s", psname.Data(), psname.Data()).Data());


### PR DESCRIPTION
Before normal painting was performed in parallel to PS production. Now only printing into batch output is done
but modified flag is reset at the end of TPad::Paint(). Therefore restore that flag that normal painting can be done in the TCanvas::Update().

Discovered with latex.C macro

