### PR TITLE
Provide none-static interface for TTF

### DIFF
--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -47,7 +47,7 @@ private:
    inline Int_t Idx(Int_t idx);
    void FillRectangleInternal(UInt_t col, Int_t x, Int_t y, UInt_t width, UInt_t height);
    void DrawTextTTF(Int_t x, Int_t y, const char *text, Int_t size, UInt_t color, const char *font_name, Float_t angle);
-   void DrawGlyph(void *bitmap, UInt_t color, Int_t x, Int_t y, TVirtualPad *clippad = nullptr, Int_t offx = 0, Int_t offy = 0);
+   void DrawFTGlyph(void *bitmap, UInt_t color, Int_t x, Int_t y, TVirtualPad *clippad = nullptr, Int_t offx = 0, Int_t offy = 0);
    void SetDefaults();
    void CreateThumbnail();
    void DestroyImage();

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -5719,34 +5719,32 @@ void TASImage::DrawText(TText *text, Int_t x, Int_t y)
 
 void TASImage::DrawTextOnPad(TText *text, Int_t x, Int_t y, TVirtualPad *pad, Int_t offx, Int_t  offy)
 {
-   if (!text)
-      return;
-   if (!InitImage("DrawTextOnPad"))
+   if (!text || !InitImage("DrawTextOnPad"))
       return;
 
-   TTF::Init();
+   TTFhandle ttf;
 
    // set text font
-   TTF::SetTextFont(text->GetTextFont());
+   ttf.SetTextFont(text->GetTextFont());
 
    UInt_t padw = pad ? pad->GetPadWidth() : 100;
    UInt_t padh = pad ? pad->GetPadHeight() : 100;
 
    // set text size
    Float_t ttfsize = text->GetTextSize() * TMath::Min(padw, padh);
-   TTF::SetTextSize(ttfsize*kScale);
+   ttf.SetTextSize(ttfsize*kScale);
 
    // set text angle
-   TTF::SetRotationMatrix(text->GetTextAngle());
+   ttf.SetRotationMatrix(text->GetTextAngle());
 
    // set text
    const wchar_t *wcsTitle = reinterpret_cast<const wchar_t *>(text->GetWcsTitle());
-   if (wcsTitle != NULL) {
-      TTF::PrepareString(wcsTitle);
-   } else {
-      TTF::PrepareString(text->GetTitle());
-   }
-   TTF::LayoutGlyphs();
+   if (wcsTitle)
+      ttf.PrepareString(wcsTitle);
+   else
+      ttf.PrepareString(text->GetTitle());
+
+   ttf.LayoutGlyphs();
 
    // color
    TColor *col = gROOT->GetColor(text->GetTextColor());
@@ -5809,41 +5807,39 @@ void TASImage::DrawTextOnPad(TText *text, Int_t x, Int_t y, TVirtualPad *pad, In
 
    // vertical alignment
    if (align == 1 || align == 2 || align == 3) {
-      ftal.y = TTF::GetAscent();
+      ftal.y = ttf.GetAscent();
    } else if (align == 4 || align == 5 || align == 6) {
-      ftal.y = TTF::GetAscent()/2;
+      ftal.y = ttf.GetAscent() / 2;
    } else {
       ftal.y = 0;
    }
 
    // horizontal alignment
    if (align == 3 || align == 6 || align == 9) {
-      ftal.x = TTF::GetWidth();
+      ftal.x = ttf.GetWidth();
    } else if (align == 2 || align == 5 || align == 8) {
-      ftal.x = TTF::GetWidth()/2;
+      ftal.x = ttf.GetWidth() / 2;
    } else {
       ftal.x = 0;
    }
 
-   FT_Vector_Transform(&ftal, TTF::GetRotMatrix());
+   FT_Vector_Transform(&ftal, ttf.GetRotMatrix());
    ftal.x = (ftal.x >> 6);
    ftal.y = (ftal.y >> 6);
 
-   TTF::TTGlyph *glyph = TTF::GetGlyphs();
+   auto glyph = ttf.GetGlyphs();
 
-   for (int n = 0; n < TTF::GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1 )) continue;
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
+      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1))
+         continue;
 
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      FT_Bitmap *source = &bitmap->bitmap;
+      auto bitmap = (FT_BitmapGlyph)glyph->fImage;
 
       Int_t bx = x - ftal.x + bitmap->left;
       Int_t by = y + ftal.y - bitmap->top;
 
-      DrawGlyph(source, color, bx, by, pad, offx, offy);
+      DrawGlyph(&bitmap->bitmap, color, bx, by, pad, offx, offy);
    }
-
-   TTF::CleanupGlyphs();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -5852,33 +5848,32 @@ void TASImage::DrawTextOnPad(TText *text, Int_t x, Int_t y, TVirtualPad *pad, In
 void TASImage::DrawTextTTF(Int_t x, Int_t y, const char *text, Int_t size,
                            UInt_t color, const char *font_name, Float_t angle)
 {
-   if (!InitImage("DrawTextTTF"))
+   if (!text || !InitImage("DrawTextTTF"))
       return;
 
-   TTF::Init();
+   TTFhandle ttf;
 
-   TTF::SetTextFont(font_name);
-   TTF::SetTextSize(size);
-   TTF::SetRotationMatrix(angle);
-   TTF::PrepareString(text);
-   TTF::LayoutGlyphs();
-
-   TTF::TTGlyph *glyph = TTF::GetGlyphs();
+   ttf.SetTextFont(font_name);
+   ttf.SetTextSize(size);
+   ttf.SetRotationMatrix(angle);
+   ttf.PrepareString(text);
+   ttf.LayoutGlyphs();
 
    // compute the size and position  that will contain the text
-   // Int_t Xoff = 0; if (TTF::GetBox().xMin < 0) Xoff = -TTF::GetBox().xMin;
-   Int_t Yoff = 0; if (TTF::GetBox().yMin < 0) Yoff = -TTF::GetBox().yMin;
-   Int_t h    = TTF::GetBox().yMax + Yoff;
+   // Int_t Xoff = ttf.GetBox().xMin < 0 ? -ttf.GetBox().xMin : 0;
+   Int_t Yoff = ttf.GetBox().yMin < 0 ? -ttf.GetBox().yMin : 0;
+   Int_t h    = ttf.GetBox().yMax + Yoff;
 
-   for (int n = 0; n < TTF::GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1 )) continue;
+   auto glyph = ttf.GetGlyphs();
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
+      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1))
+         continue;
 
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      FT_Bitmap *source = &bitmap->bitmap;
+      auto bitmap = (FT_BitmapGlyph) glyph->fImage;
 
       Int_t bx = x + bitmap->left;
       Int_t by = y + h - bitmap->top;
-      DrawGlyph(source, color, bx, by);
+      DrawGlyph(&bitmap->bitmap, color, bx, by);
    }
 }
 

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -5609,7 +5609,7 @@ void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 ////////////////////////////////////////////////////////////////////////////////
 /// Draw glyph bitmap.
 
-void TASImage::DrawGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by, TVirtualPad *clippad, Int_t offx, Int_t offy)
+void TASImage::DrawFTGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by, TVirtualPad *clippad, Int_t offx, Int_t offy)
 {
    static UInt_t col[5];
    Int_t x, y, yy, y0, xx;
@@ -5827,18 +5827,13 @@ void TASImage::DrawTextOnPad(TText *text, Int_t x, Int_t y, TVirtualPad *pad, In
    ftal.x = (ftal.x >> 6);
    ftal.y = (ftal.y >> 6);
 
-   auto glyph = ttf.GetGlyphs();
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++) {
+      if (auto bitmap = ttf.GetGlyphBitmap(n, kTRUE)) {
+         Int_t bx = x - ftal.x + bitmap->left;
+         Int_t by = y + ftal.y - bitmap->top;
 
-   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1))
-         continue;
-
-      auto bitmap = (FT_BitmapGlyph)glyph->fImage;
-
-      Int_t bx = x - ftal.x + bitmap->left;
-      Int_t by = y + ftal.y - bitmap->top;
-
-      DrawGlyph(&bitmap->bitmap, color, bx, by, pad, offx, offy);
+         DrawFTGlyph(&bitmap->bitmap, color, bx, by, pad, offx, offy);
+      }
    }
 }
 
