### PR TITLE
[ntuple] Change signature of RRealField::SetQuantized and deprecate old one

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldFundamental.hxx
@@ -455,15 +455,21 @@ public:
 
    /// Sets this field to use a quantized integer representation using `nBits` per value.
    /// It must be $1 <= nBits <= 32$.
-   /// `minValue` and `maxValue` must not be infinity, `NaN` or denormal floats.
-   /// Calling this function establishes a promise by the caller to RNTuple that this field will only contain values
-   /// contained in `[minValue, maxValue]` inclusive. If a value outside this range is assigned to this field, the
-   /// behavior is undefined.
-   /// This is mutually exclusive with SetTruncated() and SetHalfPrecision() and supersedes them if called after them.
-   void SetQuantized(T minValue, T maxValue, std::size_t nBits)
+   /// `valueRange.first` and `valueRange.second` are respectively the min and max value allowed for this field.
+   /// They must not be infinity, `NaN` or denormal floats, and valueRange.second must be greater or equal to
+   /// valueRange.first.
+   /// Calling this function establishes a promise by the caller to RNTuple that this field will only
+   /// contain values contained in `[minValue, maxValue]` inclusive. If a value outside this range is assigned to this
+   /// field, the behavior is undefined. This is mutually exclusive with SetTruncated() and SetHalfPrecision() and
+   /// supersedes them if called after them.
+   void SetQuantized(std::size_t nBits, std::pair<T, T> valueRange)
    {
       const auto &[minBits, maxBits] =
          ROOT::Internal::RColumnElementBase::GetValidBitRange(ROOT::ENTupleColumnType::kReal32Quant);
+      if (valueRange.second < valueRange.first) {
+         throw RException(R__FAIL("value range given to SetQuantized() has max < min! (" +
+                                  std::to_string(valueRange.second) + " < " + std::to_string(valueRange.first) + ")"));
+      }
       if (nBits < minBits || nBits > maxBits) {
          throw RException(R__FAIL("SetQuantized() argument nBits = " + std::to_string(nBits) +
                                   " is out of valid range [" + std::to_string(minBits) + ", " +
@@ -471,9 +477,12 @@ public:
       }
       SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32Quant}});
       fBitWidth = nBits;
-      fValueMin = minValue;
-      fValueMax = maxValue;
+      fValueMin = valueRange.first;
+      fValueMax = valueRange.second;
    }
+
+   R__DEPRECATED(6, 42, "Use SetQuantized(std::size_t nBits, std::pair<T> valueRange) instead")
+   void SetQuantized(T minValue, T maxValue, std::size_t nBits) { SetQuantized(nBits, {minValue, maxValue}); }
 };
 
 template <>

--- a/tree/ntuple/test/ntuple_cast.cxx
+++ b/tree/ntuple/test/ntuple_cast.cxx
@@ -194,12 +194,12 @@ TEST(RNTuple, TypeCastReal)
       auto ptrDoubleTrunc = model->GetDefaultEntry().GetPtr<double>("double_trunc");
 
       auto fieldFloatQuant = std::make_unique<RField<float>>("float_quant");
-      fieldFloatQuant->SetQuantized(-1, 1, 12);
+      fieldFloatQuant->SetQuantized(12, {-1, 1});
       model->AddField(std::move(fieldFloatQuant));
       auto ptrFloatQuant = model->GetDefaultEntry().GetPtr<float>("float_quant");
 
       auto fieldDoubleQuant = std::make_unique<RField<double>>("double_quant");
-      fieldDoubleQuant->SetQuantized(0, 1, 32);
+      fieldDoubleQuant->SetQuantized(32, {0, 1});
       model->AddField(std::move(fieldDoubleQuant));
       auto ptrDoubleQuant = model->GetDefaultEntry().GetPtr<double>("double_quant");
 

