### PR TITLE
[6.40] backport utf-8 fix for external `libftgl`

### DIFF
--- a/cmake/modules/FindFTGL.cmake
+++ b/cmake/modules/FindFTGL.cmake
@@ -25,3 +25,48 @@ set(FTGL_LIBRARIES ${FTGL_LIBRARY})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FTGL DEFAULT_MSG FTGL_INCLUDE_DIR FTGL_LIBRARY)
 mark_as_advanced(FTGL_FOUND FTGL_INCLUDE_DIR FTGL_LIBRARY)
+
+if(FTGL_FOUND)
+  set(FTGL_VERSION_SRC "${CMAKE_SOURCE_DIR}/cmake/modules/get_ftgl_version.cpp")
+  set(VER_INCLUDE_DIRS ${FTGL_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIR_ft2build})
+  try_compile(FTGL_VERSION_API
+      SOURCES "${FTGL_VERSION_SRC}"
+      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${VER_INCLUDE_DIRS}"
+      LINK_LIBRARIES ${FTGL_LIBRARY}
+      OUTPUT_VARIABLE FTGL_VERSION_API_LOG
+  )
+  if (FTGL_VERSION_API)
+    try_run(RUN_RESULT COMPILE_RESULT
+      "${CMAKE_BINARY_DIR}"
+      "${FTGL_VERSION_SRC}"
+      CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${VER_INCLUDE_DIRS}"
+      LINK_LIBRARIES ${FTGL_LIBRARY}
+      COMPILE_OUTPUT_VARIABLE BUILD_LOG
+      RUN_OUTPUT_VARIABLE FTGL_VERSION
+    )
+    if(COMPILE_RESULT AND RUN_RESULT EQUAL 0)
+      message(STATUS "Detected FTGL version: ${FTGL_VERSION}")
+    else()
+      message(SEND_ERROR "Could not detect FTGL version: ${BUILD_LOG}")
+    endif()
+  else()
+    message(STATUS "Failed to detect FTGL version via compilation (due to ancient system libftgl version).")
+    # ie the FTGL version is before 2.2.0dev (May 23, 2010) https://github.com/frankheckenbach/ftgl/commit/b066d7826070749499011c4f37c764b1610071ad where VERSION API was introduced
+    # sourceforge last version is 2.1.3.rc5  (June 12, 2008) so widely used
+    # Let's attempt to know if it's 2.1.3dev or earlier by looking at commits close to May 23 2008 when UTF8 support was added: https://github.com/ulrichard/ftgl/commit/84869ec7da984493b3cd268b9e56b80e7c78ac82#diff-1462936246cba8b5e9ee1c79a1207cea8efb0658be58cd25e7d3acd817ac0ac0R374
+    # May 19, 2008 is close enough and defines new headers, so just check for their existence as proxy https://github.com/frankheckenbach/ftgl/commit/f7d0017882321606d9fdb9e2899e226254d5cc69#diff-4c5d896d82d5e966afbaa229162d7cf914a87a1b1cc3f844ce3ebbc495d71a05
+    if(EXISTS ${FTGL_INCLUDE_DIR}/FTGL/FTBuffer.h)
+      set(HAS_UTF8 TRUE)
+    endif()
+    if(HAS_UTF8)
+      # Must be before 2.2.0 (May 23, 2010) and after 2.1.3.rc5 (May 23 / June 12, 2008)
+      message(STATUS "Educated guess: FTGL system version may be 2.1.3.rc5 or later")
+      set(FTGL_VERSION 2.1.3)
+    else()
+      # Must be before 2.1.3.rc5 (May 23, 2008)
+      message(STATUS "Educated guess: FTGL system version is 2.1.2 or earlier")
+      set(FTGL_VERSION 2.1.2)
+    endif()
+  endif()
+  set(FTGL_VERSION "${FTGL_VERSION}" CACHE INTERNAL "FTGL version")
+endif()

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -793,6 +793,7 @@ if(builtin_ftgl)
   set(FTGL_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/graf3d/ftgl/inc)
   set(FTGL_CFLAGS -DBUILTIN_FTGL)
   set(FTGL_LIBRARIES FTGL)
