### PR TITLE
[6.40] [padpainter] add ClearWindow(id) method

### DIFF
--- a/core/base/inc/TVirtualPadPainter.h
+++ b/core/base/inc/TVirtualPadPainter.h
@@ -95,6 +95,7 @@ public:
    //Currently, must be implemented only for X11/GDI
    virtual Int_t    CreateDrawable(UInt_t w, UInt_t h) = 0;//gVirtualX->OpenPixmap
    virtual void     ClearDrawable() = 0;//gVirtualX->Clear()
+   virtual void     ClearWindow(Int_t /* device */) {} //gVirtualX->ClearWindowW()
    virtual Int_t    ResizeDrawable(Int_t /* device */, UInt_t /* w */, UInt_t /* h */) { return 0; } //gVirtualX->ResizePixmap
    virtual void     CopyDrawable(Int_t device, Int_t px, Int_t py) = 0;
    virtual void     DestroyDrawable(Int_t device) = 0;//gVirtualX->CloseWindow

--- a/graf2d/gpad/inc/TPadPainter.h
+++ b/graf2d/gpad/inc/TPadPainter.h
@@ -41,6 +41,7 @@ public:
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h) override;
    void     ClearDrawable() override;
+   void     ClearWindow(Int_t device) override;
    Int_t    ResizeDrawable(Int_t device, UInt_t w, UInt_t h) override;
    void     CopyDrawable(Int_t device, Int_t px, Int_t py) override;
    void     DestroyDrawable(Int_t device) override;

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -616,7 +616,7 @@ void TCanvas::Build()
       fPainter->SetAttMarker({1, 1, 1});  //Set color index for markers
       fPainter->SetAttText({22, 0., 1, 42, 12}); //Set color index for text
       // Clear workstation
-      fPainter->ClearDrawable();
+      fPainter->ClearWindow(fCanvasID);
 
       // Set Double Buffer on by default
       SetDoubleBuffer(1);

--- a/graf2d/gpad/src/TPadPainter.cxx
+++ b/graf2d/gpad/src/TPadPainter.cxx
@@ -134,11 +134,22 @@ Bool_t TPadPainter::IsSupportAlpha() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Clear the current gVirtualX window.
+/// Clear the current gVirtualX window - calling gVirtualX->ClearWindowW
 
 void TPadPainter::ClearDrawable()
 {
-   gVirtualX->ClearWindowW(fWinContext);
+   if (fWinContext)
+      gVirtualX->ClearWindowW(fWinContext);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clear specified window - calling gVirtualX->ClearWindowW
+
+void TPadPainter::ClearWindow(Int_t device)
+{
+   auto ctxt = gVirtualX->GetWindowContext(device);
+   if (ctxt)
+      gVirtualX->ClearWindowW(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -68,6 +68,7 @@ public:
    //2. "Off-screen management" part.
    Int_t    CreateDrawable(UInt_t w, UInt_t h) override;
    void     ClearDrawable() override;
+   void     ClearWindow(Int_t device) override;
    Int_t    ResizeDrawable(Int_t device, UInt_t w, UInt_t h) override;
    void     CopyDrawable(Int_t device, Int_t px, Int_t py) override;
    void     DestroyDrawable(Int_t device) override;

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -166,11 +166,20 @@ Int_t TGLPadPainter::ResizeDrawable(Int_t device, UInt_t w, UInt_t h)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Call gVirtualX->ClearWindow()
+/// Do nothing, sub-pads not cleared in GL
 
 void TGLPadPainter::ClearDrawable()
 {
-   gVirtualX->ClearWindow();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clear specified window - calling gVirtualX->ClearWindowW
+
+void TGLPadPainter::ClearWindow(Int_t device)
+{
+   auto ctxt = gVirtualX->GetWindowContext(device);
+   if (ctxt)
+      gVirtualX->ClearWindowW(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Directly map gVirtualX->ClearWindowW() functionality, 
while there is tiny difference with already existing ClearDrawable() method. 

This method only used in TCanvas::Build().

Partial backport from #22088