--- a/tree/ntuple/test/ntuple_packing.cxx
+++ b/tree/ntuple/test/ntuple_packing.cxx
@@ -259,7 +259,7 @@ AddReal32QuantField(RNTupleModel &model, const std::string &fieldName, std::size
 {
    auto fld = std::make_unique<RField<float>>(fieldName);
    fld->SetColumnRepresentatives({{ENTupleColumnType::kReal32Quant}});
-   fld->SetQuantized(min, max, nBits);
+   fld->SetQuantized(nBits, {min, max});
    model.AddField(std::move(fld));
 }
 
@@ -1004,7 +1004,7 @@ TEST(Packing, Real32QuantFloatCornerCases)
       {
          auto model = RNTupleModel::Create();
          auto field = std::make_unique<RField<float>>("f");
-         field->SetQuantized(-pi, pi, 32);
+         field->SetQuantized(32, {-pi, pi});
          model->AddField(std::move(field));
          auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
          auto pf = writer->GetModel().GetDefaultEntry().GetPtr<float>("f");
@@ -1031,7 +1031,7 @@ TEST(Packing, Real32QuantFloatCornerCases)
       {
          auto model = RNTupleModel::Create();
          auto field = std::make_unique<RField<double>>("f");
-         field->SetQuantized(-pi, pi, 32);
+         field->SetQuantized(32, {-pi, pi});
          model->AddField(std::move(field));
          auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
          auto pf = writer->GetModel().GetDefaultEntry().GetPtr<double>("f");

--- a/tree/ntuple/test/ntuple_project.cxx
+++ b/tree/ntuple/test/ntuple_project.cxx
@@ -193,7 +193,7 @@ TEST(RNTupleProjection, AliasQuantDiffPrec)
    auto model = RNTupleModel::Create();
 
    auto field = std::make_unique<RField<float>>("q");
-   field->SetQuantized(0, 1, 20); // Set quantized with 20 bits of precision
+   field->SetQuantized(20, {0, 1}); // Set quantized with 20 bits of precision
    model->AddField(std::move(field));
 
    auto modelRead = model->Clone();
@@ -203,7 +203,7 @@ TEST(RNTupleProjection, AliasQuantDiffPrec)
       diags.requiredDiag(kWarning, "RProjectedFields", "on a projected field has no effect", false);
 
       auto projField = std::make_unique<RField<float>>("projq");
-      projField->SetQuantized(0, 1, 30); // Set quantized with 30 bits of precision
+      projField->SetQuantized(30, {0, 1}); // Set quantized with 30 bits of precision
       model->AddProjectedField(std::move(projField), [](const auto &) { return "q"; });
    }
 
@@ -233,7 +233,7 @@ TEST(RNTupleProjection, AliasQuantDiffRange)
    auto model = RNTupleModel::Create();
 
    auto field = std::make_unique<RField<float>>("q");
-   field->SetQuantized(0, 1, 20);
+   field->SetQuantized(20, {0, 1});
    model->AddField(std::move(field));
 
    auto modelRead = model->Clone();
@@ -243,7 +243,7 @@ TEST(RNTupleProjection, AliasQuantDiffRange)
       diags.requiredDiag(kWarning, "RProjectedFields", "on a projected field has no effect", false);
 
       auto projField = std::make_unique<RField<float>>("projq");
-      projField->SetQuantized(0, 2, 20);
+      projField->SetQuantized(20, {0, 2});
       model->AddProjectedField(std::move(projField), [](const auto &) { return "q"; });
    }
 
@@ -317,7 +317,7 @@ TEST(RNTupleProjection, AliasTruncQuantProj)
    fTrunc->SetTruncated(20);
    model->AddField(std::move(fTrunc));
    auto fQuant = std::make_unique<RField<float>>("quant");
-   fQuant->SetQuantized(-1, 1, 30);
+   fQuant->SetQuantized(30, {-1, 1});
    model->AddField(std::move(fQuant));
 
    auto modelRead = model->Clone();
@@ -327,7 +327,7 @@ TEST(RNTupleProjection, AliasTruncQuantProj)
       diags.requiredDiag(kWarning, "RProjectedFields", "on a projected field has no effect", false);
 
       auto projTruncToQuant = std::make_unique<RField<float>>("truncToQuant");
-      projTruncToQuant->SetQuantized(0, 10, 20);
+      projTruncToQuant->SetQuantized(20, {0, 10});
       model->AddProjectedField(std::move(projTruncToQuant), [](const auto &) { return "trunc"; });
 
       auto projQuantToTrunc = std::make_unique<RField<float>>("quantToTrunc");


### PR DESCRIPTION
Instead of
```c++
   SetQuantized(T min, T max, size_t nBits)
```
use
```c++
   SetQuantized(size_t nBits, pair<T, T> valueRange)
```

Rationale:
- keep nBits in first position to be more consistent with SetTruncated
- prevent mistakes of argument wrong ordering where nBits is passed first instead of min.

