### PR TITLE
[padpainter] handle text size in correspondent painters

### DIFF
--- a/core/base/inc/TVirtualPadPainter.h
+++ b/core/base/inc/TVirtualPadPainter.h
@@ -95,6 +95,7 @@ public:
    //Currently, must be implemented only for X11/GDI
    virtual Int_t    CreateDrawable(UInt_t w, UInt_t h) = 0;//gVirtualX->OpenPixmap
    virtual void     ClearDrawable() = 0;//gVirtualX->Clear()
+   virtual void     ClearWindow(Int_t /* device */) {} //gVirtualX->ClearWindowW()
    virtual Int_t    ResizeDrawable(Int_t /* device */, UInt_t /* w */, UInt_t /* h */) { return 0; } //gVirtualX->ResizePixmap
    virtual void     CopyDrawable(Int_t device, Int_t px, Int_t py) = 0;
    virtual void     DestroyDrawable(Int_t device) = 0;//gVirtualX->CloseWindow

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -377,16 +377,9 @@ void TAttText::ModifyOn(TVirtualPad &pad)
    if (!pp)
       return;
 
-   Float_t tsize0 = fTextSize;
-
-   // PS-based painter uses relative size, gVirtualX - pixels
-   Float_t tsize = pp->GetPS() ? GetTextSizeRelative(pad) : GetTextSizePixels(pad);
-
-   fTextSize = tsize;
+   pp->OnPad(&pad);
 
    pp->SetAttText(*this);