@@ -5860,20 +5855,16 @@ void TASImage::DrawTextTTF(Int_t x, Int_t y, const char *text, Int_t size,
    ttf.LayoutGlyphs();
 
    // compute the size and position  that will contain the text
-   // Int_t Xoff = ttf.GetBox().xMin < 0 ? -ttf.GetBox().xMin : 0;
-   Int_t Yoff = ttf.GetBox().yMin < 0 ? -ttf.GetBox().yMin : 0;
+   // Int_t Xoff = TMath::Max(0, (Int_t) -ttf.GetBox().xMin);
+   Int_t Yoff = TMath::Max(0, (Int_t) -ttf.GetBox().yMin);
    Int_t h    = ttf.GetBox().yMax + Yoff;
 
-   auto glyph = ttf.GetGlyphs();
-   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, ft_render_mode_normal, nullptr, 1))
-         continue;
-
-      auto bitmap = (FT_BitmapGlyph) glyph->fImage;
-
-      Int_t bx = x + bitmap->left;
-      Int_t by = y + h - bitmap->top;
-      DrawGlyph(&bitmap->bitmap, color, bx, by);
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++) {
+      if (auto bitmap = ttf.GetGlyphBitmap(n, kTRUE)) {
+         Int_t bx = x + bitmap->left;
+         Int_t by = y + h - bitmap->top;
+         DrawFTGlyph(&bitmap->bitmap, color, bx, by);
+      }
    }
 }
 

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -5611,39 +5611,35 @@ void TASImage::DrawWideLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2,
 
 void TASImage::DrawFTGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by, TVirtualPad *clippad, Int_t offx, Int_t offy)
 {
-   static UInt_t col[5];
-   Int_t x, y, yy, y0, xx;
+   UInt_t col[5];
    Bool_t has_alpha = (color & 0xff000000) != 0xff000000;
 
-   ULong_t r, g, b;
-   int idx = 0;
-   FT_Bitmap *source = (FT_Bitmap*)bitmap;
-   UChar_t d = 0, *s = source->buffer;
+   FT_Bitmap *source = (FT_Bitmap *) bitmap;
 
-   Int_t dots = Int_t(source->width * source->rows);
-   r = g = b = 0;
-   Int_t bxx, byy;
+   auto ndots = source->width * source->rows;
+   ULong_t r = 0, g = 0, b = 0;
 
-   yy = y0 = by > 0 ? by * fImage->width : 0;
-   for (y = 0; y < (int) source->rows; y++) {
-      byy = by + y;
-      if ((byy >= (int)fImage->height) || (byy <0)) continue;
+   const Int_t y0 = by > 0 ? by * fImage->width : 0;
+   Int_t yy = y0;
+   for (UInt_t y = 0; y < source->rows; y++) {
+      Int_t byy = by + y;
+      if ((byy >= (Int_t) fImage->height) || (byy < 0)) continue;
 
-      for (x = 0; x < (int) source->width; x++) {
-         bxx = bx + x;
-         if ((bxx >= (int)fImage->width) || (bxx < 0)) continue;
+      for (UInt_t x = 0; x < source->width; x++) {
+         Int_t bxx = bx + x;
+         if ((bxx >= (Int_t) fImage->width) || (bxx < 0)) continue;
 
-         idx = Idx(bxx + yy);
+         auto idx = Idx(bxx + yy);
          r += ((fImage->alt.argb32[idx] & 0xff0000) >> 16);
          g += ((fImage->alt.argb32[idx] & 0x00ff00) >> 8);
          b += (fImage->alt.argb32[idx] & 0x0000ff);
       }
       yy += fImage->width;
    }
-   if (dots != 0) {
-      r /= dots;
-      g /= dots;
-      b /= dots;
+   if (ndots > 0) {
+      r /= ndots;
+      g /= ndots;
+      b /= ndots;
    }
 
    col[0] = (r << 16) + (g << 8) + b;
@@ -5653,16 +5649,13 @@ void TASImage::DrawFTGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by, TVirt
    Int_t col4b = (col[4] & 0x0000ff);
 
    // interpolate between fore and background colors
-   for (x = 3; x > 0; x--) {
-      xx = 4-x;
+   for (Int_t x = 3; x > 0; x--) {
+      Int_t xx = 4 - x;
       Int_t colxr = (col4r*x + r*xx) >> 2;
       Int_t colxg = (col4g*x + g*xx) >> 2;
       Int_t colxb = (col4b*x + b*xx) >> 2;
       col[x] = (colxr << 16) + (colxg << 8) + colxb;
    }
-
-   yy = y0;
-   ARGB32 acolor;
 
    Int_t clipx1 = 0, clipx2 = 0, clipy1 = 0, clipy2 = 0;
    Bool_t noClip = kTRUE;
@@ -5676,22 +5669,24 @@ void TASImage::DrawFTGlyph(void *bitmap, UInt_t color, Int_t bx, Int_t by, TVirt
       noClip = kFALSE;
    }
 
-   for (y = 0; y < (int) source->rows; y++) {
-      byy = by + y;
+   yy = y0;
+   UChar_t *s = source->buffer;
 
-      for (x = 0; x < (int) source->width; x++) {
-         bxx = bx + x;
+   for (UInt_t y = 0; y < source->rows; y++) {
+      Int_t byy = by + y;
 
-         d = *s++ & 0xff;
+      for (UInt_t x = 0; x < source->width; x++) {
+         Int_t bxx = bx + x;
+
+         UChar_t d = *s++ & 0xff;
          d = ((d + 10) * 5) >> 8;
          if (d > 4) d = 4;
 
-         if (d) {
-            if ( noClip || ((x < (int) source->width) &&
-                 (bxx <  (int)clipx2) && (bxx >= (int)clipx1) &&
-                 (byy >= (int)clipy2) && (byy <  (int)clipy1) )) {
-               idx    = Idx(bxx + yy);
-               acolor = (ARGB32)col[d];
+         if (d > 0) {
+            if (noClip || ((bxx <  clipx2) && (bxx >= clipx1) &&
+                           (byy >= clipy2) && (byy <  clipy1))) {
+               auto idx = Idx(bxx + yy);
+               auto acolor = (ARGB32) col[d];
                if (has_alpha) {
                   _alphaBlend(&fImage->alt.argb32[idx], &acolor);
                } else {

--- a/graf2d/cocoa/inc/TGQuartz.h
+++ b/graf2d/cocoa/inc/TGQuartz.h
@@ -108,7 +108,7 @@ private:
    bool fUseAA;
    bool fUseFAAA;
 
-   void DrawFTGlyphIntoPixmap(void *pixmap, void *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by);
+   void DrawFTGlyph(void *pixmap, void *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by);
 
    void SetAA();
    TAttFill &GetAttFill(WinContext_t wctxt);

--- a/graf2d/cocoa/inc/TGQuartz.h
+++ b/graf2d/cocoa/inc/TGQuartz.h
@@ -16,7 +16,6 @@
 
 #include "TGCocoa.h"
 #include "TPoint.h"
-#include "TTF.h"
 
 /** \class TGQuartz
 \ingroup cocoa
@@ -26,8 +25,6 @@ MacOS X, using CoreGraphics (Quartz).
 */
 
 class TGQuartz : public TGCocoa {
-private:
-   FT_Vector   fAlign; // alignment vector
 public:
    TGQuartz();
    TGQuartz(const char *name, const char *title);
@@ -111,10 +108,7 @@ private:
    bool fUseAA;
    bool fUseFAAA;
 
-   void AlignTTFString(WinContext_t wctxt);
-   Bool_t IsTTFStringVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void RenderTTFString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode);
-   void DrawFTGlyphIntoPixmap(void *pixmap, FT_Bitmap *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by);
+   void DrawFTGlyphIntoPixmap(void *pixmap, void *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by);
 
    void SetAA();
    TAttFill &GetAttFill(WinContext_t wctxt);

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -1041,7 +1041,7 @@ void TGQuartz::SetAttText(WinContext_t wctxt, const TAttText &att)
 //TTF related part.
 
 //______________________________________________________________________________
-void TGQuartz::DrawFTGlyph(void *pHack, void *sHack, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
+void TGQuartz::DrawFTGlyph(void *_pixmap, void *_source, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
 {
    //This function is a "remake" of TGX11FFT::DrawImage.
 
@@ -1049,85 +1049,72 @@ void TGQuartz::DrawFTGlyph(void *pHack, void *sHack, ULong_t fore, ULong_t back,
    //It's quite sloppy, as in original version. I tried to make it not so ugly and
    //more or less readable.
 
-   auto pixmap = (QuartzPixmap *)pHack;
-   auto source = (FT_Bitmap *) sHack;
+   auto pixmap = (QuartzPixmap *)_pixmap;
+   auto source = (FT_Bitmap *) _source;
    assert(pixmap != nil && "DrawFTGlyph, pixmap parameter is nil");
    assert(source != nil && "DrawFTGlyph, source parameter is null");
 
    if (TTFhandle::GetSmoothing()) {
-      static ColorStruct_t col[5];
+      ColorStruct_t col[5];
       // background kClear, i.e. transparent, we take as background color
       // the average of the rgb values of all pixels covered by this character
-      if (back == ULong_t(-1) && source->width) {
-         const int maxDots = 50000;
-         int dots = Int_t(source->width * source->rows);
-         if (dots > maxDots)
-            dots = maxDots;
+      if (back == ULong_t(-1)) {
+         const UInt_t maxDots = TMath::Min((UInt_t) 50000, source->width * source->rows);
 
          //In original code, they first have to extract
          //pixels and call XQueryColors.
          //I have only one loop here.
          ULong_t r = 0, g = 0, b = 0;
-         for (int y = 0, dotCnt = 0; y < int(source->rows); y++) {
-            for (int x = 0; x < int(source->width); x++) {
-               if (x + bx < int(pixmap.fWidth) && y + by < int(pixmap.fHeight)) {
+         UInt_t dotCnt = 0;
+         for (unsigned y = 0; y < source->rows; y++) {
+            for (unsigned x = 0; x < source->width; x++) {
+               if (x + bx < pixmap.fWidth && y + by < pixmap.fHeight) {
                   const unsigned char * const pixels = pixmap.fData + (y + by) * pixmap.fWidth * 4 + (x + bx) * 4;
                   r += UShort_t(pixels[0] / 255. * 0xffff);
                   g += UShort_t(pixels[1] / 255. * 0xffff);
                   b += UShort_t(pixels[2] / 255. * 0xffff);
+                  if (++dotCnt >= maxDots)
+                     break;
                }
-
-               if (++dotCnt >= maxDots)
-                  break;
             }
          }
 
-         if (dots) {
-            r /= dots;
-            g /= dots;
-            b /= dots;
+         if (dotCnt > 0) {
+            r /= dotCnt;
+            g /= dotCnt;
+            b /= dotCnt;
          }
 
-         if (col[0].fRed == r && col[0].fGreen == g && col[0].fBlue == b) {
-            col[0].fPixel = back;
-         } else {
-            col[0].fPixel = ~back;//???
-            col[0].fRed = (UShort_t) r;
-            col[0].fGreen = (UShort_t) g;
-            col[0].fBlue = (UShort_t) b;
-         }
+         col[0].fRed = (UShort_t) r;
+         col[0].fGreen = (UShort_t) g;
+         col[0].fBlue = (UShort_t) b;
+      } else {
+         // request background color
+         col[0].fPixel = back;
+         TGCocoa::QueryColor(kNone, col[0]);
       }
 
-      // if fore or background have changed from previous character
-      // recalculate the 3 smoothing colors (interpolation between fore-
-      // and background colors)
-      if (fore != col[4].fPixel || back != col[0].fPixel) {
-         col[4].fPixel = fore;
-         TGCocoa::QueryColor(kNone, col[4]);//calculate fRed/fGreen/fBlue triple from fPixel.
-         if (back != (ULong_t)-1) {
-            col[0].fPixel = back;
-            TGCocoa::QueryColor(kNone, col[0]);
-         }
+      // request foreground color
+      col[4].fPixel = fore;
+      TGCocoa::QueryColor(kNone, col[4]);//calculate fRed/fGreen/fBlue triple from fPixel.
 
-         // interpolate between fore and background colors
-         for (int x = 3; x > 0; --x) {
-            col[x].fRed   = (col[4].fRed   * x + col[0].fRed   * (4 - x)) / 4;
-            col[x].fGreen = (col[4].fGreen * x + col[0].fGreen * (4 - x)) / 4;
-            col[x].fBlue  = (col[4].fBlue  * x + col[0].fBlue  * (4 - x)) / 4;
-            TGCocoa::AllocColor(kNone, col[x]);//Calculate fPixel from fRed/fGreen/fBlue triplet.
-         }
+      // interpolate between fore and background colors
+      for (int x = 3; x > 0; --x) {
+         col[x].fRed   = (col[4].fRed   * x + col[0].fRed   * (4 - x)) / 4;
+         col[x].fGreen = (col[4].fGreen * x + col[0].fGreen * (4 - x)) / 4;
+         col[x].fBlue  = (col[4].fBlue  * x + col[0].fBlue  * (4 - x)) / 4;
+         TGCocoa::AllocColor(kNone, col[x]);//Calculate fPixel from fRed/fGreen/fBlue triplet.
       }
 
       // put smoothed character, character pixmap values are an index
       // into the 5 colors used for aliasing (4 = foreground, 0 = background)
       const unsigned char *s = source->buffer;
-      for (int y = 0; y < (int) source->rows; ++y) {
-         for (int x = 0; x < (int) source->width; ++x) {
-            unsigned char d = *s++ & 0xff;//???
-            d = ((d + 10) * 5) / 256;//???
+      for (unsigned y = 0; y < source->rows; ++y) {
+         for (unsigned x = 0; x < source->width; ++x) {
+            unsigned char d = (((*s++ & 0xff) + 10) * 5) / 256;
             if (d > 4)
                d = 4;
-            if (d && x < (int) source->width) {
+            if (d > 0) {
                const UChar_t pixel[] = {UChar_t(double(col[d].fRed) / 0xffff * 255),
                                         UChar_t(double(col[d].fGreen) / 0xffff * 255),
                                         UChar_t(double(col[d].fBlue) / 0xffff * 255), 255};
@@ -1143,17 +1130,17 @@ void TGQuartz::DrawFTGlyph(void *pHack, void *sHack, ULong_t fore, ULong_t back,
       unsigned char d = 0;
 
       const unsigned char *row = source->buffer;
-      for (int y = 0; y < int(source->rows); ++y) {
-         int n = 0;
+      for (unsigned y = 0; y < source->rows; ++y) {
+         unsigned n = 0;
          const unsigned char *s = row;
-         for (int x = 0; x < int(source->width); ++x) {
+         for (unsigned x = 0; x < source->width; ++x) {
             if (!n)
                d = *s++;
 
             if (TESTBIT(d,7 - n))
                [pixmap putPixel : rgba X : bx + x Y : by + y];
 
-            if (++n == int(kBitsPerByte))
+            if (++n == kBitsPerByte)
                n = 0;
          }
 

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -41,8 +41,9 @@
 #include "TColor.h"
 #include "TStyle.h"
 #include "TROOT.h"
-#include "TEnv.h"
 #include "TMath.h"
+#include "TEnv.h"
+#include "TTF.h"
 
 // To scale fonts to the same size as the TTF version
 const Float_t kScale = 0.93376068;
@@ -78,15 +79,8 @@ TGQuartz::TGQuartz()
             : fUseAA(true), fUseFAAA(false)
 {
    //Default ctor.
-
-   TTF::Init();
-
-   //I do not know why TTF::Init returns void and I have to check IsInitialized() again.
-   if (!TTF::IsInitialized())
-      Error("TGQuartz", "TTF::Init() failed");
-
-   fAlign.x = 0;
-   fAlign.y = 0;
+   if (!TTFhandle::Init())
+      Error("TGQuartz", "TTFhandle::Init() failed");
 
    SetAA();
 }
@@ -98,15 +92,8 @@ TGQuartz::TGQuartz(const char *name, const char *title)
               fUseAA(true), fUseFAAA(false)
 {
    //Constructor.
-
-   TTF::Init();
-
-   //I do not know why TTF::Init returns void and I have to check IsInitialized() again.
-   if (!TTF::IsInitialized())
-      Error("TGQuartz", "TTF::Init() failed");
-
-   fAlign.x = 0;
-   fAlign.y = 0;
+   if (!TTFhandle::Init())
+      Error("TGQuartz", "TTFhandle::Init() failed");
 
    SetAA();
 }
@@ -524,23 +511,168 @@ void TGQuartz::DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
 void TGQuartz::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t /* mgn */,
                          const wchar_t *text, ETextMode mode)
 {
-   if (!text || !text[0])
+   if (!text || !*text)
       return;
 
-   if (!TTF::IsInitialized()) {
+   if (!TTFhandle::Init()) {
       Error("DrawTextW", "wchar_t string to draw, but TTF initialization failed");
       return;
    }
 
-   TTF::SetSmoothing(kTRUE);
-   TTF::SetRotationMatrix(angle);
-   TTF::PrepareString(text);
-   TTF::LayoutGlyphs();
+   auto drawable0 = (NSObject<X11Drawable> * const) wctxt;
+   if (!drawable0)
+      return;
 
-   AlignTTFString(wctxt);
-   RenderTTFString(wctxt, x, y, mode);
+   if ([drawable0 isDirectDraw])
+      return;
 
-   TTF::CleanupGlyphs();
+   auto drawable = (NSObject<X11Drawable> * const) GetPixmapDrawable(drawable0, "DrawTextW");
+   if (!drawable)
+      return;
+
+
+   //Do not draw anything, or CoreText will create some small (but not of size 0 font).
+   auto &att = GetAttText(wctxt);
+
+   if (att.GetTextSize() < 1.5)//Do not draw anything, or CoreText will create some small (but not of size 0 font).
+      return;
+
+   TTFhandle::SetSmoothing(kTRUE);
+
+   TTFhandle ttf;
+
+   ttf.SetTextFont(att.GetTextFont());
+   ttf.SetTextSize(att.GetTextSize());
+   ttf.SetRotationMatrix(angle);
+   ttf.PrepareString(text);
+   ttf.LayoutGlyphs();
+
+   Int_t txalh = att.GetTextAlign() / 10;
+   Int_t txalv = att.GetTextAlign() % 10;
+   FT_Vector   align_vect;                 ///< alignment vector
+
+   // const EAlign align = EAlign(fTextAlign);
+   // vertical alignment
+   if (txalv == 3) // align == kTLeft || align == kTCenter || align == kTRight)
+      align_vect.y = ttf.GetAscent();
+   else if (txalv == 2) //  if (align == kMLeft || align == kMCenter || align == kMRight) {
+      align_vect.y = ttf.GetAscent() / 2;
+   else
+      align_vect.y = 0;
+
+   // horizontal alignment
+   if (txalh == 3) // align == kTRight || align == kMRight || align == kBRight) {
+      align_vect.x = ttf.GetWidth();
+   else if (txalh == 2) // (align == kTCenter || align == kMCenter || align == kBCenter) {
+      align_vect.x = ttf.GetWidth() / 2;
+   else
+      align_vect.x = 0;
+
+   FT_Vector_Transform(&align_vect, ttf.GetRotMatrix());
+   //This shift is from the original code.
+   align_vect.x = align_vect.x >> 6;
+   align_vect.y = align_vect.y >> 6;
+
+
+   //This code is a modified (for Quartz) version of TG11TTF text drawing
+
+   QuartzPixmap *dstPixmap = nil;
+   if ([drawable isKindOfClass : [QuartzPixmap class]])
+      dstPixmap = (QuartzPixmap *)drawable;
+   else if ([drawable isKindOfClass : [QuartzView class]] || [drawable isKindOfClass : [QuartzWindow class]])
+      dstPixmap = ((NSObject<X11Window> *)drawable).fBackBuffer;
+
+   if (!dstPixmap) {
+      //I can not read pixels from a window (I can, but this is too slow and unreliable).
+      Error("DrawTextW", "fSelectedDrawable is neither QuartzPixmap nor a double buffered window");
+      return;
+   }
+
+   //Comment from TGX11TTF:
+   // compute the size and position of the XImage that will contain the text
+   const Int_t xOff = TMath::Max(0, (Int_t) -ttf.GetBox().xMin);
+   const Int_t yOff = TMath::Max(0, (Int_t) -ttf.GetBox().yMin);
+
+   const Int_t w = ttf.GetBox().xMax + xOff;
+   const Int_t h = ttf.GetBox().yMax + yOff;
+
+   // If w or h is 0, very likely the string is only blank characters
+   if (w <= 0 || h <= 0)
+      return;
+
+   const Int_t x1 = x - xOff - align_vect.x;
+   const Int_t y1 = y + yOff + align_vect.y - h;
+
+   UInt_t width = 0, height = 0;
+   Int_t xy = 0;
+
+   GetWindowSize((Drawable_t) drawable0.fID, xy, xy, width, height);
+
+   // If string falls outside window, there is probably no need to draw it.
+   if (x1 + w <= 0 || x1 >= (Int_t)width || y1 + h <= 0 || y1 >= (Int_t)height)
+      return;
+
+   //By default, all pixels are set to 0 (all components, that's what code in TGX11TTF also does here).
+   Util::NSScopeGuard<QuartzPixmap> pixmap([[QuartzPixmap alloc] initWithW : w H : h scaleFactor : 1.f]);
+   if (!pixmap.Get()) {
+      Error("DrawTextW", "pixmap creation failed");
+      return;
+   }
+
+   const unsigned char defaultBackgroundPixel[] = {255, 255, 255, 255};
+   Util::ScopedArray<unsigned char> arrayGuard;
+   if (mode == kClear) {
+      //For this mode, TGX11TTF does some work to: a) preserve pixels under symbols
+      //b) calculate (interpolate) pixel for glyphs.
+
+      X11::Rectangle bbox(x1, y1, w, h);
+      //We already check IsVisible, so, in principle, bbox at least has intersection with
+      //the current selected drawable.
+      if (X11::AdjustCropArea(dstPixmap, bbox))
+         arrayGuard.Reset([dstPixmap readColorBits : bbox]);
+
+      if (!arrayGuard.Get()) {
+         Error("DrawTextW", "problem with reading background pixels");
+         return;
+      }
+
+      // This is copy & paste from TGX11TTF:
+      const Int_t xo = x1 < 0 ? -x1 : 0;
+      const Int_t yo = y1 < 0 ? -y1 : 0;
+
+      for (int yp = 0; yp < int(bbox.fHeight) && yo + yp < h; ++yp) {
+         const unsigned char *srcBase = arrayGuard.Get() + bbox.fWidth * yp * 4;
+         for (int xp = 0; xp < int(bbox.fWidth) && xo + xp < w; ++xp) {
+            const unsigned char * const pixel = srcBase + xp * 4;
+            [pixmap.Get() putPixel : pixel X : xo + xp Y : yo + yp];
+         }
+      }
+   } else {
+      //Find background color and set for all pixels.
+      [pixmap.Get() addPixel : defaultBackgroundPixel];
+   }
+
+   CGContextRef ctx = drawable.fContext;
+   const Quartz::CGStateGuard ctxGuard(ctx);
+
+   CGContextSetRGBStrokeColor(ctx, 0., 0., 1., 1.);
+   // paint the glyphs in the pixmap.
+   auto glyph = ttf.GetGlyphs();
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); ++n, ++glyph) {
+      if (FT_Glyph_To_Bitmap(&glyph->fImage, TTFhandle::GetSmoothing() ? ft_render_mode_normal : ft_render_mode_mono, 0, 1))
+         continue;
+
+      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
+      const Int_t bx = bitmap->left + xOff;
+      const Int_t by = h - bitmap->top - yOff;
+
+      DrawFTGlyphIntoPixmap(pixmap.Get(), &bitmap->bitmap, TGCocoa::GetPixel(att.GetTextColor()),
+                            mode == kClear ? ULong_t(-1) : 0xffffff, bx, by);
+   }
+
+   const X11::Rectangle copyArea(0, 0, w, h);
+   const X11::Point dstPoint(x1, y1);
+   [dstPixmap copy : pixmap.Get() area : copyArea withMask : nil clipOrigin : X11::Point() toPoint : dstPoint];
 }
 
 //______________________________________________________________________________
@@ -833,16 +965,10 @@ void TGQuartz::SetTextFont(Font_t fontNumber)
 }
 
 //______________________________________________________________________________
-Int_t TGQuartz::SetTextFont(char *fontName, ETextSetMode /*mode*/)
+Int_t TGQuartz::SetTextFont(char * /* fontName */, ETextSetMode /* mode */)
 {
-   //This function is never used in gPad (in normal text rendering,
-   //so I'm not setting anything for CoreText).
-   if (!TTF::IsInitialized()) {
-      Error("SetTextFont", "TTF is not initialized");
-      return 0;
-   }
-
-   return TTF::SetTextFont(fontName);
+   Error("SetTextFont", "Direct TTF font setting not supported");
+   return 1;
 }
 
 //______________________________________________________________________________
@@ -854,7 +980,6 @@ void TGQuartz::SetTextSize(Float_t textsize)
 
    SetAttText(GetSelectedContext(), *this);
 }
-
 
 //______________________________________________________________________________
 void TGQuartz::SetOpacity(Int_t /*percent*/)
@@ -908,14 +1033,6 @@ void TGQuartz::SetAttText(WinContext_t wctxt, const TAttText &att)
 {
    att.Copy(GetAttText(wctxt));
 
-   if (!TTF::IsInitialized()) {
-      Error("SetAttText", "TTF is not initialized");
-      return;
-   }
-
-   TTF::SetTextSize(att.GetTextSize());
-   TTF::SetTextFont(att.GetTextFont());
-
    // TODO: remove this after transition done
    TAttText::SetTextAlign(att.GetTextAlign());
    TAttText::SetTextAngle(att.GetTextAngle());
@@ -927,195 +1044,7 @@ void TGQuartz::SetAttText(WinContext_t wctxt, const TAttText &att)
 //TTF related part.
 
 //______________________________________________________________________________
-void TGQuartz::AlignTTFString(WinContext_t wctxt)
-{
-   //Comment from TGX11TTF:
-   // Compute alignment variables. The alignment is done on the horizontal string
-   // then the rotation is applied on the alignment variables.
-   // SetRotation and LayoutGlyphs should have been called before.
-   //End of comment.
-
-   //This code is from TGX11TTF (with my fixes).
-   //It looks like align can not be both X and Y align?
-
-   auto &atttext = GetAttText(wctxt);
-
-   Int_t txalh = atttext.GetTextAlign() / 10;
-   Int_t txalv = atttext.GetTextAlign() % 10;
-
-   // const EAlign align = EAlign(fTextAlign);
-   // vertical alignment
-   if (txalv == 3) // align == kTLeft || align == kTCenter || align == kTRight)
-      fAlign.y = TTF::GetAscent();
-   else if (txalv == 2) //  if (align == kMLeft || align == kMCenter || align == kMRight) {
-      fAlign.y = TTF::GetAscent() / 2;
-   else
-      fAlign.y = 0;
-
-   // horizontal alignment
-   if (txalh == 3) // align == kTRight || align == kMRight || align == kBRight) {
-      fAlign.x = TTF::GetWidth();
-   else if (txalh == 2) // (align == kTCenter || align == kMCenter || align == kBCenter) {
-      fAlign.x = TTF::GetWidth() / 2;
-   else
-      fAlign.x = 0;
-
-   FT_Vector_Transform(&fAlign, TTF::GetRotMatrix());
-   //This shift is from the original code.
-   fAlign.x = fAlign.x >> 6;
-   fAlign.y = fAlign.y >> 6;
-}
-
-//______________________________________________________________________________
-Bool_t TGQuartz::IsTTFStringVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h)
-{
-   //Comment from TGX11TTF:
-   // Test if there is really something to render.
-   //End of comment.
-
-   //This code is from TGX11TTF (with modifications).
-
-   //Comment from TGX11TTF:
-   // If w or h is 0, very likely the string is only blank characters
-   if (!w || !h || !wctxt)
-      return kFALSE;
-
-   auto drawable = (NSObject<X11Drawable> * const) wctxt;
-
-   UInt_t width = 0;
-   UInt_t height = 0;
-   Int_t xy = 0;
-
-   GetWindowSize((Drawable_t) drawable.fID, xy, xy, width, height);
-
-   // If string falls outside window, there is probably no need to draw it.
-   if (x + int(w) <= 0 || x >= int(width))
-      return kFALSE;
-
-   if (y + int(h) <= 0 || y >= int(height))
-      return kFALSE;
-
-   return kTRUE;
-}
-
-//______________________________________________________________________________
-void TGQuartz::RenderTTFString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode)
-{
-   //Comment from TGX11TTF:
-   // Perform the string rendering in the pad.
-   // LayoutGlyphs should have been called before.
-   //End of comment.
-
-   //This code is a modified (for Quartz) version of TG11TTF::RenderString.
-
-   auto drawable0 = (NSObject<X11Drawable> * const) wctxt;
-   if (!drawable0)
-      return;
-
-   if ([drawable0 isDirectDraw])
-      return;
-
-   auto &atttext = GetAttText(wctxt);
-
-   if (!atttext.GetTextSize())//Do not draw anything, or CoreText will create some small (but not of size 0 font).
-      return;
-
-   auto drawable = (NSObject<X11Drawable> * const) GetPixmapDrawable(drawable0, "RenderTTFString");
-   if (!drawable)
-      return;
-
-   QuartzPixmap *dstPixmap = nil;
-   if ([drawable isKindOfClass : [QuartzPixmap class]])
-      dstPixmap = (QuartzPixmap *)drawable;
-   else if ([drawable isKindOfClass : [QuartzView class]] || [drawable isKindOfClass : [QuartzWindow class]])
-      dstPixmap = ((NSObject<X11Window> *)drawable).fBackBuffer;
-
-   if (!dstPixmap) {
-      //I can not read pixels from a window (I can, but this is too slow and unreliable).
-      Error("RenderTTFString", "fSelectedDrawable is neither QuartzPixmap nor a double buffered window");
-      return;
-   }
-
-   //Comment from TGX11TTF:
-   // compute the size and position of the XImage that will contain the text
-   const Int_t xOff = TTF::GetBox().xMin < 0 ? -TTF::GetBox().xMin : 0;
-   const Int_t yOff = TTF::GetBox().yMin < 0 ? -TTF::GetBox().yMin : 0;
-
-   const Int_t w = TTF::GetBox().xMax + xOff;
-   const Int_t h = TTF::GetBox().yMax + yOff;
-
-   const Int_t x1 = x - xOff - fAlign.x;
-   const Int_t y1 = y + yOff + fAlign.y - h;
-
-   if (!IsTTFStringVisible(wctxt, x1, y1, w, h))
-      return;
-
-   //By default, all pixels are set to 0 (all components, that's what code in TGX11TTF also does here).
-   Util::NSScopeGuard<QuartzPixmap> pixmap([[QuartzPixmap alloc] initWithW : w H : h scaleFactor : 1.f]);
-   if (!pixmap.Get()) {
-      Error("RenderTTFString", "pixmap creation failed");
-      return;
-   }
-
-   const unsigned char defaultBackgroundPixel[] = {255, 255, 255, 255};
-   Util::ScopedArray<unsigned char> arrayGuard;
-   if (mode == kClear) {
-      //For this mode, TGX11TTF does some work to: a) preserve pixels under symbols
-      //b) calculate (interpolate) pixel for glyphs.
-
-      X11::Rectangle bbox(x1, y1, w, h);
-      //We already check IsVisible, so, in principle, bbox at least has intersection with
-      //the current selected drawable.
-      if (X11::AdjustCropArea(dstPixmap, bbox))
-         arrayGuard.Reset([dstPixmap readColorBits : bbox]);
-
-      if (!arrayGuard.Get()) {
-         Error("RenderTTFString", "problem with reading background pixels");
-         return;
-      }
-
-      // This is copy & paste from TGX11TTF:
-      const Int_t xo = x1 < 0 ? -x1 : 0;
-      const Int_t yo = y1 < 0 ? -y1 : 0;
-
-      for (int yp = 0; yp < int(bbox.fHeight) && yo + yp < h; ++yp) {
-         const unsigned char *srcBase = arrayGuard.Get() + bbox.fWidth * yp * 4;
-         for (int xp = 0; xp < int(bbox.fWidth) && xo + xp < w; ++xp) {
-            const unsigned char * const pixel = srcBase + xp * 4;
-            [pixmap.Get() putPixel : pixel X : xo + xp Y : yo + yp];
-         }
-      }
-   } else {
-      //Find background color and set for all pixels.
-      [pixmap.Get() addPixel : defaultBackgroundPixel];
-   }
-
-   CGContextRef ctx = drawable.fContext;
-   const Quartz::CGStateGuard ctxGuard(ctx);
-
-   CGContextSetRGBStrokeColor(ctx, 0., 0., 1., 1.);
-   // paint the glyphs in the pixmap.
-   TTF::TTGlyph *glyph = TTF::GetGlyphs();
-   for (int n = 0; n < TTF::GetNumGlyphs(); ++n, ++glyph) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, TTF::GetSmoothing() ? ft_render_mode_normal : ft_render_mode_mono, 0, 1 ))
-         continue;
-
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      FT_Bitmap *source = &bitmap->bitmap;
-      const Int_t bx = bitmap->left + xOff;
-      const Int_t by = h - bitmap->top - yOff;
-
-      DrawFTGlyphIntoPixmap(pixmap.Get(), source, TGCocoa::GetPixel(atttext.GetTextColor()),
-                            mode == kClear ? ULong_t(-1) : 0xffffff, bx, by);
-   }
-
-   const X11::Rectangle copyArea(0, 0, w, h);
-   const X11::Point dstPoint(x1, y1);
-   [dstPixmap copy : pixmap.Get() area : copyArea withMask : nil clipOrigin : X11::Point() toPoint : dstPoint];
-}
-
-//______________________________________________________________________________
-void TGQuartz::DrawFTGlyphIntoPixmap(void *pHack, FT_Bitmap *source, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
+void TGQuartz::DrawFTGlyphIntoPixmap(void *pHack, void *sHack, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
 {
    //This function is a "remake" of TGX11FFT::DrawImage.
 
@@ -1123,11 +1052,12 @@ void TGQuartz::DrawFTGlyphIntoPixmap(void *pHack, FT_Bitmap *source, ULong_t for
    //It's quite sloppy, as in original version. I tried to make it not so ugly and
    //more or less readable.
 
-   QuartzPixmap *pixmap = (QuartzPixmap *)pHack;
+   auto pixmap = (QuartzPixmap *)pHack;
+   auto source = (FT_Bitmap *) sHack;
    assert(pixmap != nil && "DrawFTGlyphIntoPixmap, pixmap parameter is nil");
-   assert(source != 0 && "DrawFTGlyphIntoPixmap, source parameter is null");
+   assert(source != nil && "DrawFTGlyphIntoPixmap, source parameter is null");
 
-   if (TTF::GetSmoothing()) {
+   if (TTFhandle::GetSmoothing()) {
       static ColorStruct_t col[5];
       // background kClear, i.e. transparent, we take as background color
       // the average of the rgb values of all pixels covered by this character

--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -657,17 +657,14 @@ void TGQuartz::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Fl
 
    CGContextSetRGBStrokeColor(ctx, 0., 0., 1., 1.);
    // paint the glyphs in the pixmap.
-   auto glyph = ttf.GetGlyphs();
-   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); ++n, ++glyph) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage, TTFhandle::GetSmoothing() ? ft_render_mode_normal : ft_render_mode_mono, 0, 1))
-         continue;
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); ++n) {
+      if (auto bitmap = ttf.GetGlyphBitmap(n)) {
+         const Int_t bx = bitmap->left + xOff;
+         const Int_t by = h - bitmap->top - yOff;
 
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      const Int_t bx = bitmap->left + xOff;
-      const Int_t by = h - bitmap->top - yOff;
-
-      DrawFTGlyphIntoPixmap(pixmap.Get(), &bitmap->bitmap, TGCocoa::GetPixel(att.GetTextColor()),
-                            mode == kClear ? ULong_t(-1) : 0xffffff, bx, by);
+         DrawFTGlyph(pixmap.Get(), &bitmap->bitmap, TGCocoa::GetPixel(att.GetTextColor()),
+                     mode == kClear ? ULong_t(-1) : 0xffffff, bx, by);
+      }
    }
 
    const X11::Rectangle copyArea(0, 0, w, h);
@@ -1044,7 +1041,7 @@ void TGQuartz::SetAttText(WinContext_t wctxt, const TAttText &att)
 //TTF related part.
 
 //______________________________________________________________________________
-void TGQuartz::DrawFTGlyphIntoPixmap(void *pHack, void *sHack, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
+void TGQuartz::DrawFTGlyph(void *pHack, void *sHack, ULong_t fore, ULong_t back, Int_t bx, Int_t by)
 {
    //This function is a "remake" of TGX11FFT::DrawImage.
 
@@ -1054,8 +1051,8 @@ void TGQuartz::DrawFTGlyphIntoPixmap(void *pHack, void *sHack, ULong_t fore, ULo
 
    auto pixmap = (QuartzPixmap *)pHack;
    auto source = (FT_Bitmap *) sHack;
-   assert(pixmap != nil && "DrawFTGlyphIntoPixmap, pixmap parameter is nil");
-   assert(source != nil && "DrawFTGlyphIntoPixmap, source parameter is null");
+   assert(pixmap != nil && "DrawFTGlyph, pixmap parameter is nil");
+   assert(source != nil && "DrawFTGlyph, source parameter is null");
 
    if (TTFhandle::GetSmoothing()) {
       static ColorStruct_t col[5];

--- a/graf2d/gpad/src/TPadPainterBase.cxx
+++ b/graf2d/gpad/src/TPadPainterBase.cxx
@@ -56,9 +56,10 @@ void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_
       res = gVirtualX->GetTextExtentA(font, size, w, h, mess);
 
    if (!res) {
-      TTF::SetTextFont(font);
-      TTF::SetTextSize(size);
-      TTF::GetTextExtent(w, h, mess);
+      TTFhandle ttf;
+      ttf.SetTextFont(font);
+      ttf.SetTextSize(size);
+      ttf.GetTextExtent(w, h, mess);
    }
 }
 
@@ -73,9 +74,10 @@ void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_
       res = gVirtualX->GetTextExtentA(font, size, w, h, mess);
 
    if (!res) {
-      TTF::SetTextFont(font);
-      TTF::SetTextSize(size);
-      TTF::GetTextExtent(w, h, mess);
+      TTFhandle ttf;
+      ttf.SetTextFont(font);
+      ttf.SetTextSize(size);
+      ttf.GetTextExtent(w, h, mess);
    }
 }
 
@@ -95,10 +97,13 @@ void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a
    }
 
    if (!res) {
-      TTF::SetTextFont(font);
-      TTF::SetTextSize(size);
-      a = TTF::GetBox().yMax;
-      d = TMath::Abs(TTF::GetBox().yMin);
+      TTFhandle ttf;
+      ttf.SetTextFont(font);
+      ttf.SetTextSize(size);
+      UInt_t w, h;
+      ttf.GetTextExtent(w, h, mess);
+      a = ttf.GetBox().yMax;
+      d = TMath::Abs(ttf.GetBox().yMin);
    }
 }
 
@@ -119,10 +124,13 @@ void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a
    }
 
    if (!res) {
-      TTF::SetTextFont(font);
-      TTF::SetTextSize(size);
-      a = TTF::GetBox().yMax;
-      d = TMath::Abs(TTF::GetBox().yMin);
+      TTFhandle ttf;
+      ttf.SetTextFont(font);
+      ttf.SetTextSize(size);
+      UInt_t w, h;
+      ttf.GetTextExtent(w, h, mess);
+      a = ttf.GetBox().yMax;
+      d = TMath::Abs(ttf.GetBox().yMin);
    }
 }
 
@@ -137,12 +145,12 @@ UInt_t TPadPainterBase::GetTextAdvance(Font_t font, Double_t size, const char *m
          return a;
    }
 
-   Bool_t kernsave = TTF::GetKerning();
-   TTF::SetKerning(kern);
-   TTF::SetTextFont(font);
-   TTF::SetTextSize(size);
+   TTFhandle ttf;
+   ttf.SetTextFont(font);
+   ttf.SetTextSize(size);
+   ttf.SetKerning(kern);
+
    UInt_t a = 0;
-   TTF::GetTextAdvance(a, mess);
-   TTF::SetKerning(kernsave);
+   ttf.GetTextAdvance(a, mess);
    return a;
 }

--- a/graf2d/graf/inc/LinkDef.h
+++ b/graf2d/graf/inc/LinkDef.h
@@ -1,7 +1,7 @@
 /* @(#)root/graf:$Id$ */
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -57,6 +57,7 @@
 #pragma link C++ class TPolyLine-;
 #pragma link C++ class TText-;
 #pragma link C++ class TTF;
+#pragma link C++ class TTFhandle;
 #pragma link C++ class TWbox+;
 
 #pragma link C++ enum TImage::EImageFileTypes;

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -45,16 +45,7 @@ extern "C" {
 /// @endcond
 
 
-class TGX11TTF;
-class TGWin32;
-class TMathTextRenderer;
-
-
 class TTF {
-
-   friend class TGWin32;
-   friend class TMathTextRenderer;
-
 public:
 
 /** \class TTGlyph
@@ -108,6 +99,8 @@ public:
    static Int_t          GetAscent();
    static const FT_BBox &GetBox();
    static TTGlyph       *GetGlyphs();
+   static Int_t          GetCurFontIdx();
+   static FT_Face        GetCurFontFace();
    static Bool_t         GetHinting();
    static Bool_t         GetKerning();
    static Int_t          GetNumGlyphs();
@@ -115,6 +108,7 @@ public:
    static Bool_t         GetSmoothing();
    static Int_t          GetTrailingBlanksWidth();
    static Int_t          GetWidth();
+   static void           SetCurFontIdx(Int_t indx);
    static void           SetHinting(Bool_t state);
    static void           SetKerning(Bool_t state);
    static void           SetSmoothing(Bool_t state);

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -1,9 +1,10 @@
 // @(#)root/graf:$Id$
-// Author: Olivier Couet     01/10/02
-// Author: Fons Rademakers   21/11/98
+// Author: Olivier Couet     01/10/2002
+// Author: Fons Rademakers   21/11/1998
+// Author: Sergey Linev      29/14/2026
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -15,6 +16,7 @@
 
 
 #include "Rtypes.h"
+#include <memory>
 
 /// @cond DOXYGEN_IGNORE
 // Forward declare for the headers:
@@ -45,62 +47,49 @@ extern "C" {
 /// @endcond
 
 
+class TTFhandle;
+
 class TTF {
+
+   friend class TTFhandle;
+
+   static std::unique_ptr<TTFhandle>  fgHandle;   ///< global handle to support old static API
+
 public:
 
-/** \class TTGlyph
-TTF helper class containing glyphs description.
-*/
+   /** \class TTGlyph
+       TTF helper class containing glyphs description.
+   */
 
    class TTGlyph {
    public:
       UInt_t     fIndex{0};     ///< glyph index in face
       FT_Vector  fPos;          ///< position of glyph origin
       FT_Glyph   fImage{nullptr}; ///< glyph image
+      TTGlyph(UInt_t indx = 0) : fIndex(indx) {}
    };
 
-protected:
-   enum { kTTMaxFonts = 32, kMaxGlyphs = 1024 };
-
-   static Int_t          fgAscent;                ///< string ascent, used to compute Y alignment
-   static FT_BBox        fgCBox;                  ///< string control box
-   static FT_CharMap     fgCharMap[kTTMaxFonts];  ///< font character map
-   static Int_t          fgCurFontIdx;            ///< current font index
-   static Int_t          fgSymbItaFontIdx;        ///< Symbol italic font index
-   static Int_t          fgFontCount;             ///< number of fonts loaded
-   static char          *fgFontName[kTTMaxFonts]; ///< font name
-   static FT_Face        fgFace[kTTMaxFonts];     ///< font face
-   static TTF::TTGlyph   fgGlyphs[kMaxGlyphs];    ///< glyphs
-   static Bool_t         fgHinting;               ///< use hinting (true by default)
-   static Bool_t         fgInit;                  ///< true if the Init has been called
-   static Bool_t         fgKerning;               ///< use kerning (true by default)
-   static FT_Library     fgLibrary;               ///< FreeType font library
-   static Int_t          fgNumGlyphs;             ///< number of glyphs in the string
-   static FT_Matrix     *fgRotMatrix;             ///< rotation matrix
-   static Bool_t         fgSmoothing;             ///< use anti-aliasing (true when >8 planes, false otherwise)
-   static Int_t          fgTBlankW;               ///< trailing blanks width
-   static Int_t          fgWidth;                 ///< string width, used to compute X alignment
-
-public:
-   static Short_t CharToUnicode(UInt_t code);
-   static void    LayoutGlyphs();
-   static void    PrepareString(const char *string);
-   static void    PrepareString(const wchar_t *string);
-   static void    SetRotationMatrix(Float_t angle);
-   static void    CleanupGlyphs();
-
-public:
-   TTF() { }
+   TTF() {}
    virtual ~TTF();
 
+   // old static methods which are fully replaced by TTFhandle
+   // remain here only for backward compatibility until ROOT7
+
+   // minimal static interface to initialize library and handle fonts
    static void           Init();
    static void           Cleanup();
+   static Bool_t         IsInitialized();
+
+   static Short_t        CharToUnicode(UInt_t code);
+   static void           LayoutGlyphs();
+   static void           PrepareString(const char *string);
+   static void           PrepareString(const wchar_t *string);
+   static void           SetRotationMatrix(Float_t angle);
+
    static void           ComputeTrailingBlanksWidth(Int_t n);
    static Int_t          GetAscent();
    static const FT_BBox &GetBox();
    static TTGlyph       *GetGlyphs();
-   static Int_t          GetCurFontIdx();
-   static FT_Face        GetCurFontFace();
    static Bool_t         GetHinting();
    static Bool_t         GetKerning();
    static Int_t          GetNumGlyphs();
@@ -108,7 +97,6 @@ public:
    static Bool_t         GetSmoothing();
    static Int_t          GetTrailingBlanksWidth();
    static Int_t          GetWidth();
-   static void           SetCurFontIdx(Int_t indx);
    static void           SetHinting(Bool_t state);
    static void           SetKerning(Bool_t state);
    static void           SetSmoothing(Bool_t state);
@@ -118,10 +106,89 @@ public:
    static void           SetTextFont(Font_t fontnumber);
    static Int_t          SetTextFont(const char *fontname, Int_t italic=0);
    static void           SetTextSize(Float_t textsize);
-   static Bool_t         IsInitialized();
+
    static void           Version(Int_t &major, Int_t &minor, Int_t &patch);
 
+   // new temporary methods, can be removed at the end
+   static void           CleanupGlyphs();
+   static void           SetCurFontIdx(Int_t indx);
+   static Int_t          GetCurFontIdx();
+   static FT_Face        GetCurFontFace();
+
    ClassDef(TTF,0)  //Interface to TTF font handling
+};
+
+class TTFhandle {
+   friend class TTF;
+
+   private:
+      enum { kTTMaxFonts = 32 };
+
+      static FT_Library fgLibrary;               ///< FreeType font library
+      static Bool_t     fgInit;                  ///< true if the Init has been called
+      static Int_t      fgSymbItaFontIdx;        ///< Symbol italic font index
+      static Int_t      fgFontCount;             ///< number of fonts loaded
+      static char      *fgFontName[kTTMaxFonts]; ///< font name
+      static FT_Face    fgFace[kTTMaxFonts];     ///< font face
+      static FT_CharMap fgCharMap[kTTMaxFonts];  ///< font character map
+
+      Int_t          fAscent = 0;                ///< string ascent, used to compute Y alignment
+      FT_BBox        fCBox;                      ///< string control box
+      Int_t          fCurFontIdx = -1;           ///< current font index
+      std::vector<TTF::TTGlyph> fGlyphs;         ///< glyphs
+      Bool_t         fHinting = kFALSE;          ///< use hinting (true by default)
+      Bool_t         fKerning = kTRUE;           ///< use kerning (true by default)
+      std::unique_ptr<FT_Matrix> fRotMatrix;     ///< rotation matrix
+      Bool_t         fSmoothing = kTRUE;         ///< use anti-aliasing (true when >8 planes, false otherwise)
+      Int_t          fTBlankW = 0;               ///< trailing blanks width
+      Int_t          fWidth = 0;                 ///< string width, used to compute X alignment
+
+      void           ComputeTrailingBlanksWidth(Int_t n);
+
+   public:
+      TTFhandle();
+      virtual ~TTFhandle();
+
+      TTF::TTGlyph  *GetGlyphs() { return fGlyphs.data(); }
+      UInt_t         GetNumGlyphs() const { return fGlyphs.size(); }
+      Int_t          GetCurFontIdx() const { return fCurFontIdx; }
+      FT_Face        GetCurFontFace() const;
+      Int_t          GetAscent() const { return fAscent; }
+      Bool_t         GetHinting() const { return fHinting; }
+      Bool_t         GetKerning() const { return fKerning; }
+      FT_Matrix     *GetRotMatrix() const { return fRotMatrix.get(); }
+      Bool_t         GetSmoothing() const { return fSmoothing; }
+      Int_t          GetTrailingBlanksWidth() const { return fTBlankW; }
+      Int_t          GetWidth() const { return fWidth; }
+      const FT_BBox &GetBox() const { return fCBox; }
+
+
+      void           SetCurFontIdx(Int_t indx) { fCurFontIdx = indx; }
+      void           SetHinting(Bool_t state) { fHinting = state; }
+      void           SetKerning(Bool_t state) { fKerning = state; }
+      void           SetSmoothing(Bool_t state) { fSmoothing = state; }
+
+      void           SetTextFont(Font_t fontnumber);
+      Int_t          SetTextFont(const char *fontname, Int_t italic = 0);
+      Bool_t         SetTextSize(Float_t textsize);
+
+      Short_t        CharToUnicode(UInt_t code);
+      void           LayoutGlyphs();
+      void           PrepareString(const char *string);
+      void           PrepareString(const wchar_t *string);
+      void           SetRotationMatrix(Float_t angle);
+      void           CleanupGlyphs();
+
+      void           GetTextExtent(UInt_t &w, UInt_t &h, const char *text);
+      void           GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text);
+      void           GetTextAdvance(UInt_t &a, const char *text);
+
+      void           Version(Int_t &major, Int_t &minor, Int_t &patch);
+
+      static     void CloseLibrary();
+
+   ClassDef(TTFhandle, 0)  // Dynamic interface to TTF
+
 };
 
 #endif

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -30,12 +30,14 @@ extern "C" {
    struct FT_GlyphRec_;
    struct FT_Matrix_;
    struct FT_Bitmap_;
+   struct FT_BitmapGlyphRec_;
    typedef struct FT_LibraryRec_* FT_Library;
    typedef struct FT_FaceRec_* FT_Face;
    typedef struct FT_CharMapRec_* FT_CharMap;
    typedef struct FT_GlyphRec_* FT_Glyph;
    typedef struct FT_Matrix_ FT_Matrix;
    typedef struct FT_Bitmap_ FT_Bitmap; // Forward declared for TGX11TTF.h's benefit
+   typedef struct FT_BitmapGlyphRec_* FT_BitmapGlyph;
    typedef signed long FT_Pos;
    #ifndef FT_FREETYPE_H
    struct FT_Vector_ { FT_Pos x, y; };
@@ -143,6 +145,7 @@ class TTFhandle {
 
       TTF::TTGlyph  *GetGlyphs() { return fGlyphs.data(); }
       UInt_t         GetNumGlyphs() const { return fGlyphs.size(); }
+      FT_BitmapGlyph GetGlyphBitmap(UInt_t n, Bool_t smooth = kFALSE);
       FT_Face        GetFontFace() const;
       Int_t          GetAscent() const { return fAscent; }
       Bool_t         GetKerning() const { return fKerning; }
@@ -167,7 +170,6 @@ class TTFhandle {
       void           GetTextAdvance(UInt_t &a, const char *text);
 
       void           Version(Int_t &major, Int_t &minor, Int_t &patch);
-
 
       static Bool_t  Init();
       static Bool_t  GetHinting();

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -52,9 +52,8 @@ class TMathTextRenderer;
 
 class TTF {
 
-friend class TGX11TTF;
-friend class TGWin32;
-friend class TMathTextRenderer;
+   friend class TGWin32;
+   friend class TMathTextRenderer;
 
 public:
 

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -48,12 +48,11 @@ extern "C" {
 
 
 class TTFhandle;
+struct TTFontHandle;
 
 class TTF {
 
    friend class TTFhandle;
-
-   static std::unique_ptr<TTFhandle>  fgHandle;   ///< global handle to support old static API
 
 public:
 
@@ -107,13 +106,14 @@ public:
    static Int_t          SetTextFont(const char *fontname, Int_t italic=0);
    static void           SetTextSize(Float_t textsize);
 
+   static TTFontHandle*  GetCurFont();
+   static void           SetCurFont(TTFontHandle* font);
+   static FT_Face        GetCurFontFace();
+
    static void           Version(Int_t &major, Int_t &minor, Int_t &patch);
 
    // new temporary methods, can be removed at the end
    static void           CleanupGlyphs();
-   static void           SetCurFontIdx(Int_t indx);
-   static Int_t          GetCurFontIdx();
-   static FT_Face        GetCurFontFace();
 
    ClassDef(TTF,0)  //Interface to TTF font handling
 };
@@ -122,19 +122,9 @@ class TTFhandle {
    friend class TTF;
 
    private:
-      enum { kTTMaxFonts = 32 };
-
-      static FT_Library fgLibrary;               ///< FreeType font library
-      static Bool_t     fgInit;                  ///< true if the Init has been called
-      static Int_t      fgSymbItaFontIdx;        ///< Symbol italic font index
-      static Int_t      fgFontCount;             ///< number of fonts loaded
-      static char      *fgFontName[kTTMaxFonts]; ///< font name
-      static FT_Face    fgFace[kTTMaxFonts];     ///< font face
-      static FT_CharMap fgCharMap[kTTMaxFonts];  ///< font character map
-
+      TTFontHandle  *fFont = nullptr;            ///< selected font
       Int_t          fAscent = 0;                ///< string ascent, used to compute Y alignment
       FT_BBox        fCBox;                      ///< string control box
-      Int_t          fCurFontIdx = -1;           ///< current font index
       std::vector<TTF::TTGlyph> fGlyphs;         ///< glyphs
       Bool_t         fHinting = kFALSE;          ///< use hinting (true by default)
       Bool_t         fKerning = kTRUE;           ///< use kerning (true by default)
@@ -143,7 +133,12 @@ class TTFhandle {
       Int_t          fTBlankW = 0;               ///< trailing blanks width
       Int_t          fWidth = 0;                 ///< string width, used to compute X alignment
 
+      UInt_t         CharToUnicode(UInt_t code);
       void           ComputeTrailingBlanksWidth(Int_t n);
+
+      FT_Library     InitClose(Int_t direction = 0);
+
+      Int_t          SelectFontHandle(Int_t arg, const char *name = nullptr);
 
    public:
       TTFhandle();
@@ -151,8 +146,7 @@ class TTFhandle {
 
       TTF::TTGlyph  *GetGlyphs() { return fGlyphs.data(); }
       UInt_t         GetNumGlyphs() const { return fGlyphs.size(); }
-      Int_t          GetCurFontIdx() const { return fCurFontIdx; }
-      FT_Face        GetCurFontFace() const;
+      FT_Face        GetFontFace() const;
       Int_t          GetAscent() const { return fAscent; }
       Bool_t         GetHinting() const { return fHinting; }
       Bool_t         GetKerning() const { return fKerning; }
@@ -163,7 +157,6 @@ class TTFhandle {
       const FT_BBox &GetBox() const { return fCBox; }
 
 
-      void           SetCurFontIdx(Int_t indx) { fCurFontIdx = indx; }
       void           SetHinting(Bool_t state) { fHinting = state; }
       void           SetKerning(Bool_t state) { fKerning = state; }
       void           SetSmoothing(Bool_t state) { fSmoothing = state; }
@@ -172,7 +165,6 @@ class TTFhandle {
       Int_t          SetTextFont(const char *fontname, Int_t italic = 0);
       Bool_t         SetTextSize(Float_t textsize);
 
-      Short_t        CharToUnicode(UInt_t code);
       void           LayoutGlyphs();
       void           PrepareString(const char *string);
       void           PrepareString(const wchar_t *string);
@@ -183,9 +175,10 @@ class TTFhandle {
       void           GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text);
       void           GetTextAdvance(UInt_t &a, const char *text);
 
-      void           Version(Int_t &major, Int_t &minor, Int_t &patch);
+      TTFontHandle*  GetFont() const { return fFont; }
+      void           SetFont(TTFontHandle *font) { fFont = font; }
 
-      static     void CloseLibrary();
+      void           Version(Int_t &major, Int_t &minor, Int_t &patch);
 
    ClassDef(TTFhandle, 0)  // Dynamic interface to TTF
 

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -122,17 +122,18 @@ class TTFhandle {
       Int_t          fAscent = 0;                ///< string ascent, used to compute Y alignment
       FT_BBox        fCBox;                      ///< string control box
       std::vector<TTF::TTGlyph> fGlyphs;         ///< glyphs
-      Bool_t         fHinting = kFALSE;          ///< use hinting (true by default)
       Bool_t         fKerning = kTRUE;           ///< use kerning (true by default)
       std::unique_ptr<FT_Matrix> fRotMatrix;     ///< rotation matrix
-      Bool_t         fSmoothing = kTRUE;         ///< use anti-aliasing (true when >8 planes, false otherwise)
       Int_t          fTBlankW = 0;               ///< trailing blanks width
       Int_t          fWidth = 0;                 ///< string width, used to compute X alignment
+
+      static  Bool_t fgHinting;                   ///< use hinting (false by default)
+      static  Bool_t fgSmoothing;                 ///< use anti-aliasing (true when >8 planes, false otherwise)
 
       UInt_t         CharToUnicode(UInt_t code);
       void           ComputeTrailingBlanksWidth(Int_t n);
 
-      FT_Library     InitClose(Int_t direction = 0);
+      static FT_Library InitClose(Int_t direction = 0);
 
       Int_t          SelectFontHandle(Int_t arg, const char *name = nullptr);
 
@@ -144,19 +145,13 @@ class TTFhandle {
       UInt_t         GetNumGlyphs() const { return fGlyphs.size(); }
       FT_Face        GetFontFace() const;
       Int_t          GetAscent() const { return fAscent; }
-      Bool_t         GetHinting() const { return fHinting; }
       Bool_t         GetKerning() const { return fKerning; }
       FT_Matrix     *GetRotMatrix() const { return fRotMatrix.get(); }
-      Bool_t         GetSmoothing() const { return fSmoothing; }
       Int_t          GetTrailingBlanksWidth() const { return fTBlankW; }
       Int_t          GetWidth() const { return fWidth; }
       const FT_BBox &GetBox() const { return fCBox; }
 
-
-      void           SetHinting(Bool_t state) { fHinting = state; }
       void           SetKerning(Bool_t state) { fKerning = state; }
-      void           SetSmoothing(Bool_t state) { fSmoothing = state; }
-
       void           SetTextFont(Font_t fontnumber);
       Int_t          SetTextFont(const char *fontname, Int_t italic = 0);
       Bool_t         SetTextSize(Float_t textsize);
@@ -172,6 +167,13 @@ class TTFhandle {
       void           GetTextAdvance(UInt_t &a, const char *text);
 
       void           Version(Int_t &major, Int_t &minor, Int_t &patch);
+
+
+      static Bool_t  Init();
+      static Bool_t  GetHinting();
+      static Bool_t  GetSmoothing();
+      static void    SetHinting(Bool_t state);
+      static void    SetSmoothing(Bool_t state);
 
    ClassDef(TTFhandle, 0)  // Dynamic interface to TTF
 

--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -106,10 +106,6 @@ public:
    static Int_t          SetTextFont(const char *fontname, Int_t italic=0);
    static void           SetTextSize(Float_t textsize);
 
-   static TTFontHandle*  GetCurFont();
-   static void           SetCurFont(TTFontHandle* font);
-   static FT_Face        GetCurFontFace();
-
    static void           Version(Int_t &major, Int_t &minor, Int_t &patch);
 
    // new temporary methods, can be removed at the end
@@ -174,9 +170,6 @@ class TTFhandle {
       void           GetTextExtent(UInt_t &w, UInt_t &h, const char *text);
       void           GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text);
       void           GetTextAdvance(UInt_t &a, const char *text);
-
-      TTFontHandle*  GetFont() const { return fFont; }
-      void           SetFont(TTFontHandle *font) { fFont = font; }
 
       void           Version(Int_t &major, Int_t &minor, Int_t &patch);
 

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -219,16 +219,11 @@ public:
    inline mathtext::bounding_box_t
    bounding_box_char(const wchar_t character, float &current_x, const unsigned int family)
    {
-      auto font = TTF::GetCurFont();
+      TTFhandle h;
+      h.SetTextFont(is_cyrillic_or_cjk(character) ? root_cjk_face_number() : root_face_number(family));
+      h.SetTextSize(_current_font_size[family] * _pad_scale);
 
-      const bool cyrillic_or_cjk = is_cyrillic_or_cjk(character);
-
-      if (cyrillic_or_cjk)
-         TTF::SetTextFont((Font_t) root_cjk_face_number());
-      else
-         TTF::SetTextFont((Font_t) root_face_number(family));
-
-      auto font_face = TTF::GetCurFontFace();
+      auto font_face = h.GetFontFace();
       if (!font_face || font_face->units_per_EM == 0)
          return mathtext::bounding_box_t(0, 0, 0, 0, 0, 0);
 
@@ -257,8 +252,6 @@ public:
             advance, italic_correction) * scale;
 
       current_x += ret.advance();
-
-      TTF::SetCurFont(font);
 
       return ret;
    }

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -224,17 +224,16 @@ public:
    {
    }
    inline mathtext::bounding_box_t
-   bounding_box(const wchar_t character, float &current_x,
-             const unsigned int family)
+   bounding_box(const wchar_t character, float &current_x, const unsigned int family)
    {
-      const auto old_font_index = TTF::GetCurFontIdx();
+      auto font = TTF::GetCurFont();
+
       const bool cyrillic_or_cjk = is_cyrillic_or_cjk(character);
 
-      if (cyrillic_or_cjk) {
+      if (cyrillic_or_cjk)
          TTF::SetTextFont((Font_t) root_cjk_face_number());
-      } else {
+      else
          TTF::SetTextFont((Font_t) root_face_number(family));
-      }
 
       auto font_face = TTF::GetCurFontFace();
 
@@ -264,13 +263,12 @@ public:
 
       current_x += ret.advance();
 
-      TTF::SetCurFontIdx(old_font_index);
+      TTF::SetCurFont(font);
 
       return ret;
    }
    inline mathtext::bounding_box_t
-   bounding_box(const std::wstring string,
-             const unsigned int family = FAMILY_PLAIN) override
+   bounding_box(const std::wstring string, const unsigned int family = FAMILY_PLAIN) override
    {
       auto font_face = TTF::GetCurFontFace();
 

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -227,7 +227,7 @@ public:
    bounding_box(const wchar_t character, float &current_x,
              const unsigned int family)
    {
-      const size_t old_font_index = TTF::fgCurFontIdx;
+      const auto old_font_index = TTF::GetCurFontIdx();
       const bool cyrillic_or_cjk = is_cyrillic_or_cjk(character);
 
       if (cyrillic_or_cjk) {
@@ -235,16 +235,16 @@ public:
       } else {
          TTF::SetTextFont((Font_t) root_face_number(family));
       }
+
+      auto font_face = TTF::GetCurFontFace();
+
       FT_Load_Glyph(
-         TTF::fgFace[TTF::fgCurFontIdx],
-         FT_Get_Char_Index(
-            TTF::fgFace[TTF::fgCurFontIdx], character),
+         font_face,
+         FT_Get_Char_Index(font_face, character),
          FT_LOAD_NO_SCALE);
 
-      const float scale = _current_font_size[family] /
-         TTF::fgFace[TTF::fgCurFontIdx]->units_per_EM;
-      const FT_Glyph_Metrics metrics =
-         TTF::fgFace[TTF::fgCurFontIdx]->glyph->metrics;
+      const float scale = _current_font_size[family] / font_face->units_per_EM;
+      const FT_Glyph_Metrics metrics = font_face->glyph->metrics;
       const float lower_left_x = metrics.horiBearingX;
       const float lower_left_y =
          metrics.horiBearingY - metrics.height;
@@ -263,7 +263,8 @@ public:
             advance, italic_correction) * scale;
 
       current_x += ret.advance();
-      TTF::fgCurFontIdx = old_font_index;
+
+      TTF::SetCurFontIdx(old_font_index);
 
       return ret;
    }
@@ -271,11 +272,10 @@ public:
    bounding_box(const std::wstring string,
              const unsigned int family = FAMILY_PLAIN) override
    {
-      if (TTF::fgCurFontIdx<0) return mathtext::bounding_box_t(0, 0, 0, 0, 0, 0);
-      if (string.empty() || TTF::fgFace[TTF::fgCurFontIdx] == NULL ||
-         TTF::fgFace[TTF::fgCurFontIdx]->units_per_EM == 0) {
+      auto font_face = TTF::GetCurFontFace();
+
+      if (string.empty() || !font_face || font_face->units_per_EM == 0)
          return mathtext::bounding_box_t(0, 0, 0, 0, 0, 0);
-      }
 
       std::wstring::const_iterator iterator = string.begin();
       float current_x = 0;

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -64,8 +64,6 @@ private:
    float _pad_scale;
    float _pad_scale_x;
    float _pad_scale_y;
-   float _pad_scale_x_relative;
-   float _pad_scale_y_relative;
    float _current_font_size[mathtext::math_text_renderer_t::NFAMILY];
    inline size_t root_face_number(
       const unsigned int family, const bool serif = false) const
@@ -116,18 +114,17 @@ public:
       : TText(), TAttFill(0, 1001),
         _parent(parent), _font_size(0), _angle_degree(0)
    {
-      int i;
       _font_size = 0;
       _x0 = 0;
       _y0 = 0;
       _angle_degree = 0;
-      for (i = 0; i<6; i++) _pad_pixel_transform[i] = 0;
+      for (int i = 0; i<6; i++)
+         _pad_pixel_transform[i] = 0;
       _pad_scale = 0;
       _pad_scale_x = 0;
       _pad_scale_y = 0;
-      _pad_scale_x_relative = 0;
-      _pad_scale_y_relative = 0;
-      for (i = 0; i < mathtext::math_text_renderer_t::NFAMILY; i++) _current_font_size[i] = 0;
+      for (int i = 0; i < mathtext::math_text_renderer_t::NFAMILY; i++)
+         _current_font_size[i] = 0;
    }
    inline float
    font_size(const unsigned int family = FAMILY_PLAIN) const override
@@ -160,12 +157,8 @@ public:
    {
       _x0 = gPad->XtoAbsPixel(x);
       _y0 = gPad->YtoAbsPixel(y);
-      _pad_scale_x =
-         gPad->XtoPixel(gPad->GetX2()) -
-         gPad->XtoPixel(gPad->GetX1());
-      _pad_scale_y =
-         gPad->YtoPixel(gPad->GetY1()) -
-         gPad->YtoPixel(gPad->GetY2());
+      _pad_scale_x = gPad->GetPadWidth();
+      _pad_scale_y = gPad->GetPadHeight();
       _pad_scale = std::min(_pad_scale_x, _pad_scale_y);
 
       _angle_degree = angle_degree;
@@ -224,7 +217,7 @@ public:
    {
    }
    inline mathtext::bounding_box_t
-   bounding_box(const wchar_t character, float &current_x, const unsigned int family)
+   bounding_box_char(const wchar_t character, float &current_x, const unsigned int family)
    {
       auto font = TTF::GetCurFont();
 
@@ -236,6 +229,8 @@ public:
          TTF::SetTextFont((Font_t) root_face_number(family));
 
       auto font_face = TTF::GetCurFontFace();
+      if (!font_face || font_face->units_per_EM == 0)
+         return mathtext::bounding_box_t(0, 0, 0, 0, 0, 0);
 
       FT_Load_Glyph(
          font_face,
@@ -270,61 +265,52 @@ public:
    inline mathtext::bounding_box_t
    bounding_box(const std::wstring string, const unsigned int family = FAMILY_PLAIN) override
    {
-      auto font_face = TTF::GetCurFontFace();
-
-      if (string.empty() || !font_face || font_face->units_per_EM == 0)
+      if (string.empty())
          return mathtext::bounding_box_t(0, 0, 0, 0, 0, 0);
 
       std::wstring::const_iterator iterator = string.begin();
       float current_x = 0;
       mathtext::bounding_box_t ret =
-         bounding_box(*iterator, current_x, family);
+         bounding_box_char(*iterator, current_x, family);
 
       ++iterator;
       for (; iterator != string.end(); ++iterator) {
          const mathtext::point_t position =
             mathtext::point_t(current_x, 0);
          const mathtext::bounding_box_t glyph_bounding_box =
-            bounding_box(*iterator, current_x, family);
+            bounding_box_char(*iterator, current_x, family);
          ret = ret.merge(position + glyph_bounding_box);
       }
 
       return ret;
    }
-   inline void
-   text_raw(const float x, const float y,
-          const std::wstring string,
-          const unsigned int family = FAMILY_PLAIN) override
+   void text_raw(const float x, const float y,
+                 const std::wstring string,
+                 const unsigned int family = FAMILY_PLAIN) override
    {
-      SetTextFont((Font_t) root_face_number(family));
       SetTextSize(_current_font_size[family]);
-      TAttText::Modify();
 
       wchar_t buf[2];
-      float advance = 0;
+      float current_x = 0;
 
       buf[1] = L'\0';
-      for (std::wstring::const_iterator iterator = string.begin(); iterator != string.end(); ++iterator) {
-         buf[0] = *iterator;
-         const bool cyrillic_or_cjk = is_cyrillic_or_cjk(buf[0]);
-
-         if (cyrillic_or_cjk) {
+      for (auto character : string) {
+         buf[0] = character;
+         const bool cyrillic_or_cjk = is_cyrillic_or_cjk(character);
+         if (cyrillic_or_cjk)
             SetTextFont((Font_t) root_cjk_face_number());
-            TAttText::Modify();
-         }
-
-         const mathtext::bounding_box_t b =
-            bounding_box(buf, family);
-         double xt;
-         double yt;
-
-         transform_pad(xt, yt, x + advance, y);
-         gPad->PaintText(xt, yt, buf);
-         advance += b.advance();
-         if (cyrillic_or_cjk) {
+         else
             SetTextFont((Font_t) root_face_number(family));
-            TAttText::Modify();
-         }
+
+         double xt, yt;
+
+         transform_pad(xt, yt, x + current_x, y);
+
+         TAttText::ModifyOn(*gPad);
+         gPad->PaintText(xt, yt, buf);
+
+         // use bounding function to advance current_x
+         bounding_box_char(character, current_x, family);
       }
    }
    inline void

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -1,23 +1,27 @@
 // @(#)root/graf:$Id$
-// Author: Olivier Couet     01/10/02
+// Author: Olivier Couet     01/10/2002
+// Author: Sergey  Linev     29/04/2026
 
 /*************************************************************************
- * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-/** \class TTF
+
+/** \class TTFhandle
 \ingroup BasicGraphics
 
-Interface to the freetype 2 library.
+Dynamic handle to work with freetype 2 library.
+in ROOT7 TTFhandle will be renamed into TTF class
 */
 
-#  include <ft2build.h>
-#  include FT_FREETYPE_H
-#  include FT_GLYPH_H
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
 #include "TROOT.h"
 #include "TTF.h"
 #include "TSystem.h"
@@ -28,160 +32,130 @@ Interface to the freetype 2 library.
 // to scale fonts to the same size as the old TT version
 const Float_t kScale = 0.93376068;
 
-TTF gCleanupTTF; // Allows to call "Cleanup" at the end of the session
 
-Bool_t         TTF::fgInit           = kFALSE;
-Bool_t         TTF::fgSmoothing      = kTRUE;
-Bool_t         TTF::fgKerning        = kTRUE;
-Bool_t         TTF::fgHinting        = kFALSE;
-Int_t          TTF::fgTBlankW        = 0;
-Int_t          TTF::fgWidth          = 0;
-Int_t          TTF::fgAscent         = 0;
-Int_t          TTF::fgCurFontIdx     = -1;
-Int_t          TTF::fgSymbItaFontIdx = -1;
-Int_t          TTF::fgFontCount      = 0;
-Int_t          TTF::fgNumGlyphs      = 0;
-char          *TTF::fgFontName[kTTMaxFonts];
-FT_Matrix     *TTF::fgRotMatrix      = nullptr;
-FT_Library     TTF::fgLibrary;
-FT_BBox        TTF::fgCBox;
-FT_Face        TTF::fgFace[kTTMaxFonts];
-FT_CharMap     TTF::fgCharMap[kTTMaxFonts];
-TTF::TTGlyph   TTF::fgGlyphs[kMaxGlyphs];
+Bool_t      TTFhandle::fgInit   = kFALSE;
+FT_Library  TTFhandle::fgLibrary;
+Int_t       TTFhandle::fgFontCount      = 0;
+char       *TTFhandle::fgFontName[kTTMaxFonts];
+FT_Face     TTFhandle::fgFace[kTTMaxFonts];
+FT_CharMap  TTFhandle::fgCharMap[kTTMaxFonts];
+Int_t       TTFhandle::fgSymbItaFontIdx = -1;
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Cleanup TTF environment.
 
-TTF::~TTF()
+TTFhandle::TTFhandle()
 {
-   Cleanup();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Initialise the TrueType fonts interface.
-
-void TTF::Init()
-{
-   if (fgInit)
-      return;
-
-   fgInit = kTRUE;
-
-   // initialize FTF library
-   if (FT_Init_FreeType(&fgLibrary)) {
-      Error("TTF::Init", "error initializing FreeType");
-      return;
+   if (!fgInit) {
+      // initialize FTF library
+      if (FT_Init_FreeType(&fgLibrary))
+         Error("TTFhandle::TTFhandle", "error initializing FreeType");
+      else
+         fgInit = kTRUE;
    }
+}
 
-   // load default font (arialbd)
-   SetTextFont(62);
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTFhandle::~TTFhandle()
+{
+   CleanupGlyphs();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Cleanup. Is called by the gCleanupTTF destructor.
+/// Close library handle. Is called by the gCleanupTTF destructor.
 
-void TTF::Cleanup()
+void TTFhandle::CloseLibrary()
 {
    if (!fgInit)
       return;
 
-   CleanupGlyphs();
-
-   for (int i = 0; i < fgFontCount; i++) {
+   for (Int_t i = 0; i < fgFontCount; i++) {
       delete [] fgFontName[i];
       fgFontName[i] = nullptr;
 
       FT_Done_Face(fgFace[i]);
    }
-   if (fgRotMatrix) {
-      delete fgRotMatrix;
-      fgRotMatrix = nullptr;
-   }
    FT_Done_FreeType(fgLibrary);
-
    fgInit = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Map char to unicode. Returns 0 in case no mapping exists.
 
-Short_t TTF::CharToUnicode(UInt_t code)
+Short_t TTFhandle::CharToUnicode(UInt_t code)
 {
-   if (!fgCharMap[fgCurFontIdx]) {
+   if (!fgCharMap[fCurFontIdx]) {
       UShort_t i, platform, encoding;
       FT_CharMap  charmap;
 
-      if (!fgFace[fgCurFontIdx]) return 0;
-      Int_t n = fgFace[fgCurFontIdx]->num_charmaps;
+      if (!fgFace[fCurFontIdx]) return 0;
+      Int_t n = fgFace[fCurFontIdx]->num_charmaps;
       for (i = 0; i < n; i++) {
-         if (!fgFace[fgCurFontIdx]) continue;
-         charmap  = fgFace[fgCurFontIdx]->charmaps[i];
+         if (!fgFace[fCurFontIdx]) continue;
+         charmap  = fgFace[fCurFontIdx]->charmaps[i];
          platform = charmap->platform_id;
          encoding = charmap->encoding_id;
          if ((platform == 3 && encoding == 1) ||
              (platform == 0 && encoding == 0) ||
              (platform == 1 && encoding == 0 &&
-              !strcmp(fgFontName[fgCurFontIdx], "wingding.ttf")) ||
+              !strcmp(fgFontName[fCurFontIdx], "wingding.ttf")) ||
              (platform == 1 && encoding == 0 &&
-              !strcmp(fgFontName[fgCurFontIdx], "symbol.ttf")))
+              !strcmp(fgFontName[fCurFontIdx], "symbol.ttf")))
          {
-            fgCharMap[fgCurFontIdx] = charmap;
-            if (FT_Set_Charmap(fgFace[fgCurFontIdx], fgCharMap[fgCurFontIdx]))
+            fgCharMap[fCurFontIdx] = charmap;
+            if (FT_Set_Charmap(fgFace[fCurFontIdx], fgCharMap[fCurFontIdx]))
                 Error("TTF::CharToUnicode", "error in FT_Set_CharMap");
-            return FT_Get_Char_Index(fgFace[fgCurFontIdx], (FT_ULong)code);
+            return FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong)code);
          }
       }
    }
-   return FT_Get_Char_Index(fgFace[fgCurFontIdx], (FT_ULong)code);
+   return FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong)code);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Compute the trailing blanks width. It is use to compute the text width in GetTextExtent
 /// `n` is the number of trailing blanks in a string.
 
-void TTF::ComputeTrailingBlanksWidth(Int_t n)
+void TTFhandle::ComputeTrailingBlanksWidth(Int_t n)
 {
-   fgTBlankW = 0;
+   fTBlankW = 0;
    if (n) {
-      FT_Face face = fgFace[fgCurFontIdx];
+      FT_Face face = fgFace[fCurFontIdx];
       char space = ' ';
       FT_UInt load_flags = FT_LOAD_DEFAULT;
-      if (!fgHinting) load_flags |= FT_LOAD_NO_HINTING;
+      if (!fHinting) load_flags |= FT_LOAD_NO_HINTING;
       FT_Load_Char(face, space, load_flags);
 
       FT_GlyphSlot slot      = face->glyph;
       FT_Pos advance_x       = slot->advance.x;
       Int_t advance_x_pixels = advance_x >> 6;
 
-      fgTBlankW = advance_x_pixels * n;
+      fTBlankW = advance_x_pixels * n;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Get width (w) and height (h) when text is horizontal.
 
-void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const char *text)
+void TTFhandle::GetTextExtent(UInt_t &w, UInt_t &h, const char *text)
 {
-   Init();
-
    SetRotationMatrix(0);
    PrepareString(text);
    LayoutGlyphs();
-   Int_t Xoff = 0; if (fgCBox.xMin < 0) Xoff = -fgCBox.xMin;
-   Int_t Yoff = 0; if (fgCBox.yMin < 0) Yoff = -fgCBox.yMin;
-   w = fgCBox.xMax + Xoff + GetTrailingBlanksWidth();
-   h = fgCBox.yMax + Yoff;
+   Int_t Xoff = 0; if (fCBox.xMin < 0) Xoff = -fCBox.xMin;
+   Int_t Yoff = 0; if (fCBox.yMin < 0) Yoff = -fCBox.yMin;
+   w = fCBox.xMax + Xoff + GetTrailingBlanksWidth();
+   h = fCBox.yMax + Yoff;
    CleanupGlyphs();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Get advance (a) when text is horizontal.
 
-void TTF::GetTextAdvance(UInt_t &a, const char *text)
+void TTFhandle::GetTextAdvance(UInt_t &a, const char *text)
 {
-   Init();
-
    SetRotationMatrix(0);
    PrepareString(text);
    LayoutGlyphs();
@@ -192,17 +166,15 @@ void TTF::GetTextAdvance(UInt_t &a, const char *text)
 ////////////////////////////////////////////////////////////////////////////////
 /// Get width (w) and height (h) when text is horizontal.
 
-void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text)
+void TTFhandle::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text)
 {
-   Init();
-
    SetRotationMatrix(0);
    PrepareString(text);
    LayoutGlyphs();
-   Int_t Xoff = 0; if (fgCBox.xMin < 0) Xoff = -fgCBox.xMin;
-   Int_t Yoff = 0; if (fgCBox.yMin < 0) Yoff = -fgCBox.yMin;
-   w = fgCBox.xMax + Xoff + GetTrailingBlanksWidth();
-   h = fgCBox.yMax + Yoff;
+   Int_t Xoff = 0; if (fCBox.xMin < 0) Xoff = -fCBox.xMin;
+   Int_t Yoff = 0; if (fCBox.yMin < 0) Yoff = -fCBox.yMin;
+   w = fCBox.xMax + Xoff + GetTrailingBlanksWidth();
+   h = fCBox.yMax + Yoff;
    CleanupGlyphs();
 }
 
@@ -213,115 +185,105 @@ void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text)
 /// If required take the "kerning" into account.
 /// SetRotation and PrepareString should have been called before.
 
-void TTF::LayoutGlyphs()
+void TTFhandle::LayoutGlyphs()
 {
-   TTGlyph*  glyph = fgGlyphs;
    FT_Vector origin;
    FT_UInt   load_flags;
    FT_UInt   prev_index = 0;
 
-   fgAscent = 0;
-   fgWidth  = 0;
+   fAscent = 0;
+   fWidth  = 0;
 
    load_flags = FT_LOAD_DEFAULT;
-   if (!fgHinting) load_flags |= FT_LOAD_NO_HINTING;
+   if (!fHinting) load_flags |= FT_LOAD_NO_HINTING;
 
-   fgCBox.xMin = fgCBox.yMin =  32000;
-   fgCBox.xMax = fgCBox.yMax = -32000;
+   fCBox.xMin = fCBox.yMin =  32000;
+   fCBox.xMax = fCBox.yMax = -32000;
 
-   for (int n = 0; n < fgNumGlyphs; n++, glyph++) {
+   for (auto &glyph : fGlyphs) {
 
       // compute glyph origin
-      if (fgKerning) {
+      if (fKerning) {
          if (prev_index) {
             FT_Vector  kern;
-            FT_Get_Kerning(fgFace[fgCurFontIdx], prev_index, glyph->fIndex,
-                           fgHinting ? ft_kerning_default : ft_kerning_unfitted,
+            FT_Get_Kerning(fgFace[fCurFontIdx], prev_index, glyph.fIndex,
+                           fHinting ? ft_kerning_default : ft_kerning_unfitted,
                            &kern);
-            fgWidth += kern.x;
+            fWidth += kern.x;
          }
-         prev_index = glyph->fIndex;
+         prev_index = glyph.fIndex;
       }
 
-      origin.x = fgWidth;
+      origin.x = fWidth;
       origin.y = 0;
 
       // clear existing image if there is one
-      if (glyph->fImage) {
-         FT_Done_Glyph(glyph->fImage);
-         glyph->fImage = nullptr;
+      if (glyph.fImage) {
+         FT_Done_Glyph(glyph.fImage);
+         glyph.fImage = nullptr;
       }
 
       // load the glyph image (in its native format)
-      if (FT_Load_Glyph(fgFace[fgCurFontIdx], glyph->fIndex, load_flags))
+      if (FT_Load_Glyph(fgFace[fCurFontIdx], glyph.fIndex, load_flags))
          continue;
 
       // extract the glyph image
-      if (FT_Get_Glyph (fgFace[fgCurFontIdx]->glyph, &glyph->fImage))
+      if (FT_Get_Glyph(fgFace[fCurFontIdx]->glyph, &glyph.fImage))
          continue;
 
-      glyph->fPos = origin;
-      fgWidth    += fgFace[fgCurFontIdx]->glyph->advance.x;
-      fgAscent    = TMath::Max((Int_t)(fgFace[fgCurFontIdx]->glyph->metrics.horiBearingY), fgAscent);
+      glyph.fPos = origin;
+      fWidth    += fgFace[fCurFontIdx]->glyph->advance.x;
+      fAscent    = TMath::Max((Int_t)(fgFace[fCurFontIdx]->glyph->metrics.horiBearingY), fAscent);
 
       // transform the glyphs
-      FT_Vector_Transform(&glyph->fPos, fgRotMatrix);
-      if (FT_Glyph_Transform(glyph->fImage, fgRotMatrix, &glyph->fPos))
+      FT_Vector_Transform(&glyph.fPos, fRotMatrix.get());
+      if (FT_Glyph_Transform(glyph.fImage, fRotMatrix.get(), &glyph.fPos))
          continue;
 
       // compute the string control box
       FT_BBox  bbox;
-      FT_Glyph_Get_CBox(glyph->fImage, ft_glyph_bbox_pixels, &bbox);
-      if (bbox.xMin < fgCBox.xMin) fgCBox.xMin = bbox.xMin;
-      if (bbox.yMin < fgCBox.yMin) fgCBox.yMin = bbox.yMin;
-      if (bbox.xMax > fgCBox.xMax) fgCBox.xMax = bbox.xMax;
-      if (bbox.yMax > fgCBox.yMax) fgCBox.yMax = bbox.yMax;
+      FT_Glyph_Get_CBox(glyph.fImage, ft_glyph_bbox_pixels, &bbox);
+      if (bbox.xMin < fCBox.xMin) fCBox.xMin = bbox.xMin;
+      if (bbox.yMin < fCBox.yMin) fCBox.yMin = bbox.yMin;
+      if (bbox.xMax > fCBox.xMax) fCBox.xMax = bbox.xMax;
+      if (bbox.yMax > fCBox.yMax) fCBox.yMax = bbox.yMax;
    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove temporary data created by LayoutGlyphs
 
-void TTF::CleanupGlyphs()
+void TTFhandle::CleanupGlyphs()
 {
-   TTGlyph*  glyph = fgGlyphs;
-
-   for (int n = 0; n < fgNumGlyphs; n++, glyph++) {
+   for(auto &glyph : fGlyphs) {
       // clear existing image if there is one
-      if (glyph->fImage) {
-         FT_Done_Glyph(glyph->fImage);
-         glyph->fImage = nullptr;
+      if (glyph.fImage && fgInit) {
+         FT_Done_Glyph(glyph.fImage);
+         glyph.fImage = nullptr;
       }
    }
-
-   fgNumGlyphs = 0;
+   fGlyphs.clear();
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Put the characters in "string" in the "glyphs" array.
 
-void TTF::PrepareString(const char *string)
+void TTFhandle::PrepareString(const char *string)
 {
+   CleanupGlyphs();
+
    const unsigned char *p = (const unsigned char*) string;
-   TTGlyph *glyph = fgGlyphs;
-   UInt_t index;       // Unicode value
+
    Int_t NbTBlank = 0; // number of trailing blanks
 
-   fgNumGlyphs = 0;
    while (*p) {
-      index = CharToUnicode((FT_ULong)*p);
-      if (index != 0) {
-         glyph->fIndex = index;
-         glyph++;
-         fgNumGlyphs++;
-      }
-      if (*p == ' ') {
+      UInt_t index = CharToUnicode((FT_ULong)*p);
+      if (index != 0)
+         fGlyphs.emplace_back(index);
+      if (*p == ' ')
          NbTBlank++;
-      } else {
+      else
          NbTBlank = 0;
-      }
-      if (fgNumGlyphs >= kMaxGlyphs) break;
       p++;
    }
 
@@ -331,27 +293,22 @@ void TTF::PrepareString(const char *string)
 ////////////////////////////////////////////////////////////////////////////////
 /// Put the characters in "string" in the "glyphs" array.
 
-void TTF::PrepareString(const wchar_t *string)
+void TTFhandle::PrepareString(const wchar_t *string)
 {
+   CleanupGlyphs();
+
    const wchar_t *p = string;
-   TTGlyph *glyph = fgGlyphs;
-   UInt_t index;       // Unicode value
+
    Int_t NbTBlank = 0; // number of trailing blanks
 
-   fgNumGlyphs = 0;
    while (*p) {
-      index = FT_Get_Char_Index(fgFace[fgCurFontIdx], (FT_ULong)*p);
-      if (index != 0) {
-         glyph->fIndex = index;
-         glyph++;
-         fgNumGlyphs++;
-      }
-      if (*p == ' ') {
+      UInt_t index = FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong) *p);
+      if (index != 0)
+         fGlyphs.emplace_back(index);
+      if (*p == ' ')
          NbTBlank++;
-      } else {
+      else
          NbTBlank = 0;
-      }
-      if (fgNumGlyphs >= kMaxGlyphs) break;
       p++;
    }
 
@@ -361,50 +318,17 @@ void TTF::PrepareString(const wchar_t *string)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return current font index
 
-Int_t TTF::GetCurFontIdx()
+FT_Face TTFhandle::GetCurFontFace() const
 {
-   return fgCurFontIdx;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return current font index
-
-FT_Face TTF::GetCurFontFace()
-{
-   return (fgCurFontIdx < 0) || (fgCurFontIdx >= kTTMaxFonts) ? nullptr : fgFace[fgCurFontIdx];
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set current font index
-
-void TTF::SetCurFontIdx(Int_t indx)
-{
-   fgCurFontIdx = indx;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set hinting flag.
-
-void TTF::SetHinting(Bool_t state)
-{
-   fgHinting = state;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set kerning flag.
-
-void TTF::SetKerning(Bool_t state)
-{
-   fgKerning = state;
+   return (fCurFontIdx < 0) || (fCurFontIdx >= kTTMaxFonts) ? nullptr : fgFace[fCurFontIdx];
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set the rotation matrix used to rotate the font outlines.
 
-void TTF::SetRotationMatrix(Float_t angle)
+void TTFhandle::SetRotationMatrix(Float_t angle)
 {
-   Float_t rangle = Float_t(angle * TMath::Pi() / 180.); // Angle in radian
+   Float_t rangle = angle * TMath::Pi() / 180.; // Angle in radian
 #if defined(FREETYPE_PATCH) && \
     (FREETYPE_MAJOR == 2) && (FREETYPE_MINOR == 1) && (FREETYPE_PATCH == 2)
    Float_t sin    = TMath::Sin(rangle);
@@ -414,20 +338,13 @@ void TTF::SetRotationMatrix(Float_t angle)
    Float_t cos    = TMath::Cos(-rangle);
 #endif
 
-   if (!fgRotMatrix) fgRotMatrix = new FT_Matrix;
+   if (!fRotMatrix)
+      fRotMatrix = std::make_unique<FT_Matrix>();
 
-   fgRotMatrix->xx = (FT_Fixed) (cos * (1<<16));
-   fgRotMatrix->xy = (FT_Fixed) (sin * (1<<16));
-   fgRotMatrix->yx = -fgRotMatrix->xy;
-   fgRotMatrix->yy =  fgRotMatrix->xx;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set smoothing (anti-aliasing) flag.
-
-void TTF::SetSmoothing(Bool_t state)
-{
-   fgSmoothing = state;
+   fRotMatrix->xx = (FT_Fixed) (cos * (1<<16));
+   fRotMatrix->xy = (FT_Fixed) (sin * (1<<16));
+   fRotMatrix->yx = -fRotMatrix->xy;
+   fRotMatrix->yy =  fRotMatrix->xx;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -438,14 +355,12 @@ void TTF::SetSmoothing(Bool_t state)
 /// Set text font to specified name. This function returns 0 if
 /// the specified font is found, 1 if not.
 
-Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
+Int_t TTFhandle::SetTextFont(const char *fontname, Int_t italic)
 {
-   if (!fgInit) Init();
-
    if (!fontname || !fontname[0]) {
-      Warning("TTF::SetTextFont",
+      Warning("TTFhandle::SetTextFont",
               "no font name specified, using default font %s", fgFontName[0]);
-      fgCurFontIdx = 0;
+      fCurFontIdx = 0;
       return 0;
    }
    const char *basename = gSystem->BaseName(fontname);
@@ -455,13 +370,13 @@ Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
    for (i = 0; i < fgFontCount; i++) {
       if (!strcmp(fgFontName[i], basename)) {
          if (italic) {
-            if (i==fgSymbItaFontIdx) {
-               fgCurFontIdx = i;
+            if (i == fgSymbItaFontIdx) {
+               fCurFontIdx = i;
                return 0;
             }
          } else {
-            if (i!=fgSymbItaFontIdx) {
-               fgCurFontIdx = i;
+            if (i != fgSymbItaFontIdx) {
+               fCurFontIdx = i;
                return 0;
             }
          }
@@ -470,10 +385,10 @@ Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
 
    // enough space in cache to load font?
    if (fgFontCount >= kTTMaxFonts) {
-      Error("TTF::SetTextFont", "too many fonts opened (increase kTTMaxFont = %d)",
+      Error("TTFhandle::SetTextFont", "too many fonts opened (increase kTTMaxFont = %d)",
             kTTMaxFonts);
-      Warning("TTF::SetTextFont", "using default font %s", fgFontName[0]);
-      fgCurFontIdx = 0;    // use font 0 (default font, set in ctor)
+      Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
+      fCurFontIdx = 0;    // use font 0 (default font, set in ctor)
       return 0;
    }
 
@@ -483,25 +398,25 @@ Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
    char *ttfont = gSystem->Which(ttpath, fontname, kReadPermission);
 
    if (!ttfont) {
-      Error("TTF::SetTextFont", "font file %s not found in path %s", fontname, ttpath);
+      Error("TTFhandle::SetTextFont", "font file %s not found in path %s", fontname, ttpath);
       if (fgFontCount) {
-         Warning("TTF::SetTextFont", "using default font %s", fgFontName[0]);
-         fgCurFontIdx = 0;    // use font 0 (default font, set in ctor)
+         Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
+         fCurFontIdx = 0;    // use font 0 (default font, set in ctor)
          return 0;
       } else {
          return 1;
       }
    }
 
-   FT_Face  tface = (FT_Face) 0;
+   FT_Face tface = (FT_Face) 0;
 
    if (FT_New_Face(fgLibrary, ttfont, 0, &tface)) {
-      Error("TTF::SetTextFont", "error loading font %s", ttfont);
+      Error("TTFhandle::SetTextFont", "error loading font %s", ttfont);
       delete [] ttfont;
       if (tface) FT_Done_Face(tface);
       if (fgFontCount) {
-         Warning("TTF::SetTextFont", "using default font %s", fgFontName[0]);
-         fgCurFontIdx = 0;
+         Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
+         fCurFontIdx = 0;
          return 0;
       } else {
          return 1;
@@ -511,19 +426,18 @@ Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
    delete [] ttfont;
 
    fgFontName[fgFontCount] = StrDup(basename);
-   fgCurFontIdx            = fgFontCount;
-   fgFace[fgCurFontIdx]    = tface;
-   fgCharMap[fgCurFontIdx] = (FT_CharMap) 0;
-   fgFontCount++;
+   fgFace[fgFontCount]     = tface;
+   fgCharMap[fgFontCount]  = (FT_CharMap) 0;
+   fCurFontIdx             = fgFontCount++;
 
    if (italic) {
-      fgSymbItaFontIdx = fgCurFontIdx;
+      fgSymbItaFontIdx = fCurFontIdx;
       FT_Matrix slantMat;
       slantMat.xx = (1 << 16);
       slantMat.xy = ((1 << 16) >> 2);
       slantMat.yx = 0;
       slantMat.yy = (1 << 16);
-      FT_Set_Transform( fgFace[fgSymbItaFontIdx], &slantMat, NULL );
+      FT_Set_Transform(fgFace[fgSymbItaFontIdx], &slantMat, NULL);
    }
 
    return 0;
@@ -550,7 +464,7 @@ Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
 /// |     13      |   Free Serif              |    Times-Roman                |
 /// |     14      |   Wingdings               |    ZapfDingbats               |
 
-void TTF::SetTextFont(Font_t fontnumber)
+void TTFhandle::SetTextFont(Font_t fontnumber)
 {
    // Added by cholm for use of DFSG - fonts - based on Kevins fix.
    // Table of Microsoft and (for non-MSFT operating systems) backup
@@ -621,104 +535,318 @@ void TTF::SetTextFont(Font_t fontnumber)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set current text size.
 
-void TTF::SetTextSize(Float_t textsize)
+Bool_t TTFhandle::SetTextSize(Float_t textsize)
 {
-   if (!fgInit) Init();
-   if (textsize < 0) return;
+   if (textsize < 0)
+      return kFALSE;
 
-   if (fgCurFontIdx < 0 || fgFontCount <= fgCurFontIdx) {
-      Error("TTF::SetTextSize", "current font index out of bounds");
-      fgCurFontIdx = 0;
-      return;
+   if (fCurFontIdx < 0 || fgFontCount <= fCurFontIdx) {
+      Error("TTFhandle::SetTextSize", "current font index out of bounds");
+      fCurFontIdx = 0;
+      return kFALSE;
    }
 
    Int_t tsize = (Int_t)(textsize*kScale+0.5) << 6;
-   FT_Error err = FT_Set_Char_Size(fgFace[fgCurFontIdx], tsize, tsize, 72, 72);
+   FT_Error err = FT_Set_Char_Size(fgFace[fCurFontIdx], tsize, tsize, 72, 72);
+
    if (err)
-      Error("TTF::SetTextSize", "error in FT_Set_Char_Size: 0x%x (input size %f, calc. size 0x%x)", err, textsize,
-            tsize);
+      Error("TTFhandle::SetTextSize", "error in FT_Set_Char_Size: 0x%x (input size %f, calc. size 0x%x)", err, textsize, tsize);
+
+   return !err;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TTF::Version(Int_t &major, Int_t &minor, Int_t &patch)
+void TTFhandle::Version(Int_t &major, Int_t &minor, Int_t &patch)
 {
    FT_Library_Version(fgLibrary, &major, &minor, &patch);
+}
+
+
+/** \class TTF
+\ingroup BasicGraphics
+
+Interface to the freetype 2 library.
+Implements old static API.
+Unitl ROOT7 just redirects to static TTFhandle instance
+*/
+
+TTF gCleanupTTF; // Allows to call "Cleanup" at the end of the session
+std::unique_ptr<TTFhandle> TTF::fgHandle; // static handle, destroyed automatically
+
+////////////////////////////////////////////////////////////////////////////////
+/// Cleanup TTF environment.
+
+TTF::~TTF()
+{
+   TTFhandle::CloseLibrary();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Init TTF environment.
+
+void TTF::Init()
+{
+   if (!fgHandle) {
+      fgHandle = std::make_unique<TTFhandle>();
+      fgHandle->SetTextFont(62);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Bool_t TTF::GetHinting()
 {
-   return fgHinting;
+   return fgHandle ? fgHandle->GetHinting() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Bool_t TTF::GetKerning()
 {
-   return fgKerning;
+   return fgHandle ? fgHandle->GetKerning() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Bool_t TTF::GetSmoothing()
 {
-   return fgSmoothing;
+   return fgHandle ? fgHandle->GetSmoothing() : kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Bool_t TTF::IsInitialized()
 {
-   return fgInit;
+   return fgHandle.get() != nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Int_t  TTF::GetWidth()
 {
-   return fgWidth;
+   return fgHandle ? fgHandle->GetWidth() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Int_t  TTF::GetAscent()
 {
-   return fgAscent;
+   return fgHandle ? fgHandle->GetAscent() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Int_t  TTF::GetNumGlyphs()
 {
-   return fgNumGlyphs;
+   return fgHandle ? fgHandle->GetNumGlyphs() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 FT_Matrix *TTF::GetRotMatrix()
 {
-   return fgRotMatrix;
+   return fgHandle ? fgHandle->GetRotMatrix() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 Int_t  TTF::GetTrailingBlanksWidth()
 {
-   return fgTBlankW;
+   return fgHandle ? fgHandle->GetTrailingBlanksWidth() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 const FT_BBox &TTF::GetBox()
 {
-   return fgCBox;
+   static FT_BBox dummy;
+   return fgHandle ? fgHandle->GetBox() : dummy;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TTF::TTGlyph *TTF::GetGlyphs()
 {
-    return fgGlyphs;
+   return fgHandle ? fgHandle->GetGlyphs() : nullptr;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return current font index
+
+Int_t TTF::GetCurFontIdx()
+{
+   return fgHandle ? fgHandle->GetCurFontIdx() : -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return current font index
+
+FT_Face TTF::GetCurFontFace()
+{
+   return fgHandle ? fgHandle->GetCurFontFace() : nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Map char to unicode. Returns 0 in case no mapping exists.
+
+Short_t TTF::CharToUnicode(UInt_t code)
+{
+   Init();
+   return fgHandle->CharToUnicode(code);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set the rotation matrix used to rotate the font outlines.
+
+void TTF::SetRotationMatrix(Float_t angle)
+{
+   Init();
+   fgHandle->SetRotationMatrix(angle);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set current font index
+
+void TTF::SetCurFontIdx(Int_t indx)
+{
+   Init();
+   fgHandle->SetCurFontIdx(indx);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set hinting flag.
+
+void TTF::SetHinting(Bool_t state)
+{
+   Init();
+   fgHandle->SetHinting(state);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set kerning flag.
+
+void TTF::SetKerning(Bool_t state)
+{
+   Init();
+   fgHandle->SetKerning(state);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set smoothing (anti-aliasing) flag.
+
+void TTF::SetSmoothing(Bool_t state)
+{
+   Init();
+   fgHandle->SetSmoothing(state);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set text font to specified name.
+///  - font       : font name
+///  - italic     : the fonts should be slanted. Used for symbol font.
+
+Int_t TTF::SetTextFont(const char *fontname, Int_t italic)
+{
+   Init();
+   return fgHandle->SetTextFont(fontname, italic);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set specified font.
+
+void TTF::SetTextFont(Font_t fontnumber)
+{
+   Init();
+   fgHandle->SetTextFont(fontnumber);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTF::SetTextSize(Float_t textsize)
+{
+   Init();
+   fgHandle->SetTextSize(textsize);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Put the characters in "string" in the "glyphs" array.
+
+void TTF::PrepareString(const char *string)
+{
+   Init();
+   fgHandle->PrepareString(string);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Put the characters in "string" in the "glyphs" array.
+
+void TTF::PrepareString(const wchar_t *string)
+{
+   Init();
+   fgHandle->PrepareString(string);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute the glyphs positions, fgAscent and fgWidth (needed for alignment).
+
+void TTF::LayoutGlyphs()
+{
+   if (fgHandle)
+      fgHandle->LayoutGlyphs();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Compute the trailing blanks width. It is use to compute the text width in GetTextExtent
+/// `n` is the number of trailing blanks in a string.
+
+void TTF::ComputeTrailingBlanksWidth(Int_t n)
+{
+   if (fgHandle)
+      fgHandle->ComputeTrailingBlanksWidth(n);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Remove temporary data created by LayoutGlyphs
+
+void TTF::CleanupGlyphs()
+{
+   if (fgHandle)
+      fgHandle->CleanupGlyphs();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get width (w) and height (h) when text is horizontal.
+
+void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const char *text)
+{
+   Init();
+   fgHandle->GetTextExtent(w, h, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get advance (a) when text is horizontal.
+
+void TTF::GetTextAdvance(UInt_t &a, const char *text)
+{
+   Init();
+   fgHandle->GetTextAdvance(a, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get width (w) and height (h) when text is horizontal.
+
+void TTF::GetTextExtent(UInt_t &w, UInt_t &h, const wchar_t *text)
+{
+   Init();
+   fgHandle->GetTextExtent(w, h, text);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTF::Version(Int_t &major, Int_t &minor, Int_t &patch)
+{
+   Init();
+   fgHandle->Version(major, minor, patch);
+}
+

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -835,26 +835,3 @@ void TTF::Version(Int_t &major, Int_t &minor, Int_t &patch)
    Init();
    fgHandle->Version(major, minor, patch);
 }
-
-////////////////////////////////////////////////////////////////////////////////
-
-TTFontHandle *TTF::GetCurFont()
-{
-   return fgHandle ? fgHandle->GetFont() : nullptr;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-void TTF::SetCurFont(TTFontHandle *font)
-{
-   if (fgHandle)
-      fgHandle->SetFont(font);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-FT_Face TTF::GetCurFontFace()
-{
-   Init();
-   return fgHandle->GetFontFace();
-}

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -33,26 +33,21 @@ in ROOT7 TTFhandle will be renamed into TTF class
 const Float_t kScale = 0.93376068;
 
 
-Bool_t      TTFhandle::fgInit   = kFALSE;
-FT_Library  TTFhandle::fgLibrary;
-Int_t       TTFhandle::fgFontCount      = 0;
-char       *TTFhandle::fgFontName[kTTMaxFonts];
-FT_Face     TTFhandle::fgFace[kTTMaxFonts];
-FT_CharMap  TTFhandle::fgCharMap[kTTMaxFonts];
-Int_t       TTFhandle::fgSymbItaFontIdx = -1;
-
+struct TTFontHandle {
+   std::string name;
+   FT_Face face = nullptr;
+   FT_CharMap charmap = nullptr;
+   bool is_symbol() const
+   {
+      return (name == "wingding.ttf") || (name.find("symbol.ttf") == 0);
+   }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TTFhandle::TTFhandle()
 {
-   if (!fgInit) {
-      // initialize FTF library
-      if (FT_Init_FreeType(&fgLibrary))
-         Error("TTFhandle::TTFhandle", "error initializing FreeType");
-      else
-         fgInit = kTRUE;
-   }
+   InitClose(1);
 }
 
 
@@ -64,54 +59,55 @@ TTFhandle::~TTFhandle()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Close library handle. Is called by the gCleanupTTF destructor.
+/// Initialize or close FreeType library
+/// If argument is 0 - just return current handle
+/// Library initialized per thread
 
-void TTFhandle::CloseLibrary()
+FT_Library TTFhandle::InitClose(Int_t direction)
 {
-   if (!fgInit)
-      return;
-
-   for (Int_t i = 0; i < fgFontCount; i++) {
-      delete [] fgFontName[i];
-      fgFontName[i] = nullptr;
-
-      FT_Done_Face(fgFace[i]);
+   thread_local FT_Library _library = nullptr;
+   if ((direction > 0) || !_library) {
+      if (FT_Init_FreeType(&_library)) {
+         Error("TTFhandle::InitClose", "error initializing FreeType");
+         _library = nullptr;
+      }
+   } else if ((direction < 0) && _library) {
+      // SelectFontHandle(-1); // delete all font handles
+      FT_Done_FreeType(_library);
+      _library = nullptr;
    }
-   FT_Done_FreeType(fgLibrary);
-   fgInit = kFALSE;
+
+   return _library;
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Map char to unicode. Returns 0 in case no mapping exists.
 
-Short_t TTFhandle::CharToUnicode(UInt_t code)
+UInt_t TTFhandle::CharToUnicode(UInt_t code)
 {
-   if (!fgCharMap[fCurFontIdx]) {
-      UShort_t i, platform, encoding;
-      FT_CharMap  charmap;
+   FT_Face face = fFont ? fFont->face : nullptr;
+   if (!face)
+      return 0;
 
-      if (!fgFace[fCurFontIdx]) return 0;
-      Int_t n = fgFace[fCurFontIdx]->num_charmaps;
-      for (i = 0; i < n; i++) {
-         if (!fgFace[fCurFontIdx]) continue;
-         charmap  = fgFace[fCurFontIdx]->charmaps[i];
-         platform = charmap->platform_id;
-         encoding = charmap->encoding_id;
+   if (!fFont->charmap) {
+      Int_t n = face->num_charmaps;
+      for (Int_t i = 0; i < n; i++) {
+         FT_CharMap charmap  = face->charmaps[i];
+         auto platform = charmap->platform_id;
+         auto encoding = charmap->encoding_id;
          if ((platform == 3 && encoding == 1) ||
              (platform == 0 && encoding == 0) ||
-             (platform == 1 && encoding == 0 &&
-              !strcmp(fgFontName[fCurFontIdx], "wingding.ttf")) ||
-             (platform == 1 && encoding == 0 &&
-              !strcmp(fgFontName[fCurFontIdx], "symbol.ttf")))
+             (platform == 1 && encoding == 0 && fFont->is_symbol()))
          {
-            fgCharMap[fCurFontIdx] = charmap;
-            if (FT_Set_Charmap(fgFace[fCurFontIdx], fgCharMap[fCurFontIdx]))
-                Error("TTF::CharToUnicode", "error in FT_Set_CharMap");
-            return FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong)code);
+            fFont->charmap = charmap;
+            if (FT_Set_Charmap(face, charmap))
+               Error("TTF::CharToUnicode", "error in FT_Set_CharMap");
+            break;
          }
       }
    }
-   return FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong)code);
+   return FT_Get_Char_Index(face, (FT_ULong)code);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -121,8 +117,8 @@ Short_t TTFhandle::CharToUnicode(UInt_t code)
 void TTFhandle::ComputeTrailingBlanksWidth(Int_t n)
 {
    fTBlankW = 0;
-   if (n) {
-      FT_Face face = fgFace[fCurFontIdx];
+   if (n && fFont) {
+      FT_Face face = fFont->face;
       char space = ' ';
       FT_UInt load_flags = FT_LOAD_DEFAULT;
       if (!fHinting) load_flags |= FT_LOAD_NO_HINTING;
@@ -195,10 +191,15 @@ void TTFhandle::LayoutGlyphs()
    fWidth  = 0;
 
    load_flags = FT_LOAD_DEFAULT;
-   if (!fHinting) load_flags |= FT_LOAD_NO_HINTING;
+   if (!fHinting)
+      load_flags |= FT_LOAD_NO_HINTING;
 
    fCBox.xMin = fCBox.yMin =  32000;
    fCBox.xMax = fCBox.yMax = -32000;
+
+   FT_Face face = fFont ? fFont->face : nullptr;
+   if (!face)
+      return;
 
    for (auto &glyph : fGlyphs) {
 
@@ -206,7 +207,7 @@ void TTFhandle::LayoutGlyphs()
       if (fKerning) {
          if (prev_index) {
             FT_Vector  kern;
-            FT_Get_Kerning(fgFace[fCurFontIdx], prev_index, glyph.fIndex,
+            FT_Get_Kerning(face, prev_index, glyph.fIndex,
                            fHinting ? ft_kerning_default : ft_kerning_unfitted,
                            &kern);
             fWidth += kern.x;
@@ -224,16 +225,16 @@ void TTFhandle::LayoutGlyphs()
       }
 
       // load the glyph image (in its native format)
-      if (FT_Load_Glyph(fgFace[fCurFontIdx], glyph.fIndex, load_flags))
+      if (FT_Load_Glyph(face, glyph.fIndex, load_flags))
          continue;
 
       // extract the glyph image
-      if (FT_Get_Glyph(fgFace[fCurFontIdx]->glyph, &glyph.fImage))
+      if (FT_Get_Glyph(face->glyph, &glyph.fImage))
          continue;
 
       glyph.fPos = origin;
-      fWidth    += fgFace[fCurFontIdx]->glyph->advance.x;
-      fAscent    = TMath::Max((Int_t)(fgFace[fCurFontIdx]->glyph->metrics.horiBearingY), fAscent);
+      fWidth    += face->glyph->advance.x;
+      fAscent    = TMath::Max((Int_t)(face->glyph->metrics.horiBearingY), fAscent);
 
       // transform the glyphs
       FT_Vector_Transform(&glyph.fPos, fRotMatrix.get());
@@ -255,9 +256,11 @@ void TTFhandle::LayoutGlyphs()
 
 void TTFhandle::CleanupGlyphs()
 {
+   bool is_lib = InitClose() != nullptr;
+
    for(auto &glyph : fGlyphs) {
       // clear existing image if there is one
-      if (glyph.fImage && fgInit) {
+      if (glyph.fImage && is_lib) {
          FT_Done_Glyph(glyph.fImage);
          glyph.fImage = nullptr;
       }
@@ -297,12 +300,16 @@ void TTFhandle::PrepareString(const wchar_t *string)
 {
    CleanupGlyphs();
 
+   FT_Face face = fFont ? fFont->face : nullptr;
+   if (!face)
+      return;
+
    const wchar_t *p = string;
 
    Int_t NbTBlank = 0; // number of trailing blanks
 
    while (*p) {
-      UInt_t index = FT_Get_Char_Index(fgFace[fCurFontIdx], (FT_ULong) *p);
+      UInt_t index = FT_Get_Char_Index(face, (FT_ULong) *p);
       if (index != 0)
          fGlyphs.emplace_back(index);
       if (*p == ' ')
@@ -318,9 +325,9 @@ void TTFhandle::PrepareString(const wchar_t *string)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return current font index
 
-FT_Face TTFhandle::GetCurFontFace() const
+FT_Face TTFhandle::GetFontFace() const
 {
-   return (fCurFontIdx < 0) || (fCurFontIdx >= kTTMaxFonts) ? nullptr : fgFace[fCurFontIdx];
+   return fFont ? fFont->face : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -348,6 +355,47 @@ void TTFhandle::SetRotationMatrix(Float_t angle)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return thread_local instance of TTFontHandle for speified font
+
+Int_t TTFhandle::SelectFontHandle(Int_t arg, const char *name)
+{
+   thread_local std::map<std::string, TTFontHandle> _fonts;
+
+   fFont = nullptr;
+
+   if (arg == 111) {
+      // select any existing font, fallback solution for some errors in SetTextFont
+      if (!_fonts.empty())
+         fFont =  &(_fonts.begin()->second);
+      Warning("TTFhandle::SetTextFont", "%s, using %s", name, fFont ? fFont->name.c_str() : "<nothing>");
+      return fFont ? 0 : 1;
+   }
+
+   if (arg >= 0) {
+      auto iter = _fonts.find(name);
+      if (iter != _fonts.end()) {
+         fFont = &iter->second;
+         return 0;
+      }
+      if (arg == 0)
+         return 1;
+      _fonts[name] = { name, nullptr, nullptr };
+      fFont = &_fonts[name];
+      return 0;
+   }
+
+   for (auto &font : _fonts) {
+      if (font.second.face) {
+         FT_Done_Face(font.second.face);
+         font.second.face = nullptr;
+      }
+   }
+   _fonts.clear();
+   return 0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set text font to specified name.
 ///  - font       : font name
 ///  - italic     : the fonts should be slanted. Used for symbol font.
@@ -357,39 +405,26 @@ void TTFhandle::SetRotationMatrix(Float_t angle)
 
 Int_t TTFhandle::SetTextFont(const char *fontname, Int_t italic)
 {
-   if (!fontname || !fontname[0]) {
-      Warning("TTFhandle::SetTextFont",
-              "no font name specified, using default font %s", fgFontName[0]);
-      fCurFontIdx = 0;
-      return 0;
-   }
+   fFont = nullptr;
+
+   if (!fontname || !*fontname)
+      return SelectFontHandle(111, "no font name specified");
+
    const char *basename = gSystem->BaseName(fontname);
 
-   // check if font is in cache
-   int i;
-   for (i = 0; i < fgFontCount; i++) {
-      if (!strcmp(fgFontName[i], basename)) {
-         if (italic) {
-            if (i == fgSymbItaFontIdx) {
-               fCurFontIdx = i;
-               return 0;
-            }
-         } else {
-            if (i != fgSymbItaFontIdx) {
-               fCurFontIdx = i;
-               return 0;
-            }
-         }
-      }
+   if (SelectFontHandle(1, TString::Format("%s%s", basename, italic ? ".italic" : ""))) {
+      Fatal("TTFhandle::SetTextFont", "Fail to create font handle for font %s", basename);
+      return 1;
    }
 
-   // enough space in cache to load font?
-   if (fgFontCount >= kTTMaxFonts) {
-      Error("TTFhandle::SetTextFont", "too many fonts opened (increase kTTMaxFont = %d)",
-            kTTMaxFonts);
-      Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
-      fCurFontIdx = 0;    // use font 0 (default font, set in ctor)
+   // font face exists and initialized
+   if (fFont->face)
       return 0;
+
+   auto lib = InitClose();
+   if (!lib) {
+      Error("TTFhandle::SetTextFont", "no free type library initialized");
+      return 1;
    }
 
    // try to load font (font must be in Root.TTFontPath resource)
@@ -397,47 +432,22 @@ Int_t TTFhandle::SetTextFont(const char *fontname, Int_t italic)
                                        TROOT::GetTTFFontDir());
    char *ttfont = gSystem->Which(ttpath, fontname, kReadPermission);
 
-   if (!ttfont) {
-      Error("TTFhandle::SetTextFont", "font file %s not found in path %s", fontname, ttpath);
-      if (fgFontCount) {
-         Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
-         fCurFontIdx = 0;    // use font 0 (default font, set in ctor)
-         return 0;
-      } else {
-         return 1;
-      }
-   }
+   if (!ttfont)
+      return SelectFontHandle(111, TString::Format("font file %s not found in path %s", fontname, ttpath));
 
-   FT_Face tface = (FT_Face) 0;
-
-   if (FT_New_Face(fgLibrary, ttfont, 0, &tface)) {
-      Error("TTFhandle::SetTextFont", "error loading font %s", ttfont);
-      delete [] ttfont;
-      if (tface) FT_Done_Face(tface);
-      if (fgFontCount) {
-         Warning("TTFhandle::SetTextFont", "using default font %s", fgFontName[0]);
-         fCurFontIdx = 0;
-         return 0;
-      } else {
-         return 1;
-      }
-   }
-
+   std::string filename = ttfont;
    delete [] ttfont;
 
-   fgFontName[fgFontCount] = StrDup(basename);
-   fgFace[fgFontCount]     = tface;
-   fgCharMap[fgFontCount]  = (FT_CharMap) 0;
-   fCurFontIdx             = fgFontCount++;
+   if (FT_New_Face(lib, filename.c_str(), 0, &fFont->face))
+      return SelectFontHandle(111, TString::Format("error loading font %s", filename.c_str()));
 
    if (italic) {
-      fgSymbItaFontIdx = fCurFontIdx;
       FT_Matrix slantMat;
       slantMat.xx = (1 << 16);
       slantMat.xy = ((1 << 16) >> 2);
       slantMat.yx = 0;
       slantMat.yy = (1 << 16);
-      FT_Set_Transform(fgFace[fgSymbItaFontIdx], &slantMat, NULL);
+      FT_Set_Transform(fFont->face, &slantMat, nullptr);
    }
 
    return 0;
@@ -524,12 +534,13 @@ void TTFhandle::SetTextFont(Font_t fontnumber)
          thisset = 1;
       }
    }
-   Int_t italic = 0;
-   if (fontid==15) italic = 1;
-   int ret = SetTextFont(gEnv->GetValue(fonttable[fontid][thisset], fonttable[fontid][1]), italic);
+   Int_t italic = fontid == 15 ? 1 : 0;
+   auto ret = SetTextFont(gEnv->GetValue(fonttable[fontid][thisset], fonttable[fontid][1]), italic);
+
    // Do not define font set is we're loading the symbol.ttf - it's
    // the same in both cases.
-   if (ret == 0 && fontid != 12) fontset = thisset;
+   if (ret == 0 && fontid != 12)
+      fontset = thisset;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -540,14 +551,13 @@ Bool_t TTFhandle::SetTextSize(Float_t textsize)
    if (textsize < 0)
       return kFALSE;
 
-   if (fCurFontIdx < 0 || fgFontCount <= fCurFontIdx) {
-      Error("TTFhandle::SetTextSize", "current font index out of bounds");
-      fCurFontIdx = 0;
+   if (!fFont || !fFont->face) {
+      Error("TTFhandle::SetTextSize", "current font not selected");
       return kFALSE;
    }
 
    Int_t tsize = (Int_t)(textsize*kScale+0.5) << 6;
-   FT_Error err = FT_Set_Char_Size(fgFace[fCurFontIdx], tsize, tsize, 72, 72);
+   FT_Error err = FT_Set_Char_Size(fFont->face, tsize, tsize, 72, 72);
 
    if (err)
       Error("TTFhandle::SetTextSize", "error in FT_Set_Char_Size: 0x%x (input size %f, calc. size 0x%x)", err, textsize, tsize);
@@ -559,7 +569,7 @@ Bool_t TTFhandle::SetTextSize(Float_t textsize)
 
 void TTFhandle::Version(Int_t &major, Int_t &minor, Int_t &patch)
 {
-   FT_Library_Version(fgLibrary, &major, &minor, &patch);
+   FT_Library_Version(InitClose(), &major, &minor, &patch);
 }
 
 
@@ -571,15 +581,16 @@ Implements old static API.
 Unitl ROOT7 just redirects to static TTFhandle instance
 */
 
-TTF gCleanupTTF; // Allows to call "Cleanup" at the end of the session
-std::unique_ptr<TTFhandle> TTF::fgHandle; // static handle, destroyed automatically
+thread_local TTF gCleanupTTF; // Allows to call "Cleanup" at the end of the session
+thread_local std::unique_ptr<TTFhandle> fgHandle; // static handle, destroyed automatically
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Cleanup TTF environment.
 
 TTF::~TTF()
 {
-   TTFhandle::CloseLibrary();
+   if (fgHandle)
+      fgHandle->InitClose(-1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -672,22 +683,6 @@ TTF::TTGlyph *TTF::GetGlyphs()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return current font index
-
-Int_t TTF::GetCurFontIdx()
-{
-   return fgHandle ? fgHandle->GetCurFontIdx() : -1;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return current font index
-
-FT_Face TTF::GetCurFontFace()
-{
-   return fgHandle ? fgHandle->GetCurFontFace() : nullptr;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Map char to unicode. Returns 0 in case no mapping exists.
 
 Short_t TTF::CharToUnicode(UInt_t code)
@@ -703,15 +698,6 @@ void TTF::SetRotationMatrix(Float_t angle)
 {
    Init();
    fgHandle->SetRotationMatrix(angle);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set current font index
-
-void TTF::SetCurFontIdx(Int_t indx)
-{
-   Init();
-   fgHandle->SetCurFontIdx(indx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -850,3 +836,25 @@ void TTF::Version(Int_t &major, Int_t &minor, Int_t &patch)
    fgHandle->Version(major, minor, patch);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+TTFontHandle *TTF::GetCurFont()
+{
+   return fgHandle ? fgHandle->GetFont() : nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTF::SetCurFont(TTFontHandle *font)
+{
+   if (fgHandle)
+      fgHandle->SetFont(font);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+FT_Face TTF::GetCurFontFace()
+{
+   Init();
+   return fgHandle->GetFontFace();
+}

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -254,6 +254,20 @@ void TTFhandle::LayoutGlyphs()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return bitmap for specified glyph
+
+FT_BitmapGlyph TTFhandle::GetGlyphBitmap(UInt_t n, Bool_t smooth)
+{
+   if (n >= fGlyphs.size())
+      return nullptr;
+
+   if (FT_Glyph_To_Bitmap(&fGlyphs[n].fImage, smooth || GetSmoothing() ? ft_render_mode_normal : ft_render_mode_mono, nullptr, 1))
+      return nullptr;
+
+   return (FT_BitmapGlyph) fGlyphs[n].fImage;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Remove temporary data created by LayoutGlyphs
 
 void TTFhandle::CleanupGlyphs()

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -359,6 +359,31 @@ void TTF::PrepareString(const wchar_t *string)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return current font index
+
+Int_t TTF::GetCurFontIdx()
+{
+   return fgCurFontIdx;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return current font index
+
+FT_Face TTF::GetCurFontFace()
+{
+   return (fgCurFontIdx < 0) || (fgCurFontIdx >= kTTMaxFonts) ? nullptr : fgFace[fgCurFontIdx];
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set current font index
+
+void TTF::SetCurFontIdx(Int_t indx)
+{
+   fgCurFontIdx = indx;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Set hinting flag.
 
 void TTF::SetHinting(Bool_t state)

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -32,6 +32,9 @@ in ROOT7 TTFhandle will be renamed into TTF class
 // to scale fonts to the same size as the old TT version
 const Float_t kScale = 0.93376068;
 
+Bool_t TTFhandle::fgHinting = kFALSE;
+Bool_t TTFhandle::fgSmoothing = kTRUE;
+
 
 struct TTFontHandle {
    std::string name;
@@ -80,7 +83,6 @@ FT_Library TTFhandle::InitClose(Int_t direction)
    return _library;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Map char to unicode. Returns 0 in case no mapping exists.
 
@@ -121,7 +123,7 @@ void TTFhandle::ComputeTrailingBlanksWidth(Int_t n)
       FT_Face face = fFont->face;
       char space = ' ';
       FT_UInt load_flags = FT_LOAD_DEFAULT;
-      if (!fHinting) load_flags |= FT_LOAD_NO_HINTING;
+      if (!fgHinting) load_flags |= FT_LOAD_NO_HINTING;
       FT_Load_Char(face, space, load_flags);
 
       FT_GlyphSlot slot      = face->glyph;
@@ -191,7 +193,7 @@ void TTFhandle::LayoutGlyphs()
    fWidth  = 0;
 
    load_flags = FT_LOAD_DEFAULT;
-   if (!fHinting)
+   if (!fgHinting)
       load_flags |= FT_LOAD_NO_HINTING;
 
    fCBox.xMin = fCBox.yMin =  32000;
@@ -208,7 +210,7 @@ void TTFhandle::LayoutGlyphs()
          if (prev_index) {
             FT_Vector  kern;
             FT_Get_Kerning(face, prev_index, glyph.fIndex,
-                           fHinting ? ft_kerning_default : ft_kerning_unfitted,
+                           fgHinting ? ft_kerning_default : ft_kerning_unfitted,
                            &kern);
             fWidth += kern.x;
          }
@@ -573,12 +575,50 @@ void TTFhandle::Version(Int_t &major, Int_t &minor, Int_t &patch)
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+
+Bool_t TTFhandle::Init()
+{
+   return InitClose(1) != nullptr;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+Bool_t TTFhandle::GetHinting()
+{
+   return fgHinting;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Bool_t TTFhandle::GetSmoothing()
+{
+   return fgSmoothing;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTFhandle::SetHinting(Bool_t state)
+{
+   fgHinting = state;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TTFhandle::SetSmoothing(Bool_t state)
+{
+   fgSmoothing = state;
+}
+
+
 /** \class TTF
 \ingroup BasicGraphics
 
 Interface to the freetype 2 library.
 Implements old static API.
-Unitl ROOT7 just redirects to static TTFhandle instance
+Unitl ROOT7 just redirects to static TTFhandle instance,
+then TTFhandle will be renamed into TTF class
 */
 
 thread_local TTF gCleanupTTF; // Allows to call "Cleanup" at the end of the session
@@ -589,8 +629,7 @@ thread_local std::unique_ptr<TTFhandle> fgHandle; // static handle, destroyed au
 
 TTF::~TTF()
 {
-   if (fgHandle)
-      fgHandle->InitClose(-1);
+   TTFhandle::InitClose(-1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -608,7 +647,7 @@ void TTF::Init()
 
 Bool_t TTF::GetHinting()
 {
-   return fgHandle ? fgHandle->GetHinting() : kFALSE;
+   return TTFhandle::GetHinting();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -622,7 +661,7 @@ Bool_t TTF::GetKerning()
 
 Bool_t TTF::GetSmoothing()
 {
-   return fgHandle ? fgHandle->GetSmoothing() : kFALSE;
+   return TTFhandle::GetSmoothing();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -634,14 +673,14 @@ Bool_t TTF::IsInitialized()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t  TTF::GetWidth()
+Int_t TTF::GetWidth()
 {
    return fgHandle ? fgHandle->GetWidth() : 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t  TTF::GetAscent()
+Int_t TTF::GetAscent()
 {
    return fgHandle ? fgHandle->GetAscent() : 0;
 }
@@ -705,8 +744,7 @@ void TTF::SetRotationMatrix(Float_t angle)
 
 void TTF::SetHinting(Bool_t state)
 {
-   Init();
-   fgHandle->SetHinting(state);
+   TTFhandle::SetHinting(state);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -723,8 +761,7 @@ void TTF::SetKerning(Bool_t state)
 
 void TTF::SetSmoothing(Bool_t state)
 {
-   Init();
-   fgHandle->SetSmoothing(state);
+   TTFhandle::SetSmoothing(state);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/win32gdk/inc/TGWin32.h
+++ b/graf2d/win32gdk/inc/TGWin32.h
@@ -66,8 +66,8 @@ class TExMap;
 class TGWin32 : public TVirtualX {
 
 private:
-   void    DrawImage(void *source, ULong_t fore, ULong_t back, GdkImage *xim,
-                     Int_t bx, Int_t by);
+   void    DrawFTGlyph(void *source, ULong_t fore, ULong_t back, GdkImage *xim,
+                       Int_t bx, Int_t by);
    GdkImage *GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
 
    template<class CharType>

--- a/graf2d/win32gdk/inc/TGWin32.h
+++ b/graf2d/win32gdk/inc/TGWin32.h
@@ -15,8 +15,6 @@
 
 #include "TVirtualX.h"
 
-#include "TTF.h"
-
 #include <memory>
 #include <map>
 
@@ -68,12 +66,13 @@ class TExMap;
 class TGWin32 : public TVirtualX {
 
 private:
-   void    Align(WinContext_t wctxt);
-   void    DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back, GdkImage *xim,
+   void    DrawImage(void *source, ULong_t fore, ULong_t back, GdkImage *xim,
                      Int_t bx, Int_t by);
-   Bool_t  IsVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
    GdkImage *GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void    RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode);
+
+   template<class CharType>
+   void      DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle,
+                            const CharType *text, ETextMode mode);
 
    std::unordered_map<Int_t,std::unique_ptr<XWindow_t>> fWindows; // map of windows
    TExMap          *fColors;                ///< Hash list of colors
@@ -117,7 +116,6 @@ protected:
    Handle_t    fXEvent;             ///< Current native (GDK) event
    TObject*    fRefreshTimer;       ///< TGWin32RefreshTimer for GUI thread message handler
 
-   // needed by TGWin32TTF
    Bool_t     AllocColor(GdkColormap *cmap, GdkColor *color);
    void       QueryColors(GdkColormap *cmap, GdkColor *colors, Int_t ncolors);
    GdkGC     *GetGC(Int_t which) const;

--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -41,6 +41,7 @@ by Olivier Couet (package X11INT).
 #include "TApplication.h"
 #include "TColor.h"
 #include "TPoint.h"
+#include "TTF.h"
 #include "TMath.h"
 #include "TStorage.h"
 #include "TStyle.h"
@@ -181,11 +182,6 @@ static XWindow_t *gTws;         // gTws: temporary pointer
 const Int_t kBIGGEST_RGB_VALUE = 65535;
 
 static GdkGC *gGCecho;          // Input echo - global
-
-//
-// Text management
-//
-static const char *gTextFont = "arial.ttf";      // Current font
 
 //
 // Markers
@@ -1052,16 +1048,10 @@ Int_t TGWin32::OpenDisplay(const char *dpyName)
    SetName("Win32TTF");
    SetTitle("ROOT interface to Win32 with TrueType fonts");
 
-   TTF::Init();
-
-   if (fDepth > 8) {
-      TTF::SetSmoothing(kTRUE);
-   } else {
-      TTF::SetSmoothing(kFALSE);
-   }
+   TTFhandle::SetSmoothing(fDepth > 8);
 
    TGWin32VirtualXProxy::fMaxResponseTime = 1000;
-   fHasTTFonts = kTRUE;
+   fHasTTFonts = TTFhandle::Init();
    return 0;
 }
 
@@ -1121,51 +1111,19 @@ void TGWin32::QueryColors(GdkColormap *cmap, GdkColor *color, Int_t ncolors)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Compute alignment variables. The alignment is done on the horizontal string
-/// then the rotation is applied on the alignment variables.
-/// SetRotation and LayoutGlyphs should have been called before.
-
-void TGWin32::Align(WinContext_t wctxt)
-{
-   auto ctxt = (XWindow_t *) wctxt;
-
-   auto align = ctxt->textAlign;
-
-   // vertical alignment
-   if (align == kTLeft || align == kTCenter || align == kTRight) {
-      ctxt->alignVector.y = TTF::GetAscent();
-   } else if (align == kMLeft || align == kMCenter || align == kMRight) {
-      ctxt->alignVector.y = TTF::GetAscent()/2;
-   } else {
-      ctxt->alignVector.y = 0;
-   }
-   // horizontal alignment
-   if (align == kTRight || align == kMRight || align == kBRight) {
-      ctxt->alignVector.x = TTF::GetWidth();
-   } else if (align == kTCenter || align == kMCenter || align == kBCenter) {
-      ctxt->alignVector.x = TTF::GetWidth()/2;
-   } else {
-      ctxt->alignVector.x = 0;
-   }
-
-   FT_Vector_Transform(&ctxt->alignVector, TTF::GetRotMatrix());
-   ctxt->alignVector.x = ctxt->alignVector.x >> 6;
-   ctxt->alignVector.y = ctxt->alignVector.y >> 6;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Draw FT_Bitmap bitmap to xim image at position bx,by using specified
 /// foreground color.
 
-void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
-                         GdkImage *xim, Int_t bx, Int_t by)
+void TGWin32::DrawImage(void *_source, ULong_t fore, ULong_t back,
+                        GdkImage *xim, Int_t bx, Int_t by)
 {
+   FT_Bitmap *source = (FT_Bitmap *) _source;
+
    UChar_t d = 0, *s = source->buffer;
 
-   if (TTF::GetSmoothing()) {
+   if (TTFhandle::GetSmoothing()) {
 
-      static GdkColor col[5];
-      GdkColor *bcol = 0, *bc;
+      GdkColor col[5];
       Int_t    x, y;
 
       // background kClear, i.e. transparent, we take as background color
@@ -1177,10 +1135,10 @@ void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
 
          dots = Int_t(source->width * source->rows);
          dots = dots > maxdots ? maxdots : dots;
-         bcol = new GdkColor[dots];
-         if (!bcol) return;
+         std::vector<GdkColor> bcol(dots);
+         if (!bcol.size()) return;
 
-         bc = bcol;
+         GdkColor *bc = bcol.data();
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
             for (x = 0; x < (int) source->width; x++, bc++) {
@@ -1188,9 +1146,9 @@ void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
                if (++dotcnt >= maxdots) break;
             }
          }
-         QueryColors(fColormap, bcol, dots);
+         QueryColors(fColormap, bcol.data(), dots);
          r = g = b = 0;
-         bc = bcol;
+         bc = bcol.data();
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
             for (x = 0; x < (int) source->width; x++, bc++) {
@@ -1215,7 +1173,6 @@ void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
             bc->blue  = (UShort_t) b;
          }
       }
-      delete [] bcol;
 
       // if fore or background have changed from previous character
       // recalculate the 3 smooting colors (interpolation between fore-
@@ -1283,124 +1240,67 @@ void TGWin32::DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
    DrawTextW((WinContext_t) gCws, x, y, angle, mgn, text, mode);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Draw text using TrueType fonts on specified window.
-/// If TrueType fonts are not available the
-/// text is drawn with TGWin32::DrawText.
 
-void TGWin32::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
-                        const char *text, ETextMode mode)
-{
-   if (!wctxt) return;
-
-   TTF::Init();
-   TTF::SetRotationMatrix(angle);
-   TTF::PrepareString(text);
-   TTF::LayoutGlyphs();
-   Align(wctxt);
-   RenderString(wctxt, x, y, mode);
-   TTF::CleanupGlyphs();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Draw text using TrueType fonts. If TrueType fonts are not available the
-/// text is drawn with TGWin32::DrawText.
-
-void TGWin32::DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
-                       const wchar_t *text, ETextMode mode)
-{
-   DrawTextW((WinContext_t) gCws, x, y, angle, mgn, text, mode);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Draw text using TrueType fonts on specified window.
-/// If TrueType fonts are not available the
-/// text is drawn with TGWin32::DrawText.
-
-void TGWin32::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
-                        const wchar_t *text, ETextMode mode)
-{
-   if (!wctxt) return;
-
-   TTF::Init();
-   TTF::SetRotationMatrix(angle);
-   TTF::PrepareString(text);
-   TTF::LayoutGlyphs();
-   Align(wctxt);
-   RenderString(wctxt, x, y, mode);
-   TTF::CleanupGlyphs();
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get the background of the current window in an XImage.
-
-GdkImage *TGWin32::GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h)
+template<class CharType>
+void TGWin32::DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle,
+                             const CharType *text, ETextMode mode)
 {
    auto ctxt = (XWindow_t *) wctxt;
+   if (!ctxt)
+      return;
 
-   UInt_t width;
-   UInt_t height;
-   Int_t xy;
-   GetWindowSize((Drawable_t) ctxt->drawing, xy, xy, width, height);
+   TTFhandle ttf;
+   ttf.SetTextFont(ctxt->fAttText.GetTextFont());
+   ttf.SetTextSize(ctxt->fAttText.GetTextSize());
+   ttf.SetRotationMatrix(angle);
+   ttf.PrepareString(text);
 
-   if (x < 0) {
-      w += x;
-      x  = 0;
+   ttf.LayoutGlyphs();
+
+   auto align = ctxt->textAlign;
+
+   // vertical alignment
+   if (align == kTLeft || align == kTCenter || align == kTRight) {
+      ctxt->alignVector.y = ttf.GetAscent();
+   } else if (align == kMLeft || align == kMCenter || align == kMRight) {
+      ctxt->alignVector.y = ttf.GetAscent() / 2;
+   } else {
+      ctxt->alignVector.y = 0;
    }
-   if (y < 0) {
-      h += y;
-      y  = 0;
+   // horizontal alignment
+   if (align == kTRight || align == kMRight || align == kBRight) {
+      ctxt->alignVector.x = ttf.GetWidth();
+   } else if (align == kTCenter || align == kMCenter || align == kBCenter) {
+      ctxt->alignVector.x = ttf.GetWidth()/2;
+   } else {
+      ctxt->alignVector.x = 0;
    }
 
-   if (x+w > width)  w = width - x;
-   if (y+h > height) h = height - y;
-
-   return gdk_image_get(ctxt->drawing, x, y, w, h);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Test if there is really something to render
-
-Bool_t TGWin32::IsVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h)
-{
-   auto ctxt = (XWindow_t *) wctxt;
-
-   UInt_t width;
-   UInt_t height;
-   Int_t xy;
-   GetWindowSize((Drawable_t) ctxt->drawing, xy, xy, width, height);
-
-   // If w or h is 0, very likely the string is only blank characters
-   if ((int)w == 0 || (int)h == 0)  return kFALSE;
-
-   // If string falls outside window, there is probably no need to draw it.
-   if (x + (int)w <= 0 || x >= (int)width)  return kFALSE;
-   if (y + (int)h <= 0 || y >= (int)height) return kFALSE;
-
-   return kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Perform the string rendering in the pad.
-/// LayoutGlyphs should have been called before.
-
-void TGWin32::RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode)
-{
-   auto ctxt = (XWindow_t *) wctxt;
+   FT_Vector_Transform(&ctxt->alignVector, ttf.GetRotMatrix());
+   ctxt->alignVector.x = ctxt->alignVector.x >> 6;
+   ctxt->alignVector.y = ctxt->alignVector.y >> 6;
 
    GdkGCValues gcvals;
 
    // compute the size and position of the XImage that will contain the text
-   Int_t Xoff = 0; if (TTF::GetBox().xMin < 0) Xoff = -TTF::GetBox().xMin;
-   Int_t Yoff = 0; if (TTF::GetBox().yMin < 0) Yoff = -TTF::GetBox().yMin;
-   Int_t w    = TTF::GetBox().xMax + Xoff;
-   Int_t h    = TTF::GetBox().yMax + Yoff;
+   Int_t Xoff = TMath::Max(0, (Int_t) -ttf.GetBox().xMin);
+   Int_t Yoff = TMath::Max(0, (Int_t) -ttf.GetBox().yMin);
+   Int_t w    = ttf.GetBox().xMax + Xoff;
+   Int_t h    = ttf.GetBox().yMax + Yoff;
    Int_t x1   = x - Xoff - ctxt->alignVector.x;
    Int_t y1   = y + Yoff + ctxt->alignVector.y - h;
 
-   if (!IsVisible(wctxt, x1, y1, w, h)) {
-       return;
-   }
+   UInt_t width = 0, height = 0;
+   Int_t xy;
+   GetWindowSize((Drawable_t) ctxt->drawing, xy, xy, width, height);
+
+   // If w or h is 0, very likely the string is only blank characters
+   if (w <= 0 || h <= 0)
+      return;
+
+   // If string falls outside window, there is probably no need to draw it.
+   if (x1 + w <= 0 || x1 >= (Int_t)width || y1 + h <= 0 || y1 >= (Int_t) height)
+      return;
 
    // create the XImage that will contain the text
    UInt_t depth = fDepth;
@@ -1466,25 +1366,82 @@ void TGWin32::RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode)
    }
 
    // paint the glyphs in the XImage
-   TTF::TTGlyph* glyph = TTF::GetGlyphs();
-   for (int n = 0; n < TTF::GetNumGlyphs(); n++, glyph++) {
+   auto glyph = ttf.GetGlyphs();
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
       if (FT_Glyph_To_Bitmap(&glyph->fImage,
-                             TTF::GetSmoothing() ? ft_render_mode_normal
-                                              : ft_render_mode_mono,
-                             0, 1 )) continue;
+                             TTFhandle::GetSmoothing() ? ft_render_mode_normal
+                                                       : ft_render_mode_mono,
+                             0, 1)) continue;
       FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      FT_Bitmap*     source = &bitmap->bitmap;
-      Int_t          bx, by;
-
-      bx = bitmap->left+Xoff;
-      by = h - bitmap->top-Yoff;
-      DrawImage(source, gcvals.foreground.pixel, bg, xim, bx, by);
+      Int_t bx = bitmap->left + Xoff;
+      Int_t by = h - bitmap->top - Yoff;
+      DrawImage(&bitmap->bitmap, gcvals.foreground.pixel, bg, xim, bx, by);
    }
 
    // put the Ximage on the screen
    gdk_draw_image(ctxt->drawing, ctxt->fGClist[kGCpxmp], xim, 0, 0, x1, y1, w, h);
 
    gdk_image_unref(xim);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw text using TrueType fonts on specified window.
+/// If TrueType fonts are not available the
+/// text is drawn with TGWin32::DrawText.
+
+void TGWin32::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t /* mgn */,
+                        const char *text, ETextMode mode)
+{
+   DrawTextHelper(wctxt, x, y, angle, text, mode);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw text using TrueType fonts. If TrueType fonts are not available the
+/// text is drawn with TGWin32::DrawText.
+
+void TGWin32::DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn,
+                       const wchar_t *text, ETextMode mode)
+{
+   DrawTextW((WinContext_t) gCws, x, y, angle, mgn, text, mode);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Draw text using TrueType fonts on specified window.
+/// If TrueType fonts are not available the
+/// text is drawn with TGWin32::DrawText.
+
+void TGWin32::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t /* mgn */,
+                        const wchar_t *text, ETextMode mode)
+{
+   DrawTextHelper(wctxt, x, y, angle, text, mode);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get the background of the current window in an XImage.
+
+GdkImage *TGWin32::GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h)
+{
+   auto ctxt = (XWindow_t *) wctxt;
+
+   UInt_t width;
+   UInt_t height;
+   Int_t xy;
+   GetWindowSize((Drawable_t) ctxt->drawing, xy, xy, width, height);
+
+   if (x < 0) {
+      w += x;
+      x  = 0;
+   }
+   if (y < 0) {
+      h += y;
+      y  = 0;
+   }
+
+   if (x+w > width)  w = width - x;
+   if (y+h > height) h = height - y;
+
+   return gdk_image_get(ctxt->drawing, x, y, w, h);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1510,9 +1467,10 @@ void TGWin32::SetTextFont(Font_t fontnumber)
 /// Set text font to specified name. This function returns 0 if
 /// the specified font is found, 1 if not.
 
-Int_t TGWin32::SetTextFont(char *fontname, ETextSetMode /* mode */)
+Int_t TGWin32::SetTextFont(char * /* fontname */, ETextSetMode /* mode */)
 {
-   return TTF::SetTextFont(fontname);
+   Error("SetTextFont", "Direct set of TTF font no longer supported");
+   return 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2043,16 +2001,17 @@ void TGWin32::GetRGB(int index, float &r, float &g, float &b)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the size of a character string.
+/// Return the size of a character string - no longer used
 /// iw          : text width
 /// ih          : text height
 /// mess        : message
 
 void TGWin32::GetTextExtent(UInt_t &w, UInt_t &h, char *mess)
 {
-   TTF::SetTextFont(gTextFont);
-   TTF::SetTextSize(fTextSize);
-   TTF::GetTextExtent(w, h, mess);
+   TTFhandle ttf;
+   ttf.SetTextFont(GetTextFont());
+   ttf.SetTextSize(GetTextSize());
+   ttf.GetTextExtent(w, h, mess);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2060,9 +2019,10 @@ void TGWin32::GetTextExtent(UInt_t &w, UInt_t &h, char *mess)
 
 void TGWin32::GetTextExtent(UInt_t &w, UInt_t &h, wchar_t *mess)
 {
-   TTF::SetTextFont(gTextFont);
-   TTF::SetTextSize(fTextSize);
-   TTF::GetTextExtent(w, h, mess);
+   TTFhandle ttf;
+   ttf.SetTextFont(GetTextFont());
+   ttf.SetTextSize(GetTextSize());
+   ttf.GetTextExtent(w, h, mess);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2492,8 +2452,9 @@ Int_t TGWin32::RequestString(int x, int y, char *text)
    // Set max response time to 2 minutes to avoid timeout
    // in TGWin32ProxyBase::ForwardCallBack during RequestString
    TGWin32VirtualXProxy::fMaxResponseTime = 120000;
-   TTF::SetTextFont(gTextFont);
-   TTF::SetTextSize(fTextSize);
+   TTFhandle ttf;
+   ttf.SetTextFont(GetTextFont());
+   ttf.SetTextSize(GetTextSize());
    do {
       char tmp[2];
       char keybuf[8];
@@ -2510,7 +2471,7 @@ Int_t TGWin32::RequestString(int x, int y, char *text)
       }
 
       DrawText(x, y, 0.0, 1.0, text, kOpaque);
-      TTF::GetTextExtent(dx, h, text);
+      ttf.GetTextExtent(dx, h, text);
       DrawText(x+dx, y, 0.0, 1.0, " ", kOpaque);
 
       if (pt == 0) {
@@ -2519,7 +2480,7 @@ Int_t TGWin32::RequestString(int x, int y, char *text)
          char *stmp = new char[pt+1];
          strncpy(stmp, text, pt);
          stmp[pt] = '\0';
-         TTF::GetTextExtent(ddx, h, stmp);
+         ttf.GetTextExtent(ddx, h, stmp);
          dx = ddx;
          delete[] stmp;
       }
@@ -4043,9 +4004,6 @@ void TGWin32::SetAttText(WinContext_t wctxt, const TAttText &att)
    gdk_gc_set_foreground(ctxt->fGClist[kGCinvt], &values.background);
    gdk_gc_set_background(ctxt->fGClist[kGCinvt], &values.foreground);
    gdk_gc_set_background(ctxt->fGClist[kGCtext], (GdkColor *) & GetColor(0).color);
-
-   TTF::SetTextFont(att.GetTextFont());
-   TTF::SetTextSize(att.GetTextSize());
 
    ctxt->fAttText = att;
 }

--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -1114,8 +1114,8 @@ void TGWin32::QueryColors(GdkColormap *cmap, GdkColor *color, Int_t ncolors)
 /// Draw FT_Bitmap bitmap to xim image at position bx,by using specified
 /// foreground color.
 
-void TGWin32::DrawImage(void *_source, ULong_t fore, ULong_t back,
-                        GdkImage *xim, Int_t bx, Int_t by)
+void TGWin32::DrawFTGlyph(void *_source, ULong_t fore, ULong_t back,
+                          GdkImage *xim, Int_t bx, Int_t by)
 {
    FT_Bitmap *source = (FT_Bitmap *) _source;
 
@@ -1366,16 +1366,12 @@ void TGWin32::DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle
    }
 
    // paint the glyphs in the XImage
-   auto glyph = ttf.GetGlyphs();
-   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage,
-                             TTFhandle::GetSmoothing() ? ft_render_mode_normal
-                                                       : ft_render_mode_mono,
-                             0, 1)) continue;
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      Int_t bx = bitmap->left + Xoff;
-      Int_t by = h - bitmap->top - Yoff;
-      DrawImage(&bitmap->bitmap, gcvals.foreground.pixel, bg, xim, bx, by);
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++) {
+      if (auto bitmap = ttf.GetGlyphBitmap(n)) {
+         Int_t bx = bitmap->left + Xoff;
+         Int_t by = h - bitmap->top - Yoff;
+         DrawFTGlyph(&bitmap->bitmap, gcvals.foreground.pixel, bg, xim, bx, by);
+      }
    }
 
    // put the Ximage on the screen

--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -1119,111 +1119,86 @@ void TGWin32::DrawFTGlyph(void *_source, ULong_t fore, ULong_t back,
 {
    FT_Bitmap *source = (FT_Bitmap *) _source;
 
-   UChar_t d = 0, *s = source->buffer;
+   UChar_t *s = source->buffer;
 
    if (TTFhandle::GetSmoothing()) {
 
       GdkColor col[5];
-      Int_t    x, y;
 
       // background kClear, i.e. transparent, we take as background color
       // the average of the rgb values of all pixels covered by this character
-      if (back == (ULong_t) -1 && (UInt_t)source->width) {
-         ULong_t r, g, b;
-         Int_t   dots, dotcnt;
-         const Int_t maxdots = 50000;
+      if (back == (ULong_t) -1) {
+         const UInt_t ndots = TMath::Min((UInt_t) 50000, source->width * source->rows);
+         std::vector<GdkColor> bcol(ndots);
+         if (!bcol.size())
+            return;
 
-         dots = Int_t(source->width * source->rows);
-         dots = dots > maxdots ? maxdots : dots;
-         std::vector<GdkColor> bcol(dots);
-         if (!bcol.size()) return;
-
-         GdkColor *bc = bcol.data();
-         dotcnt = 0;
-         for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
-               bc->pixel = GetPixelImage((Drawable_t)xim, bx + x, by + y);
-               if (++dotcnt >= maxdots) break;
+         UInt_t dotcnt = 0;
+         for (unsigned y = 0; y < source->rows; y++) {
+            for (unsigned x = 0; x < source->width; x++) {
+               bcol[dotcnt].pixel = GetPixelImage((Drawable_t)xim, bx + x, by + y);
+               if (++dotcnt >= bcol.size())
+                  break;
             }
          }
-         QueryColors(fColormap, bcol.data(), dots);
-         r = g = b = 0;
-         bc = bcol.data();
-         dotcnt = 0;
-         for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
-               r += bc->red;
-               g += bc->green;
-               b += bc->blue;
-               if (++dotcnt >= maxdots) break;
-            }
+         QueryColors(fColormap, bcol.data(), bcol.size());
+         ULong_t r = 0, g = 0, b = 0;
+         for (auto &bc : bcol) {
+            r += bc.red;
+            g += bc.green;
+            b += bc.blue;
          }
-         if (dots != 0) {
-            r /= dots;
-            g /= dots;
-            b /= dots;
-         }
-         bc = &col[0];
-         if (bc->red == r && bc->green == g && bc->blue == b) {
-            bc->pixel = back;
-         } else {
-            bc->pixel = ~back;
-            bc->red   = (UShort_t) r;
-            bc->green = (UShort_t) g;
-            bc->blue  = (UShort_t) b;
-         }
+         col[0].red   = (UShort_t) (r / bcol.size());
+         col[0].green = (UShort_t) (g / bcol.size());
+         col[0].blue  = (UShort_t) (b / bcol.size());
+      } else {
+         // query background color
+         col[0].pixel = back;
+         QueryColors(fColormap, &col[0], 1);
       }
 
-      // if fore or background have changed from previous character
-      // recalculate the 3 smooting colors (interpolation between fore-
-      // and background colors)
-      if (fore != col[4].pixel || back != col[0].pixel) {
-         col[4].pixel = fore;
-         if (back != (ULong_t) -1) {
-            col[3].pixel = back;
-            QueryColors(fColormap, &col[3], 2);
-            col[0] = col[3];
-         } else {
-            QueryColors(fColormap, &col[4], 1);
-         }
+      // query foreground color
+      col[4].pixel = fore;
+      QueryColors(fColormap, &col[4], 1);
 
-         // interpolate between fore and backgound colors
-         for (x = 3; x > 0; x--) {
-            col[x].red   = (col[4].red  *x + col[0].red  *(4-x)) /4;
-            col[x].green = (col[4].green*x + col[0].green*(4-x)) /4;
-            col[x].blue  = (col[4].blue *x + col[0].blue *(4-x)) /4;
-            if (!AllocColor(fColormap, &col[x])) {
-               Warning("DrawImage", "cannot allocate smoothing color");
-               col[x].pixel = col[x+1].pixel;
-            }
+      // calculate the 3 smooting colors
+      // (interpolation between fore- and background colors)
+
+      // interpolate between fore and backgound colors
+      for (int x = 3; x > 0; x--) {
+         col[x].red   = (col[4].red  *x + col[0].red  *(4-x)) /4;
+         col[x].green = (col[4].green*x + col[0].green*(4-x)) /4;
+         col[x].blue  = (col[4].blue *x + col[0].blue *(4-x)) /4;
+         if (!AllocColor(fColormap, &col[x])) {
+            Warning("DrawImage", "cannot allocate smoothing color");
+            col[x].pixel = col[x+1].pixel;
          }
       }
 
       // put smoothed character, character pixmap values are an index
       // into the 5 colors used for aliasing (4 = foreground, 0 = background)
-      for (y = 0; y < (int) source->rows; y++) {
-         for (x = 0; x < (int) source->width; x++) {
-            d = *s++ & 0xff;
-            d = ((d + 10) * 5) / 256;
+      for (unsigned y = 0; y < source->rows; y++) {
+         for (unsigned x = 0; x < source->width; x++) {
+            UChar_t d = (((*s++ & 0xff) + 10) * 5) / 256;
             if (d > 4) d = 4;
-            if (d && x < (int) source->width) {
-               ULong_t p = col[d].pixel;
-               PutPixel((Drawable_t)xim, bx + x, by + y, p);
-            }
+            if (d > 0)
+               PutPixel((Drawable_t)xim, bx + x, by + y, col[d].pixel);
          }
       }
    } else {
       // no smoothing, just put character using foreground color
-      UChar_t* row=s;
-      for (int y = 0; y < (int) source->rows; y++) {
-         int n = 0;
+      UChar_t* row = s;
+      for (unsigned y = 0; y < source->rows; y++) {
+         unsigned n = 0;
          s = row;
-         for (int x = 0; x < (int) source->width; x++) {
-            if (n == 0) d = *s++;
-            if (TESTBIT(d,7-n)) {
+         UChar_t d;
+         for (unsigned x = 0; x < source->width; x++) {
+            if (n == 0)
+               d = *s++;
+            if (TESTBIT(d, 7-n))
                PutPixel((Drawable_t)xim, bx + x, by + y, fore);
-            }
-            if (++n == (int) kBitsPerByte) n = 0;
+            if (++n == kBitsPerByte)
+               n = 0;
          }
          row += source->pitch;
       }

--- a/graf2d/x11/inc/TGX11.h
+++ b/graf2d/x11/inc/TGX11.h
@@ -129,6 +129,7 @@ protected:
    Window_t  GetWindow(WinContext_t wctxt) const;
    void      *GetGCW(WinContext_t wctxt, Int_t which) const;
    EAlign     GetTextAlignW(WinContext_t wctxt) const;
+   const TAttText& GetTextAttW(WinContext_t wctxt) const;
 
    XColor_t  &GetColor(Int_t cid);
 

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -1072,6 +1072,17 @@ TGX11::EAlign TGX11::GetTextAlignW(WinContext_t wctxt) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return text attributes for specified window context.
+/// Protected method used by TGX11TTF.
+
+const TAttText& TGX11::GetTextAttW(WinContext_t wctxt) const
+{
+   auto ctxt = (XWindow_t *) wctxt;
+   return ctxt->fAttText;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Query the double buffer value for the window wid.
 
 Int_t TGX11::GetDoubleBuffer(int wid)

--- a/graf2d/x11ttf/inc/TGX11TTF.h
+++ b/graf2d/x11ttf/inc/TGX11TTF.h
@@ -29,8 +29,8 @@ private:
    static Bool_t  gXftInit;            ///< does xft was initialized
 #endif
 
-   void     DrawImage(void *source, ULong_t fore, ULong_t back, RXImage *xim,
-                      Int_t bx, Int_t by);
+   void     DrawFTGlyph(void *source, ULong_t fore, ULong_t back, RXImage *xim,
+                        Int_t bx, Int_t by);
    RXImage *GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
 
    template<class CharType>

--- a/graf2d/x11ttf/inc/TGX11TTF.h
+++ b/graf2d/x11ttf/inc/TGX11TTF.h
@@ -13,10 +13,7 @@
 #ifndef ROOT_TGX11TTF
 #define ROOT_TGX11TTF
 
-
 #include "TGX11.h"
-
-#include "TTF.h"
 
 #include "RConfigure.h"
 
@@ -27,18 +24,18 @@ class TXftFontHash;
 class TGX11TTF : public TGX11 {
 
 private:
-   FT_Vector   fAlign;                 ///< alignment vector
 #ifdef R__HAS_XFT
    TXftFontHash  *fXftFontHash;        ///< hash table for Xft fonts
    static Bool_t  gXftInit;            ///< does xft was initialized
 #endif
 
-   void     Align(WinContext_t wctxt);
-   void     DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back, RXImage *xim,
+   void     DrawImage(void *source, ULong_t fore, ULong_t back, RXImage *xim,
                       Int_t bx, Int_t by);
-   Bool_t   IsVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
    RXImage *GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void     RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode);
+
+   template<class CharType>
+   void   DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
+                         const CharType *text, ETextMode mode);
 
 public:
    TGX11TTF(TGX11 &&org);
@@ -50,13 +47,6 @@ public:
                    const char *text, ETextMode mode) override;
    void   DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
                    const wchar_t *text, ETextMode mode) override;
-
-   using TGX11::SetTextFont;
-   Int_t  SetTextFont(char *fontname, ETextSetMode mode) override;
-
-   //---- Methods used for new graphics -----
-   void  SetAttText(WinContext_t wctxt, const TAttText &att) override;
-
 
 #ifdef R__HAS_XFT
    //---- Methods used text/fonts handling via Xft -----

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -209,117 +209,87 @@ void TGX11TTF::DrawFTGlyph(void *_source, ULong_t fore, ULong_t back,
                            RXImage *xim, Int_t bx, Int_t by)
 {
    auto source = (FT_Bitmap *) _source;
+   if (!source->width)
+      return;
 
-   UChar_t d = 0, *s = source->buffer;
+   UChar_t *s = source->buffer;
 
    if (TTFhandle::GetSmoothing()) {
-
-      static RXColor col[5];
-      RXColor  *bcol = nullptr;
-      XColor  *bc;
-      Int_t    x, y;
+      RXColor col[5];
 
       // background kClear, i.e. transparent, we take as background color
       // the average of the rgb values of all pixels covered by this character
-      if (back == (ULong_t) -1 && (UInt_t)source->width) {
-         ULong_t r, g, b;
-         Int_t   dots, dotcnt;
-         const Int_t maxdots = 50000;
+      if (back == (ULong_t) -1) {
+         const UInt_t ndots = TMath::Min((UInt_t) 50000, source->width * source->rows);
 
-         dots = Int_t(source->width * source->rows);
-         dots = dots > maxdots ? maxdots : dots;
-         bcol = new RXColor[dots];
-         if (!bcol) return;
-         bc = bcol;
-         dotcnt = 0;
-         for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
+         std::vector<RXColor> bcol(ndots);
+         if (!bcol.size())
+            return;
+         UInt_t dotcnt = 0;
+         for (unsigned y = 0; y < source->rows; y++) {
+            for (unsigned x = 0; x < source->width; x++) {
 ///               bc->pixel = XGetPixel(xim, bx + x, by - c->TTF::GetAscent() + y);
-               bc->pixel = XGetPixel(xim, bx + x, by + y);
-               bc->flags = DoRed | DoGreen | DoBlue;
-               if (++dotcnt >= maxdots) break;
+               auto &bc = bcol[dotcnt];
+               bc.pixel = XGetPixel(xim, bx + x, by + y);
+               bc.flags = DoRed | DoGreen | DoBlue;
+               if (++dotcnt >= bcol.size()) break;
             }
          }
-         QueryColors(fColormap, bcol, dots);
-         r = g = b = 0;
-         bc = bcol;
-         dotcnt = 0;
-         for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
-               r += bc->red;
-               g += bc->green;
-               b += bc->blue;
-               if (++dotcnt >= maxdots) break;
-            }
+         QueryColors(fColormap, bcol.data(), bcol.size());
+         ULong_t r = 0, g = 0, b = 0;
+         for (auto &entry : bcol) {
+            r += entry.red;
+            g += entry.green;
+            b += entry.blue;
          }
-         if (dots != 0) {
-            r /= dots;
-            g /= dots;
-            b /= dots;
-         }
-         bc = &col[0];
-         if (bc->red == r && bc->green == g && bc->blue == b)
-            bc->pixel = back;
-         else {
-            bc->pixel = ~back;
-            bc->red   = (UShort_t) r;
-            bc->green = (UShort_t) g;
-            bc->blue  = (UShort_t) b;
-         }
+         col[0].red = (UShort_t) (r / bcol.size());
+         col[0].green = (UShort_t) (g / bcol.size());
+         col[0].blue = (UShort_t) (b / bcol.size());
+      } else {
+         // just request rgb value for background color
+         col[0].pixel = back;
+         col[0].flags = DoRed | DoGreen | DoBlue;
+         QueryColors(fColormap, &col[0], 1);
       }
-      delete [] bcol;
 
-      // if fore or background have changed from previous character
-      // recalculate the 3 smoothing colors (interpolation between fore-
-      // and background colors)
-      if (fore != col[4].pixel || back != col[0].pixel) {
-         col[4].pixel = fore;
-         col[4].flags = DoRed|DoGreen|DoBlue;
-         if (back != (ULong_t) -1) {
-            col[3].pixel = back;
-            col[3].flags = DoRed | DoGreen | DoBlue;
-            QueryColors(fColormap, &col[3], 2);
-            col[0] = col[3];
-         } else {
-            QueryColors(fColormap, &col[4], 1);
-         }
+      // request rgb value for foreground color
+      col[4].pixel = fore;
+      col[4].flags = DoRed | DoGreen | DoBlue;
+      QueryColors(fColormap, &col[4], 1);
 
-         // interpolate between fore and background colors
-         for (x = 3; x > 0; x--) {
-            col[x].red   = (col[4].red  *x + col[0].red  *(4-x)) /4;
-            col[x].green = (col[4].green*x + col[0].green*(4-x)) /4;
-            col[x].blue  = (col[4].blue *x + col[0].blue *(4-x)) /4;
-            if (!AllocColor(fColormap, &col[x])) {
-               Warning("DrawImage", "cannot allocate smoothing color");
-               col[x].pixel = col[x+1].pixel;
-            }
+      // recalculate the 3 smoothing colors
+      // (interpolation between fore- and background colors)
+      for (int x = 3; x > 0; x--) {
+         col[x].red   = (col[4].red  *x + col[0].red  *(4-x)) /4;
+         col[x].green = (col[4].green*x + col[0].green*(4-x)) /4;
+         col[x].blue  = (col[4].blue *x + col[0].blue *(4-x)) /4;
+         if (!AllocColor(fColormap, &col[x])) {
+            Warning("DrawFTGlyph", "cannot allocate smoothing color");
+            col[x].pixel = col[x+1].pixel;
          }
       }
 
       // put smoothed character, character pixmap values are an index
       // into the 5 colors used for aliasing (4 = foreground, 0 = background)
-      for (y = 0; y < (int) source->rows; y++) {
-         for (x = 0; x < (int) source->width; x++) {
-            d = *s++ & 0xff;
-            d = ((d + 10) * 5) / 256;
-            if (d > 4) d = 4;
-            if (d && x < (int) source->width) {
-               ULong_t p = col[d].pixel;
-               XPutPixel(xim, bx + x, by + y, p);
-            }
+      for (unsigned y = 0; y < source->rows; y++) {
+         for (unsigned x = 0; x < source->width; x++) {
+            UChar_t d = TMath::Min((UChar_t) 4, (UChar_t)((((*s++ & 0xff) + 10) * 5) / 256));
+            if (d > 0)
+               XPutPixel(xim, bx + x, by + y, col[d].pixel);
          }
       }
    } else {
       // no smoothing, just put character using foreground color
-      UChar_t* row=s;
-      for (int y = 0; y < (int) source->rows; y++) {
-         int n = 0;
+      UChar_t *row = s;
+      for (unsigned y = 0; y < source->rows; y++) {
+         unsigned n = 0;
+         UChar_t d;
          s = row;
-         for (int x = 0; x < (int) source->width; x++) {
+         for (unsigned x = 0; x < source->width; x++) {
             if (n == 0) d = *s++;
             if (TESTBIT(d,7-n))
                XPutPixel(xim, bx + x, by + y, fore);
-            if (++n == (int) kBitsPerByte) n = 0;
+            if (++n == kBitsPerByte) n = 0;
          }
          row += source->pitch;
       }

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -217,23 +217,23 @@ void TGX11TTF::Align(WinContext_t wctxt)
 
    // vertical alignment
    if (align == kTLeft || align == kTCenter || align == kTRight) {
-      fAlign.y = TTF::fgAscent;
+      fAlign.y = TTF::GetAscent();
    } else if (align == kMLeft || align == kMCenter || align == kMRight) {
-      fAlign.y = TTF::fgAscent/2;
+      fAlign.y = TTF::GetAscent() / 2;
    } else {
       fAlign.y = 0;
    }
 
    // horizontal alignment
    if (align == kTRight || align == kMRight || align == kBRight) {
-      fAlign.x = TTF::fgWidth;
+      fAlign.x = TTF::GetWidth();
    } else if (align == kTCenter || align == kMCenter || align == kBCenter) {
-      fAlign.x = TTF::fgWidth/2;
+      fAlign.x = TTF::GetWidth() / 2;
    } else {
       fAlign.x = 0;
    }
 
-   FT_Vector_Transform(&fAlign, TTF::fgRotMatrix);
+   FT_Vector_Transform(&fAlign, TTF::GetRotMatrix());
    fAlign.x = fAlign.x >> 6;
    fAlign.y = fAlign.y >> 6;
 }
@@ -247,7 +247,7 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
 {
    UChar_t d = 0, *s = source->buffer;
 
-   if (TTF::fgSmoothing) {
+   if (TTF::GetSmoothing()) {
 
       static RXColor col[5];
       RXColor  *bcol = nullptr;
@@ -269,7 +269,7 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
             for (x = 0; x < (int) source->width; x++, bc++) {
-///               bc->pixel = XGetPixel(xim, bx + x, by - c->TTF::fgAscent + y);
+///               bc->pixel = XGetPixel(xim, bx + x, by - c->TTF::GetAscent() + y);
                bc->pixel = XGetPixel(xim, bx + x, by + y);
                bc->flags = DoRed | DoGreen | DoBlue;
                if (++dotcnt >= maxdots) break;
@@ -529,8 +529,8 @@ void TGX11TTF::RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode
    TTF::TTGlyph *glyph = TTF::GetGlyphs();
    for (int n = 0; n < TTF::GetNumGlyphs(); n++, glyph++) {
       if (FT_Glyph_To_Bitmap(&glyph->fImage,
-                             TTF::fgSmoothing ? ft_render_mode_normal
-                                              : ft_render_mode_mono,
+                             TTF::GetSmoothing() ? ft_render_mode_normal
+                                                 : ft_render_mode_mono,
                              nullptr, 1 )) continue;
       FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
       FT_Bitmap*     source = &bitmap->bitmap;

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -28,6 +28,9 @@ is redirected to point to this class.
 #include FT_GLYPH_H
 #include "TGX11TTF.h"
 #include "TEnv.h"
+#include "TTF.h"
+#include "TMathBase.h"
+
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -156,12 +159,8 @@ TGX11TTF::TGX11TTF(TGX11 &&org) : TGX11(std::move(org))
    SetName("X11TTF");
    SetTitle("ROOT interface to X11 with TrueType fonts");
 
-   TTF::Init();
-
-   fHasTTFonts = kTRUE;
+   fHasTTFonts = TTFhandle::Init();
    fHasXft = kFALSE;
-   fAlign.x = 0;
-   fAlign.y = 0;
 
 #ifdef R__HAS_XFT
    fXftFontHash = nullptr;
@@ -197,57 +196,23 @@ Bool_t TGX11TTF::Init(void *display)
 #endif
    Bool_t r = TGX11::Init(display);
 
-   if (fDepth > 8) {
-      TTF::SetSmoothing(kTRUE);
-   } else {
-      TTF::SetSmoothing(kFALSE);
-   }
+   TTFhandle::SetSmoothing(fDepth > 8);
 
    return r;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Compute alignment variables. The alignment is done on the horizontal string
-/// then the rotation is applied on the alignment variables.
-/// SetRotation and LayoutGlyphs should have been called before.
-
-void TGX11TTF::Align(WinContext_t wctxt)
-{
-   auto align = GetTextAlignW(wctxt);
-
-   // vertical alignment
-   if (align == kTLeft || align == kTCenter || align == kTRight) {
-      fAlign.y = TTF::GetAscent();
-   } else if (align == kMLeft || align == kMCenter || align == kMRight) {
-      fAlign.y = TTF::GetAscent() / 2;
-   } else {
-      fAlign.y = 0;
-   }
-
-   // horizontal alignment
-   if (align == kTRight || align == kMRight || align == kBRight) {
-      fAlign.x = TTF::GetWidth();
-   } else if (align == kTCenter || align == kMCenter || align == kBCenter) {
-      fAlign.x = TTF::GetWidth() / 2;
-   } else {
-      fAlign.x = 0;
-   }
-
-   FT_Vector_Transform(&fAlign, TTF::GetRotMatrix());
-   fAlign.x = fAlign.x >> 6;
-   fAlign.y = fAlign.y >> 6;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Draw FT_Bitmap bitmap to xim image at position bx,by using specified
 /// foreground color.
 
-void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
+void TGX11TTF::DrawImage(void *_source, ULong_t fore, ULong_t back,
                          RXImage *xim, Int_t bx, Int_t by)
 {
+   auto source = (FT_Bitmap *) _source;
+
    UChar_t d = 0, *s = source->buffer;
 
-   if (TTF::GetSmoothing()) {
+   if (TTFhandle::GetSmoothing()) {
 
       static RXColor col[5];
       RXColor  *bcol = nullptr;
@@ -361,6 +326,148 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
    }
 }
 
+template<class CharType>
+void TGX11TTF::DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
+                              const CharType *text, ETextMode mode)
+{
+   if (!fHasTTFonts) {
+      TGX11::DrawTextW(wctxt, x, y, angle, mgn, text, mode);
+      return;
+   }
+
+   if (!wctxt)
+      return;
+
+   auto &att = GetTextAttW(wctxt);
+   auto align = GetTextAlignW(wctxt);
+
+   TTFhandle ttf;
+   ttf.SetTextFont(att.GetTextFont());
+   ttf.SetTextSize(att.GetTextSize());
+   ttf.SetRotationMatrix(angle);
+   ttf.PrepareString(text);
+   ttf.LayoutGlyphs();
+
+   FT_Vector   align_vect;                 ///< alignment vector
+   // vertical alignment
+   if (align == kTLeft || align == kTCenter || align == kTRight) {
+      align_vect.y = ttf.GetAscent();
+   } else if (align == kMLeft || align == kMCenter || align == kMRight) {
+      align_vect.y = ttf.GetAscent() / 2;
+   } else {
+      align_vect.y = 0;
+   }
+
+   // horizontal alignment
+   if (align == kTRight || align == kMRight || align == kBRight) {
+      align_vect.x = ttf.GetWidth();
+   } else if (align == kTCenter || align == kMCenter || align == kBCenter) {
+      align_vect.x = ttf.GetWidth() / 2;
+   } else {
+      align_vect.x = 0;
+   }
+
+   FT_Vector_Transform(&align_vect, ttf.GetRotMatrix());
+   align_vect.x = align_vect.x >> 6;
+   align_vect.y = align_vect.y >> 6;
+
+   Int_t Xoff = TMath::Max(0, (Int_t) -ttf.GetBox().xMin);
+   Int_t Yoff = TMath::Max(0, (Int_t) -ttf.GetBox().yMin);
+   Int_t w    = ttf.GetBox().xMax + Xoff;
+   Int_t h    = ttf.GetBox().yMax + Yoff;
+   // If w or h is 0, very likely the string is only blank characters
+   if (w <= 0 || h <= 0)
+      return;
+
+   Int_t x1   = x - Xoff - align_vect.x;
+   Int_t y1   = y + Yoff + align_vect.y - h;
+
+   Window_t cws = GetWindow(wctxt);
+   UInt_t width, height;
+   Int_t xy;
+   GetWindowSize(cws, xy, xy, width, height);
+
+   // If string falls outside window, there is probably no need to draw it.
+   if (x + w <= 0 || x >= (Int_t)width || y + h <= 0 || y >= (Int_t)height)
+      return;
+
+   // If w or h are much larger than the window size, there is probably no need
+   // to draw it. Moreover a to large text size may produce a Seg Fault in
+   // malloc in DrawTextW.
+   if (((UInt_t) w > 10 * width) || ((UInt_t) h > 10 * height))
+      return;
+
+   // create the XImage that will contain the text
+   UInt_t depth = fDepth;
+   XImage *xim = XCreateImage((Display*)fDisplay, fVisual,
+                               depth, ZPixmap, 0, nullptr, w, h,
+                               depth <= 8 ? 8 : (depth <= 16 ? 16 : 32), 0);
+   //bitmap_pad should be 8, 16 or 32 https://www.x.org/releases/X11R7.5/doc/man/man3/XPutPixel.3.html
+   if (!xim)
+      return;
+
+   // use malloc since Xlib will use free() in XDestroyImage
+   xim->data = (char *) malloc(xim->bytes_per_line * h);
+   memset(xim->data, 0, xim->bytes_per_line * h);
+
+   ULong_t   bg;
+   XGCValues values;
+   auto gc = (GC *) GetGCW(wctxt, 3);
+   if (!gc) {
+      Error("DrawTextW", "error getting Graphics Context");
+      return;
+   }
+   XGetGCValues((Display*)fDisplay, *gc, GCForeground | GCBackground, &values);
+
+   // get the background
+   if (mode == kClear) {
+      // if mode == kClear we need to get an image of the background
+      XImage *bim = GetBackground(wctxt, x1, y1, w, h);
+      if (!bim) {
+         Error("DrawTextW", "error getting background image");
+         return;
+      }
+
+      // and copy it into the text image
+      Int_t xo = 0, yo = 0;
+      if (x1 < 0) xo = -x1;
+      if (y1 < 0) yo = -y1;
+
+      for (int yp = 0; yp < (int) bim->height; yp++) {
+         for (int xp = 0; xp < (int) bim->width; xp++) {
+            ULong_t pixel = XGetPixel(bim, xp, yp);
+            XPutPixel(xim, xo+xp, yo+yp, pixel);
+         }
+      }
+      XDestroyImage(bim);
+      bg = (ULong_t) -1;
+   } else {
+      // if mode == kOpaque its simple, we just draw the background
+      XAddPixel(xim, values.background);
+      bg = values.background;
+   }
+
+   // paint the glyphs in the XImage
+   auto glyph = ttf.GetGlyphs();
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
+      if (FT_Glyph_To_Bitmap(&glyph->fImage,
+                             TTFhandle::GetSmoothing() ? ft_render_mode_normal
+                                                       : ft_render_mode_mono,
+                             nullptr, 1)) continue;
+      auto bitmap = (FT_BitmapGlyph)glyph->fImage;
+
+      Int_t bx = bitmap->left + Xoff;
+      Int_t by = h - bitmap->top - Yoff;
+      DrawImage(&bitmap->bitmap, values.foreground, bg, (RXImage *)xim, bx, by);
+   }
+
+   // put the Ximage on the screen
+   gc = (GC *) GetGCW(wctxt, 6);
+   if (gc)
+      XPutImage((Display*)fDisplay, cws, *gc, xim, 0, 0, x1, y1, w, h);
+   XDestroyImage(xim);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Draw text using TrueType fonts. If TrueType fonts are not available the
 /// text is drawn with TGX11::DrawTextW.
@@ -368,17 +475,7 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
 void TGX11TTF::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
                          const char *text, ETextMode mode)
 {
-   if (!fHasTTFonts) {
-      TGX11::DrawTextW(wctxt, x, y, angle, mgn, text, mode);
-   } else {
-      TTF::Init();
-      TTF::SetRotationMatrix(angle);
-      TTF::PrepareString(text);
-      TTF::LayoutGlyphs();
-      Align(wctxt);
-      RenderString(wctxt, x, y, mode);
-      TTF::CleanupGlyphs();
-   }
+   DrawTextHelper(wctxt, x, y, angle, mgn, text, mode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -388,17 +485,7 @@ void TGX11TTF::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Fl
 void TGX11TTF::DrawTextW(WinContext_t wctxt, Int_t x, Int_t y, Float_t angle, Float_t mgn,
                          const wchar_t *text, ETextMode mode)
 {
-   if (!fHasTTFonts) {
-      TGX11::DrawTextW(wctxt, x, y, angle, mgn, text, mode);
-   } else {
-      TTF::Init();
-      TTF::SetRotationMatrix(angle);
-      TTF::PrepareString(text);
-      TTF::LayoutGlyphs();
-      Align(wctxt);
-      RenderString(wctxt, x, y, mode);
-      TTF::CleanupGlyphs();
-   }
+   DrawTextHelper(wctxt, x, y, angle, mgn, text, mode);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -427,161 +514,6 @@ RXImage *TGX11TTF::GetBackground(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w,
    return (RXImage *)XGetImage((Display*)fDisplay, cws, x, y, w, h, AllPlanes, ZPixmap);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Test if there is really something to render.
-
-Bool_t TGX11TTF::IsVisible(WinContext_t wctxt, Int_t x, Int_t y, UInt_t w, UInt_t h)
-{
-   Window_t cws = GetWindow(wctxt);
-   UInt_t width;
-   UInt_t height;
-   Int_t xy;
-   GetWindowSize(cws, xy, xy, width, height);
-
-   // If w or h is 0, very likely the string is only blank characters
-   if ((int)w == 0 || (int)h == 0)
-      return kFALSE;
-
-   // If string falls outside window, there is probably no need to draw it.
-   if (x + (int)w <= 0 || x >= (int)width)
-      return kFALSE;
-   if (y + (int)h <= 0 || y >= (int)height)
-      return kFALSE;
-
-   // If w or h are much larger than the window size, there is probably no need
-   // to draw it. Moreover a to large text size may produce a Seg Fault in
-   // malloc in RenderString.
-   if (w > 10*width)
-      return kFALSE;
-   if (h > 10*height)
-      return kFALSE;
-
-   return kTRUE;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Perform the string rendering in the pad.
-/// LayoutGlyphs should have been called before.
-
-void TGX11TTF::RenderString(WinContext_t wctxt, Int_t x, Int_t y, ETextMode mode)
-{
-   // compute the size and position of the XImage that will contain the text
-   Int_t Xoff = 0; if (TTF::GetBox().xMin < 0) Xoff = -TTF::GetBox().xMin;
-   Int_t Yoff = 0; if (TTF::GetBox().yMin < 0) Yoff = -TTF::GetBox().yMin;
-   Int_t w    = TTF::GetBox().xMax + Xoff;
-   Int_t h    = TTF::GetBox().yMax + Yoff;
-   Int_t x1   = x-Xoff-fAlign.x;
-   Int_t y1   = y+Yoff+fAlign.y-h;
-
-   if (!IsVisible(wctxt, x1, y1, w, h))
-      return;
-
-   // create the XImage that will contain the text
-   UInt_t depth = fDepth;
-   XImage *xim = XCreateImage((Display*)fDisplay, fVisual,
-                               depth, ZPixmap, 0, nullptr, w, h,
-                               depth <= 8 ? 8 : (depth <= 16 ? 16 : 32), 0);
-   //bitmap_pad should be 8, 16 or 32 https://www.x.org/releases/X11R7.5/doc/man/man3/XPutPixel.3.html
-   if (!xim) return;
-
-   // use malloc since Xlib will use free() in XDestroyImage
-   xim->data = (char *) malloc(xim->bytes_per_line * h);
-   memset(xim->data, 0, xim->bytes_per_line * h);
-
-   ULong_t   bg;
-   XGCValues values;
-   auto gc = (GC *) GetGCW(wctxt, 3);
-   if (!gc) {
-      Error("RenderString", "error getting Graphics Context");
-      return;
-   }
-   XGetGCValues((Display*)fDisplay, *gc, GCForeground | GCBackground, &values);
-
-   // get the background
-   if (mode == kClear) {
-      // if mode == kClear we need to get an image of the background
-      XImage *bim = GetBackground(wctxt, x1, y1, w, h);
-      if (!bim) {
-         Error("DrawText", "error getting background image");
-         return;
-      }
-
-      // and copy it into the text image
-      Int_t xo = 0, yo = 0;
-      if (x1 < 0) xo = -x1;
-      if (y1 < 0) yo = -y1;
-
-      for (int yp = 0; yp < (int) bim->height; yp++) {
-         for (int xp = 0; xp < (int) bim->width; xp++) {
-            ULong_t pixel = XGetPixel(bim, xp, yp);
-            XPutPixel(xim, xo+xp, yo+yp, pixel);
-         }
-      }
-      XDestroyImage(bim);
-      bg = (ULong_t) -1;
-   } else {
-      // if mode == kOpaque its simple, we just draw the background
-      XAddPixel(xim, values.background);
-      bg = values.background;
-   }
-
-   // paint the glyphs in the XImage
-   TTF::TTGlyph *glyph = TTF::GetGlyphs();
-   for (int n = 0; n < TTF::GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage,
-                             TTF::GetSmoothing() ? ft_render_mode_normal
-                                                 : ft_render_mode_mono,
-                             nullptr, 1 )) continue;
-      FT_BitmapGlyph bitmap = (FT_BitmapGlyph)glyph->fImage;
-      FT_Bitmap*     source = &bitmap->bitmap;
-      Int_t          bx, by;
-
-      bx = bitmap->left+Xoff;
-      by = h - bitmap->top-Yoff;
-      DrawImage(source, values.foreground, bg, (RXImage*)xim, bx, by);
-   }
-
-   // put the Ximage on the screen
-   Window_t cws = GetWindow(wctxt);
-   gc = (GC *) GetGCW(wctxt, 6);
-   if (gc)
-      XPutImage((Display*)fDisplay, cws, *gc, xim, 0, 0, x1, y1, w, h);
-   XDestroyImage(xim);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set specified font.
-
-void TGX11TTF::SetAttText(WinContext_t wctxt, const TAttText &att)
-{
-   // TODO: add to window context custom part for TTF,
-   // it can be allocated and provided via private interface
-   TGX11::SetAttText(wctxt, att);
-
-   if (fHasTTFonts) {
-      TTF::SetTextFont(att.GetTextFont());
-      TTF::SetTextSize(att.GetTextSize());
-   }
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set text font to specified name.
-/// mode       : loading flag
-/// mode=0     : search if the font exist (kCheck)
-/// mode=1     : search the font and load it if it exists (kLoad)
-/// font       : font name
-///
-/// Set text font to specified name. This function returns 0 if
-/// the specified font is found, 1 if not.
-
-Int_t TGX11TTF::SetTextFont(char *fontname, ETextSetMode mode)
-{
-   if (!fHasTTFonts) {
-      return TGX11::SetTextFont(fontname, mode);
-   } else {
-      return TTF::SetTextFont(fontname);
-   }
-}
 
 #ifdef R__HAS_XFT
 

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -205,8 +205,8 @@ Bool_t TGX11TTF::Init(void *display)
 /// Draw FT_Bitmap bitmap to xim image at position bx,by using specified
 /// foreground color.
 
-void TGX11TTF::DrawImage(void *_source, ULong_t fore, ULong_t back,
-                         RXImage *xim, Int_t bx, Int_t by)
+void TGX11TTF::DrawFTGlyph(void *_source, ULong_t fore, ULong_t back,
+                           RXImage *xim, Int_t bx, Int_t by)
 {
    auto source = (FT_Bitmap *) _source;
 
@@ -448,17 +448,12 @@ void TGX11TTF::DrawTextHelper(WinContext_t wctxt, Int_t x, Int_t y, Float_t angl
    }
 
    // paint the glyphs in the XImage
-   auto glyph = ttf.GetGlyphs();
-   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++, glyph++) {
-      if (FT_Glyph_To_Bitmap(&glyph->fImage,
-                             TTFhandle::GetSmoothing() ? ft_render_mode_normal
-                                                       : ft_render_mode_mono,
-                             nullptr, 1)) continue;
-      auto bitmap = (FT_BitmapGlyph)glyph->fImage;
-
-      Int_t bx = bitmap->left + Xoff;
-      Int_t by = h - bitmap->top - Yoff;
-      DrawImage(&bitmap->bitmap, values.foreground, bg, (RXImage *)xim, bx, by);
+   for (UInt_t n = 0; n < ttf.GetNumGlyphs(); n++) {
+      if (auto bitmap = ttf.GetGlyphBitmap(n)) {
+         Int_t bx = bitmap->left + Xoff;
+         Int_t by = h - bitmap->top - Yoff;
+         DrawFTGlyph(&bitmap->bitmap, values.foreground, bg, (RXImage *)xim, bx, by);
+      }
    }
 
    // put the Ximage on the screen


### PR DESCRIPTION
Now TTF class uses fully static API - no chance to run code in parallel.
Also there are several static arrays preallocated - which leads to certain limitations.

Introduce new `TTFhandle` class which provides "normal" API without all previous static limitations.
ttf library handle and fonts lists created per-thread using `thread_local` instances. 
Thus functionality can be used from many threads without limitation.

Old `TTF` class API preserved until ROOT7. 
It creates static instance of `std::unique_ptr<TTFhandle>` and redirect all calls to it.

All ROOT classes tested first with modified `TTF` implementation and then converted to use
new API. 

Important improvement - there is no global state for text attributes which was always set to static `TTF` members
by each call to `TAttText::Modify()`. Now text attributes preserved in `TVirtualX` instance and applied to temporary 
`TTFhandle` instance only when text is painted. 

Adjust all `DrawFTGlyph` methods to have similar structure. Avoid static variables for smooth colors
