### PR TITLE
[Tutorials] Fix warning when subclassing base with no virtual destructor

### DIFF
--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
@@ -90,7 +90,7 @@ class HypoTestInvTool {
 
    public:
    HypoTestInvTool();
-   ~HypoTestInvTool(){};
+   virtual ~HypoTestInvTool() {}
 
    HypoTestInverterResult *RunInverter(RooWorkspace *w, const char *modelSBName, const char *modelBName,
    const char *dataName, int type, int testStatType, bool useCLs, int npoints,


### PR DESCRIPTION
Fixes the following cppyy warning:
```txt
class "RooStats::HypoTestInvTool" has no virtual destructor
  class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
```

These kind of warnings need to be fixed, because at some point we want to treat warnings as errors in the Python tests, including the tutorial tests.