-
-   fTextSize = tsize0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/cocoa/CMakeLists.txt
+++ b/graf2d/cocoa/CMakeLists.txt
@@ -14,6 +14,7 @@ find_library(OPENGL_FRAMEWORK OpenGL REQUIRED)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(GCocoa
   HEADERS
+    CocoaGuiTypes.h
     TGCocoa.h
     TGOSXGL.h
     TGQuartz.h

--- a/graf2d/cocoa/inc/TGCocoa.h
+++ b/graf2d/cocoa/inc/TGCocoa.h
@@ -15,7 +15,6 @@
 
 #include "CocoaGuiTypes.h"
 #include "TVirtualX.h"
-#include "X11Atoms.h"
 
 #include <map>
 #include <memory>
@@ -70,24 +69,24 @@ public:
    Bool_t      Init(void *display) override;
    Int_t       OpenDisplay(const char *displayName) override;
    const char *DisplayName(const char *) override;
-   Int_t       SupportsExtension(const char *extensionName)const override;
+   Int_t       SupportsExtension(const char *extensionName) const override;
    void        CloseDisplay() override;
-   Display_t   GetDisplay()const override;
-   Visual_t    GetVisual()const override;
-   Int_t       GetScreen()const override;
-   UInt_t      ScreenWidthMM()const override;
-   Int_t       GetDepth()const override;
+   Display_t   GetDisplay() const override;
+   Visual_t    GetVisual() const override;
+   Int_t       GetScreen() const override;
+   UInt_t      ScreenWidthMM() const override;
+   Int_t       GetDepth() const override;
    void        Update(Int_t mode) override;
 
    //Non-virtual functions.
-           void                         ReconfigureDisplay();
-           ROOT::MacOSX::X11::Rectangle GetDisplayGeometry()const;
+   void        ReconfigureDisplay();
+   ROOT::MacOSX::X11::Rectangle GetDisplayGeometry() const;
    //End of general.
    ///////////////////////////////////////
 
    ///////////////////////////////////////
    //Window management part:
-   Window_t  GetDefaultRootWindow()const override;
+   Window_t  GetDefaultRootWindow() const override;
    //-Functions used by TCanvas/TPad (work with window, selected by SelectWindow).
    Int_t     InitWindow(ULong_t window) override;
    Window_t  GetWindowID(Int_t wid) override;//TGCocoa simply returns wid.
@@ -98,7 +97,7 @@ public:
    void      RescaleWindow(Int_t wid, UInt_t w, UInt_t h) override;
    void      ResizeWindow(Int_t wid) override;
    void      UpdateWindow(Int_t mode) override;
-   Window_t  GetCurrentWindow()const override;
+   Window_t  GetCurrentWindow() const override;
    void      CloseWindow() override;
    Int_t     AddWindow(ULong_t qwid, UInt_t w, UInt_t h) override; //-"Qt ROOT".
    void      RemoveWindow(ULong_t qwid) override; //-"Qt ROOT".
@@ -127,8 +126,8 @@ public:
    void      ChangeWindowAttributes(Window_t wid, SetWindowAttributes_t *attr) override;
    void      SelectInput(Window_t wid, UInt_t evmask) override;//Can also be in events-related part.
 
-           void      ReparentChild(Window_t wid, Window_t pid, Int_t x, Int_t y);//Non-overrider.
-           void      ReparentTopLevel(Window_t wid, Window_t pid, Int_t x, Int_t y);//Non-overrider.
+   void      ReparentChild(Window_t wid, Window_t pid, Int_t x, Int_t y);//Non-overrider.
+   void      ReparentTopLevel(Window_t wid, Window_t pid, Int_t x, Int_t y);//Non-overrider.
    void      ReparentWindow(Window_t wid, Window_t pid, Int_t x, Int_t y) override;
 
    void      MapWindow(Window_t wid) override;
@@ -150,7 +149,7 @@ public:
    void      SetWindowBackground(Window_t wid, ULong_t color) override;
    void      SetWindowBackgroundPixmap(Window_t wid, Pixmap_t pxm) override;
 
-   Window_t  GetParent(Window_t wid)const override;
+   Window_t  GetParent(Window_t wid) const override;
 
    void      SetWindowName(Window_t wid, char *name) override;
    void      SetIconName(Window_t wid, char *name) override;
@@ -176,23 +175,23 @@ public:
 
    ///////////////////////////////////////
    //GUI-rendering part.
-           void      DrawLineAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x1, Int_t y1, Int_t x2, Int_t y2);//Non-overrider.
+   void      DrawLineAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x1, Int_t y1, Int_t x2, Int_t y2);//Non-overrider.
    void      DrawLine(Drawable_t wid, GContext_t gc, Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
-           void      DrawSegmentsAux(Drawable_t wid, const GCValues_t &gcVals, const Segment_t *segments, Int_t nSegments);//Non-overrider.
+   void      DrawSegmentsAux(Drawable_t wid, const GCValues_t &gcVals, const Segment_t *segments, Int_t nSegments);//Non-overrider.
    void      DrawSegments(Drawable_t wid, GContext_t gc, Segment_t *segments, Int_t nSegments) override;
-           void      DrawRectangleAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
+   void      DrawRectangleAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
    void      DrawRectangle(Drawable_t wid, GContext_t gc, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
-           void      FillRectangleAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
+   void      FillRectangleAux(Drawable_t wid, const GCValues_t &gcVals, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
    void      FillRectangle(Drawable_t wid, GContext_t gc, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
-           void      FillPolygonAux(Window_t wid, const GCValues_t &gcVals, const Point_t *polygon, Int_t nPoints) ;//Non-overrider.
+   void      FillPolygonAux(Window_t wid, const GCValues_t &gcVals, const Point_t *polygon, Int_t nPoints) ;//Non-overrider.
    void      FillPolygon(Window_t wid, GContext_t gc, Point_t *polygon, Int_t nPoints) override;
-           void      CopyAreaAux(Drawable_t src, Drawable_t dst, const GCValues_t &gc, Int_t srcX, Int_t srcY, UInt_t width,
+   void      CopyAreaAux(Drawable_t src, Drawable_t dst, const GCValues_t &gc, Int_t srcX, Int_t srcY, UInt_t width,
                                  UInt_t height, Int_t dstX, Int_t dstY);//Non-overrider.
    void      CopyArea(Drawable_t src, Drawable_t dst, GContext_t gc, Int_t srcX, Int_t srcY, UInt_t width,
-                              UInt_t height, Int_t dstX, Int_t dstY) override;
-           void      DrawStringAux(Drawable_t wid, const GCValues_t &gc, Int_t x, Int_t y, const char *s, Int_t len);//Non-overrider.
+                      UInt_t height, Int_t dstX, Int_t dstY) override;
+   void      DrawStringAux(Drawable_t wid, const GCValues_t &gc, Int_t x, Int_t y, const char *s, Int_t len);//Non-overrider.
    void      DrawString(Drawable_t wid, GContext_t gc, Int_t x, Int_t y, const char *s, Int_t len) override;
-           void      ClearAreaAux(Window_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
+   void      ClearAreaAux(Window_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h);//Non-overrider.
    void      ClearArea(Window_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
    void      ClearWindow(Window_t wid) override;
    //End of GUI-rendering part.
@@ -215,7 +214,7 @@ public:
    Pixmap_t  CreatePixmapFromData(unsigned char *bits, UInt_t width, UInt_t height) override;
    Pixmap_t  CreateBitmap(Drawable_t wid, const char *bitmap,
                                   UInt_t width, UInt_t height) override;
-           void      DeletePixmapAux(Pixmap_t pixmapID);//Non-overrider.
+   void      DeletePixmapAux(Pixmap_t pixmapID);//Non-overrider.
    void      DeletePixmap(Pixmap_t pixmapID) override;
 
    //-"Qt ROOT".
@@ -231,7 +230,7 @@ public:
    void         GetImageSize(Drawable_t wid, UInt_t &width, UInt_t &height) override;
    void         PutPixel(Drawable_t wid, Int_t x, Int_t y, ULong_t pixel) override;
    void         PutImage(Drawable_t wid, GContext_t gc, Drawable_t img, Int_t dx, Int_t dy,
-                                 Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+                         Int_t x, Int_t y, UInt_t w, UInt_t h) override;
    void         DeleteImage(Drawable_t img) override;
    //"Images".
    /////////////////////////////
@@ -239,11 +238,11 @@ public:
    /////////////////////////////
    //Mouse (cursor, events, etc.)
    void      GrabButton(Window_t wid, EMouseButton button, UInt_t modifier,
-                                UInt_t evmask, Window_t confine, Cursor_t cursor,
-                                Bool_t grab = kTRUE) override;
+                        UInt_t evmask, Window_t confine, Cursor_t cursor,
+                        Bool_t grab = kTRUE) override;
    void      GrabPointer(Window_t wid, UInt_t evmask, Window_t confine,
-                                 Cursor_t cursor, Bool_t grab = kTRUE,
-                                 Bool_t owner_events = kTRUE) override;
+                         Cursor_t cursor, Bool_t grab = kTRUE,
+                         Bool_t owner_events = kTRUE) override;
    void      ChangeActivePointerGrab(Window_t, UInt_t, Cursor_t) override;//Noop.
    //End of mouse related part.
    /////////////////////////////
@@ -307,8 +306,8 @@ public:
    void         SetCursor(Int_t win, ECursor cursor) override;
    void         QueryPointer(Int_t &x, Int_t &y) override;
    void         QueryPointer(Window_t wid, Window_t &rootw, Window_t &childw,
-                                     Int_t &root_x, Int_t &root_y, Int_t &win_x,
-                                     Int_t &win_y, UInt_t &mask) override;
+                             Int_t &root_x, Int_t &root_y, Int_t &win_x,
+                             Int_t &win_y, UInt_t &mask) override;
    //Cursors.
    /////////////////////////////
 
@@ -360,14 +359,14 @@ public:
    void      ConvertPrimarySelection(Window_t wid, Atom_t clipboard, Time_t when) override;
    void      ConvertSelection(Window_t, Atom_t&, Atom_t&, Atom_t&, Time_t&) override;
    Int_t     GetProperty(Window_t, Atom_t, Long_t, Long_t, Bool_t, Atom_t,
-                                    Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**) override;
+                         Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**) override;
    void      GetPasteBuffer(Window_t wid, Atom_t atom, TString &text, Int_t &nchar,
-                                    Bool_t del) override;
+                            Bool_t del) override;
 
    void      ChangeProperty(Window_t wid, Atom_t property, Atom_t type,
-                                    UChar_t *data, Int_t len) override;
+                            UChar_t *data, Int_t len) override;
    void      ChangeProperties(Window_t wid, Atom_t property, Atom_t type,
-                                      Int_t format, UChar_t *data, Int_t len) override;
+                              Int_t format, UChar_t *data, Int_t len) override;
    void      DeleteProperty(Window_t, Atom_t&) override;
 
    void      SetDNDAware(Window_t, Atom_t *) override;
