### PR TITLE
[CMake] Warn if the build type is omitted in a single-config generator.

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -16,6 +16,8 @@ if(NOT GENERATOR_IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)
   if(NOT CMAKE_C_FLAGS AND NOT CMAKE_CXX_FLAGS AND NOT CMAKE_Fortran_FLAGS)
     set(CMAKE_BUILD_TYPE Release CACHE STRING
       "Specifies the build type on single-configuration generators" FORCE)
+  else()
+    message(WARNING "CMAKE_BUILD_TYPE is not set. Please set it or specify any relevant compilation flag, including optimization level, in CMAKE_CXX_FLAGS.")
   endif()
 endif()
 


### PR DESCRIPTION
A user reported a performance regression to @vepadulano for RNT, which turned out to be missing optimisation flags. These were missing because the user didn't choose a build type, but had set CMAKE_CXX_FLAGS.
An empty build type is supported in CMake (the assumption is that all flags will be specified in the `CXX_FLAGS`), but ROOT will now warn that all relevant compilation flags should be specified by the user.
