### PR TITLE
[gl] pass char to FTFont

### DIFF
--- a/graf3d/gl/src/TGLFontManager.cxx
+++ b/graf3d/gl/src/TGLFontManager.cxx
@@ -276,7 +276,7 @@ void TGLFont::Render(const TString &txt) const
    }
 
    // FTGL is not const correct.
-   const_cast<FTFont*>(fFont)->Render(txt);
+   const_cast<FTFont*>(fFont)->Render(txt.Data());
 
    if (scaleDepth) {
       glPopMatrix();

--- a/graf3d/gl/src/TGLFontManager.cxx
+++ b/graf3d/gl/src/TGLFontManager.cxx
@@ -295,7 +295,7 @@ void  TGLFont:: Render(const TString &txt, Float_t x, Float_t y, Float_t z,
 
    x=0, y=0;
    Float_t llx, lly, llz, urx, ury, urz;
-   BBox(txt, llx, lly, llz, urx, ury, urz);
+   BBox(txt.Data(), llx, lly, llz, urx, ury, urz);
 
    switch (alignH)
    {


### PR DESCRIPTION
use explicit cast to const char since FTFont does not know what TString is

fyi @osschar