@@ -405,11 +404,11 @@ public:
 
 
    Bool_t       CreatePictureFromFile(Drawable_t wid, const char *filename,
-                                              Pixmap_t &pict, Pixmap_t &pict_mask,
-                                              PictureAttributes_t &attr) override;
+                                      Pixmap_t &pict, Pixmap_t &pict_mask,
+                                      PictureAttributes_t &attr) override;
    Bool_t       CreatePictureFromData(Drawable_t wid, char **data,
-                                              Pixmap_t &pict, Pixmap_t &pict_mask,
-                                              PictureAttributes_t &attr) override;
+                                      Pixmap_t &pict, Pixmap_t &pict_mask,
+                                      PictureAttributes_t &attr) override;
    Bool_t       ReadPictureDataFromFile(const char *filename, char ***ret_data) override;
    void         DeletePictureData(void *data) override;
    void         SetDashes(GContext_t gc, Int_t offset, const char *dash_list, Int_t n) override;
@@ -434,15 +433,15 @@ public:
    void         GetRegionBox(Region_t reg, Rectangle_t *rect) override;
    //
 
-   Bool_t       IsCmdThread()const override { return kTRUE; }
+   Bool_t       IsCmdThread() const override { return kTRUE; }
 
    //Non virtual, non-overriding functions.
