### PR TITLE
[ntuple] add read support to SoA I/O

### DIFF
--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -31,6 +31,10 @@ namespace Detail {
 class RFieldVisitor;
 } // namespace Detail
 
+namespace Experimental {
+class RSoAField;
+}
+
 namespace Internal {
 std::unique_ptr<RFieldBase> CreateEmulatedVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
                                                       std::string_view emulatedFromType);
@@ -112,6 +116,7 @@ public:
 /// The type-erased field for a RVec<Type>
 class RRVecField : public RFieldBase {
    friend class RArrayAsRVecField; // to use the RRVecDeleter and to call ResizeRVec()
+   friend class ROOT::Experimental::RSoAField; // to call ResizeRVec()
 
    // Ensures that the RVec pointed to by rvec has at least nItems valid elements
    // Returns the possibly new "begin pointer" of the RVec, i.e. the pointer to the data area.

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -66,6 +66,8 @@ class RSoAField : public RFieldBase {
    /// The offset of the RVec members in the SoA type in the order of subfields of the underlying record type.
    /// In particular, the order is not necessarily the same then the order of RVec members in the SoA class.
    std::vector<std::size_t> fSoAMemberOffsets;
+   ///< A deleter returned by each record member's GetDeleter()
+   std::vector<std::unique_ptr<RDeleter>> fRecordMemberDeleters;
    std::size_t fMaxAlignment = 1;
    ROOT::Internal::RColumnIndex fNWritten;
 
@@ -84,8 +86,6 @@ protected:
 
    std::size_t AppendImpl(const void *from) final;
    void ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to) final;
-
-   void ReconcileOnDiskField(const RNTupleDescriptor &) final {}
 
    void CommitClusterImpl() final { fNWritten = 0; }
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <typeinfo>
 #include <vector>
@@ -70,6 +71,13 @@ class RSoAField : public RFieldBase {
    std::vector<std::unique_ptr<RDeleter>> fRecordMemberDeleters;
    std::size_t fMaxAlignment = 1;
    ROOT::Internal::RColumnIndex fNWritten;
+
+   /// For reading and writing, the RVecs of the SoA class do not have a dedicated field. The in-memory RVecs of the
+   /// SoA object are used directly with the subfields of the underlying record type. For splitting a SoA class object
+   /// (SplitValue()), however, we need actual RRVecFields so that we can recursively split the in-memory SoA value.
+   /// The split fields are created only when SplitField() is called.
+   mutable std::unique_ptr<std::vector<std::unique_ptr<ROOT::RRVecField>>> fSplitFields;
+   mutable std::unique_ptr<std::mutex> fLockSplitFields; ///< protects the fSplitFields member.
 
    RSoAField(std::string_view fieldName, const RSoAField &source); ///< Used by CloneImpl
    RSoAField(std::string_view fieldName, TClass *clSoA);

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -104,8 +104,7 @@ public:
    /// of any user object. If the class is not polymorphic, return nullptr.
    /// TODO(jblomer): use information in unique pointer field
    const std::type_info *GetPolymorphicTypeInfo() const;
-   // TODO(jblomer)
-   // void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
+   void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 
    TClass *GetSoAClass() const { return fSoAClass; }
 };

--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -90,6 +90,7 @@ public:
    virtual void VisitVectorField(const ROOT::RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const ROOT::RField<std::vector<bool>> &field) { VisitField(field); }
    virtual void VisitRVecField(const ROOT::RRVecField &field) { VisitField(field); }
+   virtual void VisitSoAField(const ROOT::Experimental::RSoAField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail

--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -236,6 +236,7 @@ public:
    void VisitNullableField(const ROOT::RNullableField &field) final;
    void VisitEnumField(const ROOT::REnumField &field) final;
    void VisitAtomicField(const ROOT::RAtomicField &field) final;
+   void VisitSoAField(const ROOT::Experimental::RSoAField &field) final;
 };
 
 // clang-format off

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -665,6 +665,7 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, const RSoAF
    fRecordMemberDeleters.reserve(fRecordMemberFields.size());
    for (const auto f : fRecordMemberFields)
       fRecordMemberDeleters.emplace_back(GetDeleterOf(*f));
+   fLockSplitFields = std::make_unique<std::mutex>();
 }
 
 ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, std::string_view className)
