### PR TITLE
[ntuple] Make deserializer fail upon finding feature flags in the footer

### DIFF
--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -1762,7 +1762,9 @@ ROOT::RResult<std::uint32_t> ROOT::Internal::RNTupleSerializer::SerializeFooter(
    pos += SerializeEnvelopePreamble(kEnvelopeTypeFooter, *where);
 
    // So far we don't make use of footer feature flags
-   if (auto res = SerializeFeatureFlags(std::vector<std::uint64_t>(), *where)) {
+   // NOTE: we currently serialize all feature flags in the footer, even those that were already written in the
+   // header. This is fine, as they will be logically OR-ed together during deserialization.
+   if (auto res = SerializeFeatureFlags(desc.GetFeatureFlags(), *where)) {
       pos += res.Unwrap();
    } else {
       return R__FORWARD_ERROR(res);
@@ -1864,6 +1866,19 @@ ROOT::Internal::RNTupleSerializer::SerializeAttributeSet(const Experimental::RNT
    }
 }
 
+static ROOT::RResult<void> CheckFeatureFlags(const std::vector<std::uint64_t> &featureFlags)
+{
+   for (std::size_t i = 0; i < featureFlags.size(); ++i) {
+      if (!featureFlags[i])
+         continue;
+      unsigned int bit = 0;
+      while (!(featureFlags[i] & (static_cast<uint64_t>(1) << bit)))
+         bit++;
+      return R__FAIL("unsupported format feature: " + std::to_string(i * 64 + bit));
+   }
+   return ROOT::RResult<void>::Success();
+}
+
 ROOT::RResult<void> ROOT::Internal::RNTupleSerializer::DeserializeHeader(const void *buffer, std::uint64_t bufSize,
                                                                          RNTupleDescriptorBuilder &descBuilder)
 {
@@ -1885,13 +1900,8 @@ ROOT::RResult<void> ROOT::Internal::RNTupleSerializer::DeserializeHeader(const v
    } else {
       return R__FORWARD_ERROR(res);
    }
-   for (std::size_t i = 0; i < featureFlags.size(); ++i) {
-      if (!featureFlags[i])
-         continue;
-      unsigned int bit = 0;
-      while (!(featureFlags[i] & (static_cast<uint64_t>(1) << bit)))
-         bit++;
-      return R__FAIL("unsupported format feature: " + std::to_string(i * 64 + bit));
+   if (auto res = CheckFeatureFlags(featureFlags); !res) {
+      return R__FORWARD_ERROR(res);
    }
 
    std::string name;
@@ -1945,9 +1955,8 @@ ROOT::RResult<void> ROOT::Internal::RNTupleSerializer::DeserializeFooter(const v
    } else {
       return R__FORWARD_ERROR(res);
    }
-   for (auto f : featureFlags) {
-      if (f)
-         R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "Unsupported feature flag! " << f;
+   if (auto res = CheckFeatureFlags(featureFlags); !res) {
+      return R__FORWARD_ERROR(res);
    }
 
    std::uint64_t xxhash3{0};

--- a/tree/ntuple/test/ntuple_compat.cxx
+++ b/tree/ntuple/test/ntuple_compat.cxx
@@ -67,6 +67,46 @@ TEST(RNTupleCompat, FeatureFlag)
    }
 }
 
+TEST(RNTupleCompat, FeatureFlagInFooter)
+{
+   FileRaii fileGuard("test_ntuple_compat_feature_flag_footer.root");
+
+   RNTupleDescriptorBuilder descBuilder;
+   descBuilder.SetVersionForWriting();
+   descBuilder.SetNTuple("ntpl", "");
+   descBuilder.AddField(RFieldDescriptorBuilder::FromField(ROOT::RFieldZero()).FieldId(0).MakeDescriptor().Unwrap());
+   ASSERT_TRUE(static_cast<bool>(descBuilder.EnsureValidDescriptor()));
+
+   RNTupleWriteOptions options;
+   auto writer = RNTupleFileWriter::Recreate("ntpl", fileGuard.GetPath(), EContainerFormat::kTFile, options);
+   RNTupleSerializer serializer;
+
+   auto ctx = serializer.SerializeHeader(nullptr, descBuilder.GetDescriptor()).Unwrap();
+   auto buffer = std::make_unique<unsigned char[]>(ctx.GetHeaderSize());
+   ctx = serializer.SerializeHeader(buffer.get(), descBuilder.GetDescriptor()).Unwrap();
+   writer->WriteNTupleHeader(buffer.get(), ctx.GetHeaderSize(), ctx.GetHeaderSize());
+
+   // Write the feature flags in the footer
+   descBuilder.SetFeature(RNTupleDescriptor::kFeatureFlagTest);
+
+   auto szFooter = serializer.SerializeFooter(nullptr, descBuilder.GetDescriptor(), ctx).Unwrap();
+   buffer = std::make_unique<unsigned char[]>(szFooter);
+   serializer.SerializeFooter(buffer.get(), descBuilder.GetDescriptor(), ctx);
+   writer->WriteNTupleFooter(buffer.get(), szFooter, szFooter);
+
+   writer->Commit();
+   // Call destructor to flush data to disk
+   writer = nullptr;
+
+   auto pageSource = RPageSource::Create("ntpl", fileGuard.GetPath());
+   try {
+      pageSource->Attach();
+      FAIL() << "opening an RNTuple that uses an unsupported feature should fail";
+   } catch (const ROOT::RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("unsupported format feature: 137"));
+   }
+}
+
 TEST(RNTupleCompat, FwdCompat_FutureNTupleAnchor)
 {
    using ROOT::RXTuple;


### PR DESCRIPTION
For compliance with the specs, the serializer should behave the same in the header and the footer in regards to feature flags, and the proper behavior when finding unknown flags is failing.

This PR must be backported, likely up to 6.36.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