-   ROOT::MacOSX::X11::EventTranslator *GetEventTranslator()const;
-   ROOT::MacOSX::X11::CommandBuffer *GetCommandBuffer()const;
+   ROOT::MacOSX::X11::EventTranslator *GetEventTranslator() const;
+   ROOT::MacOSX::X11::CommandBuffer *GetCommandBuffer() const;
 
    void CocoaDrawON();
    void CocoaDrawOFF();
-   Bool_t IsCocoaDraw()const;
+   Bool_t IsCocoaDraw() const;
 
 protected:
    void *GetCurrentContext();
@@ -463,7 +462,7 @@ private:
    bool fForegroundProcess;
    std::vector<GCValues_t> fX11Contexts;
    //
-   ROOT::MacOSX::X11::name_to_atom_map fNameToAtom;
+   std::map<std::string, Atom_t> fNameToAtom;
    std::vector<std::string> fAtomToName;
 
    std::map<Atom_t, Window_t> fSelectionOwners;

--- a/graf2d/cocoa/inc/X11Atoms.h
+++ b/graf2d/cocoa/inc/X11Atoms.h
@@ -11,9 +11,8 @@ namespace ROOT {
 namespace MacOSX {
 namespace X11 {
 
-typedef std::map<std::string, Atom_t> name_to_atom_map;
 
-void InitWithPredefinedAtoms(name_to_atom_map &nameToAtom, std::vector<std::string> &atomNames);
+void InitWithPredefinedAtoms(std::map<std::string, Atom_t> &nameToAtom, std::vector<std::string> &atomNames);
 
 }
 }

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -27,6 +27,7 @@
 #include "TVirtualGL.h"
 #include "X11Events.h"
 #include "X11Buffer.h"
+#include "X11Atoms.h"
 #include "TGClient.h"
 #include "TGWindow.h"
 #include "TSystem.h"
@@ -600,7 +601,7 @@ void TGCocoa::ReconfigureDisplay()
 }
 
 //______________________________________________________________________________
