### PR TITLE
[Python] Use `is not` instead of `!=` in _gROOTWrapper

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -35,7 +35,7 @@ class _gROOTWrapper(object):
         return gROOT
 
     def __getattr__(self, name):
-        if name != "SetBatch" and self._facade.__dict__["gROOT"] != self._gROOT:
+        if name != "SetBatch" and self._facade.__dict__["gROOT"] is not self._gROOT:
             self._facade._finalSetup()
         return getattr(self._gROOT, name)
 


### PR DESCRIPTION
The check is asking whether _finalSetup() has already replaced the facade's `gROOT` slot with the real TROOT*, which is purely an identity question. Using `!=` invokes the cppyy comparison machinery, which considers TROOT's `operator==` as a candidate. That is undesirable: the left-hand side is an unrelated Python wrapper type, so falling back to identity comparison is the only sensible outcome anyway. Using `is not` expresses this directly and avoids involving cppyy's overload resolution.

This is part of the campaign to only use equality comparisons that would also semantically be allowed in C++, if possible.