### PR TITLE
[6.38] Mark initialization method of DistRDF Base as `staticmethod`

### DIFF
--- a/bindings/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/distrdf/python/DistRDF/Backends/Base.py
@@ -201,7 +201,7 @@ class BaseBackend(ABC):
 
             **kwargs (dict): Keyword arguments used to execute the function.
         """
-        cls.initialization = partial(fun, *args, **kwargs)    
+        cls.initialization = staticmethod(partial(fun, *args, **kwargs))
         fun(*args, **kwargs) 
 
     @classmethod


### PR DESCRIPTION
We were missing a backport of https://github.com/root-project/root/pull/21021 for 6.38