-X11::Rectangle TGCocoa::GetDisplayGeometry()const
+X11::Rectangle TGCocoa::GetDisplayGeometry() const
 {
    if (fDisplayShapeChanged) {
       NSArray * const screens = [NSScreen screens];
@@ -4458,13 +4459,13 @@ void TGCocoa::GetRegionBox(Region_t /*reg*/, Rectangle_t * /*rect*/)
 #pragma mark - Details and aux. functions.
 
 //______________________________________________________________________________
-ROOT::MacOSX::X11::EventTranslator *TGCocoa::GetEventTranslator()const
+ROOT::MacOSX::X11::EventTranslator *TGCocoa::GetEventTranslator() const
 {
    return &fPimpl->fX11EventTranslator;
 }
 
 //______________________________________________________________________________
-ROOT::MacOSX::X11::CommandBuffer *TGCocoa::GetCommandBuffer()const
+ROOT::MacOSX::X11::CommandBuffer *TGCocoa::GetCommandBuffer() const
 {
    return &fPimpl->fX11CommandBuffer;
 }
@@ -4483,7 +4484,7 @@ void TGCocoa::CocoaDrawOFF()
 }
 
 //______________________________________________________________________________
-bool TGCocoa::IsCocoaDraw()const
+bool TGCocoa::IsCocoaDraw() const
 {
    return bool(fCocoaDraw);
 }

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -699,7 +699,7 @@ Bool_t TGQuartz::GetFontAscentDescent(Font_t font, Double_t size, UInt_t &a, UIn
       //Greek and math symbols.
       auto unichars = quartz_get_greek_unicars(text);
       a = fPimpl->fFontManager.GetAscent(fontref, unichars);
-      a = fPimpl->fFontManager.GetDescent(fontref, unichars);
+      d = fPimpl->fFontManager.GetDescent(fontref, unichars);
    } else {
       a = fPimpl->fFontManager.GetAscent(fontref, text);
       d = fPimpl->fFontManager.GetDescent(fontref, text);

--- a/graf2d/cocoa/src/X11Atoms.mm
+++ b/graf2d/cocoa/src/X11Atoms.mm
@@ -80,7 +80,7 @@ const char *predefinedAtoms[] =
 const unsigned nPredefined = sizeof predefinedAtoms / sizeof predefinedAtoms[0];
 
 //______________________________________________________________________________
-void InitWithPredefinedAtoms(name_to_atom_map &nameToAtom, std::vector<std::string> &atomNames)
+void InitWithPredefinedAtoms(std::map<std::string, Atom_t> &nameToAtom, std::vector<std::string> &atomNames)
 {
    nameToAtom.clear();
 

--- a/graf2d/gpad/inc/TPadPainter.h
+++ b/graf2d/gpad/inc/TPadPainter.h
@@ -25,6 +25,7 @@ class TVirtualPad;
 class TPadPainter : public TPadPainterBase {
    WinContext_t   fWinContext;
    Int_t          fDoubleBuffer;
+   TVirtualPad   *fPad = nullptr;
 
 public:
    TPadPainter();
@@ -82,6 +83,8 @@ public:
 
    //jpg, png, bmp, gif output.
    void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const override;
+
+   void     OnPad(TVirtualPad *pad) override { fPad = pad; }
 
    Bool_t   IsNative() const override { return kTRUE; }
 

--- a/graf2d/gpad/inc/TPadPainter.h
+++ b/graf2d/gpad/inc/TPadPainter.h
@@ -42,6 +42,7 @@ public:
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h) override;
    void     ClearDrawable() override;
+   void     ClearWindow(Int_t device) override;
    Int_t    ResizeDrawable(Int_t device, UInt_t w, UInt_t h) override;
    void     CopyDrawable(Int_t device, Int_t px, Int_t py) override;
    void     DestroyDrawable(Int_t device) override;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -614,7 +614,7 @@ void TCanvas::Build()
       fPainter->SetAttFill({1, 1001});    //Set color index for fill area
       fPainter->SetAttLine({1, 1, 1});    //Set color index for lines
       fPainter->SetAttMarker({1, 1, 1});  //Set color index for markers
-      fPainter->SetAttText({22, 0., 1, 42, 12}); //Set color index for text
+      // fPainter->SetAttText({22, 0., 1, 42, 12}); //Set color index for text
       // Clear workstation
       fPainter->ClearDrawable();
 

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -616,7 +616,7 @@ void TCanvas::Build()
       fPainter->SetAttMarker({1, 1, 1});  //Set color index for markers
       // fPainter->SetAttText({22, 0., 1, 42, 12}); //Set color index for text
       // Clear workstation
-      fPainter->ClearDrawable();
+      fPainter->ClearWindow(fCanvasID);
 
       // Set Double Buffer on by default
       SetDoubleBuffer(1);

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5724,6 +5724,7 @@ void TPad::ResizePad(Option_t *option)
          pp->SetAttLine(attl);
          auto attt = pp->GetAttText();
          attt.SetTextSize(-1);
+         pp->OnPad(this);
          pp->SetAttText(attt);
          // create or re-create off-screen pixmap
          if (fPixmapID) {
@@ -6216,6 +6217,7 @@ void TPad::SetAttTextPS(Int_t align, Float_t angle, Color_t color, Style_t font,
                tsize = dy/(GetY2()-GetY1());
             }
          }
+         pp->OnPad(this);
          pp->SetAttText({align, angle, color, font, tsize});
       }
 }

--- a/graf2d/gpad/src/TPadPainter.cxx
+++ b/graf2d/gpad/src/TPadPainter.cxx
@@ -134,11 +134,22 @@ Bool_t TPadPainter::IsSupportAlpha() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Clear the current gVirtualX window.
+/// Clear the current gVirtualX window - calling gVirtualX->ClearWindowW
 
 void TPadPainter::ClearDrawable()
 {
-   gVirtualX->ClearWindowW(fWinContext);
+   if (fWinContext)
+      gVirtualX->ClearWindowW(fWinContext);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clear specified window - calling gVirtualX->ClearWindowW
+
+void TPadPainter::ClearWindow(Int_t device)
+{
+   auto ctxt = gVirtualX->GetWindowContext(device);
+   if (ctxt)
+      gVirtualX->ClearWindowW(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TPadPainter.cxx
+++ b/graf2d/gpad/src/TPadPainter.cxx
@@ -243,7 +243,16 @@ void TPadPainter::SetAttText(const TAttText &att)
 {
    TPadPainterBase::SetAttText(att);
 
-   gVirtualX->SetAttText(fWinContext, att);
+   // TODO: in ROOT7 move text size handling directly to correspondent PS engine
+   //       One not need to recalculate text size many time back and forth
+
+   if (!fPad)
+      Fatal("SetAttText", "Pad not specified");
+
+   TAttText attm(att);
+   attm.SetTextSize(att.GetTextSizePixels(*fPad));
+
+   gVirtualX->SetAttText(fWinContext, attm);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TPadPainterPS.cxx
+++ b/graf2d/gpad/src/TPadPainterPS.cxx
@@ -105,10 +105,20 @@ void TPadPainterPS::SetAttText(const TAttText &att)
 {
    TPadPainterBase::SetAttText(att);
 
+   // TODO: in ROOT7 move text size handling directly to correspondent PS engine
+   //       One not need to recalculate text size many time back and forth
+
+   Float_t tsize = 0.03;
+
+   if (fPad)
+      tsize = att.GetTextSizeRelative(*fPad);
+   else
+      Fatal("SetAttText", "Pad not set when invoke method");
+
    fPS->SetTextAlign(att.GetTextAlign());
    fPS->SetTextAngle(att.GetTextAngle());
    fPS->SetTextColor(att.GetTextColor());
-   fPS->SetTextSize(att.GetTextSize());
+   fPS->SetTextSize(tsize);
    fPS->SetTextFont(att.GetTextFont());
 }
 

--- a/graf3d/gl/inc/TGLFontManager.h
+++ b/graf3d/gl/inc/TGLFontManager.h
@@ -90,6 +90,7 @@ public:
    void  BBox(const wchar_t* txt,
               Float_t& llx, Float_t& lly, Float_t& llz,
               Float_t& urx, Float_t& ury, Float_t& urz) const;
+   Float_t Advance(const char* txt) const;
 
    void  Render(const char* txt, Double_t x, Double_t y, Double_t angle, Double_t mgn) const;
    void  Render(const wchar_t* txt, Double_t x, Double_t y, Double_t angle, Double_t mgn) const;

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -48,8 +48,17 @@ private:
 
    Bool_t                      fLocked;
 
+   void SelectGLFont(Font_t font, Float_t size);
+
    template<class Char_t>
    void DrawTextHelper(Double_t x, Double_t y, const Char_t *text, ETextMode mode);
+
+   template<class Char_t>
+   void TextExtentHelper(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const Char_t *text);
+
+   template<class Char_t>
+   void TextAscentDescentHelper(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const Char_t *text);
+
 public:
    TGLPadPainter();
 
@@ -99,6 +108,12 @@ public:
    void     DrawText(Double_t, Double_t, const wchar_t *, ETextMode) override;
    void     DrawTextNDC(Double_t x, Double_t y, const char *text, ETextMode mode) override;
    void     DrawTextNDC(Double_t, Double_t, const wchar_t *, ETextMode) override;
+
+   void     GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess) override;
+   void     GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess) override;
+   void     GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess) override;
+   void     GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *mess) override;
+   UInt_t   GetTextAdvance(Font_t font, Double_t size, const char *text, Bool_t kern) override;
 
    //jpg, png, gif and bmp output.
    void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const override;

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -63,7 +63,6 @@ public:
    void      SetAttFill(const TAttFill &att) override;
    void      SetAttLine(const TAttLine &att) override;
    void      SetAttMarker(const TAttMarker &att) override;
-   void      SetAttText(const TAttText &att) override;
 
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h) override;

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -76,6 +76,7 @@ public:
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h) override;
    void     ClearDrawable() override;