@@ -777,6 +778,7 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, TClass *clS
       fTypeAlias = renormalizedAlias;
 
    fTraits |= kTraitSoACollection | kTraitTypeChecksum;
+   fLockSplitFields = std::make_unique<std::mutex>();
 }
 
 std::unique_ptr<ROOT::RFieldBase> ROOT::Experimental::RSoAField::CloneImpl(std::string_view newName) const
@@ -881,10 +883,31 @@ void ROOT::Experimental::RSoAField::RSoADeleter::operator()(void *objPtr, bool d
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
-std::vector<ROOT::RFieldBase::RValue> ROOT::Experimental::RSoAField::SplitValue(const RValue & /* value */) const
+std::vector<ROOT::RFieldBase::RValue> ROOT::Experimental::RSoAField::SplitValue(const RValue &value) const
 {
-   throw RException(R__FAIL("not yet implemented"));
-   return std::vector<RValue>();
+   const auto nSoAMembers = fSoAMemberOffsets.size();
+
+   {
+      std::lock_guard<std::mutex> lockGuard(*fLockSplitFields);
+      if (!fSplitFields) {
+         fSplitFields = std::make_unique<std::vector<std::unique_ptr<ROOT::RRVecField>>>();
+         fSplitFields->reserve(nSoAMembers);
+         for (std::size_t i = 0; i < nSoAMembers; ++i) {
+            const auto itemField = fRecordMemberFields[i];
+            fSplitFields->emplace_back(std::make_unique<RRVecField>(itemField->GetFieldName(), itemField->Clone("_0")));
+         }
+      }
+   }
+
+   auto valuePtr = value.GetPtr<void>();
+   auto soaPtr = static_cast<unsigned char *>(valuePtr.get());
+   std::vector<RValue> values;
+   values.reserve(nSoAMembers);
+   for (std::size_t i = 0; i < nSoAMembers; ++i) {
+      values.emplace_back(
+         (*fSplitFields)[i]->BindValue(std::shared_ptr<void>(valuePtr, soaPtr + fSoAMemberOffsets[i])));
+   }
+   return values;
 }
 
 size_t ROOT::Experimental::RSoAField::GetValueSize() const

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -912,6 +912,11 @@ const std::type_info *ROOT::Experimental::RSoAField::GetPolymorphicTypeInfo() co
    return fSoAClass->GetTypeInfo();
 }
 
+void ROOT::Experimental::RSoAField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const
+{
+   visitor.VisitSoAField(*this);
+}
+
 //------------------------------------------------------------------------------
 
 ROOT::REnumField::REnumField(std::string_view fieldName, std::string_view enumName)

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -662,6 +662,9 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, const RSoAF
    fTraits = source.GetTraits();
    Attach(source.fSubfields[0]->Clone(source.fSubfields[0]->GetFieldName()));
    fRecordMemberFields = fSubfields[0]->GetMutableSubfields();
+   fRecordMemberDeleters.reserve(fRecordMemberFields.size());
+   for (const auto f : fRecordMemberFields)
+      fRecordMemberDeleters.emplace_back(GetDeleterOf(*f));
 }
 
 ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, std::string_view className)
@@ -700,6 +703,8 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, TClass *clS
    fRecordMemberFields = fSubfields[0]->GetMutableSubfields();
 
    std::unordered_map<std::string, std::size_t> recordFieldNameToIdx;
