### PR TITLE
[RF] Make RooProjectedPdf compile to an Evaluator-friendly compute graph 

### DIFF
--- a/roofit/roofitcore/inc/RooEvaluatorWrapper.h
+++ b/roofit/roofitcore/inc/RooEvaluatorWrapper.h
@@ -54,12 +54,6 @@ public:
 
    void applyWeightSquared(bool flag) override { _topNode->applyWeightSquared(flag); }
 
-   void printMultiline(std::ostream &os, Int_t /*contents*/, bool /*verbose*/ = false,
-                       TString /*indent*/ = "") const override
-   {
-      _evaluator->print(os);
-   }
-
    /// The RooFit::Evaluator is dealing with constant terms itself.
    void constOptimizeTestStatistic(ConstOpCode /*opcode*/, bool /*doAlsoTrackingOpt*/) override {}
 
@@ -76,6 +70,8 @@ public:
    void writeDebugMacro(std::string const &) const;
 
    std::unique_ptr<ChangeOperModeRAII> setOperModes(RooAbsArg::OperMode opMode);
+
+   RooFit::Evaluator &evaluator() const { return *_evaluator; }
 
 protected:
    double evaluate() const override;

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -34,7 +34,9 @@ is therefore identical to that of <pre>f->createProjection(RooArgSet(x,y))</pre>
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 #include "RooNameReg.h"
+#include "RooRatio.h"
 #include "RooWrapperPdf.h"
+#include "RooFitImplHelpers.h"
 
  ////////////////////////////////////////////////////////////////////////////////
  /// Default constructor
@@ -280,16 +282,55 @@ RooProjectedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
    intpdf->getObservables(&normSet, nset2);
    nset2.add(intobs);
 
-   auto newArg = std::unique_ptr<RooAbsReal>{intpdf->createIntegral(intobs, &nset2)};
+   bool forcedAnalyticalInt = false;
+   for (RooAbsArg *obs : intobs) {
+      forcedAnalyticalInt |= intpdf->forceAnalyticalInt(*obs);
+   }
 
-   std::string namePdf = std::string{newArg->GetName()} + "_wrapped_pdf";
+   // If the pdf forces analytical integration, it is usually because it is
+   // expoliting the analytical integration hooks for special integral
+   // semantics (e.g. conditional RooProdPdfs). In these cases, we can't take
+   // the optimized code path below that splits up the projection into
+   // numerator and denominator, as the integral might not factorize like this.
+   if (forcedAnalyticalInt) {
+      auto newArg = std::unique_ptr<RooAbsReal>{intpdf->createIntegral(intobs, &nset2)};
 
-   auto newArgPdf = std::make_unique<RooWrapperPdf>(namePdf.c_str(), namePdf.c_str(), *newArg);
+      std::string namePdf = std::string{newArg->GetName()} + "_wrapped_pdf";
 
-   ctx.markAsCompiled(*newArg);
+      auto newArgPdf = std::make_unique<RooWrapperPdf>(namePdf.c_str(), namePdf.c_str(), *newArg);
+
+      ctx.markAsCompiled(*newArg);
+      newArgPdf->addOwnedComponents(std::move(newArg));
+
+      return newArgPdf;
+   }
+
+   // Build the projection as an explicit ratio of two integrals instead of a
+   // single RooRealIntegral with a function-normalization set. The latter
+   // would force the integrand to evaluate the *normalized* pdf, hiding the
+   // normalization integral inside RooAbsPdf::_normMgr. That hidden integral
+   // is invisible to the RooFit::Evaluator and is therefore re-run for every
+   // step of the outer integrator during minimization (because the evaluator
+   // sets all its tracked nodes to ADirty). Exposing the normalization as a
+   // sibling node lets the evaluator cache it once per likelihood evaluation.
+   std::unique_ptr<RooAbsReal> numerator{intpdf->createIntegral(intobs)};
+   std::unique_ptr<RooAbsReal> denominator{intpdf->createIntegral(nset2)};
+
+   std::string nameRatio =
+      std::string{numerator->GetName()} + "_Norm[" + RooHelpers::getColonSeparatedNameString(nset2, ',') + "]";
+   auto ratio = std::make_unique<RooRatio>(nameRatio.c_str(), nameRatio.c_str(), *numerator, *denominator);
+
+   std::string namePdf = nameRatio + "_wrapped_pdf";
+   auto newArgPdf = std::make_unique<RooWrapperPdf>(namePdf.c_str(), namePdf.c_str(), *ratio);
+
+   ctx.markAsCompiled(*numerator);
+   ctx.markAsCompiled(*denominator);
+   ctx.markAsCompiled(*ratio);
    ctx.markAsCompiled(*newArgPdf);
 
