### PR TITLE
[df] Remove redundant call to FinalizeSlot

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1350,7 +1350,6 @@ void ROOT::Detail::RDF::RLoopManager::DataSourceThreadTask(const std::pair<ULong
       std::cerr << "RDataFrame::Run: event loop was interrupted\n";
       throw;
    }
-   fDataSource->FinalizeSlot(slot);
 #else
    (void)entryRange;
    (void)slotStack;


### PR DESCRIPTION
Already called by the destructor of RDSRangeRAII
