### PR TITLE
[RF] Implement RooMomentMorphFuncND::compileForNormSet()

### DIFF
--- a/roofit/roofit/inc/LinkDef1.h
+++ b/roofit/roofit/inc/LinkDef1.h
@@ -56,6 +56,7 @@
 #pragma link C++ class RooMomentMorphFunc + ;
 #pragma link C++ class RooMomentMorphFuncND + ;
 #pragma link C++ class RooMomentMorphFuncND::Grid2 + ;
+#pragma link C++ class RooFit::Detail::RooMomentMorphFraction + ;
 #pragma link C++ class RooSpline+ ;
 #pragma link C++ class RooStepFunction+ ;
 #pragma link C++ class RooMultiBinomial+ ;

--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -20,6 +20,7 @@
 #include "RooListProxy.h"
 #include "RooArgList.h"
 #include "RooBinning.h"
+#include "RooFit/Detail/NormalizationHelpers.h"
 
 #include "TMatrixD.h"
 #include "TMap.h"
@@ -29,6 +30,12 @@
 
 class RooChangeTracker;
 class RooRealSumFunc;
+
+namespace RooFit {
+namespace Detail {
+class RooMomentMorphFraction;
+}
+} // namespace RooFit
 
 class RooMomentMorphFuncND : public RooAbsReal {
 
@@ -129,6 +136,9 @@ public:
    double evaluate() const override;
    double getValV(const RooArgSet *set = nullptr) const override;
 
+   std::unique_ptr<RooAbsArg>
+   compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const override;
+
 protected:
    void initialize();
 
@@ -139,6 +149,7 @@ protected:
 
    friend class CacheElem;
    friend class Grid2;
+   friend class RooFit::Detail::RooMomentMorphFraction;
 
    mutable RooObjCacheManager _cacheMgr;     ///<! Transient cache manager
    mutable RooArgSet *_curNormSet = nullptr; ///<! Transient cache manager
@@ -161,5 +172,33 @@ protected:
 
    ClassDefOverride(RooMomentMorphFuncND, 4);
 };
+
+namespace RooFit {
+namespace Detail {
+
+/// Helper compute-graph node that exposes one of the morph mixing fractions to
+/// the RooFit::Evaluator. It re-runs RooMomentMorphFuncND::CacheElem::calculateFractions
+/// only when the morph parameters change, then returns the cached fraction value
+/// for this index.
+class RooMomentMorphFraction : public RooAbsReal {
+public:
+   RooMomentMorphFraction() {}
+   RooMomentMorphFraction(const char *name, const char *title, RooMomentMorphFuncND const &parent, int index);
+   RooMomentMorphFraction(RooMomentMorphFraction const &other, const char *name = nullptr);
+   TObject *clone(const char *newname) const override { return new RooMomentMorphFraction(*this, newname); }
+
+protected:
+   double evaluate() const override;
+
+private:
+   RooListProxy _parList;
+   const RooMomentMorphFuncND *_parent = nullptr; ///<! morph that owns the cache (not owned)
+   int _index = 0;
+
+   ClassDefOverride(RooFit::Detail::RooMomentMorphFraction, 0);
+};
+
+} // namespace Detail
+} // namespace RooFit
 
 #endif

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -346,6 +346,112 @@ void RooMomentMorphFuncND::Grid2::addPdf(const RooMomentMorphFuncND::Base_t &pdf
 }
 
 //_____________________________________________________________________________