-   newArgPdf->addOwnedComponents(std::move(newArg));
+   newArgPdf->addOwnedComponents(std::move(numerator));
+   newArgPdf->addOwnedComponents(std::move(denominator));
+   newArgPdf->addOwnedComponents(std::move(ratio));
 
    return newArgPdf;
 }

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -454,8 +454,6 @@ set(extra_veto
   io/tree/hsimpleProxy.C # A driver uses this macro which cannot be executed directly
   io/tree/tree103_tree.C
   io/tree/tree106_tree.C
-  roofit/roostats/rs401d_FeldmanCousins.C  # Takes too much time
-  roofit/roostats/rs401d_FeldmanCousins.py
   roofit/histfactory/ModifyInterpolation.C
   io/tree/tree110_copy.C
   io/tree/tree111_copy.C

--- a/tutorials/roofit/roostats/rs401d_FeldmanCousins.C
+++ b/tutorials/roofit/roostats/rs401d_FeldmanCousins.C
@@ -56,6 +56,7 @@ using namespace RooStats;
 
 void rs401d_FeldmanCousins(bool doFeldmanCousins = false, bool doMCMC = true)
 {
+   RooRealVar::enableSilentClipping();
 
    // to time the macro
    TStopwatch t;

--- a/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
+++ b/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
@@ -19,6 +19,8 @@ import ROOT
 
 def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
 
+    ROOT.RooRealVar.enableSilentClipping()
+
     # to time the macro
     t = ROOT.TStopwatch()
     t.Start()
@@ -173,7 +175,7 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
     modelConfig.SetPdf(model)
     modelConfig.SetParametersOfInterest(parameters)
 
-    fc = RooStats.FeldmanCousins(data, modelConfig)
+    fc = ROOT.RooStats.FeldmanCousins(data, modelConfig)
     fc.SetTestSize(0.1)  # set size of test
     fc.UseAdaptiveSampling(True)
     fc.SetNBins(10)  # number of points to test per parameter
@@ -185,7 +187,7 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
 
     # ---------------------------------------------------------
     # show use of ProfileLikeihoodCalculator utility in RooStats
-    plc = RooStats.ProfileLikelihoodCalculator(data, modelConfig)
+    plc = ROOT.RooStats.ProfileLikelihoodCalculator(data, modelConfig)
     plc.SetTestSize(0.1)
 
     plcInterval = plc.GetInterval()
@@ -196,8 +198,8 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
 
     if doMCMC:
         # turn some messages back on
-        RooMsgService.instance().setStreamStatus(0, True)
-        RooMsgService.instance().setStreamStatus(1, True)
+        ROOT.RooMsgService.instance().setStreamStatus(0, True)
+        ROOT.RooMsgService.instance().setStreamStatus(1, True)
 
         mcmcWatch = ROOT.TStopwatch()
         mcmcWatch.Start()
@@ -256,13 +258,13 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
     mcPlot = ROOT.kNone
     if mcInt:
         print(f"MCMC actual confidence level: ", mcInt.GetActualConfidenceLevel())
-        mcPlot = MCMCIntervalPlot(mcInt)
-        mcPlot.SetLineColor(kMagenta)
+        mcPlot = ROOT.RooStats.MCMCIntervalPlot(mcInt)
+        mcPlot.SetLineColor(ROOT.kMagenta)
         mcPlot.Draw()
 
     dataCanvas.Update()
 
-    plotInt = LikelihoodIntervalPlot(plcInterval)
+    plotInt = ROOT.RooStats.LikelihoodIntervalPlot(plcInterval)
 
     plotInt.SetTitle("90% Confidence Intervals")
     if mcInt:


### PR DESCRIPTION
RooProjectedPdf::compileForNormSet built the projection as a single RooRealIntegral with a function-normalization set. That integral's integrand evaluates the *normalized* inner pdf, hiding the normalization integral inside `RooAbsPdf::_normMgr`. With the recent move to ADirty for non-fundamental compute-graph nodes during minimization, the hidden integral is forced into ADirty too (it shares fundamental variable with the graph) and recomputes from scratch on every call by the outer integrator. For models with deep projections like the RooStats Feldman-Cousins tutorial, this caused a large performance regression.

This RP suggests to rewrite the projection as an explicit ratio of two unnormalized integrals, so both integrals become sibling nodes in the compute graph and the `RooFit::Evaluator` caches their values.

The factorization is not always safe: when the inner pdf forces analytical integration for any of the integration observables, the pdf
is usually exploiting analytical-integration hooks for special integral semantics (e.g. a RooProdPdf with Conditional terms) and the simple numerator/denominator identity does not hold. Fall back to the original code path in that case.

Also run the `rs401d_FeldmanCousins` tutorials in tests, so we don't discover performance regressions only when running the tutorial builds...