+   fRecordMemberDeleters.reserve(fRecordMemberFields.size());
+   recordFieldNameToIdx.reserve(fRecordMemberFields.size());
    for (std::size_t i = 0; i < fRecordMemberFields.size(); ++i) {
       const RFieldBase *f = fRecordMemberFields[i];
       assert(!f->GetFieldName().empty());
@@ -707,6 +712,7 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, TClass *clS
          throw RException(R__FAIL("SoA fields with inheritance are currently unsupported"));
       }
       recordFieldNameToIdx[f->GetFieldName()] = i;
+      fRecordMemberDeleters.emplace_back(GetDeleterOf(*f));
    }
 
    const auto *bases = fSoAClass->GetListOfBases();
@@ -840,9 +846,28 @@ std::size_t ROOT::Experimental::RSoAField::AppendImpl(const void *from)
    return nbytes + fPrincipalColumn->GetElement()->GetPackedSize();
 }
 
-void ROOT::Experimental::RSoAField::ReadGlobalImpl(ROOT::NTupleSize_t /* globalIndex */, void * /* to */)
+void ROOT::Experimental::RSoAField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)
 {
-   throw RException(R__FAIL("not yet implemented"));
+   // Read collection info for this entry
+   ROOT::NTupleSize_t N;
+   RNTupleLocalIndex collectionStart;
+   fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &N);
+
+   const auto nSoAMembers = fSoAMemberOffsets.size();
+   for (std::size_t i = 0; i < nSoAMembers; ++i) {
+      RFieldBase *memberField = fRecordMemberFields[i];
+      const auto memberSize = memberField->GetValueSize();
+      void *rvecPtr = static_cast<unsigned char *>(to) + fSoAMemberOffsets[i];
+      auto begin = ROOT::RRVecField::ResizeRVec(rvecPtr, N, memberSize, memberField, fRecordMemberDeleters[i].get());
+
+      if (memberField->IsSimple() && N) {
+         GetPrincipalColumnOf(*memberField)->ReadV(collectionStart, N, begin);
+      } else {
+         for (std::size_t j = 0; j < N; ++j) {
+            CallReadOn(*memberField, collectionStart + j, begin + (j * memberSize));
+         }
+      }
+   }
 }
 
 void ROOT::Experimental::RSoAField::ConstructValue(void *where) const

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -408,6 +408,11 @@ void ROOT::Internal::RPrintValueVisitor::VisitRVecField(const ROOT::RRVecField &
    PrintCollection(field);
 }
 
+void ROOT::Internal::RPrintValueVisitor::VisitSoAField(const ROOT::Experimental::RSoAField &field)
+{
+   PrintRecord(field);
+}
+
 //---------------------------- RNTupleFormatter --------------------------------
 
 std::string ROOT::Internal::RNTupleFormatter::FitString(const std::string &str, int availableSpace)

--- a/tree/ntuple/test/SoAField.hxx
+++ b/tree/ntuple/test/SoAField.hxx
@@ -91,4 +91,27 @@ struct SoASimpleWrongMember {
    ClassDefNV(SoASimpleWrongMember, 2);
 };
 
+/// class with non-trivial constructor and destructor
+struct ComplexMember {
+   inline static int gNCallConstructor = 0;
+   inline static int gNCallDestructor = 0;
+
+   ComplexMember() { gNCallConstructor++; }
+   ~ComplexMember() { gNCallDestructor++; }
+
+   ClassDefNV(ComplexMember, 2);
+};
+
+struct RecordComplex {
+   ComplexMember fA;
+
+   ClassDefNV(RecordComplex, 2);
+};
+
+struct SoAComplex {
+   ROOT::RVec<ComplexMember> fA;
+
+   ClassDefNV(SoAComplex, 2);
+};
+
 #endif // ROOT_RNTuple_Test_SoAField

--- a/tree/ntuple/test/SoAFieldLinkDef.h
+++ b/tree/ntuple/test/SoAFieldLinkDef.h
@@ -21,4 +21,8 @@
 #pragma link C++ options=rntupleSoARecord(RecordSimple) class SoASimpleMissingMember+;
 #pragma link C++ options=rntupleSoARecord(RecordSimple) class SoASimpleWrongMember+;
 
