### PR TITLE
[cppinterop] Use threadsafe death-test style in TracingTests

### DIFF
--- a/interpreter/CppInterOp/unittests/CppInterOp/CMakeLists.txt
+++ b/interpreter/CppInterOp/unittests/CppInterOp/CMakeLists.txt
@@ -85,6 +85,10 @@ add_cppinterop_unittest(TracingTests
   TracingTests.cpp
   Utils.cpp
 )
+
+set_property(TEST cppinterop-TracingTests APPEND PROPERTY
+  ENVIRONMENT "GTEST_DEATH_TEST_STYLE=threadsafe")
+
 target_compile_definitions(TracingTests PRIVATE
   "CPPINTEROP_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../../\""
 )


### PR DESCRIPTION
This should fix the failures seen on mac-beta and mac26. On apple systems, gtest's default "fast" death-test style forks the child without exec(), so the child inherits parent process state (atfork handlers, dyld closures, stdio locks) which can kill/stall before EXPECT_DEATH writes to stderr, so gtest captures an empty buffer and reports "died but not with expected error" with an empty Actualmsg.

This is a known issue and the fix as seen in LLVM's compiler-rt sanitizer tests, which set `testing::GTEST_FLAG(death_test_style) = "threadsafe";`  in their gtest entry points. Also see `gtest-death-test.cc:250 - "Death tests use fork(), which is unsafe particularly in a threaded context"`, and the project's docs recommend threadsafe for this case.