### PR TITLE
[ntuple] Merger: skip a buffer copy when out compression is 0

### DIFF
--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -278,7 +278,7 @@ struct RChangeCompressionFunc {
 
    RPageStorage::RSealedPage &fSealedPage;
    ROOT::Internal::RPageAllocator &fPageAlloc;
-   std::uint8_t *fBuffer;
+   std::byte *fBuffer;
    std::size_t fBufSize;
    const ROOT::RNTupleWriteOptions &fWriteOpts;
 
@@ -289,15 +289,28 @@ struct RChangeCompressionFunc {
       fSealedPage.VerifyChecksumIfEnabled().ThrowOnError();
 
       const auto bytesPacked = fSrcColElement.GetPackedSize(fSealedPage.GetNElements());
+      const auto compression = fMergeOptions.fCompressionSettings.value_or(0);
       // TODO: this buffer could be kept and reused across pages
-      auto unzipBuf = MakeUninitArray<unsigned char>(bytesPacked);
+      std::unique_ptr<std::byte[]> unzipBufOwned;
+      std::byte *unzipBuf;
+      if (compression != 0) {
+         unzipBufOwned = MakeUninitArray<std::byte>(bytesPacked);
+         unzipBuf = unzipBufOwned.get();
+      } else {
+         unzipBuf = fBuffer;
+      }
       ROOT::Internal::RNTupleDecompressor::Unzip(fSealedPage.GetBuffer(), fSealedPage.GetDataSize(), bytesPacked,
-                                                 unzipBuf.get());
+                                                 unzipBuf);
 
       const auto checksumSize = fWriteOpts.GetEnablePageChecksums() * sizeof(std::uint64_t);
-      assert(fBufSize >= bytesPacked + checksumSize);
-      auto nBytesZipped = ROOT::Internal::RNTupleCompressor::Zip(unzipBuf.get(), bytesPacked,
-                                                                 fMergeOptions.fCompressionSettings.value(), fBuffer);
+      std::size_t nBytesZipped;
+      if (compression != 0) {
+         assert(fBuffer != unzipBuf);
+         assert(fBufSize >= bytesPacked + checksumSize);
+         nBytesZipped = ROOT::Internal::RNTupleCompressor::Zip(unzipBuf, bytesPacked, compression, fBuffer);
+      } else {
+         nBytesZipped = bytesPacked;
+      }
 
       fSealedPage = {fBuffer, nBytesZipped + checksumSize, fSealedPage.GetNElements(), fSealedPage.GetHasChecksum()};
       fSealedPage.ChecksumIfEnabled();
@@ -311,7 +324,7 @@ struct RResealFunc {
 
    RPageStorage::RSealedPage &fSealedPage;
    ROOT::Internal::RPageAllocator &fPageAlloc;
-   std::uint8_t *fBuffer;
+   std::byte *fBuffer;
    std::size_t fBufSize;
    const ROOT::RNTupleWriteOptions &fWriteOpts;
 
@@ -414,7 +427,7 @@ struct RSealedPageMergeData {
    // never invalidated.
    std::deque<RPageStorage::SealedPageSequence_t> fPagesV;
    std::vector<RPageStorage::RSealedPageGroup> fGroups;
-   std::vector<std::unique_ptr<std::uint8_t[]>> fBuffers;
+   std::vector<std::unique_ptr<std::byte[]>> fBuffers;
 };
 
 std::ostream &operator<<(std::ostream &os, const std::optional<ROOT::RColumnDescriptor::RValueRange> &x)
@@ -792,7 +805,7 @@ GenerateZeroPagesForColumns(size_t nEntriesToGenerate, std::span<const RColumnMe
          page.GrowUnchecked(nElementsPerPage);
          memset(page.GetBuffer(), 0, page.GetNBytes());
 
-         auto &buffer = sealedPageData.fBuffers.emplace_back(new unsigned char[bufSize]);
+         auto &buffer = sealedPageData.fBuffers.emplace_back(new std::byte[bufSize]);
          RPageSink::RSealPageConfig sealConf;
          sealConf.fElement = colElement.get();
          sealConf.fPage = &page;
@@ -918,7 +931,7 @@ RNTupleMerger::MergeCommonColumns(ROOT::Internal::RClusterPool &clusterPool,
             // NOTE: we currently allocate the max possible size for this buffer and don't shrink it afterward.
             // We might want to introduce an option that trades speed for memory usage and shrink the buffer to fit
             // the actual data size after recompressing.
-            buffer = MakeUninitArray<std::uint8_t>(bufSize);
+            buffer = MakeUninitArray<std::byte>(bufSize);
 
             // clang-format off
             if (needsResealing) {


### PR DESCRIPTION
When recompressing pages we can skip the creation of the zip auxiliary buffer if we don't need to actually zip back the pages. This also saves a memcpy per page in that case.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


