### PR TITLE
Improve PS/PDF/SVG/ImageDump classes

### DIFF
--- a/core/base/inc/TVirtualPS.h
+++ b/core/base/inc/TVirtualPS.h
@@ -44,6 +44,7 @@ protected:
 
    Bool_t         OpenStream(const char *fname, Bool_t binary = kFALSE);
    void           CloseStream();
+   void           ClearBuffer();
 
 public:
    TVirtualPS();

--- a/core/base/src/TVirtualPS.cxx
+++ b/core/base/src/TVirtualPS.cxx
@@ -62,9 +62,18 @@ TVirtualPS::TVirtualPS(const char *name, Int_t)
 
 TVirtualPS::~TVirtualPS()
 {
-   if (fBuffer)
-      delete [] fBuffer;
+   delete [] fBuffer;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clear content of internal buffer
+
+void TVirtualPS::ClearBuffer()
+{
+   for (Int_t i = 0; i < fSizBuffer; ++i)
+      fBuffer[i] = ' ';
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Open output stream

--- a/graf2d/asimage/inc/TASPluginGS.h
+++ b/graf2d/asimage/inc/TASPluginGS.h
@@ -25,7 +25,7 @@
 class TASPluginGS : public TASImagePlugin {
 
 private:
-   char  *fInterpreter;   ///< path to GhostScript interpreter
+   TString fGsExe;   ///< path to GhostScript interpreter
 
 public:
    TASPluginGS(const char *ext);

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -2633,17 +2633,17 @@ void TASImage::DrawText(Int_t x, Int_t y, const char *text, Int_t size,
    fn.Strip();
 
    // This is for backward compatibility...
-   if (fn.Last('/') == 0) fn = fn(1, fn.Length() - 1);
+   if (fn.Last('/') == 0)
+      fn = fn(1, fn.Length() - 1);
 
    const char *ttpath = gEnv->GetValue("Root.TTFontPath",
                                        TROOT::GetTTFFontDir());
-   char *tmpstr = gSystem->Which(ttpath, fn, kReadPermission);
-   fn = tmpstr;
-   delete [] tmpstr;
 
-   if (fn.EndsWith(".pfa") || fn.EndsWith(".PFA") || fn.EndsWith(".pfb") || fn.EndsWith(".PFB") || fn.EndsWith(".ttf") || fn.EndsWith(".TTF") || fn.EndsWith(".otf") || fn.EndsWith(".OTF")) {
+   // if file will be found, fn will contain full name - otherwise empty
+   gSystem->FindFile(ttpath, fn, kReadPermission);
+
+   if (fn.EndsWith(".pfa") || fn.EndsWith(".PFA") || fn.EndsWith(".pfb") || fn.EndsWith(".PFB") || fn.EndsWith(".ttf") || fn.EndsWith(".TTF") || fn.EndsWith(".otf") || fn.EndsWith(".OTF"))
       ttfont = kTRUE;
-   }
 
    if (color) {
       parse_argb_color(color, &text_color);
@@ -2663,7 +2663,7 @@ void TASImage::DrawText(Int_t x, Int_t y, const char *text, Int_t size,
       return;
    }
 
-   ASFont *font = get_asfont(gFontManager, fn.Data(), 0, size, ASF_GuessWho);
+   ASFont *font = fn.IsNull() ? nullptr : get_asfont(gFontManager, fn.Data(), 0, size, ASF_GuessWho);
 
    if (!font) {
       font = get_asfont(gFontManager, "fixed", 0, size, ASF_GuessWho);

--- a/graf2d/asimage/src/TASPluginGS.cxx
+++ b/graf2d/asimage/src/TASPluginGS.cxx
@@ -46,14 +46,14 @@ Allows to read PS/EPS/PDF files via GhostScript
 TASPluginGS::TASPluginGS(const char *ext) : TASImagePlugin(ext)
 {
 #ifndef WIN32
-   fInterpreter = gSystem->Which(gSystem->Getenv("PATH"), "gs", kExecutePermission);
+   fGsExe = "gs";
+   gSystem->FindFile(gSystem->Getenv("PATH"), fGsExe, kExecutePermission);
 #else
-   fInterpreter = gSystem->Which(gSystem->Getenv("PATH"), "gswin32c.exe", kExecutePermission);
-   if (fInterpreter) {
-      // which returned path may include blanks, like "Program Files" which popen does not like
-      delete [] fInterpreter;
-      fInterpreter = StrDup("gswin32c.exe");
-   }
+   fGsExe = "gswin32c.exe";
+   // FindFile returned path may include blanks, like "Program Files" which popen does not like
+   // Therefore if executable found in defined paths, just use it name as is
+   if (gSystem->FindFile(gSystem->Getenv("PATH"), fGsExe, kExecutePermission))
+      fGsExe = "gswin32c.exe";
 #endif
 }
 
@@ -63,9 +63,6 @@ TASPluginGS::TASPluginGS(const char *ext) : TASImagePlugin(ext)
 TASPluginGS::~TASPluginGS()
 {
    ROOT::CallRecursiveRemoveIfNeeded(*this);
-
-   delete [] fInterpreter;
-   fInterpreter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,7 +70,7 @@ TASPluginGS::~TASPluginGS()
 
 ASImage *TASPluginGS::File2ASImage(const char *filename)
 {
-   if (!fInterpreter) {
+   if (fGsExe.IsNull()) {
       Warning("File2ASImage", "GhostScript is not available");
       return nullptr;
    }
@@ -83,16 +80,19 @@ ASImage *TASPluginGS::File2ASImage(const char *filename)
       return nullptr;
    }
 
-   TString ext = (strrchr(filename, '.') + 1);
-   ext.Strip();
-   ext.ToLower();
+   const char *ppos = strrchr(filename, '.');
 
-   UInt_t width = 0;
-   UInt_t height = 0;
-   Bool_t eps = kFALSE;
+   TString ext;
+   if (ppos) {
+      ext = ppos + 1;
+      ext.Strip();
+      ext.ToLower();
+   }
 
-   if (ext == "eps") {
-      eps = kTRUE;
+   UInt_t width = 0, height = 0;
+   Bool_t eps = ext == "eps";
+
+   if (eps) {
       FILE *fd = fopen(filename, "r");
       if (!fd) {
          Warning("File2ASImage", "input file %s is not readable", filename);
@@ -102,7 +102,8 @@ ASImage *TASPluginGS::File2ASImage(const char *filename)
       do {
          char buf[128];
          TString line = fgets(buf, 128, fd);
-         if (line.IsNull() || !line.BeginsWith("%")) break;
+         if (line.IsNull() || !line.BeginsWith("%"))
+            break;
 
          if (line.BeginsWith("%%BoundingBox:")) {
             int lx, ly, ux, uy;
@@ -118,20 +119,18 @@ ASImage *TASPluginGS::File2ASImage(const char *filename)
    }
 
    // command line to execute
-   TString cmd = fInterpreter;
-   if (eps) {
+   TString cmd = fGsExe;
+   if (eps)
       cmd += TString::Format(" -g%dx%d", width, height);
-   }
    cmd += " -dSAFER -dBATCH -dNOPAUSE -dQUIET -sDEVICE=png16m -dGraphicsAlphaBits=4 -sOutputFile=- ";
    cmd += filename;
    FILE *in = gSystem->OpenPipe(cmd.Data(), popen_flags);
 
-   if (!in) {
+   if (!in)
       return nullptr;
-   }
 
    const UInt_t kBuffLength = 32768;
-   static char buf[kBuffLength];
+   char buf[kBuffLength];
    TString raw;
 
    do {

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -429,7 +429,7 @@ Int_t TTFhandle::SetTextFont(const char *fontname, Int_t italic)
    const char *basename = gSystem->BaseName(fontname);
 
    if (SelectFontHandle(1, TString::Format("%s%s", basename, italic ? ".italic" : ""))) {
-      Fatal("TTFhandle::SetTextFont", "Fail to create font handle for font %s", basename);
+      Fatal("SetTextFont", "Fail to create font handle for font %s", basename);
       return 1;
    }
 
@@ -439,23 +439,21 @@ Int_t TTFhandle::SetTextFont(const char *fontname, Int_t italic)
 
    auto lib = InitClose();
    if (!lib) {
-      Error("TTFhandle::SetTextFont", "no free type library initialized");
+      Error("SetTextFont", "no free type library initialized");
       return 1;
    }
 
    // try to load font (font must be in Root.TTFontPath resource)
-   const char *ttpath = gEnv->GetValue("Root.TTFontPath",
-                                       TROOT::GetTTFFontDir());
-   char *ttfont = gSystem->Which(ttpath, fontname, kReadPermission);
+   const char *ttpath = gEnv->GetValue("Root.TTFontPath", TROOT::GetTTFFontDir());
+
+   TString fname = fontname;
+   const char *ttfont = gSystem->FindFile(ttpath, fname, kReadPermission);
 
    if (!ttfont)
       return SelectFontHandle(111, TString::Format("font file %s not found in path %s", fontname, ttpath));
 
-   std::string filename = ttfont;
-   delete [] ttfont;
-
-   if (FT_New_Face(lib, filename.c_str(), 0, &fFont->face))
-      return SelectFontHandle(111, TString::Format("error loading font %s", filename.c_str()));
+   if (FT_New_Face(lib, ttfont, 0, &fFont->face))
+      return SelectFontHandle(111, TString::Format("error loading font %s", ttfont));
 
    if (italic) {
       FT_Matrix slantMat;
@@ -541,14 +539,9 @@ void TTFhandle::SetTextFont(Font_t fontnumber)
       // to see which fontset we have available
       const char *ttpath = gEnv->GetValue("Root.TTFontPath",
                                           TROOT::GetTTFFontDir());
-      char *ttfont = gSystem->Which(ttpath, gEnv->GetValue(fonttable[fontid][0], fonttable[fontid][1]), kReadPermission);
-      if (ttfont) {
-         delete [] ttfont;
-         thisset = 0;
-      } else {
-         // try backup free font
-         thisset = 1;
-      }
+      TString fname = gEnv->GetValue(fonttable[fontid][0], fonttable[fontid][1]);
+      const char *ttfont = gSystem->FindFile(ttpath, fname, kReadPermission);
+      thisset = ttfont ? 0 : 1;
    }
    Int_t italic = fontid == 15 ? 1 : 0;
    auto ret = SetTextFont(gEnv->GetValue(fonttable[fontid][thisset], fonttable[fontid][1]), italic);

--- a/graf2d/postscript/inc/TPDF.h
+++ b/graf2d/postscript/inc/TPDF.h
@@ -31,41 +31,41 @@ class TPoints;
 class TPDF : public TVirtualPS {
 
 protected:
-   Float_t fRed;                   ///< Per cent of red
-   Float_t fGreen;                 ///< Per cent of green
-   Float_t fBlue;                  ///< Per cent of blue
-   Float_t fAlpha;                 ///< Per cent of transparency
-   std::vector<float> fAlphas;     ///< List of alpha values used
-   Float_t fXsize;                 ///< Page size along X
-   Float_t fYsize;                 ///< Page size along Y
-   Int_t fType;                    ///< Workstation type used to know if the PDF is open
-   Int_t fPageFormat;              ///< Page format (A4, Letter etc ...)
-   Int_t fPageOrientation;         ///< Page orientation (Portrait, Landscape)
-   Int_t fStartStream;             ///< Stream start
-   Float_t fLineScale;             ///< Line width scale factor
-   Int_t *fObjPos{nullptr};        ///< Objects position
-   Int_t fObjPosSize{0};           ///< Real size of fObjPos
-   Int_t fNbObj{0};                ///< Number of objects
-   Int_t fNbPage;                  ///< Number of pages
-   Int_t fCurrentPage;             ///< Object number of the current page
-   std::vector<int> fPageObjects;  ///< Page object numbers
-   std::vector<std::string> fUrls; ///< URLs
-   std::vector<float> fRectX1;     ///< x1 /Rect coordinates for url annots
-   std::vector<float> fRectY1;     ///< y1 /Rect coordinates for url annots
-   std::vector<float> fRectX2;     ///< x2 /Rect coordinates for url annots
-   std::vector<float> fRectY2;     ///< y2 /Rect coordinates for url annots
-   Bool_t fObjectIsOpen;           ///< True if an object is opened
-   Bool_t fPageNotEmpty;           ///< True if the current page is not empty
-   Bool_t fCompress;               ///< True when fBuffer must be compressed
-   Bool_t fRange;                  ///< True when a range has been defined
-   Bool_t fUrl;                    ///< True when the text has an URL
-   Int_t fNbUrl;                   ///< Number of URLs in the current page
-   Double_t fA;                    ///< "a" value of the Current Transformation Matrix (CTM)
-   Double_t fB;                    ///< "b" value of the Current Transformation Matrix (CTM)
-   Double_t fC;                    ///< "c" value of the Current Transformation Matrix (CTM)
-   Double_t fD;                    ///< "d" value of the Current Transformation Matrix (CTM)
-   Double_t fE;                    ///< "e" value of the Current Transformation Matrix (CTM)
-   Double_t fF;                    ///< "f" value of the Current Transformation Matrix (CTM)
+   Float_t fRed = 0.;                   ///< Per cent of red
+   Float_t fGreen = 0.;                 ///< Per cent of green
+   Float_t fBlue = 0.;                  ///< Per cent of blue
+   Float_t fAlpha = 1.;                 ///< Per cent of transparency
+   std::vector<float> fAlphas;          ///< List of alpha values used
+   Float_t fXsize = 0.;                 ///< Page size along X
+   Float_t fYsize = 0.;                 ///< Page size along Y
+   Int_t fType = 0;                     ///< Workstation type used to know if the PDF is open
+   Int_t fPageFormat = 0;               ///< Page format (A4, Letter etc ...)
+   Int_t fPageOrientation = 0;          ///< Page orientation (Portrait, Landscape)
+   Int_t fStartStream = 0;              ///< Stream start
+   Float_t fLineScale = 0.;             ///< Line width scale factor
+   Int_t *fObjPos = nullptr;            ///< Objects position
+   Int_t fObjPosSize = 0;               ///< Real size of fObjPos
+   Int_t fNbObj = 0;                    ///< Number of objects
+   Int_t fNbPage = 0;                   ///< Number of pages
+   Int_t fCurrentPage = 0;              ///< Object number of the current page
+   std::vector<int> fPageObjects;       ///< Page object numbers
+   std::vector<std::string> fUrls;      ///< URLs
+   std::vector<float> fRectX1;          ///< x1 /Rect coordinates for url annots
+   std::vector<float> fRectY1;          ///< y1 /Rect coordinates for url annots
+   std::vector<float> fRectX2;          ///< x2 /Rect coordinates for url annots
+   std::vector<float> fRectY2;          ///< y2 /Rect coordinates for url annots
+   Bool_t fObjectIsOpen = kFALSE;       ///< True if an object is opened
+   Bool_t fPageNotEmpty = kFALSE;       ///< True if the current page is not empty
+   Bool_t fCompress = kFALSE;           ///< True when fBuffer must be compressed
+   Bool_t fRange = kFALSE;              ///< True when a range has been defined
+   Bool_t fUrl = kFALSE;                ///< True when the text has an URL
+   Int_t fNbUrl = 1;                    ///< Number of URLs in the current page
+   Double_t fA = 1.;                    ///< "a" value of the Current Transformation Matrix (CTM)
+   Double_t fB = 0.;                    ///< "b" value of the Current Transformation Matrix (CTM)
+   Double_t fC = 0.;                    ///< "c" value of the Current Transformation Matrix (CTM)
+   Double_t fD = 1.;                    ///< "d" value of the Current Transformation Matrix (CTM)
+   Double_t fE = 0.;                    ///< "e" value of the Current Transformation Matrix (CTM)
+   Double_t fF = 0.;                    ///< "f" value of the Current Transformation Matrix (CTM)
 
    static Int_t fgLineJoin; ///< Appearance of joining lines
    static Int_t fgLineCap;  ///< Appearance of line caps

--- a/graf2d/postscript/inc/TPDF.h
+++ b/graf2d/postscript/inc/TPDF.h
@@ -43,9 +43,7 @@ protected:
    Int_t fPageOrientation = 0;          ///< Page orientation (Portrait, Landscape)
    Int_t fStartStream = 0;              ///< Stream start
    Float_t fLineScale = 0.;             ///< Line width scale factor
-   Int_t *fObjPos = nullptr;            ///< Objects position
-   Int_t fObjPosSize = 0;               ///< Real size of fObjPos
-   Int_t fNbObj = 0;                    ///< Number of objects
+   std::vector<Int_t> fObjPos;          ///< Objects position
    Int_t fNbPage = 0;                   ///< Number of pages
    Int_t fCurrentPage = 0;              ///< Object number of the current page
    std::vector<int> fPageObjects;       ///< Page object numbers

--- a/graf2d/postscript/inc/TPDF.h
+++ b/graf2d/postscript/inc/TPDF.h
@@ -68,6 +68,7 @@ protected:
    static Int_t fgLineJoin; ///< Appearance of joining lines
    static Int_t fgLineCap;  ///< Appearance of line caps
 
+   void EnsureBufferSize(Int_t required_size);
 
 public:
    TPDF();

--- a/graf2d/postscript/inc/TPostScript.h
+++ b/graf2d/postscript/inc/TPostScript.h
@@ -20,67 +20,67 @@ class TPoints;
 class TPostScript : public TVirtualPS {
 
 protected:
-   Float_t fX1v;             ///< X bottom left corner of paper
-   Float_t fY1v;             ///< Y bottom left corner of paper
-   Float_t fX2v;             ///< X top right corner of paper
-   Float_t fY2v;             ///< Y top right corner of paper
-   Float_t fX1w;             ///<
-   Float_t fY1w;             ///<
-   Float_t fX2w;             ///<
-   Float_t fY2w;             ///<
-   Float_t fDXC;             ///<
-   Float_t fDYC;             ///<
-   Float_t fXC;              ///<
-   Float_t fYC;              ///<
-   Float_t fFX;              ///<
-   Float_t fFY;              ///<
-   Float_t fXVP1;            ///<
-   Float_t fXVP2;            ///<
-   Float_t fYVP1;            ///<
-   Float_t fYVP2;            ///<
-   Float_t fXVS1;            ///<
-   Float_t fXVS2;            ///<
-   Float_t fYVS1;            ///<
-   Float_t fYVS2;            ///<
-   Float_t fXsize;           ///< Page size along X
-   Float_t fYsize;           ///< Page size along Y
-   Float_t fMaxsize;         ///< Largest dimension of X and Y
-   Float_t fRed;             ///< Per cent of red
-   Float_t fGreen;           ///< Per cent of green
-   Float_t fBlue;            ///< Per cent of blue
-   Float_t fWidth;           ///< Current line width
-   Int_t   fStyle;           ///< Current line style
-   Float_t fLineScale;       ///< Line width scale factor
-   Int_t   fSave;            ///< Number of gsave for restore
-   Int_t   fNXzone;          ///< Number of zones along X
-   Int_t   fNYzone;          ///< Number of zones along Y
-   Int_t   fIXzone;          ///< Current zone along X
-   Int_t   fIYzone;          ///< Current zone along Y
-   Float_t fMarkerSizeCur;   ///< current transformed value of marker size
-   Int_t   fNpages;          ///< number of pages
-   Int_t   fType;            ///< PostScript workstation type
-   Int_t   fMode;            ///< PostScript mode
-   Int_t   fClip;            ///< Clipping mode
-   Bool_t  fBoundingBox;     ///< True for Encapsulated PostScript
-   Bool_t  fClear;           ///< True when page must be cleared
-   Bool_t  fClipStatus;      ///< Clipping Indicator
-   Bool_t  fRange;           ///< True when a range has been defined
-   Bool_t  fZone;            ///< Zone indicator
-   char    fPatterns[32];    ///< Indicate if pattern n is defined
-   Int_t   fNbinCT;          ///< Number of entries in the current Cell Array
-   Int_t   fNbCellW;         ///< Number of boxes per line
-   Int_t   fNbCellLine;      ///< Number of boxes in the current line
-   Int_t   fMaxLines;        ///< Maximum number of lines in a PS array
-   Int_t   fLastCellRed;     ///< Last red value
-   Int_t   fLastCellGreen;   ///< Last green value
-   Int_t   fLastCellBlue;    ///< Last blue value
-   Int_t   fNBSameColorCell; ///< Number of boxes with the same color
-   TString fFileName;        ///< PS file name
-   Bool_t  fFontEmbed;       ///< True is FontEmbed has been called
-   Bool_t  fMustEmbed[29];   ///< flag to embed font
+   Float_t fX1v = 0.;             ///< X bottom left corner of paper
+   Float_t fY1v = 0.;             ///< Y bottom left corner of paper
+   Float_t fX2v = 0.;             ///< X top right corner of paper
+   Float_t fY2v = 0.;             ///< Y top right corner of paper
+   Float_t fX1w = 0.;             ///<
+   Float_t fY1w = 0.;             ///<
+   Float_t fX2w = 0.;             ///<
+   Float_t fY2w = 0.;             ///<
+   Float_t fDXC = 0.;             ///<
+   Float_t fDYC = 0.;             ///<
+   Float_t fXC = 0.;              ///<
+   Float_t fYC = 0.;              ///<
+   Float_t fFX = 0.;              ///<
+   Float_t fFY = 0.;              ///<
+   Float_t fXVP1 = 0.;            ///<
+   Float_t fXVP2 = 0.;            ///<
+   Float_t fYVP1 = 0.;            ///<
+   Float_t fYVP2 = 0.;            ///<
+   Float_t fXVS1 = 0.;            ///<
+   Float_t fXVS2 = 0.;            ///<
+   Float_t fYVS1 = 0.;            ///<
+   Float_t fYVS2 = 0.;            ///<
+   Float_t fXsize = 0.;           ///< Page size along X
+   Float_t fYsize = 0.;           ///< Page size along Y
+   Float_t fMaxsize = 0.;         ///< Largest dimension of X and Y
+   Float_t fRed = 0.;             ///< Per cent of red
+   Float_t fGreen = 0.;           ///< Per cent of green
+   Float_t fBlue = 0.;            ///< Per cent of blue
+   Float_t fWidth = 0.;           ///< Current line width
+   Int_t   fStyle = 1;            ///< Current line style
+   Float_t fLineScale = 0.;       ///< Line width scale factor
+   Int_t   fSave = 0;             ///< Number of gsave for restore
+   Int_t   fNXzone = 0;           ///< Number of zones along X
+   Int_t   fNYzone = 0;           ///< Number of zones along Y
+   Int_t   fIXzone = 0;           ///< Current zone along X
+   Int_t   fIYzone = 0;           ///< Current zone along Y
+   Float_t fMarkerSizeCur = 0.;   ///< current transformed value of marker size
+   Int_t   fNpages = 0;           ///< number of pages
+   Int_t   fType = 0;             ///< PostScript workstation type
+   Int_t   fMode = 0;             ///< PostScript mode
+   Int_t   fClip = 0;             ///< Clipping mode
+   Bool_t  fBoundingBox = kFALSE; ///< True for Encapsulated PostScript
+   Bool_t  fClear = kFALSE;       ///< True when page must be cleared
+   Bool_t  fClipStatus = kFALSE;  ///< Clipping Indicator
+   Bool_t  fRange = kFALSE;       ///< True when a range has been defined
+   Bool_t  fZone = kFALSE;        ///< Zone indicator
+   char    fPatterns[32];         ///< Indicate if pattern n is defined
+   Int_t   fNbinCT = 0;           ///< Number of entries in the current Cell Array
+   Int_t   fNbCellW = 0;          ///< Number of boxes per line
+   Int_t   fNbCellLine = 0;       ///< Number of boxes in the current line
+   Int_t   fMaxLines = 0;         ///< Maximum number of lines in a PS array
+   Int_t   fLastCellRed = 0;      ///< Last red value
+   Int_t   fLastCellGreen = 0;    ///< Last green value
+   Int_t   fLastCellBlue = 0;     ///< Last blue value
+   Int_t   fNBSameColorCell = 0;  ///< Number of boxes with the same color
+   TString fFileName;             ///< PS file name
+   Bool_t  fFontEmbed = kFALSE;   ///< True is FontEmbed has been called
+   Bool_t  fMustEmbed[29];        ///< flag to embed font
 
-   static Int_t fgLineJoin;  ///< Appearance of joining lines
-   static Int_t fgLineCap;   ///< Appearance of line caps
+   static Int_t fgLineJoin;       ///< Appearance of joining lines
+   static Int_t fgLineCap;        ///< Appearance of line caps
 
 public:
    TPostScript();

--- a/graf2d/postscript/inc/TPostScript.h
+++ b/graf2d/postscript/inc/TPostScript.h
@@ -77,6 +77,7 @@ protected:
    Int_t   fNBSameColorCell; ///< Number of boxes with the same color
    TString fFileName;        ///< PS file name
    Bool_t  fFontEmbed;       ///< True is FontEmbed has been called
+   Bool_t  fMustEmbed[29];   ///< flag to embed font
 
    static Int_t fgLineJoin;  ///< Appearance of joining lines
    static Int_t fgLineCap;   ///< Appearance of line caps

--- a/graf2d/postscript/inc/TSVG.h
+++ b/graf2d/postscript/inc/TSVG.h
@@ -20,13 +20,13 @@ class TPoints;
 class TSVG : public TVirtualPS {
 
 protected:
-   Float_t      fXsize;           ///< Page size along X
-   Float_t      fYsize;           ///< Page size along Y
-   Int_t        fType;            ///< Workstation type used to know if the SVG is open
-   Bool_t       fCompact;         ///< True when the SVG header is printed
-   Bool_t       fBoundingBox;     ///< True when the SVG header is printed
-   Bool_t       fRange;           ///< True when a range has been defined
-   Double_t     fYsizeSVG;        ///< Page's Y size in SVG units
+   Float_t      fXsize = 0.;           ///< Page size along X
+   Float_t      fYsize = 0.;           ///< Page size along Y
+   Int_t        fType = 0;             ///< Workstation type used to know if the SVG is open
+   Bool_t       fCompact = kFALSE;     ///< True when the SVG header is printed
+   Bool_t       fBoundingBox = kFALSE; ///< True when the SVG header is printed
+   Bool_t       fRange = kFALSE;       ///< True when a range has been defined
+   Double_t     fYsizeSVG = 0.;        ///< Page's Y size in SVG units
 
    static Int_t fgLineJoin;       ///< Appearance of joining lines
    static Int_t fgLineCap;        ///< Appearance of line caps

--- a/graf2d/postscript/inc/TTeXDump.h
+++ b/graf2d/postscript/inc/TTeXDump.h
@@ -20,18 +20,17 @@ class TPoints;
 class TTeXDump : public TVirtualPS {
 
 protected:
-   Float_t      fXsize;           ///< Page size along X
-   Float_t      fYsize;           ///< Page size along Y
-   Int_t        fType;            ///< Workstation type used to know if the Tex is open
-   Bool_t       fBoundingBox;     ///< True when the TeX header is printed
-   Bool_t       fRange;           ///< True when a range has been defined
-   Bool_t       fStandalone;      ///< True when a TeX file should be standalone
-   Float_t      fCurrentRed;      ///< Current Red component
-   Float_t      fCurrentGreen;    ///< Current Green component
-   Float_t      fCurrentBlue;     ///< Current Blue component
-   Float_t      fCurrentAlpha;    ///< Current Alpha value
-   Float_t      fLineScale;       ///< Line width scale factor
-
+   Float_t      fXsize = 0.;           ///< Page size along X
+   Float_t      fYsize = 0.;           ///< Page size along Y
+   Int_t        fType = 0;             ///< Workstation type used to know if the Tex is open
+   Bool_t       fBoundingBox = kFALSE; ///< True when the TeX header is printed
+   Bool_t       fRange = kFALSE;       ///< True when a range has been defined
+   Bool_t       fStandalone = kFALSE;  ///< True when a TeX file should be standalone
+   Float_t      fCurrentRed = -1.;     ///< Current Red component
+   Float_t      fCurrentGreen = -1.;   ///< Current Green component
+   Float_t      fCurrentBlue = -.1;    ///< Current Blue component
+   Float_t      fCurrentAlpha = 1.;    ///< Current Alpha value
+   Float_t      fLineScale = 0.;       ///< Line width scale factor
 
 public:
    TTeXDump();

--- a/graf2d/postscript/src/TImageDump.cxx
+++ b/graf2d/postscript/src/TImageDump.cxx
@@ -51,9 +51,7 @@ TImageDump can be used in any mode (batch, interactive) as follows
 
 TImageDump::TImageDump() : TVirtualPS()
 {
-   fImage     = nullptr;
    gVirtualPS = this;
-   fType      = 0;
    SetTitle("IMG");
 }
 

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -130,8 +130,6 @@ TPDF::TPDF(const char *fname, Int_t wtype) : TVirtualPS(fname, wtype)
 TPDF::~TPDF()
 {
    Close();
-
-   if (fObjPos) delete [] fObjPos;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -140,7 +138,7 @@ TPDF::~TPDF()
 void TPDF::CellArrayBegin(Int_t, Int_t, Double_t, Double_t, Double_t,
                           Double_t)
 {
-   Warning("TPDF::CellArrayBegin", "not yet implemented");
+   Warning("CellArrayBegin", "not yet implemented");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -148,7 +146,7 @@ void TPDF::CellArrayBegin(Int_t, Int_t, Double_t, Double_t, Double_t,
 
 void TPDF::CellArrayFill(Int_t, Int_t, Int_t)
 {
-   Warning("TPDF::CellArrayFill", "not yet implemented");
+   Warning("CellArrayFill", "not yet implemented");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -156,7 +154,7 @@ void TPDF::CellArrayFill(Int_t, Int_t, Int_t)
 
 void TPDF::CellArrayEnd()
 {
-   Warning("TPDF::CellArrayEnd", "not yet implemented");
+   Warning("CellArrayEnd", "not yet implemented");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -295,12 +293,12 @@ void TPDF::Close(Option_t *)
    Int_t refInd = fNByte;
    PrintStr("xref@");
    PrintStr("0");
-   WriteInteger(fNbObj+1);
+   WriteInteger(fObjPos.size() + 1);
    PrintStr("@");
    PrintStr("0000000000 65535 f @");
    char str[21];
-   for (int i = 0; i < fNbObj; i++) {
-      snprintf(str,21,"%10.10d 00000 n @",fObjPos[i]);
+   for (std::size_t i = 0; i < fObjPos.size(); ++i) {
+      snprintf(str,21,"%10.10d 00000 n @", fObjPos[i]);
       PrintStr(str);
    }
 
@@ -308,7 +306,7 @@ void TPDF::Close(Option_t *)
    PrintStr("trailer@");
    PrintStr("<<@");
    PrintStr("/Size");
-   WriteInteger(fNbObj+1);
+   WriteInteger(fObjPos.size() + 1);
    PrintStr("@");
    PrintStr("/Root");
    WriteInteger(kObjRoot);
@@ -1359,7 +1357,7 @@ void TPDF::DrawPS(Int_t nn, Double_t *xw, Double_t *yw)
 void TPDF::EndObject()
 {
    if (!fObjectIsOpen)
-      Warning("TPDF::EndObject", "No Object currently opened.");
+      Warning("EndObject", "No Object currently opened.");
    fObjectIsOpen = kFALSE;
 
    PrintStr("endobj@");
@@ -1423,21 +1421,14 @@ void TPDF::MoveTo(Double_t x, Double_t y)
 void TPDF::NewObject(Int_t n)
 {
    if (fObjectIsOpen)
-      Warning("TPDF::NewObject", "An Object is already open.");
+      Warning("NewObject", "An Object is already open.");
    fObjectIsOpen = kTRUE;
-   if (!fObjPos || n >= fObjPosSize) {
-      Int_t newN = TMath::Max(2*fObjPosSize,n+1);
-      Int_t *saveo = new Int_t [newN];
-      if (fObjPos && fObjPosSize) {
-         memcpy(saveo,fObjPos,fObjPosSize*sizeof(Int_t));
-         memset(&saveo[fObjPosSize],0,(newN-fObjPosSize)*sizeof(Int_t));
-         delete [] fObjPos;
-      }
-      fObjPos     = saveo;
-      fObjPosSize = newN;
-   }
-   fObjPos[n-1] = fNByte;
-   fNbObj       = TMath::Max(fNbObj,n);
+   if (n > (Int_t) fObjPos.size())
+      fObjPos.resize(n, 0); // filling new elements with 0
+   if (n > 0)
+      fObjPos[n-1] = fNByte;
+   else
+      Error("NewObject", "Wrong id %d is specified.", n);
    WriteInteger(n, false);
    PrintStr(" 0 obj");
    PrintStr("@");
@@ -1666,8 +1657,6 @@ void TPDF::On()
 
 void TPDF::Open(const char *fname, Int_t wtype)
 {
-   Int_t i;
-
    if (fStream) {
       Warning("Open", "PDF file already open");
       return;
@@ -1706,7 +1695,8 @@ void TPDF::Open(const char *fname, Int_t wtype)
 
    gVirtualPS = this;
 
-   for (i=0; i<fSizBuffer; i++) fBuffer[i] = ' ';
+   for (Int_t i=0; i<fSizBuffer; i++)
+      fBuffer[i] = ' ';
 
    // The page orientation is last digit of PDF workstation type
    //  orientation = 1 for portrait
@@ -1730,9 +1720,7 @@ void TPDF::Open(const char *fname, Int_t wtype)
    // Set a default range
    Range(fXsize, fYsize);
 
-   fObjPos = nullptr;
-   fObjPosSize = 0;
-   fNbObj = 0;
+   fObjPos.clear();
    fNbPage = 0;
    fUrl = kFALSE;
 
@@ -1792,7 +1780,7 @@ void TPDF::Open(const char *fname, Int_t wtype)
 
    PrintStr("/Font@");
    PrintStr("<<@");
-   for (i=0; i<kNumberOfFonts; i++) {
+   for (Int_t i=0; i<kNumberOfFonts; i++) {
       PrintStr(" /F");
       WriteInteger(i+1,false);
       WriteInteger(kObjFont+i);

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -1940,7 +1940,7 @@ void TPDF::SetAlpha(Float_t a)
       }
    }
    if (!known) fAlphas.push_back(fAlpha);
-   PrintStr(Form(" /ca%3.2f gs /CA%3.2f gs",fAlpha,fAlpha));
+   PrintStr(TString::Format(" /ca%3.2f gs /CA%3.2f gs",fAlpha,fAlpha));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -1811,6 +1811,20 @@ void TPDF::Open(const char *fname, Int_t wtype)
    fPageNotEmpty = kFALSE;
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+/// Ensure that required space in the buffer is available
+
+void TPDF::EnsureBufferSize(Int_t required_size)
+{
+   if (required_size >= fSizBuffer) {
+      // increase buffer size by integer factor, normally 2
+      Int_t mult = (required_size + 1) / fSizBuffer + 1;
+      fBuffer = TStorage::ReAllocChar(fBuffer, mult*fSizBuffer, fSizBuffer);
+      fSizBuffer = mult*fSizBuffer;
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Output the string str in the output buffer
 
@@ -1821,16 +1835,12 @@ void TPDF::PrintStr(const char *str)
    fPageNotEmpty = kTRUE;
 
    if (fCompress) {
-      if (fLenBuffer+len >= fSizBuffer) {
-         fBuffer  = TStorage::ReAllocChar(fBuffer, 2*fSizBuffer, fSizBuffer);
-         fSizBuffer = 2*fSizBuffer;
-      }
+      EnsureBufferSize(fLenBuffer + len);
       strcpy(fBuffer + fLenBuffer, str);
       fLenBuffer += len;
-      return;
+   } else {
+      TVirtualPS::PrintStr(str);
    }
-
-   TVirtualPS::PrintStr(str);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1840,16 +1850,12 @@ void TPDF::PrintFast(Int_t len, const char *str)
 {
    fPageNotEmpty = kTRUE;
    if (fCompress) {
-      if (fLenBuffer+len >= fSizBuffer) {
-         fBuffer  = TStorage::ReAllocChar(fBuffer, 2*fSizBuffer, fSizBuffer);
-         fSizBuffer = 2*fSizBuffer;
-      }
+      EnsureBufferSize(fLenBuffer + len);
       strcpy(fBuffer + fLenBuffer, str);
       fLenBuffer += len;
-      return;
+   } else {
+      TVirtualPS::PrintFast(len, str);
    }
-
-   TVirtualPS::PrintFast(len, str);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -103,33 +103,9 @@ Int_t TPDF::fgLineCap = 0;
 
 TPDF::TPDF() : TVirtualPS()
 {
-   fCompress = kFALSE;
-   fPageNotEmpty = kFALSE;
-   fObjectIsOpen = kFALSE;
-   gVirtualPS = this;
-   fRed = 0.;
-   fGreen = 0.;
-   fBlue = 0.;
-   fAlpha = 1.;
-   fXsize = 0.;
-   fYsize = 0.;
-   fType = 0;
-   fPageFormat = 0;
-   fPageOrientation = 0;
-   fStartStream = 0;
-   fLineScale = 0.;
-   fNbPage = 0;
    fCurrentPage = kObjFirstPage;
-   fRange = kFALSE;
-   fUrl = kFALSE;
-   fNbUrl = 1;
-   fA = 1.;
-   fB = 0.;
-   fC = 0.;
-   fD = 1.;
-   fE = 0.;
-   fF = 0.;
    SetTitle("PDF");
+   gVirtualPS = this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -143,31 +119,7 @@ TPDF::TPDF() : TVirtualPS()
 
 TPDF::TPDF(const char *fname, Int_t wtype) : TVirtualPS(fname, wtype)
 {
-   fCompress = kFALSE;
-   fPageNotEmpty = kFALSE;
-   fObjectIsOpen = kFALSE;
-   fRed = 0.;
-   fGreen = 0.;
-   fBlue = 0.;
-   fAlpha = 1.;
-   fXsize = 0.;
-   fYsize = 0.;
-   fType = 0;
-   fPageFormat = 0;
-   fPageOrientation = 0;
-   fStartStream = 0;
-   fLineScale = 0.;
-   fNbPage = 0;
    fCurrentPage = kObjFirstPage;
-   fRange = kFALSE;
-   fUrl = kFALSE;
-   fNbUrl = 1;
-   fA = 1.;
-   fB = 0.;
-   fC = 0.;
-   fD = 1.;
-   fE = 0.;
-   fF = 0.;
    SetTitle("PDF");
    Open(fname, wtype);
 }

--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -1695,8 +1695,7 @@ void TPDF::Open(const char *fname, Int_t wtype)
 
    gVirtualPS = this;
 
-   for (Int_t i=0; i<fSizBuffer; i++)
-      fBuffer[i] = ' ';
+   ClearBuffer();
 
    // The page orientation is last digit of PDF workstation type
    //  orientation = 1 for portrait

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -756,7 +756,7 @@ void TPostScript::DefineMarkers()
 
 void TPostScript::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t  y2)
 {
-   static Double_t x[4], y[4];
+   Double_t x[4], y[4];
    Int_t ix1 = XtoPS(x1);
    Int_t ix2 = XtoPS(x2);
    Int_t iy1 = YtoPS(y1);
@@ -819,7 +819,7 @@ void TPostScript::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t  y2)
 void TPostScript::DrawFrame(Double_t xl, Double_t yl, Double_t xt, Double_t  yt,
                             Int_t mode, Int_t border, Int_t dark, Int_t light)
 {
-   static Int_t xps[7], yps[7];
+   Int_t xps[7], yps[7];
    Int_t i, ixd0, iyd0, idx, idy, ixdi, iydi, ix, iy;
 
    // Draw top&left part of the box
@@ -1099,7 +1099,7 @@ void TPostScript::DrawPolyMarker(Int_t n, Float_t *x, Float_t *y)
 {
    Int_t i, np, markerstyle;
    Float_t markersize;
-   static char chtemp[10];
+   char chtemp[10];
 
    if (!fMarkerSize) return;
    fMarkerStyle = TMath::Abs(fMarkerStyle);
@@ -1173,7 +1173,7 @@ void TPostScript::DrawPolyMarker(Int_t n, Double_t *x, Double_t *y)
 {
    Int_t i, np, markerstyle;
    Float_t markersize;
-   static char chtemp[10];
+   char chtemp[10];
 
    if (!fMarkerSize) return;
    fMarkerStyle = TMath::Abs(fMarkerStyle);

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -256,8 +256,6 @@ To change the color model use `gStyle->SetColorModelPS(c)`.
 const Float_t kScale = 0.93376068;
 
 // Array defining if a font must be embedded or not.
-static Bool_t MustEmbed[32];
-
 Int_t TPostScript::fgLineJoin = 0;
 Int_t TPostScript::fgLineCap  = 0;
 
@@ -269,7 +267,6 @@ TPostScript::TPostScript() : TVirtualPS()
 {
    fStream          = nullptr;
    fType            = 0;
-   gVirtualPS       = this;
    fBlue            = 0.;
    fBoundingBox     = kFALSE;
    fClear           = kFALSE;
@@ -325,10 +322,13 @@ TPostScript::TPostScript() : TVirtualPS()
    fZone            = kFALSE;
    fFileName        = "";
    fFontEmbed       = kFALSE;
-   Int_t i;
-   for (i=0; i<32; i++) fPatterns[i] = 0;
-   for (i=0; i<32; i++) MustEmbed[i] = kFALSE;
+   for (Int_t i=0; i<32; i++)
+      fPatterns[i] = 0;
+   for (Int_t i=0; i<29; i++)
+      fMustEmbed[i] = kFALSE;
    SetTitle("PS");
+
+   gVirtualPS       = this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -347,6 +347,9 @@ TPostScript::TPostScript(const char *fname, Int_t wtype)
 :TVirtualPS(fname, wtype)
 {
    fStream = nullptr;
+   for (Int_t i=0; i<29; i++)
+      fMustEmbed[i] = kFALSE;
+
    SetTitle("PS");
    Open(fname, wtype);
 }
@@ -1580,7 +1583,7 @@ Bool_t TPostScript::FontEmbedType42(const char *filename)
 ////////////////////////////////////////////////////////////////////////////////
 /// Embed font in PS file.
 
-void TPostScript::FontEmbed(void)
+void TPostScript::FontEmbed()
 {
    static const char *fonttable[32][2] = {
       { "Root.TTFont.0", "FreeSansBold.otf" },
@@ -1624,27 +1627,23 @@ void TPostScript::FontEmbed(void)
                                        TROOT::GetTTFFontDir());
 
    for (Int_t fontid = 1; fontid < 30; fontid++) {
-      if (fontid != 15 && MustEmbed[fontid-1]) {
-         const char *filename = gEnv->GetValue(
-                                               fonttable[fontid][0], fonttable[fontid][1]);
-         char *ttfont = gSystem->Which(ttpath, filename, kReadPermission);
+      if (fontid != 15 && fMustEmbed[fontid-1]) {
+         TString filename = gEnv->GetValue(fonttable[fontid][0], fonttable[fontid][1]);
+         const char *ttfont = gSystem->FindFile(ttpath, filename, kReadPermission);
          if (!ttfont) {
-            Error("TPostScript::FontEmbed",
-                  "font %d (filename `%s') not found in path",
-                  fontid, filename);
+            Error("FontEmbed",
+                  "font %d (filename '%s') not found in path",
+                  fontid, filename.Data());
+         } else if (FontEmbedType2(ttfont)) {
+            // nothing
+         } else if(FontEmbedType1(ttfont)) {
+            // nothing
+         } else if(FontEmbedType42(ttfont)) {
+            // nothing
          } else {
-            if (FontEmbedType2(ttfont)) {
-               // nothing
-            } else if(FontEmbedType1(ttfont)) {
-               // nothing
-            } else if(FontEmbedType42(ttfont)) {
-               // nothing
-            } else {
-               Error("TPostScript::FontEmbed",
-                     "failed to embed font %d (filename `%s')",
-                     fontid, filename);
-            }
-            delete [] ttfont;
+            Error("FontEmbed",
+                  "failed to embed font %d (filename '%s')",
+                  fontid, filename.Data());
          }
       }
    }
@@ -2885,8 +2884,8 @@ void TPostScript::Text(Double_t xx, Double_t yy, const wchar_t *chars)
    // Compute the font size. Exit if it is 0
    // The font size is computed from the TTF size to get exactly the same
    // size on the screen and in the PostScript file.
-   Double_t wh = (Double_t)gPad->XtoPixel(gPad->GetX2());
-   Double_t hh = (Double_t)gPad->YtoPixel(gPad->GetY1());
+   Double_t wh = (Double_t)gPad->GetPadWidth();
+   Double_t hh = (Double_t)gPad->GetPadHeight();
    Float_t tsize, ftsize;
 
    if (wh < hh) {
@@ -2899,7 +2898,7 @@ void TPostScript::Text(Double_t xx, Double_t yy, const wchar_t *chars)
       ftsize        = (sizeTTF*fYsize*gPad->GetAbsHNDC())/hh;
    }
    Double_t fontsize = 4*(72*(ftsize)/2.54);
-   if( fontsize <= 0) return;
+   if(fontsize <= 0) return;
 
    Float_t tsizex = gPad->AbsPixeltoX(Int_t(tsize))-gPad->AbsPixeltoX(0);
    Float_t tsizey = gPad->AbsPixeltoY(0)-gPad->AbsPixeltoY(Int_t(tsize));
@@ -2955,7 +2954,7 @@ void TPostScript::Text(Double_t xx, Double_t yy, const wchar_t *chars)
    PrintStr(TString::Format(" t %d r ", psangle));
    if(txalh == 2) PrintStr(TString::Format(" %d 0 t ", -psCharsLength/2));
    if(txalh == 3) PrintStr(TString::Format(" %d 0 t ", -psCharsLength));
-   MustEmbed[font-1] = kTRUE; // This font will be embedded in the file at EOF time.
+   fMustEmbed[font-1] = kTRUE; // This font will be embedded in the file at EOF time.
    PrintStr(gEnv->GetValue(psfont[font-1][0], psfont[font-1][1]));
    PrintStr(TString::Format(" findfont %g sf 0 0 m ",fontsize));
 

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -265,66 +265,9 @@ Int_t TPostScript::fgLineCap  = 0;
 
 TPostScript::TPostScript() : TVirtualPS()
 {
-   fStream          = nullptr;
-   fType            = 0;
-   fBlue            = 0.;
-   fBoundingBox     = kFALSE;
-   fClear           = kFALSE;
-   fClip            = 0;
-   fClipStatus      = kFALSE;
-   fDXC             = 0.;
-   fDYC             = 0.;
-   fFX              = 0.;
-   fFY              = 0.;
-   fGreen           = 0.;
-   fIXzone          = 0;
-   fIYzone          = 0;
-   fLastCellBlue    = 0;
-   fLastCellGreen   = 0;
-   fLastCellRed     = 0;
-   fLineScale       = 0.;
-   fMarkerSizeCur   = 0.;
-   fMaxLines        = 0;
-   fMaxsize         = 0;
-   fMode            = 0;
-   fNBSameColorCell = 0;
-   fNXzone          = 0;
-   fNYzone          = 0;
-   fNbCellLine      = 0;
-   fNbCellW         = 0;
-   fNbinCT          = 0;
-   fNpages          = 0;
-   fRange           = kFALSE;
-   fRed             = 0.;
-   fSave            = 0;
-   fWidth           = 0.;
-   fStyle           = 1;
-   fX1v             = 0.;
-   fX1w             = 0.;
-   fX2v             = 0.;
-   fX2w             = 0.;
-   fXC              = 0.;
-   fXVP1            = 0.;
-   fXVP2            = 0.;
-   fXVS1            = 0.;
-   fXVS2            = 0.;
-   fXsize           = 0.;
-   fY1v             = 0.;
-   fY1w             = 0.;
-   fY2v             = 0.;
-   fY2w             = 0.;
-   fYC              = 0.;
-   fYVP1            = 0.;
-   fYVP2            = 0.;
-   fYVS1            = 0.;
-   fYVS2            = 0.;
-   fYsize           = 0.;
-   fZone            = kFALSE;
-   fFileName        = "";
-   fFontEmbed       = kFALSE;
-   for (Int_t i=0; i<32; i++)
+   for (Int_t i = 0; i < 32; i++)
       fPatterns[i] = 0;
-   for (Int_t i=0; i<29; i++)
+   for (Int_t i = 0; i < 29; i++)
       fMustEmbed[i] = kFALSE;
    SetTitle("PS");
 
@@ -343,11 +286,11 @@ TPostScript::TPostScript() : TVirtualPS()
 ///    - 112 ps  Landscape
 ///    - 113 eps
 
-TPostScript::TPostScript(const char *fname, Int_t wtype)
-:TVirtualPS(fname, wtype)
+TPostScript::TPostScript(const char *fname, Int_t wtype) : TVirtualPS(fname, wtype)
 {
-   fStream = nullptr;
-   for (Int_t i=0; i<29; i++)
+   for (Int_t i = 0; i < 32; i++)
+      fPatterns[i] = 0;
+   for (Int_t i = 0; i < 29; i++)
       fMustEmbed[i] = kFALSE;
 
    SetTitle("PS");
@@ -370,7 +313,7 @@ void TPostScript::Open(const char *fname, Int_t wtype)
    fBlue          = -1;
    fLenBuffer     = 0;
    fClip          = 0;
-   fType          = abs(wtype);
+   fType          = std::abs(wtype);
    fClear         = kTRUE;
    fZone          = kFALSE;
    fSave          = 0;
@@ -409,7 +352,8 @@ void TPostScript::Open(const char *fname, Int_t wtype)
    }
    gVirtualPS = this;
 
-   for (Int_t i=0;i<fSizBuffer;i++) fBuffer[i] = ' ';
+   for (Int_t i = 0; i < fSizBuffer; i++)
+      fBuffer[i] = ' ';
    if( fType == 113) {
       fBoundingBox = kFALSE;
       PrintStr("%!PS-Adobe-2.0 EPSF-2.0@");
@@ -426,7 +370,8 @@ void TPostScript::Open(const char *fname, Int_t wtype)
    Range(fXsize, fYsize);
 
    fPrinted    = kFALSE;
-   if (fType == 113) NewPage();
+   if (fType == 113)
+      NewPage();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -491,7 +436,7 @@ void TPostScript::Close(Option_t *)
          return;
       }
       char line[255];
-      while (fgets(line,255,sg)) {
+      while (fgets(line, 255, sg)) {
          if (strstr(line,"EndComments")) PrintStr("%%DocumentNeededResources: ProcSet (FontSetInit)@");
          fStream->write(line,strlen(line));
          if (!fFontEmbed && strstr(line,"m5")) {

--- a/graf2d/postscript/src/TPostScript.cxx
+++ b/graf2d/postscript/src/TPostScript.cxx
@@ -352,8 +352,8 @@ void TPostScript::Open(const char *fname, Int_t wtype)
    }
    gVirtualPS = this;
 
-   for (Int_t i = 0; i < fSizBuffer; i++)
-      fBuffer[i] = ' ';
+   ClearBuffer();
+
    if( fType == 113) {
       fBoundingBox = kFALSE;
       PrintStr("%!PS-Adobe-2.0 EPSF-2.0@");

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -139,7 +139,7 @@ void TSVG::Open(const char *fname, Int_t wtype)
 
    gVirtualPS = this;
 
-   for (Int_t i=0;i<fSizBuffer;i++) fBuffer[i] = ' ';
+   ClearBuffer();
 
    fBoundingBox = kFALSE;
 

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -82,14 +82,7 @@ using the file extension `.svgz`.
 
 TSVG::TSVG() : TVirtualPS()
 {
-   fType        = 0;
-   fCompact     = kFALSE;
    gVirtualPS   = this;
-   fBoundingBox = kFALSE;
-   fRange       = kFALSE;
-   fXsize       = 0.;
-   fYsize       = 0.;
-   fYsizeSVG    = 0;
    SetTitle("SVG");
 }
 
@@ -120,7 +113,7 @@ void TSVG::Open(const char *fname, Int_t wtype)
    }
 
    fLenBuffer = 0;
-   fType      = abs(wtype);
+   fType      = std::abs(wtype);
    SetLineJoin(gStyle->GetJoinLinePS());
    SetLineCap(gStyle->GetCapLinePS());
    SetLineScale(gStyle->GetLineScalePS());

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1531,7 +1531,7 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 954) ichar = 966;
       if (ic == 922) ichar = 952;
       if (ic == 753) ichar = 965;
-      PrintStr(Form("&#%4.4d;",ichar));
+      PrintStr(TString::Format("&#%4.4d;",ichar));
    } else {
       Int_t len=strlen(chars);
       for (Int_t i=0; i<len;i++) {

--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -83,18 +83,7 @@ corresponding pdf file `simple.pdf`.
 
 TTeXDump::TTeXDump() : TVirtualPS()
 {
-   fStream       = nullptr;
-   fType         = 0;
    gVirtualPS    = this;
-   fBoundingBox  = kFALSE;
-   fRange        = kFALSE;
-   fXsize        = 0.;
-   fYsize        = 0.;
-   fCurrentRed   = -1.;
-   fCurrentGreen = -1.;
-   fCurrentBlue  = -1.;
-   fCurrentAlpha = 1.;
-   fLineScale    = 0.;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -108,18 +97,7 @@ TTeXDump::TTeXDump() : TVirtualPS()
 
 TTeXDump::TTeXDump(const char *fname, Int_t wtype) : TVirtualPS(fname, wtype)
 {
-   fStream       = nullptr;
-   fType         = 0;
    gVirtualPS    = this;
-   fBoundingBox  = kFALSE;
-   fRange        = kFALSE;
-   fXsize        = 0.;
-   fYsize        = 0.;
-   fCurrentRed   = -1.;
-   fCurrentGreen = -1.;
-   fCurrentBlue  = -1.;
-   fCurrentAlpha = 1.;
-   fLineScale    = 0.;
 
    Open(fname, wtype);
 }
@@ -170,7 +148,8 @@ void TTeXDump::Open(const char *fname, Int_t wtype)
    // Set a default range
    Range(fXsize, fYsize);
 
-   if (strstr(GetTitle(),"Standalone")) fStandalone = kTRUE;
+   if (strstr(GetTitle(),"Standalone"))
+      fStandalone = kTRUE;
    if (fStandalone) {
       PrintStr("\\documentclass{standalone}@");
       PrintStr("\\usepackage{tikz}@");

--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -139,7 +139,7 @@ void TTeXDump::Open(const char *fname, Int_t wtype)
 
    gVirtualPS = this;
 
-   for (Int_t i=0;i<fSizBuffer;i++) fBuffer[i] = ' ';
+   ClearBuffer();
 
    fBoundingBox = kFALSE;
    fRange       = kFALSE;

--- a/graf3d/gl/src/TGLFontManager.cxx
+++ b/graf3d/gl/src/TGLFontManager.cxx
@@ -485,7 +485,8 @@ TGLFontManager::~TGLFontManager()
 
 void TGLFontManager::RegisterFont(Int_t sizeIn, Int_t fileID, TGLFont::EMode mode, TGLFont &out)
 {
-   if (fgStaticInitDone == kFALSE) InitStatics();
+   if (fgStaticInitDone == kFALSE)
+      InitStatics();
 
    Int_t  size = GetFontSize(sizeIn);
    if (mode == out.GetMode() && fileID == out.GetFile() && size == out.GetSize())
@@ -494,18 +495,17 @@ void TGLFontManager::RegisterFont(Int_t sizeIn, Int_t fileID, TGLFont::EMode mod
    FontMap_i it = fFontMap.find(TGLFont(size, fileID, mode));
    if (it == fFontMap.end())
    {
-      TString ttpath, file;
-      ttpath = gEnv->GetValue("Root.TTGLFontPath", TROOT::GetTTFFontDir());
-      {
-         //For extenede we have both ttf and otf.
-         char *fp = gSystem->Which(ttpath, fileID < fgExtendedFontStart ?
-                                   ((TObjString*)fgFontFileArray[fileID])->String() + ".ttf" :
-                                   ((TObjString*)fgFontFileArray[fileID])->String());
-         file = fp;
-         delete [] fp;
+      TString ttpath = gEnv->GetValue("Root.TTGLFontPath", TROOT::GetTTFFontDir());
+      TString file = fgFontFileArray[fileID]->GetName();
+      if (fileID < fgExtendedFontStart)
+         file += ".ttf";
+      gSystem->FindFile(ttpath, file);
+      if (file.IsNull()) {
+         Error("RegisterFont", "File for font id %d not found", fileID);
+         return;
       }
 
-      FTFont* ftfont = 0;
+      FTFont* ftfont = nullptr;
       switch (mode)
       {
          case TGLFont::kBitmap:
@@ -528,9 +528,8 @@ void TGLFontManager::RegisterFont(Int_t sizeIn, Int_t fileID, TGLFont::EMode mod
             ftfont = new FTGLTextureFont(file);
             break;
          default:
-            Error("TGLFontManager::RegisterFont", "invalid FTGL type");
+            Error("RegisterFont", "invalid FTGL type");
             return;
-            break;
       }
       ftfont->FaceSize(size);
       const TGLFont &mf = fFontMap.insert(std::make_pair(TGLFont(size, fileID, mode, ftfont, 0), 1)).first->first;


### PR DESCRIPTION
1. Use `TPostScript::fMustEmbed` instead of static array, correctly initialize it.
2. Use in TPDF `std::vector` for storing object positions - simplify code
3. Provide initializers for all members of all `TVirtualPS`-derived classes
4. Use `gSystem->FindFile()` instead `Which()` to search files
5. Do not use `Form()` - replace by `TString::Format()`
6. Do not use static variables inside paint primitive methods
 7. Use TVirtualPS::ClearBuffer() in all derived classes
 8. Implement `TPDF::EnsureBufferSize()`, increase factor can be larger than 2 if required