+   void     ClearWindow(Int_t device) override;
    Int_t    ResizeDrawable(Int_t device, UInt_t w, UInt_t h) override;
    void     CopyDrawable(Int_t device, Int_t px, Int_t py) override;
    void     DestroyDrawable(Int_t device) override;

--- a/graf3d/gl/src/TGLFontManager.cxx
+++ b/graf3d/gl/src/TGLFontManager.cxx
@@ -170,6 +170,15 @@ void TGLFont::BBox(const wchar_t* txt,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Get advance
+
+Float_t TGLFont::Advance(const char* txt) const
+{
+   // FTGL is not const correct.
+   return const_cast<FTFont*>(fFont)->Advance(txt);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 ///mgn is simply ignored, because ROOT's TVirtualX TGX11 are complete mess with
 ///painting attributes.
 

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -154,11 +154,20 @@ Int_t TGLPadPainter::ResizeDrawable(Int_t device, UInt_t w, UInt_t h)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Call gVirtualX->ClearWindow()
+/// Do nothing, sub-pads not cleared in GL
 
 void TGLPadPainter::ClearDrawable()
 {
-   gVirtualX->ClearWindow();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clear specified window - calling gVirtualX->ClearWindowW
+
+void TGLPadPainter::ClearWindow(Int_t device)
+{
+   auto ctxt = gVirtualX->GetWindowContext(device);
+   if (ctxt)
+      gVirtualX->ClearWindowW(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -942,7 +942,9 @@ UInt_t TGLPadPainter::GetTextAdvance(Font_t font, Double_t size, const char *tex
 {
    SelectGLFont(font, size);
 
-   // return (UInt_t) fF.Advance(text);
+   auto advance = fF.Advance(text);
+
+   return (UInt_t) (advance > 0. ? advance : 0.);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -769,6 +769,30 @@ void TGLPadPainter::DrawPolyMarker()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Select specified font/size
+
+void TGLPadPainter::SelectGLFont(Font_t font, Float_t tsize)
+{
+   //10 is the first valid font index.
+   //20 is FreeSerifBold, as in TTF.cxx and in TGLFontManager.cxx.
+   //shift - is the shift to access "extended" fonts.
+   const Int_t shift = TGLFontManager::GetExtendedFontStartIndex();
+
+   Int_t fontIndex = TMath::Max(Font_t(10), font);
+   if (fontIndex / 10 + shift > TGLFontManager::GetFontFileArray()->GetEntries())
+      fontIndex = 20 + shift * 10;
+   else
+      fontIndex += shift * 10;
+
+   Int_t textSize = TMath::Max(Int_t(tsize) - 1, 10);
+
+   const char *name = TGLFontManager::GetFontNameFromId(fontIndex);
+
+   fFM.RegisterFont(textSize, name, TGLFont::kTexture, fF);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Helper function to draw text
 
 template<class Char>
 void TGLPadPainter::DrawTextHelper(Double_t x, Double_t y, const Char *text, ETextMode /*mode*/)
@@ -785,23 +809,10 @@ void TGLPadPainter::DrawTextHelper(Double_t x, Double_t y, const Char *text, ETe
    Rgl::Pad::ExtractRGBA(GetAttText().GetTextColor(), rgba);
    glColor4fv(rgba);
 
-   //10 is the first valid font index.
-   //20 is FreeSerifBold, as in TTF.cxx and in TGLFontManager.cxx.
-   //shift - is the shift to access "extended" fonts.
-   const Int_t shift = TGLFontManager::GetExtendedFontStartIndex();
-
-   Int_t fontIndex = TMath::Max(Short_t(10), GetAttText().GetTextFont());
-   if (fontIndex / 10 + shift > TGLFontManager::GetFontFileArray()->GetEntries())
-      fontIndex = 20 + shift * 10;
-   else
-      fontIndex += shift * 10;
+   SelectGLFont(GetAttText().GetTextFont(), GetAttText().GetTextSizePixels(*gPad));
 
    fF.SetTextAlign(GetAttText().GetTextAlign());
 
-   //kTexture does not work if size < 10.
-   Int_t textSize = TMath::Max(Int_t(GetAttText().GetTextSizePixels(*gPad)) - 1, 10);
-
-   fFM.RegisterFont(textSize, TGLFontManager::GetFontNameFromId(fontIndex), TGLFont::kTexture, fF);
    fF.PreRender();
 
    const UInt_t padH = UInt_t(gPad->GetAbsHNDC() * gPad->GetWh());
@@ -814,6 +825,42 @@ void TGLPadPainter::DrawTextHelper(Double_t x, Double_t y, const Char *text, ETe
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Helper function to get text extent
+
+template<class Char_t>
+void TGLPadPainter::TextExtentHelper(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const Char_t *text)
+{
+   SelectGLFont(font, size);
+
+   Float_t llx, lly, llz, urx, ury, urz;
+   fF.BBox(text, llx, lly, llz, urx, ury, urz);
+   urx -= llx;
+   ury -= lly;
+   w = (UInt_t) (urx > 0. ? urx : 0.);
+   h = (UInt_t) (ury > 0. ? ury : 0.);
+   (void) llz;
+   (void) urz;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Helper function to get text ascent / descent
+
+template<class Char_t>
+void TGLPadPainter::TextAscentDescentHelper(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const Char_t *text)
+{
+   SelectGLFont(font, size);
+
+   Float_t llx, lly, llz, urx, ury, urz;
+   fF.BBox(text, llx, lly, llz, urx, ury, urz);
+   a = (UInt_t) (ury > 0. ? ury : 0.);
+   d = (UInt_t) (lly < 0. ? -lly : 0.);
+   (void) llx;
+   (void) llz;
+   (void) urx;
+   (void) urz;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 ///Draw text. This operation is especially
 ///dangerous if in locked state -
 ///ftgl will assert on zero texture size
@@ -823,10 +870,8 @@ void TGLPadPainter::DrawText(Double_t x, Double_t y, const char *text, ETextMode
 {
    if (fLocked) return;
 
-   if (!GetAttText().GetTextSize())
-      return;
-
-   DrawTextHelper(x, y, text, mode);
+   if (GetAttText().GetTextSize() > 0)
+      DrawTextHelper(x, y, text, mode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -839,10 +884,8 @@ void TGLPadPainter::DrawText(Double_t x, Double_t y, const wchar_t *text, ETextM
 {
    if (fLocked) return;
 
-   if (!GetAttText().GetTextSize())
-      return;
-
-   DrawTextHelper(x, y, text, mode);
+   if (GetAttText().GetTextSize() > 0)
+      DrawTextHelper(x, y, text, mode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -858,6 +901,48 @@ void TGLPadPainter::DrawTextNDC(Double_t u, Double_t v, const char *text, ETextM
    const Double_t xRange = gPad->GetX2() - gPad->GetX1();
    const Double_t yRange = gPad->GetY2() - gPad->GetY1();
    DrawText(gPad->GetX1() + u * xRange, gPad->GetY1() + v * yRange, text, mode);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get text extent
+
+void TGLPadPainter::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *text)
+{
+   TextExtentHelper(font, size, w, h, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get text extent
+
+void TGLPadPainter::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *text)
+{
+   TextExtentHelper(font, size, w, h, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get text extent
+
+void TGLPadPainter::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *text)
+{
+   TextAscentDescentHelper(font, size, a, d, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get text extent
+
+void TGLPadPainter::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *text)
+{
+   TextAscentDescentHelper(font, size, a, d, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get text advance
+
+UInt_t TGLPadPainter::GetTextAdvance(Font_t font, Double_t size, const char *text, Bool_t)
+{
+   SelectGLFont(font, size);
+
+   // return (UInt_t) fF.Advance(text);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -132,18 +132,6 @@ void TGLPadPainter::SetAttMarker(const TAttMarker &att)
       gVirtualX->SetAttMarker(fWinContext, att);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Set text attributes
-
-void TGLPadPainter::SetAttText(const TAttText &att)
-{
-   TPadPainterBase::SetAttText(att);
-
-   // TODO: dismiss in the future, gVirtualX attributes not needed in GL
-   if (fWinContext && gVirtualX)
-      gVirtualX->SetAttText(fWinContext, att);
-}
-
 /*
 "Pixmap" part of TGLPadPainter.
 */
@@ -810,9 +798,10 @@ void TGLPadPainter::DrawTextHelper(Double_t x, Double_t y, const Char *text, ETe
 
    fF.SetTextAlign(GetAttText().GetTextAlign());
 
-   fFM.RegisterFont(TMath::Max(Int_t(GetAttText().GetTextSize()) - 1, 10),//kTexture does not work if size < 10.
-                               TGLFontManager::GetFontNameFromId(fontIndex),
-                               TGLFont::kTexture, fF);
+   //kTexture does not work if size < 10.
+   Int_t textSize = TMath::Max(Int_t(GetAttText().GetTextSizePixels(*gPad)) - 1, 10);
+
+   fFM.RegisterFont(textSize, TGLFontManager::GetFontNameFromId(fontIndex), TGLFont::kTexture, fF);
    fF.PreRender();
 
    const UInt_t padH = UInt_t(gPad->GetAbsHNDC() * gPad->GetWh());


### PR DESCRIPTION
Normal `TPadPainter` require pixel size, but `TPadPainterPS` expects relative units.
Move this difference from `TAttText` to correspondent painter classes.

Implement new text extension routines for `TGLPadPainter`. 
While it uses own `ftgl`-based text rendering - also let it provide text extension/ascent/descent metrics.

Adjust `TGCocoa` build - move necessary includes to public include directory, otherwise "TGCocoa.h" is not usable.

