### PR TITLE
[v636][TPython] Fix `LoadMacro` for filenames containing special characters

### DIFF
--- a/bindings/tpython/src/TPython.cxx
+++ b/bindings/tpython/src/TPython.cxx
@@ -313,11 +313,25 @@ void TPython::LoadMacro(const char *name)
    // obtain a reference to look for new classes later
    PyObject *old = PyDict_Values(gMainDict);
 
+   // escape characters in the file name that would otherwise terminate or
+   // alter the Python string literal we put the file name into below
+   std::string escapedName;
+   escapedName.reserve(std::char_traits<char>::length(name));
+   for (const char *p = name; *p; ++p) {
+      switch (*p) {
+      case '\\': escapedName += "\\\\"; break;
+      case '"':  escapedName += "\\\""; break;
+      case '\n': escapedName += "\\n";  break;
+      case '\r': escapedName += "\\r";  break;
+      default:   escapedName += *p;     break;
+      }
+   }
+
 // actual execution
 #if PY_VERSION_HEX < 0x03000000
-   Exec((std::string("execfile(\"") + name + "\")").c_str());
+   Exec((std::string("execfile(\"") + escapedName + "\")").c_str());
 #else
-   Exec((std::string("__pyroot_f = open(\"") + name +
+   Exec((std::string("__pyroot_f = open(\"") + escapedName +
          "\"); "
          "exec(__pyroot_f.read()); "
          "__pyroot_f.close(); del __pyroot_f")


### PR DESCRIPTION
The implementation inserted the file name argument directly into a Python string literal delimited by double quotes, so any `"` in the name terminated the literal early and made the constructed source invalid (or, with a carefully crafted name, a different program than intended). Escape `\`, `"`, `\n` and `\r` in the name before using it, so that the whole name is used as a literal.

Also add test coverage for filenames containing these special characters.

(cherry picked from commit fac6e65bbfe0eab2780ed3e73fa71853f3729873)