### PR TITLE
[v6-28] Use python3 in the python tools. Fixes #14416

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -57,7 +57,7 @@ foreach(rawUtilName ${utils})
     # We need the .py only on Windows
     string(REPLACE ".py" "" utilName ${utilName})
   endif()
-  set(python ${PYTHON_EXECUTABLE_Development_Main})
+  set(python python3)
   configure_file(${rawUtilName} ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/${utilName} @ONLY)
 
   install(FILES ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/${utilName}


### PR DESCRIPTION
Use `python3` in the shebang instead of the full path of Python used to build ROOT.
