### PR TITLE
Fix tests failing in Gentoo

### DIFF
--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -82,6 +82,7 @@ class ImportLoadLibs(unittest.TestCase):
         "libclang_rt.asan-.*",
         "libROOTSanitizerConfig",
         "libjitterentropy",  # by libssl on openSUSE
+        "libsandbox",  # Gentoo portage test environment
     ]
 
     # Verbose mode of the test

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -2960,6 +2960,9 @@ function(ROOTTEST_ADD_OLDTEST)
                      WORKING_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                      DEPENDS roottest-root-io-event
                      FIXTURES_REQUIRED UtilsLibraryBuild
+                     # The Makefile breaks if these two variables are in the environment by accident:
+                     # If they are unset, root-config --arch --platform is invoked correctly
+                     ENVIRONMENT ARCH=;PLATFORM=
                      LABELS ${ARG_LABELS} TIMEOUT ${ARG_TIMEOUT})
   if(MSVC)
     ROOTTEST_TARGETNAME_FROM_FILE(testprefix .)

--- a/cmake/modules/RootTestDriver.cmake
+++ b/cmake/modules/RootTestDriver.cmake
@@ -89,15 +89,17 @@ if(ENV)
     # value as a single string.
     string(REPLACE ";" "\\;" pair "${pair}")
 
-    # Split KEY=VALUE into a 2-element CMake list: [KEY;VALUE]
-    string(REGEX REPLACE "^([^=]+)=(.*)$" "\\1;\\2" pair "${pair}")
+    # Split KEY=VALUE
+    string(REGEX REPLACE "^([^=]+)=(.*)$" "\\1" var "${pair}")
+    string(REGEX REPLACE "^([^=]+)=(.*)$" "\\2" val "${pair}")
 
-    list(GET pair 0 var)
-    list(GET pair 1 val)
-
-    # As before, quoting is important here so the semicolons are not
-    # interpreted as list separators.
-    set(ENV{${var}} "${val}")
+    if(val STREQUAL "")
+      unset(ENV{${var}})
+    else()
+      # As before, quoting is important here so the semicolons are not
+      # interpreted as list separators.
+      set(ENV{${var}} "${val}")
+    endif()
 
     if(DBG)
       message(STATUS "testdriver[ENV]:${var}==>${val}")

--- a/roottest/cling/dict/ROOT-9185/CMakeLists.txt
+++ b/roottest/cling/dict/ROOT-9185/CMakeLists.txt
@@ -1,4 +1,4 @@
 ROOTTEST_ADD_TEST(ROOT9185
-                  EXEC rootcling
+                  EXEC $<TARGET_FILE:rootcling>
                   OPTS -v2 -f ROOT9185Dict.cxx -s ROOT9185Dict.so -rml ROOT9185Dict.so -rmf ROOT9185Dict.rootmap ROOT9185.h ${CMAKE_CURRENT_SOURCE_DIR}/ROOT9185Linkdef.h
                   COPY_TO_BUILDDIR ROOT9185.h)


### PR DESCRIPTION
These changes are needed to run ROOT's test suite in Gentoo. The failures are often caused
- by the fact that ROOT might already be installed in `/usr/local`, which can break the test suite
- or by the fact that the environment in portage's test sandbox is different from what ROOT expects.