### PR TITLE
[df] Enable tail scheduling with GlobalEntryRange in RNTupleDS

### DIFF
--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -117,8 +117,9 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
    ///      c) trigger staging of the next batch of files in the I/O background thread.
    ///   4. On `Finalize()`, the I/O background thread is stopped.
    std::vector<std::unique_ptr<ROOT::Internal::RPageSource>> fStagingArea;
-   std::size_t fNextFileIndex = 0; ///< Index into fFileNames to the next file to process
 
+   std::map<std::string_view, uint64_t> fRangeOffsets;
+   std::size_t fNextFileIndex = 0; ///< Index into fFileNames to the next file to process
    /// We prepare a prototype field for every column. If a column reader is actually requested
    /// in GetColumnReaders(), we move a clone of the field into a new column reader for RDataFrame.
    /// Only the clone connects to the backing page store and acquires I/O resources.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -655,7 +655,7 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
 
    // Easy work scheduling: one file per slot. We skip empty files (files without entries).
 
-   if ((nRemainingFiles >= fNSlots) || (fGlobalEntryRange.has_value() && nRemainingFiles != 1)) {
+   if (nRemainingFiles >= fNSlots) {
       while ((fNextRanges.size() < fNSlots) && (fNextFileIndex < nFiles)) {
          REntryRangeDS range;
 
@@ -670,6 +670,7 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
          range.fSource->Attach();
          fNextFileIndex++;
          auto nEntries = range.fSource->GetNEntries();
+         fRangeOffsets.insert({range.fFileName, nEntries});
          if (nEntries == 0)
             continue;
          range.fLastEntry = nEntries; // whole file per slot, i.e. entry range [0..nEntries - 1]
@@ -683,6 +684,7 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
    // Every slot still has its own page source but these page sources may open the same file.
    // Again, we need to skip empty files.
    unsigned int nSlotsPerFile = fNSlots / nRemainingFiles;
+   size_t rangeOffset = 0;
    for (std::size_t i = 0; (fNextRanges.size() < fNSlots) && (fNextFileIndex < nFiles); ++i) {
       std::unique_ptr<ROOT::Internal::RPageSource> source;
       // Need to look for the file name to populate the sample info later
@@ -696,6 +698,7 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
       fNextFileIndex++;
 
       auto nEntries = source->GetNEntries();
+      fRangeOffsets.insert({sourceFileName, nEntries});
       if (nEntries == 0)
          continue;
 
@@ -711,15 +714,17 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
       unsigned int iFirstRange = 0;
       unsigned int iLastRange = rangesByCluster.size() - 1;
       if (fGlobalEntryRange.has_value() && fGlobalEntryRange->first != fGlobalEntryRange->second) {
+
          for (size_t j = 0; j < rangesByCluster.size(); j++) {
-            if (rangesByCluster[j].fFirstEntry + fSeenEntriesNoGlobalRange <= fGlobalEntryRange->first) {
+            if (rangesByCluster[j].fFirstEntry + rangeOffset <= fGlobalEntryRange->first) {
                iFirstRange = j;
             }
-            if (rangesByCluster[j].fLastEntryPlusOne + fSeenEntriesNoGlobalRange >= fGlobalEntryRange->second) {
+            if (rangesByCluster[j].fLastEntryPlusOne + rangeOffset >= fGlobalEntryRange->second) {
                iLastRange = j;
                break;
             }
          }
+         rangeOffset += fRangeOffsets[sourceFileName];
       }
 
       const unsigned int nRangesByCluster = iLastRange - iFirstRange + 1;
@@ -806,14 +811,16 @@ std::vector<std::pair<ULong64_t, ULong64_t>> ROOT::RDF::RNTupleDS::GetEntryRange
    fOriginalRanges.clear();
 
    ULong64_t nEntriesPerSource = 0;
-
+   auto lastFileName = fCurrentRanges[0].fFileName;
    for (std::size_t i = 0; i < fCurrentRanges.size(); ++i) {
 
       // Several consecutive ranges may operate on the same file (each with their own page source clone).
       // We can detect a change of file when the first entry number jumps back to 0.
-      if (fCurrentRanges[i].fFirstEntry == 0) {
+      auto currentFileName = fCurrentRanges[i].fFileName;
+      if ((lastFileName != currentFileName || fCurrentRanges[i].fFirstEntry == 0) && i != 0) {
          // New source
-         fSeenEntriesNoGlobalRange += nEntriesPerSource;
+         fSeenEntriesNoGlobalRange += fRangeOffsets[lastFileName];
+         lastFileName = currentFileName;
          nEntriesPerSource = 0;
       }
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -655,7 +655,7 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
 
    // Easy work scheduling: one file per slot. We skip empty files (files without entries).
 
-   if ((nRemainingFiles >= fNSlots) || (fGlobalEntryRange.has_value())) {
+   if ((nRemainingFiles >= fNSlots) || (fGlobalEntryRange.has_value() && nRemainingFiles != 1)) {
       while ((fNextRanges.size() < fNSlots) && (fNextFileIndex < nFiles)) {
          REntryRangeDS range;
 
@@ -708,13 +708,26 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
          const auto descGuard = source->GetSharedDescriptorGuard();
          return ROOT::Internal::GetClusterBoundaries(descGuard.GetRef());
       }();
+      unsigned int iFirstRange = 0;
+      unsigned int iLastRange = rangesByCluster.size() - 1;
+      if (fGlobalEntryRange.has_value() && fGlobalEntryRange->first != fGlobalEntryRange->second) {
+         for (size_t j = 0; j < rangesByCluster.size(); j++) {
+            if (rangesByCluster[j].fFirstEntry + fSeenEntriesNoGlobalRange <= fGlobalEntryRange->first) {
+               iFirstRange = j;
+            }
+            if (rangesByCluster[j].fLastEntryPlusOne + fSeenEntriesNoGlobalRange >= fGlobalEntryRange->second) {
+               iLastRange = j;
+               break;
+            }
+         }
+      }
 
-      const unsigned int nRangesByCluster = rangesByCluster.size();
+      const unsigned int nRangesByCluster = iLastRange - iFirstRange + 1;
 
       // Distribute slots equidistantly over the entry range, aligned on cluster boundaries
       const auto nClustersPerSlot = nRangesByCluster / nSlotsPerFile;
       const auto remainder = nRangesByCluster % nSlotsPerFile;
-      std::size_t iRange = 0;
+      std::size_t iRange = iFirstRange;
       unsigned int iSlot = 0;
       const unsigned int N = std::min(nSlotsPerFile, nRangesByCluster);
       for (; iSlot < N; ++iSlot) {

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -282,27 +282,75 @@ struct IMTRAII {
    ~IMTRAII() { ROOT::DisableImplicitMT(); }
 };
 
-
-TEST_F(RNTupleDSTest, TailSchedulingWithGlobalRange)
+TEST_F(RNTupleDSTest, GlobalRangeTailScheduling)
 {
    IMTRAII _;
    FileRAII f("GlobalRangeSingleFileTail.root");
+   FileRAII m("SecondTestFile.root");
+   FileRAII p("ThirdTestFile.root");
    {
       auto model = RNTupleModel::Create();
       auto ptrX = model->MakeField<int>("x");
       auto writer = RNTupleWriter::Recreate(std::move(model), "tail", f.GetPath());
-      for(int i = 0; i < 11;i++){
+      for (int i = 0; i < 1 << 20; i++) {
+         *ptrX = i;
+         writer->Fill();
+      }
+   }
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrX = model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "tail", m.GetPath());
+      for (int i = 0; i < 1 << 10; i++) {
+         *ptrX = i;
+         writer->Fill();
+      }
+   }
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrX = model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "tail", p.GetPath());
+      for (int i = 0; i < 1 << 14; i++) {
          *ptrX = i;
          writer->Fill();
       }
    }
    ROOT::RDF::Experimental::RDatasetSpec spec;
    ROOT::RDF::Experimental::RSample sample("smpl", "tail", f.GetPath());
+   ROOT::RDF::Experimental::RSample sample2("smpl2", "tail", m.GetPath());
+   ROOT::RDF::Experimental::RSample sample3("smpl3", "tail", p.GetPath());
+
    spec.AddSample(sample);
-   spec.WithGlobalRange({3, 10});
-   ROOT::RDataFrame df(spec);
-   auto s = df.Sum("x");
-   EXPECT_EQ(*s, 42);
+   spec.AddSample(sample2);
+   spec.AddSample(sample3);
+
+   spec.WithGlobalRange({3, 11});
+   ROOT::RDataFrame df_short(spec);
+   auto s = df_short.Sum<int>("x");
+
+   spec.WithGlobalRange({5000, 10000});
+   ROOT::RDataFrame df_long(spec);
+   auto q = df_long.Sum<int>("x");
+
+   spec.WithGlobalRange({1048576, 1048776});
+   ROOT::RDataFrame df_secondfile(spec);
+   auto h = df_secondfile.Sum<int>("x");
+
+   spec.WithGlobalRange({1038576, 1048596});
+   ROOT::RDataFrame df_multifile(spec);
+   auto a = df_multifile.Count();
+   auto b = df_multifile.Filter([](int x) { return x < 1040575; }, {"x"}).Count();
+
+   spec.WithGlobalRange({40000, 1050000});
+   ROOT::RDataFrame df_allfiles(spec);
+   auto c = df_allfiles.Count();
+
+   EXPECT_EQ(*c, 1010000);
+   EXPECT_EQ(*a, 10020);
+   EXPECT_EQ(*b, 2019);
+   EXPECT_EQ(*h, 19900);
+   EXPECT_EQ(*q, 37497500);
+   EXPECT_EQ(*s, 52);
 }
 TEST_F(RNTupleDSTest, ReadMT)
 {

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -282,6 +282,28 @@ struct IMTRAII {
    ~IMTRAII() { ROOT::DisableImplicitMT(); }
 };
 
+
+TEST_F(RNTupleDSTest, TailSchedulingWithGlobalRange)
+{
+   IMTRAII _;
+   FileRAII f("GlobalRangeSingleFileTail.root");
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrX = model->MakeField<int>("x");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "tail", f.GetPath());
+      for(int i = 0; i < 11;i++){
+         *ptrX = i;
+         writer->Fill();
+      }
+   }
+   ROOT::RDF::Experimental::RDatasetSpec spec;
+   ROOT::RDF::Experimental::RSample sample("smpl", "tail", f.GetPath());
+   spec.AddSample(sample);
+   spec.WithGlobalRange({3, 10});
+   ROOT::RDataFrame df(spec);
+   auto s = df.Sum("x");
+   EXPECT_EQ(*s, 42);
+}
 TEST_F(RNTupleDSTest, ReadMT)
 {
    IMTRAII _;


### PR DESCRIPTION
Increases speed when processing with IMT enabled and GlobalEntryRange set

# This Pull request:
Modifies the logic of how an RNTupleDS prepares entry ranges for processing by RDataFrame when IMT is enabled. Now allows for use of multiple slots on a single file.

Related issue:[#22066](https://github.com/root-project/root/issues/22066)
