### PR TITLE
[http] discard web socket connection without handler

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1300,8 +1300,10 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
       return kTRUE;
    }
 
-   if (!handler)
+   if (!handler) {
+      arg->Set404();
       return kFALSE;
+   }
 
    Bool_t process = kFALSE;
 


### PR DESCRIPTION
If no any handler was found - http request associated with specified web socket can be directly discarded. 

Before connection was established - but was not handled in the ROOT.
Just was consuming resources - `civetweb` thread.
