### PR TITLE
[v640][TPython] Fix `LoadMacro` for filenames containing special characters

### DIFF
--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -266,8 +266,22 @@ void TPython::LoadMacro(const char *name)
    // obtain a reference to look for new classes later
    PyObjectRef old{PyDict_Values(gMainDict)};
 
-// actual execution
-   Exec((std::string("__pyroot_f = open(\"") + name +
+   // escape characters in the file name that would otherwise terminate or
+   // alter the Python string literal we put the file name into below
+   std::string escapedName;
+   escapedName.reserve(std::char_traits<char>::length(name));
+   for (const char *p = name; *p; ++p) {
+      switch (*p) {
+      case '\\': escapedName += "\\\\"; break;
+      case '"':  escapedName += "\\\""; break;
+      case '\n': escapedName += "\\n";  break;
+      case '\r': escapedName += "\\r";  break;
+      default:   escapedName += *p;     break;
+      }
+   }
+
+   // actual execution
+   Exec((std::string("__pyroot_f = open(\"") + escapedName +
          "\"); "
          "exec(__pyroot_f.read()); "
          "__pyroot_f.close(); del __pyroot_f")

--- a/bindings/tpython/test/testTPython.cxx
+++ b/bindings/tpython/test/testTPython.cxx
@@ -1,8 +1,12 @@
 #include <TPython.h>
 
 #include <any>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <sstream>
+#include <string>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -40,3 +44,67 @@ TEST(TPython, ExecMultithreading)
    TPython::Exec("_anyresult = ROOT.std.make_any['int'](len(arr))", &len);
    EXPECT_EQ(std::any_cast<int>(len), nThreads);
 }
+
+namespace {
+
+// Write a tiny Python macro that sets the variable `tpython_loadmacro_marker` to `marker`.
+// to a temp file whose name contains `nameSubstr`. Returns the path used.
+std::filesystem::path writeMarkerMacro(const std::string &nameSubstr, int marker)
+{
+   auto path = std::filesystem::temp_directory_path() / (std::string("tpython_loadmacro_") + nameSubstr + "_test.py");
+   std::ofstream{path} << "tpython_loadmacro_marker = " << marker << "\n";
+   return path;
+}
+
+int readMarker()
+{
+   std::any out;
+   TPython::Exec("_anyresult = ROOT.std.make_any['int'](tpython_loadmacro_marker)", &out);
+   return std::any_cast<int>(out);
+}
+
+} // namespace
+
+// LoadMacro must accept filenames containing a single quote character.
+TEST(TPython, LoadMacroSingleQuoteInName)
+{
+   auto path = writeMarkerMacro("with'quote", 11);
+   TPython::Exec("tpython_loadmacro_marker = 0");
+   TPython::LoadMacro(path.string().c_str());
+   EXPECT_EQ(readMarker(), 11);
+   std::filesystem::remove(path);
+}
+
+#ifndef _MSC_VER
+// On platforms whose filesystems allow it (i.e. not Windows), LoadMacro must
+// also accept filenames containing a double quote character.
+TEST(TPython, LoadMacroDoubleQuoteInName)
+{
+   auto path = writeMarkerMacro("with\"quote", 22);
+   TPython::Exec("tpython_loadmacro_marker = 0");
+   TPython::LoadMacro(path.string().c_str());
+   EXPECT_EQ(readMarker(), 22);
+   std::filesystem::remove(path);
+}
+
+// Same idea for newline / carriage-return characters in the file name: these
+// are legal on POSIX filesystems and used to break the Python source across
+// lines, turning it into a SyntaxError.
+TEST(TPython, LoadMacroNewlineInName)
+{
+   auto path = writeMarkerMacro("with\nnewline", 33);
+   TPython::Exec("tpython_loadmacro_marker = 0");
+   TPython::LoadMacro(path.string().c_str());
+   EXPECT_EQ(readMarker(), 33);
+   std::filesystem::remove(path);
+}
+
+TEST(TPython, LoadMacroCarriageReturnInName)
+{
+   auto path = writeMarkerMacro("with\rcarriagereturn", 44);
+   TPython::Exec("tpython_loadmacro_marker = 0");
+   TPython::LoadMacro(path.string().c_str());
+   EXPECT_EQ(readMarker(), 44);
+   std::filesystem::remove(path);
+}
+#endif


### PR DESCRIPTION
The implementation inserted the file name argument directly into a Python string literal delimited by double quotes, so any `"` in the name terminated the literal early and made the constructed source invalid (or, with a carefully crafted name, a different program than intended). Escape `\`, `"`, `\n` and `\r` in the name before using it, so that the whole name is used as a literal.

Also add test coverage for filenames containing these special characters.

(cherry picked from commit fac6e65bbfe0eab2780ed3e73fa71853f3729873)