+  set(FTGL_VERSION 2.1.2)
 endif()
 
 #---Check for R/Rcpp/RInside--------------------------------------------------------------------

--- a/cmake/modules/get_ftgl_version.cpp
+++ b/cmake/modules/get_ftgl_version.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <FTGL/ftgl.h>
+
+int main()
+{
+   std::cout << FTGL::GetString(FTGL::CONFIG_VERSION) << std::flush;
+   return 0;
+}

--- a/graf3d/gl/CMakeLists.txt
+++ b/graf3d/gl/CMakeLists.txt
@@ -227,3 +227,7 @@ target_include_directories(RGL PRIVATE
 if(MACOSX_GLU_DEPRECATED)
   target_compile_options(RGL PRIVATE -Wno-deprecated-declarations)
 endif()
+
+if(FTGL_VERSION VERSION_GREATER 2.1.2)
+  target_compile_definitions(RGL PRIVATE HAVE_UTF8)
+endif()

--- a/graf3d/gl/src/TGLFontManager.cxx
+++ b/graf3d/gl/src/TGLFontManager.cxx
@@ -36,6 +36,26 @@
 # include "FTGLBitmapFont.h"
 #endif
 
+namespace {
+#ifdef HAVE_UTF8
+// https://github.com/root-project/root/issues/22076#issuecomment-4342764706
+TString AsUTF8(const char *txt)
+{
+   TString utxt;
+   const auto len = strlen(txt);
+   for (auto i = 0UL; i < len; ++i) {
+      if (static_cast<unsigned char>(txt[i]) >= static_cast<unsigned char>(192)) {
+         utxt.Append(static_cast<unsigned char>(0xc3));
+         utxt.Append(static_cast<unsigned char>(0x80) +
+                     (static_cast<unsigned char>(txt[i]) - static_cast<unsigned char>(192)));
+      } else {
+         utxt.Append(txt[i]);
+      }
+   }
+   return utxt;
+}
+#endif
+} // namespace
 
 /** \class TGLFont
 \ingroup opengl
@@ -140,6 +160,10 @@ Float_t TGLFont::GetLineHeight() const
 void TGLFont::MeasureBaseLineParams(Float_t& ascent, Float_t& descent, Float_t& line_height,
                                     const char* txt) const
 {
+#ifdef HAVE_UTF8
+   TString utxt = AsUTF8(txt);
+   txt = utxt.Data();
+#endif
    Float_t dum, lly, ury;
    const_cast<FTFont*>(fFont)->BBox(txt, dum, lly, dum, dum, ury, dum);
    ascent      =  ury;
@@ -154,6 +178,7 @@ void TGLFont::BBox(const char* txt,
                    Float_t& llx, Float_t& lly, Float_t& llz,
                    Float_t& urx, Float_t& ury, Float_t& urz) const
 {
+   // HAVE_UTF8 was already called by functions above BBox so no need to transform here
    // FTGL is not const correct.
    const_cast<FTFont*>(fFont)->BBox(txt, llx, lly, llz, urx, ury, urz);
 }
@@ -165,6 +190,7 @@ void TGLFont::BBox(const wchar_t* txt,
                    Float_t& llx, Float_t& lly, Float_t& llz,
                    Float_t& urx, Float_t& ury, Float_t& urz) const
 {
+   // HAVE_UTF8 was already called by functions above BBox so no need to transform here
    // FTGL is not const correct.
    const_cast<FTFont*>(fFont)->BBox(txt, llx, lly, llz, urx, ury, urz);
 }
@@ -176,6 +202,8 @@ void TGLFont::BBox(const wchar_t* txt,
 template<class Char>
 void TGLFont::RenderHelper(const Char *txt, Double_t x, Double_t y, Double_t angle, Double_t /*mgn*/) const
 {
+   // no need to check HAVE_UTF8 here, since it was called by functions above it
+
    glPushMatrix();
    //glLoadIdentity();
 
@@ -242,6 +270,7 @@ void TGLFont::RenderHelper(const Char *txt, Double_t x, Double_t y, Double_t ang
 
 void TGLFont::Render(const wchar_t* txt, Double_t x, Double_t y, Double_t angle, Double_t mgn) const
 {
+   // TODO handle UTF8
    RenderHelper(txt, x, y, angle, mgn);
 }
 
@@ -249,6 +278,10 @@ void TGLFont::Render(const wchar_t* txt, Double_t x, Double_t y, Double_t angle,
 
 void TGLFont::Render(const char* txt, Double_t x, Double_t y, Double_t angle, Double_t mgn) const
 {
+#ifdef HAVE_UTF8
+   TString utxt = AsUTF8(txt);
+   txt = utxt.Data();
+#endif
    RenderHelper(txt, x, y, angle, mgn);
 }
 
@@ -266,8 +299,14 @@ void TGLFont::Render(const TString &txt) const
       glScalef(1.0f, 1.0f, fDepth);
    }
 
+#ifdef HAVE_UTF8
+   TString utxt = AsUTF8(txt);
    // FTGL is not const correct.
-   const_cast<FTFont*>(fFont)->Render(txt);
+   const_cast<FTFont *>(fFont)->Render(utxt.Data());
+#else
+   // FTGL is not const correct.
+   const_cast<FTFont *>(fFont)->Render(txt.Data());
+#endif
 
    if (scaleDepth) {
       glPopMatrix();
@@ -277,8 +316,8 @@ void TGLFont::Render(const TString &txt) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Render text with given alignmentrepl and at given position.
 
-void  TGLFont:: Render(const TString &txt, Float_t x, Float_t y, Float_t z,
-             ETextAlignH_e alignH, ETextAlignV_e alignV) const
+void TGLFont::Render(const TString &txt, Float_t x, Float_t y, Float_t z, ETextAlignH_e alignH,
+                     ETextAlignV_e alignV) const
 {
    glPushMatrix();
 
@@ -286,7 +325,13 @@ void  TGLFont:: Render(const TString &txt, Float_t x, Float_t y, Float_t z,
 
    x=0, y=0;
    Float_t llx, lly, llz, urx, ury, urz;
-   BBox(txt, llx, lly, llz, urx, ury, urz);
+
+#ifdef HAVE_UTF8
+   TString utxt = AsUTF8(txt);
+   BBox(utxt.Data(), llx, lly, llz, urx, ury, urz);
+#else
+   BBox(txt.Data(), llx, lly, llz, urx, ury, urz);
+#endif
 
    switch (alignH)
    {
@@ -322,7 +367,27 @@ void  TGLFont:: Render(const TString &txt, Float_t x, Float_t y, Float_t z,
    {
       glTranslatef(x, y, 0);
    }
-   Render(txt);
+
+   Bool_t scaleDepth = (fMode == kExtrude && fDepth != 1.0f);
+
+   if (scaleDepth) {
+      glPushMatrix();
+      // !!! 0.2*fSize is hard-coded in TGLFontManager::GetFont(), too.
+      glTranslatef(0.0f, 0.0f, 0.5f * fDepth * 0.2f * fSize);
+      glScalef(1.0f, 1.0f, fDepth);
+   }
+
+#ifdef HAVE_UTF8
+   // FTGL is not const correct.
+   const_cast<FTFont *>(fFont)->Render(utxt.Data());
+#else
+   // FTGL is not const correct.
+   const_cast<FTFont *>(fFont)->Render(txt.Data());
+#endif
+
+   if (scaleDepth) {
+      glPopMatrix();
+   }
    glPopMatrix();
 }
 


### PR DESCRIPTION
Backport #22129 and #22101 from @ferdymercury 