+std::unique_ptr<RooAbsArg>
+RooMomentMorphFuncND::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileContext &ctx) const
+{
+   // Build (or fetch) the cache that holds the morph's internal compute graph:
+   // moment integrals, slope/offset formulas, RooLinearVar transforms, the per-pdf
+   // RooHistPdf clones, and the final RooAddPdf/RooRealSumFunc sum.
+   CacheElem *cache = getCache(&normSet);
+
+   // Make sure fractions hold sensible initial values (the replacement nodes
+   // below will keep them in sync going forward).
+   cache->calculateFractions(*this, false);
+
+   // The cache's subtree carries ORIGNAME: attributes left over from the
+   // RooCustomizer that built the per-pdf transformed RooHistPdf clones (it
+   // tagged each transVar with ORIGNAME:<obs>). RooCustomizer::build calls
+   // redirectServers with nameChange=true and will throw if it sees several
+   // candidates with the same ORIGNAME:* attribute, which is exactly what
+   // happens here once we ask it to clone the subtree. Strip those stale
+   // markers before cloning.
+   {
+      RooArgSet branches;
+      cache->_sum->branchNodeServerList(&branches);
+      branches.add(*cache->_sum);
+      for (auto *b : branches) {
+         std::vector<std::string> toRemove;
+         for (auto const &attr : b->attributes()) {
+            if (attr.rfind("ORIGNAME:", 0) == 0)
+               toRemove.push_back(attr);
+         }
+         for (auto const &attr : toRemove)
+            b->setAttribute(attr.c_str(), false);
+      }
+   }
+
+   // Replace each of the imperatively-updated fraction RooRealVars with a
+   // RooMomentMorphFraction node. This puts the fraction-recomputation inside
+   // the Evaluator's compute graph, so the moment integrals (which the
+   // fractions depend on transitively via the slope/offset formulas) become
+   // sibling nodes that the Evaluator caches once per minimization step.
+   RooArgList newFractions;
+   const int nFrac = cache->_frac.size();
+   for (int i = 0; i < nFrac; ++i) {
+      auto frac = static_cast<RooRealVar *>(cache->_frac.at(i));
+      std::string newName = std::string{frac->GetName()} + "_compiled";
+      newFractions.addOwned(
+         std::make_unique<RooFit::Detail::RooMomentMorphFraction>(newName.c_str(), frac->GetTitle(), *this, i));
+   }
+
+   RooArgSet clonedBranches;
+   RooCustomizer cust(*cache->_sum, "compiled");
+   cust.setCloneBranchSet(clonedBranches);
+   for (int i = 0; i < nFrac; ++i) {
+      cust.replaceArg(*cache->_frac.at(i), newFractions[i]);
+   }
+
+   // RooCustomizer::build() already transfers ownership of the cloned branches
+   // (everything in `clonedBranches` except the returned top node) to the new
+   // top node's owned-components list, so we only have to attach the
+   // newly-created fraction nodes here.
+   std::unique_ptr<RooAbsReal> newSum{static_cast<RooAbsReal *>(cust.build())};
+   newSum->addOwnedComponents(std::move(newFractions));
+
+   // Mark every node in the freshly-cloned subtree as already compiled, so
+   // the recursive compileServers call below doesn't try to re-clone any of
+   // them. The leaves we still want compiled (the morph parameters and the
+   // observables) are reachable from these nodes' own server lists and will
+   // be visited.
+   ctx.markAsCompiled(*newSum);
+   RooArgSet allBranches;
+   newSum->branchNodeServerList(&allBranches);
+   for (auto *b : allBranches) {
+      ctx.markAsCompiled(*b);
+   }
+   ctx.compileServers(*newSum, normSet);
+
+   return newSum;
+}
+
+namespace RooFit {
+namespace Detail {
+
+RooMomentMorphFraction::RooMomentMorphFraction(const char *name, const char *title, RooMomentMorphFuncND const &parent,
+                                               int index)
+   : RooAbsReal(name, title), _parList("parList", "parList", this), _parent(&parent), _index(index)
+{
+   _parList.add(parent._parList);
+}
+
+RooMomentMorphFraction::RooMomentMorphFraction(RooMomentMorphFraction const &other, const char *name)
+   : RooAbsReal(other, name), _parList("parList", this, other._parList), _parent(other._parent), _index(other._index)
+{
+}
+
+double RooMomentMorphFraction::evaluate() const
+{
+   auto *cache = _parent->getCache(nullptr);
+   if (cache->_tracker->hasChanged(true)) {
+      cache->calculateFractions(*_parent, false);
+   }
+   return cache->frac(_index)->getVal();
+}
+
+} // namespace Detail
+} // namespace RooFit
+
+//_____________________________________________________________________________
 RooMomentMorphFuncND::CacheElem *RooMomentMorphFuncND::getCache(const RooArgSet * /*nset*/) const
 {
    auto cache = static_cast<CacheElem *>(_cacheMgr.getObj(nullptr, static_cast<RooArgSet const*>(nullptr)));

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -368,7 +368,6 @@ RooMomentMorphFuncND::compileForNormSet(RooArgSet const &normSet, RooFit::Detail
    {
       RooArgSet branches;
       cache->_sum->branchNodeServerList(&branches);
-      branches.add(*cache->_sum);
       for (auto *b : branches) {
          std::vector<std::string> toRemove;
          for (auto const &attr : b->attributes()) {
@@ -408,17 +407,10 @@ RooMomentMorphFuncND::compileForNormSet(RooArgSet const &normSet, RooFit::Detail
    std::unique_ptr<RooAbsReal> newSum{static_cast<RooAbsReal *>(cust.build())};
    newSum->addOwnedComponents(std::move(newFractions));
 
-   // Mark every node in the freshly-cloned subtree as already compiled, so
-   // the recursive compileServers call below doesn't try to re-clone any of
-   // them. The leaves we still want compiled (the morph parameters and the
-   // observables) are reachable from these nodes' own server lists and will
-   // be visited.
-   ctx.markAsCompiled(*newSum);
-   RooArgSet allBranches;
-   newSum->branchNodeServerList(&allBranches);
-   for (auto *b : allBranches) {
-      ctx.markAsCompiled(*b);
-   }
+   // Tell the compile context the freshly-cloned subtree is already in its
+   // final form, so the recursive descent below only visits the leaves that
+   // still need compiling (the morph parameters and the observables).
+   ctx.markSubtreeAsCompiled(*newSum);
    ctx.compileServers(*newSum, normSet);
 
    return newSum;

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -134,6 +134,14 @@ private:
 
   bool _disableCache = false; ///< Flag to run object in passthrough (= non-caching mode)
 
+  /// Pinned at compileForNormSet() time on the cloned cache pdf, so that
+  /// doEval() looks up the same _cacheMgr slot that getAnalyticalIntegralWN()
+  /// populates while the surrounding RooNormalizedPdf is being constructed.
+  /// Without this, the two paths used different (or null) keys and the cache
+  /// was rebuilt on the first Evaluator step of every fit.
+  mutable RooArgSet _compiledNormSet;       ///<! stable normalization set for the compiled clone
+  mutable bool _hasCompiledNormSet = false; ///<! whether _compiledNormSet has been populated
+
   ClassDefOverride(RooAbsCachedPdf,2) // Abstract base class for cached p.d.f.s
 };
 

--- a/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/NormalizationHelpers.h
@@ -42,6 +42,7 @@ public:
    void compileServer(RooAbsArg &server, RooAbsArg &arg, RooArgSet const &normSet);
 
    void markAsCompiled(RooAbsArg &arg) const;
+   void markSubtreeAsCompiled(RooAbsArg &arg) const;
 
    // This information is used for the binned likelihood optimization.
    void setLikelihoodMode(bool flag) { _likelihoodMode = flag; }

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -76,6 +76,21 @@ void RooFit::Detail::CompileContext::markAsCompiled(RooAbsArg &arg) const
    arg.setAttribute("_COMPILED");
 }
 
+/// Mark `arg` and every branch node reachable through its server tree as
+/// already compiled. Use this after assembling or cloning a sub-graph
+/// yourself inside `compileForNormSet`: it prevents a follow-up
+/// `compileServers` call from re-cloning any of those internal nodes, while
+/// still letting the recursive descent reach the genuine leaves
+/// (fundamental observables and parameters) at the bottom of the tree.
+void RooFit::Detail::CompileContext::markSubtreeAsCompiled(RooAbsArg &arg) const
+{
+   RooArgSet branches;
+   arg.branchNodeServerList(&branches);
+   for (RooAbsArg *b : branches) {
+      markAsCompiled(*b);
+   }
+}
+
 bool RooFit::Detail::CompileContext::isMarkedAsCompiled(RooAbsArg const &arg) const
 {
    return arg.getAttribute("_COMPILED");

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -406,12 +406,9 @@ RooAbsCachedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
 
    auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
-   // The direct servers are this pdf and the normalization integral, which
-   // don't need to be compiled further.
-   for (RooAbsArg *server : newArg->servers()) {
-      ctx.markAsCompiled(*server);
-   }
-   ctx.markAsCompiled(*newArg);
+   // The direct servers are the cloned pdf (already compiled above) and the
+   // freshly-built normalization integral. Neither needs further compilation.
+   ctx.markSubtreeAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -374,7 +374,13 @@ double RooAbsCachedPdf::analyticalIntegralWN(int code, const RooArgSet* normSet,
   RooArgSet *dummy(nullptr);
   const std::vector<int> codeList = _anaReg.retrieve(code-1,allVars,anaVars,normSet2,dummy) ;
 
-  PdfCacheElem* cache = getCache(normSet2?normSet2:anaVars,false) ;
+  // Mirror getAnalyticalIntegralWN's lookup key. If the caller passed a null
+  // normSet to getAnalyticalIntegralWN, the stored normSet2 is non-null but
+  // empty; use anaVars (content-equivalent to the original allVars) instead,
+  // so that analyticalIntegralWN and getAnalyticalIntegralWN both key the
+  // _cacheMgr lookup on the same content and hit the same slot.
+  const RooArgSet *cacheNset = (normSet2 && !normSet2->empty()) ? normSet2 : anaVars;
+  PdfCacheElem *cache = getCache(cacheNset, false);
   double ret = cache->pdf()->analyticalIntegralWN(codeList[0],normSet,rangeName) ;
 
   if (codeList[1]>0) {
@@ -391,7 +397,8 @@ double RooAbsCachedPdf::analyticalIntegralWN(int code, const RooArgSet* normSet,
 
 void RooAbsCachedPdf::doEval(RooFit::EvalContext &ctx) const
 {
-   getCachePdf(_normSet)->doEval(ctx);
+   const RooArgSet *nset = _hasCompiledNormSet ? &_compiledNormSet : _normSet;
+   getCachePdf(nset)->doEval(ctx);
 }
 
 
@@ -403,6 +410,17 @@ RooAbsCachedPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Com
    }
    std::unique_ptr<RooAbsPdf> pdfClone(static_cast<RooAbsPdf *>(this->Clone()));
    ctx.compileServers(*pdfClone, {});
+
+   // Pin a stable normalization set on the clone so that doEval() and the
+   // analytical integration path triggered inside RooNormalizedPdf below hit
+   // the same _cacheMgr slot. Otherwise the analytical-integral path keys the
+   // slot on its own (local) integration variable set while doEval keys it on
+   // the unset (null) _normSet of the clone, and the heavy cache content is
+   // rebuilt on the first Evaluator step of every fit.
+   auto *cachedClone = static_cast<RooAbsCachedPdf *>(pdfClone.get());
+   cachedClone->_compiledNormSet.removeAll();
+   cachedClone->_compiledNormSet.add(normSet);
+   cachedClone->_hasCompiledNormSet = true;
 
    auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -2784,12 +2784,9 @@ RooAbsPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileCo
 
    auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, normSet);
 
-   // The direct servers are this pdf and the normalization integral, which
-   // don't need to be compiled further.
-   for (RooAbsArg *server : newArg->servers()) {
-      ctx.markAsCompiled(*server);
-   }
-   ctx.markAsCompiled(*newArg);
+   // The direct servers are the cloned pdf (already compiled above) and the
+   // freshly-built normalization integral. Neither needs further compilation.
+   ctx.markSubtreeAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -767,12 +767,9 @@ RooRealSumPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::Compi
 
    auto newArg = std::make_unique<RooFit::Detail::RooNormalizedPdf>(*pdfClone, depList);
 
-   // The direct servers are this pdf and the normalization integral, which
-   // don't need to be compiled further.
-   for (RooAbsArg *server : newArg->servers()) {
-      ctx.markAsCompiled(*server);
-   }
-   ctx.markAsCompiled(*newArg);
+   // The direct servers are the cloned pdf (already compiled above) and the
+   // freshly-built normalization integral. Neither needs further compilation.
+   ctx.markSubtreeAsCompiled(*newArg);
    newArg->addOwnedComponents(std::move(pdfClone));
    return newArg;
 }


### PR DESCRIPTION
Transform the RooMomentMorphFuncND instance to an expended computation graph that can be evaluated by the `RooFit::Evaluator` without missing some internal RooAbsArgs that could be cached.

Closes #22070.