### PR TITLE
[ML] Fix cluster count handling during filtered dataset split

### DIFF
--- a/tree/ml/inc/ROOT/ML/RDataLoaderEngine.hxx
+++ b/tree/ml/inc/ROOT/ML/RDataLoaderEngine.hxx
@@ -297,12 +297,9 @@ public:
             break;
          }
 
-         const std::size_t numTrainingClusters = fClusterLoader->GetNumTrainingClusters();
-         const std::size_t numValidationClusters = fClusterLoader->GetNumValidationClusters();
-
          // Helper: check if validation queue below watermark and needs the producer
          auto validationEmpty = [&] {
-            if (!fValidationEpochActive || fValidationClusterIdx >= numValidationClusters)
+            if (!fValidationEpochActive || fValidationClusterIdx >= fClusterLoader->GetNumValidationClusters())
                return false;
             if (fValidationBatchLoader->isProducerDone())
                return false;
@@ -311,6 +308,8 @@ public:
 
          // -- TRAINING --
          if (fTrainingEpochActive) {
+            const std::size_t numTrainingClusters = fClusterLoader->GetNumTrainingClusters();
+
             while (true) {
                // Stop conditions (shutdown or epoch end)
                if (!fIsActive || !fTrainingEpochActive)
@@ -397,6 +396,8 @@ public:
 
          // -- VALIDATION --
          if (fValidationEpochActive) {
+            const std::size_t numValidationClusters = fClusterLoader->GetNumValidationClusters();
+
             while (true) {
                // Stop conditions (shutdown or epoch end)
                if (!fIsActive || !fValidationEpochActive)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This fixes a race condition caused by caching cluster counts (`numTrainingClusters`, `numValidationClusters`) at the start of the loading loop, this causes an issue for the case of filtered datasets, where the number of clusters is not fully known until split discovery is finalized, which happens lazily during training:

On some platforms (notably arm64 CI) the scheduling allows this interleaving to happen:

- training starts with incomplete cluster information
- we cash the values of `numTrainingClusters`, `numValidationClusters`
- we start loading clusters for training --> this can update the value of `numValidationClusters`
- validation is activated, still sees the old value of `numValidationClusters`
- the loader incorrectly believes there are no validation clusters left
- Python receives an unexpected StopIteration

## Checklist:

- [x] tested changes locally