### PR TITLE
[Python] Replace `cppyy.gbl.gInterpreter` usage with cppyy functions

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/support.py
+++ b/bindings/pyroot/cppyy/cppyy/test/support.py
@@ -47,3 +47,13 @@ try:
     ispypy = True
 except ImportError:
     ispypy = False
+
+def has_cpp_20():
+    import cppyy
+    cppyy.cppdef("""
+        #ifndef CPPYY_CPP_STANDARD_PROBE
+        #define CPPYY_CPP_STANDARD_PROBE
+        constexpr long cppyy_cpp_standard = __cplusplus;
+        #endif
+    """)
+    return cppyy.gbl.cppyy_cpp_standard >= 202002

--- a/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_crossinheritance.py
@@ -1199,7 +1199,7 @@ class TestCROSSINHERITANCE:
 
         import cppyy
 
-        cppyy.gbl.gInterpreter.Declare("""\
+        cppyy.cppdef("""\
         namespace NonStandardOffset {
         struct Calc1 {
           virtual int calc1() = 0;

--- a/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_datatypes.py
@@ -1,14 +1,8 @@
 import sys, pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, pyunicode, IS_MAC, IS_MAC_ARM, IS_WINDOWS
+from support import setup_make, pylong, pyunicode, IS_MAC, IS_MAC_ARM, IS_WINDOWS, has_cpp_20
 
 test_dct = "datatypes_cxx"
-
-
-def has_cpp_20():
-    import cppyy
-
-    return cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") >= 202002
 
 
 def is_modules_off():

--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -1,15 +1,10 @@
 import os, sys, pytest
 from pytest import mark, raises, skip
-from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM
+from support import setup_make, ispypy, IS_WINDOWS, IS_MAC_ARM, has_cpp_20
 
 
 test_dct = "fragile_cxx"
 
-
-def has_cpp_20():
-    import cppyy
-
-    return cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") >= 202002
 
 def has_asserts():
     import cppyy

--- a/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_stltypes.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 import sys, pytest, os
 from pytest import mark, raises, skip
-from support import setup_make, pylong, pyunicode, maxvalue, ispypy, IS_WINDOWS
+from support import setup_make, pylong, pyunicode, maxvalue, ispypy, IS_WINDOWS, has_cpp_20
 
 test_dct = "stltypes_cxx"
 
@@ -2183,12 +2183,6 @@ class TestSTLEXCEPTION:
 
         gc.collect()
         assert cppyy.gbl.GetMyErrorCount() == 0
-
-
-def has_cpp_20():
-    import cppyy
-
-    return cppyy.gbl.gInterpreter.ProcessLine("__cplusplus;") >= 202002
 
 
 @mark.skipif(not has_cpp_20(), reason="std::span requires C++20")

--- a/roottest/python/basic/PyROOT_overloadtests.py
+++ b/roottest/python/basic/PyROOT_overloadtests.py
@@ -228,7 +228,7 @@ class TestClassOVERLOADS:
     def test11_free_function_namespace(self):
         """Free functions on a namespace"""
         import cppyy
-        cppyy.gbl.gInterpreter.Declare("""
+        cppyy.cppdef("""
           namespace Gaudi { 
             namespace Utils { 
               namespace Histos { 

--- a/roottest/python/cpp/PyROOT_advancedtests.py
+++ b/roottest/python/cpp/PyROOT_advancedtests.py
@@ -648,8 +648,8 @@ class Cpp12NamespaceLazyFunctions( MyTestCase ):
       """Lazy lookup of late created functions"""
 
       import cppyy
-      cppyy.gbl.gInterpreter.ProcessLine( 'namespace PyCpp12_ns_test1 {}' )
-      cppyy.gbl.gInterpreter.ProcessLine(
+      cppyy.cppdef( 'namespace PyCpp12_ns_test1 {}' )
+      cppyy.cppdef(
          'namespace PyCpp12_ns_test1 { class PyCpp12_A {}; int PyCpp12_f() {return 32;}; }' )
 
       self.assertTrue( cppyy.gbl.PyCpp12_ns_test1.PyCpp12_A() )
@@ -659,8 +659,8 @@ class Cpp12NamespaceLazyFunctions( MyTestCase ):
       """Lazy lookup of late created overloaded functions"""
 
       import cppyy
-      cppyy.gbl.gInterpreter.ProcessLine( 'namespace PyCpp12_ns_test2 {}')
-      cppyy.gbl.gInterpreter.ProcessLine(
+      cppyy.cppdef( 'namespace PyCpp12_ns_test2 {}')
+      cppyy.cppdef(
          'namespace PyCpp12_ns_test2 { class PyCpp12_A {}; \
           int PyCpp12_f(int n) {return 32*n;} \
           int PyCpp12_f() {return 32;}; }')
@@ -669,7 +669,7 @@ class Cpp12NamespaceLazyFunctions( MyTestCase ):
       self.assertEqual( cppyy.gbl.PyCpp12_ns_test2.PyCpp12_f(2), 64 )
       self.assertEqual( cppyy.gbl.PyCpp12_ns_test2.PyCpp12_f(),  32 )
 
-      cppyy.gbl.gInterpreter.ProcessLine(
+      cppyy.cppdef(
          'namespace PyCpp12_ns_test2 { \
           int PyCpp12_g(const std::string&) {return 42;} \
           int PyCpp12_g() {return 13;}; }')

--- a/roottest/python/regression/PyROOT_regressiontests.py
+++ b/roottest/python/regression/PyROOT_regressiontests.py
@@ -573,7 +573,7 @@ class Regression24CppPythonInheritance(MyTestCase):
    def test01DeletedCopyConstructor(self):
       """Test that deleted base class copy constructor is not used"""
       # ROOT-10872
-      cppyy.gbl.gInterpreter.Declare('''
+      cppyy.cppdef('''
       struct NoCopy1 {
          NoCopy1() = default;
          NoCopy1(const NoCopy1&) = delete;
@@ -589,7 +589,7 @@ class Regression24CppPythonInheritance(MyTestCase):
    def test02MoveConstructor(self):
       """Test that move constructor is not mistaken for copy constructor"""
       # ROOT-10872
-      cppyy.gbl.gInterpreter.Declare('''
+      cppyy.cppdef('''
       struct NoCopy2 {
          NoCopy2() = default;
          NoCopy2(const NoCopy2&) = delete;
@@ -675,7 +675,7 @@ class Regression24CppPythonInheritance(MyTestCase):
    def test06MultiInheritance(self):
        """Test for a Python derived class in presence of multiple inheritance in C++"""
        # 6376
-       cppyy.gbl.gInterpreter.Declare("""
+       cppyy.cppdef("""
        #include <array>
        #include <iostream>
 
@@ -738,7 +738,7 @@ class Regression24CppPythonInheritance(MyTestCase):
        """Presence of multiple protected overloads of a method and both private and protected"""
        # 6345
 
-       cppyy.gbl.gInterpreter.Declare('''
+       cppyy.cppdef('''
        class MyClass6345 {
        public:
           virtual ~MyClass6345() {}
@@ -765,7 +765,7 @@ class Regression24CppPythonInheritance(MyTestCase):
        """Virtual call resolution in deep hierarchy (C++->Py->Py)"""
        # 6470
 
-       cppyy.gbl.gInterpreter.Declare('''
+       cppyy.cppdef('''
        class CppBase6470 {
        public:
           virtual ~CppBase6470() {}
@@ -804,7 +804,7 @@ class Regression24CppPythonInheritance(MyTestCase):
        class PurePy2:
           def bar(self): return 2
 
-       cppyy.gbl.gInterpreter.Declare('''
+       cppyy.cppdef('''
        class MyCppClass11 {
        public:
           int foo() { return 3; }


### PR DESCRIPTION
We should not use ROOT details like `gInterpreter` from `cppyy` without going throught the ROOT facade so we don't have a circular dependency between ROOT and cppyy.

Therefore, this commit suggests to replace all `cppyy.gbl.gInterpreter` usage with the corresponding cppyy functions. The user facing `ROOT.gInterpreter` is of course still there.