+#pragma link C++ class ComplexMember+;
+#pragma link C++ class RecordComplex+;
+#pragma link C++ options=rntupleSoARecord(RecordComplex) class SoAComplex+;
+
 #endif // __CLING__

--- a/tree/ntuple/test/ntuple_soa.cxx
+++ b/tree/ntuple/test/ntuple_soa.cxx
@@ -1,6 +1,7 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldUtils.hxx>
+#include <ROOT/RFieldVisitor.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleReader.hxx>
 #include <ROOT/RNTupleView.hxx>
@@ -15,6 +16,7 @@
 #include <TVirtualStreamerInfo.h>
 
 #include <memory>
+#include <sstream>
 #include <utility>
 
 #include "gmock/gmock.h"
@@ -414,4 +416,55 @@ TEST(RNTuple, SoAFromVector)
       EXPECT_THAT(e.what(), testing::HasSubstr(
                                "in-memory field simple of type SoASimple is incompatible with on-disk field simple"));
    }
+}
+
+TEST(RNTuple, SoAShow)
+{
+   ROOT::TestSupport::FileRaii fileGuard("test_rntuple_soa_show.root");
+
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      model->AddField(std::make_unique<RSoAField>("simple", "SoASimple"));
+      model->AddField(std::make_unique<RSoAField>("empty", "SoA"));
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      auto simpleSoA = writer->GetModel().GetDefaultEntry().GetPtr<SoASimple>("simple");
+      auto emptySoA = writer->GetModel().GetDefaultEntry().GetPtr<SoA>("empty");
+
+      simpleSoA->fX.push_back(1.0);
+      simpleSoA->fY.push_back(2.0);
+      simpleSoA->fX.push_back(3.0);
+      simpleSoA->fY.push_back(4.0);
+      writer->Fill();
+
+      simpleSoA->fX.clear();
+      simpleSoA->fY.clear();
+      writer->Fill();
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+
+   std::ostringstream os;
+   reader->Show(0, os);
+   reader->Show(1, os);
+
+   // clang-format off
+   std::string expected{
+R"({
+  "simple": {
+    "fX": [1, 3],
+    "fY": [2, 4]
+  },
+  "empty": {  }
+}
+{
+  "simple": {
+    "fX": [],
+    "fY": []
+  },
+  "empty": {  }
+}
+)" };
+   // clang-format on
+   EXPECT_EQ(expected, os.str());
 }

--- a/tree/ntuple/test/ntuple_soa.cxx
+++ b/tree/ntuple/test/ntuple_soa.cxx
@@ -264,3 +264,154 @@ TEST(RNTuple, SoASimpleSwapped)
    EXPECT_FLOAT_EQ(1.0, v(0).at(0).fX);
    EXPECT_FLOAT_EQ(2.0, v(0).at(0).fY);
 }
