### PR TITLE
[CMake] Update two CMake policies to NEW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ foreach(directoryName IN ITEMS ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_I
 endforeach()
 
 set(policy_new CMP0072 CMP0076 CMP0077 CMP0079
+    CMP0135 # Timestamps of downloaded archives are set to time of extraction
+    CMP0144 # <PACKAGENAME>_ROOT (converted to upper case) can be used to search for dependencies
     CMP0156 CMP0179 #deduplicate static libraries when linker supports it
 )
 foreach(policy ${policy_new})
@@ -40,7 +42,7 @@ foreach(policy ${policy_new})
   endif()
 endforeach()
 
-set(policy_old CMP0116 CMP0135 CMP0144)
+set(policy_old CMP0116)
 foreach(policy ${policy_old})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} OLD)


### PR DESCRIPTION
The two policies in question should not affect ROOT:
- ROOT does not use `<PACKAGENAME>_ROOT` for purposes other than finding a package, so the NEW version of the policy is fine.
- And it is preferable to update the timestamps of files extracted from an archive if the URL changes (NEW) as opposed to keeping the timestamps found in the archive (OLD).
