### PR TITLE
[v640] Deprecate R programming language interface

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -64,6 +64,7 @@ The following people have contributed to this new version:
   The Davix I/O code in ROOT remains uneffected and is built as before provided that the Davix library is found on the system.
 * `RRealField::SetQuantized` now has a new overload and the existing signature has been deprecated. The new overload enforces proper ordering of the arguments.
   The deprecated overload will be removed in ROOT 6.42.
+* The bindings to the R programming language that are enabled with the `r=ON` build option (`TRInterface` and friends) are deprecated and will be removed in ROOT 6.42. Their maintenance is no longer justified, given the broader adoption of the scientific Python ecosystem. Users who still rely on R from C++ are encouraged to call R directly via https://cran.r-project.org/package=RInside, which is what the ROOT bindings were using internally.
 
 ## Removals
 

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -383,7 +383,7 @@ foreach(opt afdsmgrd afs alien bonjour builtin_afterimage builtin_davix castor c
 endforeach()
 
 #---Deprecated options------------------------------------------------------------------------
-foreach(opt builtin_cppzmq builtin_zeromq)
+foreach(opt builtin_cppzmq builtin_zeromq r)
   if(${opt})
     message(DEPRECATION ">>> Option '${opt}' is deprecated and will be removed in the next release of ROOT. Please contact root-dev@cern.ch should you still need it.")
   endif()


### PR DESCRIPTION
Maintaining the ROOT R bindings is no longer justified given the large-scale adoption of Python over R in the particle physics community.

(cherry picked from commit 4bf18d904b96327a649e065aa5c7243d612eb711)