+
+TEST(RNTuple, SoABasicWriteRead)
+{
+   ROOT::TestSupport::FileRaii fileGuard("test_rntuple_soa_write_read.root");
+
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      model->AddField(std::make_unique<RSoAField>("simple", "SoASimple"));
+      model->AddField(std::make_unique<RSoAField>("empty", "SoA"));
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      auto simpleSoA = writer->GetModel().GetDefaultEntry().GetPtr<SoASimple>("simple");
+      auto emptySoA = writer->GetModel().GetDefaultEntry().GetPtr<SoA>("empty");
+
+      simpleSoA->fX.push_back(1.0);
+      simpleSoA->fY.push_back(2.0);
+      writer->Fill();
+      writer->CommitCluster();
+
+      simpleSoA->fX.clear();
+      simpleSoA->fY.clear();
+      writer->Fill();
+
+      simpleSoA->fX.push_back(3.0);
+      simpleSoA->fY.push_back(4.0);
+      simpleSoA->fX.push_back(5.0);
+      simpleSoA->fY.push_back(6.0);
+      writer->Fill();
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(3u, reader->GetNEntries());
+   auto simpleSoA = reader->GetModel().GetDefaultEntry().GetPtr<SoASimple>("simple");
+
+   reader->LoadEntry(0);
+   EXPECT_EQ(1U, simpleSoA->fX.size());
+   EXPECT_EQ(1U, simpleSoA->fY.size());
+   EXPECT_FLOAT_EQ(1.0, simpleSoA->fX[0]);
+   EXPECT_FLOAT_EQ(2.0, simpleSoA->fY[0]);
+
+   reader->LoadEntry(1);
+   EXPECT_TRUE(simpleSoA->fX.empty());
+   EXPECT_TRUE(simpleSoA->fY.empty());
+
+   reader->LoadEntry(2);
+   EXPECT_EQ(2U, simpleSoA->fX.size());
+   EXPECT_EQ(2U, simpleSoA->fY.size());
+   EXPECT_FLOAT_EQ(3.0, simpleSoA->fX[0]);
+   EXPECT_FLOAT_EQ(4.0, simpleSoA->fY[0]);
+   EXPECT_FLOAT_EQ(5.0, simpleSoA->fX[1]);
+   EXPECT_FLOAT_EQ(6.0, simpleSoA->fY[1]);
+}
+
+TEST(RNTuple, SoAReadAdopted)
+{
+   ROOT::TestSupport::FileRaii fileGuard("test_rntuple_soa_read_adopted.root");
+
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      model->AddField(std::make_unique<RSoAField>("simple", "SoASimple"));
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      auto simpleSoA = writer->GetModel().GetDefaultEntry().GetPtr<SoASimple>("simple");
+
+      simpleSoA->fX.push_back(1.0);
+      simpleSoA->fY.push_back(2.0);
+      simpleSoA->fX.push_back(3.0);
+      simpleSoA->fY.push_back(4.0);
+      writer->Fill();
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(1u, reader->GetNEntries());
+
+   auto viewSize = reader->GetView<ROOT::RNTupleCardinality<std::uint64_t>>("simple");
+   EXPECT_EQ(2u, viewSize(0));
+
+   float x[2] = {.0, .0};
+   float y[2] = {.0, .0};
+   SoASimple soa;
+   soa.fX = ROOT::RVec<float>(x, 2);
+   soa.fY = ROOT::RVec<float>(y, 2);
+   auto viewSoA = reader->GetView("simple", &soa, "SoASimple");
+   viewSoA(0);
+   EXPECT_FLOAT_EQ(1.0, x[0]);
+   EXPECT_FLOAT_EQ(2.0, y[0]);
+   EXPECT_FLOAT_EQ(3.0, x[1]);
+   EXPECT_FLOAT_EQ(4.0, y[1]);
+}
+
+TEST(RNTuple, SoAReadComplex)
+{
+   ROOT::TestSupport::FileRaii fileGuard("test_rntuple_soa_read_complex.root");
+
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      model->AddField(std::make_unique<RSoAField>("complex", "SoAComplex"));
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      auto complexSoA = writer->GetModel().GetDefaultEntry().GetPtr<SoAComplex>("complex");
+
+      complexSoA->fA.resize(2);
+      writer->Fill();
+      complexSoA->fA.clear();
+      writer->Fill();
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   EXPECT_EQ(2u, reader->GetNEntries());
+
+   auto complexSoA = reader->GetModel().GetDefaultEntry().GetPtr<SoAComplex>("complex");
+   ComplexMember::gNCallConstructor = 0;
+   ComplexMember::gNCallDestructor = 0;
+
+   reader->LoadEntry(0);
+   EXPECT_EQ(2U, complexSoA->fA.size());
+   EXPECT_EQ(2, ComplexMember::gNCallConstructor);
+   EXPECT_EQ(0, ComplexMember::gNCallDestructor);
+
+   reader->LoadEntry(1);
+   EXPECT_TRUE(complexSoA->fA.empty());
+   EXPECT_EQ(2, ComplexMember::gNCallConstructor);
+   EXPECT_EQ(2, ComplexMember::gNCallDestructor);
+}
+
+TEST(RNTuple, SoAFromVector)
+{
+   ROOT::TestSupport::FileRaii fileGuard("test_rntuple_soa_from_vector.root");
+
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto v = model->MakeField<std::vector<RecordSimple>>("simple");
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      v->emplace_back(RecordSimple{1.0, 2.0});
+
+      writer->Fill();
+   }
+
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   SoASimple soa;
+
+   // Until SoA schema evolution is implemented, the reading the vector as SoA will
+   try {
+      reader->GetView("simple", &soa, "SoASimple");
+      FAIL() << "reading a vector with a SoA field should fail";
+   } catch (const ROOT::RException &e) {
+      EXPECT_THAT(e.what(), testing::HasSubstr(
+                               "in-memory field simple of type SoASimple is incompatible with on-disk field simple"));
+   }
+}

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -100,6 +100,8 @@ if(MSVC AND NOT win_broken_tests)
                           io/ntuple/ntpl013_staged.C
                           io/ntuple/ntpl014_framework.C
                           io/ntuple/ntpl017_shared_reader.C)
+  # The RNTuple SoA tutorial fails on Windows if interpreted for unknown reasons
+  list(APPEND ntuple_veto io/ntuple/ntpl020_soa.C)
 endif()
 
 # TODO: fix the problem and re-enable the tutorial test. The rf615 tutorial

--- a/tutorials/io/ntuple/ntpl020_soa.C
+++ b/tutorials/io/ntuple/ntpl020_soa.C
@@ -1,0 +1,137 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Example of RNTuple I/O on collections with a SoA memory layout
+///
+/// RNTuple on-disk collections can be used in struct-of-arrays (SoA) memory layout.
+/// An RNTuple SoA class consists of persistent members of type `RVec` corresponding to
+/// and underlying record type, as shown in this tutorial.
+///
+/// NOTE: The RNTuple SoA I/O is still experimental at this point.
+/// Functionality and interface are subject to changes.
+///
+/// \macro_code
+///
+/// \date April 2026
+/// \author The ROOT Team
+
+#include <ROOT/REntry.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleReader.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RVec.hxx>
+
+#include <TCanvas.h>
+#include <TClass.h>
+#include <TDictAttributeMap.h>
+#include <TEllipse.h>
+#include <TGraph.h>
+#include <TRandom.h>
+
+#include <iostream>
+#include <memory>
+
+constexpr const char *kFileName = "ntpl020_soa.root";
+constexpr const char *kNTupleName = "ntpl";
+
+// The SoA class for this tutorial. Contains a number of 2D points. All vectors have to have the same length.
+// Note that RVecs can adopt memory.
+struct PointSoA {
+   ROOT::RVec<float> fX;
+   ROOT::RVec<float> fY;
+};
+
+// The underlying record type for the SoA class. Members between the SoA class and the underlying record type
+// are matched by name. Every member of type `T` in the underlying record type has to be of type `ROOT::RVec<T>` in
+// the SoA class.
+struct PointRecord {
+   float fX;
+   float fY;
+};
+
+void Write()
+{
+   // Create a model with a SoA field
+   auto model = ROOT::RNTupleModel::CreateBare();
+   model->AddField(ROOT::RFieldBase::Create("points", "PointSoA").Unwrap());
+
+   auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), kNTupleName, kFileName);
+   auto entry = writer->GetModel().CreateBareEntry();
+
+   for (auto nPoints : {100, 500, 1000, 10000}) {
+      // We will use our own memory are to store the points
+      auto memory = std::make_unique<float[]>(nPoints * 2);
+
+      // Create random points in the unit square
+      gRandom->RndmArray(2 * nPoints, memory.get());
+
+      // Adopt the memory by a PointSoA object. First all x values, then all y values.
+      PointSoA points{ROOT::RVec<float>(memory.get(), nPoints), ROOT::RVec<float>(memory.get() + nPoints, nPoints)};
+
+      entry->BindRawPtr("points", &points);
+      writer->Fill(*entry);
+   }
+}
+
+void Read()
+{
+   auto reader = ROOT::RNTupleReader::Open(kNTupleName, kFileName);
+
+   // Show on-disk layout: collection of underlying record type (AoS)
+   reader->PrintInfo();
+
+   // Used to draw the points
+   auto canvas = new TCanvas("c", "", 1200, 1200);
+   canvas->Divide(2, 2);
+
+   // Read back the points in two steps: first get the size and then read into adopted RVecs.
+   auto viewSize = reader->GetCollectionView("points");
+   PointSoA points;
+   auto viewSoA = reader->GetView("points", &points, "PointSoA");
+
+   for (auto i : reader->GetEntryRange()) {
+      const auto N = viewSize(i); // size of this entry's SoA collection
+      auto memory = std::make_unique<float[]>(N * 2);
+
+      points.fX = ROOT::RVec<float>(memory.get(), N);
+      points.fY = ROOT::RVec<float>(memory.get() + N, N);
+      viewSoA(i);
+
+      // Use the raw memory area to draw the points
+      canvas->cd(i + 1);
+      auto *graph = new TGraph(N, &memory[0], &memory[N]);
+      graph->SetTitle((std::to_string(N) + " Points").c_str());
+      graph->SetMarkerStyle(29);
+      graph->SetMarkerSize(1);
+      graph->SetMarkerColor(kRed);
+      graph->Draw("AP");
+      auto *circle = new TEllipse(0.5, 0.5, 0.5, 0.5);
+      circle->SetFillStyle(0);
+      circle->SetLineColor(kBlue);
+      circle->SetLineWidth(4);
+      circle->Draw();
+
+      // Use adopted RVec's to approximate PI
+      points.fX -= 0.5;
+      points.fY -= 0.5;
+      auto isInCircle = points.fX * points.fX + points.fY * points.fY < 0.25;
+      auto hits = ROOT::VecOps::Sum(isInCircle);
+      float approxPI = 4.0 * static_cast<float>(hits) / static_cast<float>(N);
+      std::cout << "Approximated PI with " << N << " points to " << approxPI << std::endl;
+   }
+   canvas->Update();
+}
+
+void ntpl020_soa()
+{
+   // Usually, the SoA class dictionary definition would mark it as a SoA class of the corresponding
+   // underlying record type like this
+   //     #pragma link C++ options=rntupleSoARecord(PointRecord) class PointSoA+;
+   // For the interpreted classes in this tutorial, we mark the SoA class at runtime:
+   auto cl = TClass::GetClass("PointSoA");
+   cl->CreateAttributeMap();
+   cl->GetAttributeMap()->AddProperty("rntuple.SoARecord", "PointRecord");
+
+   Write();
+   Read();
+}


### PR DESCRIPTION
Part of #19230

Tutorial output:
```
************************************ NTUPLE ************************************
* N-Tuple : ntpl                                                               *
* Entries : 4                                                                  *
********************************************************************************
* Field 1           : points (PointSoA)                                        *
*   Field 1.1       : _0 (PointRecord)                                         *
*     Field 1.1.1   : fX (float)                                               *
*     Field 1.1.2   : fY (float)                                               *
********************************************************************************
Approximated PI with 100 points to 3.2
Approximated PI with 500 points to 3.104
Approximated PI with 1000 points to 3.172
Approximated PI with 10000 points to 3.1388
```

<img width="1136" height="1145" alt="image" src="https://github.com/user-attachments/assets/a4366446-1e2a-4698-88cc-bcfa70efce7a" />
