### PR TITLE
[RF] Add HistFactory preprocess callbacks

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -14,6 +14,7 @@
 #include <TNamed.h>
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -699,6 +700,10 @@ public:
    const std::vector<RooStats::HistFactory::PreprocessFunction> &GetFunctionObjects() const { return fFunctionObjects; }
    std::vector<std::string> GetPreprocessFunctions() const;
 
+   using PreprocessFunctionCallback = std::function<void(RooWorkspace &)>;
+   void AddPreprocessFunctionCallback(PreprocessFunctionCallback callback);
+   void ApplyPreprocessFunctionCallbacks(RooWorkspace &ws) const;
+
    /// get vector of defined Asimov Datasets
    std::vector<RooStats::HistFactory::Asimov> &GetAsimovDatasets() { return fAsimovDatasets; }
    /// add an Asimov Dataset
@@ -771,6 +776,10 @@ private:
 
    /// List of Preprocess Function objects
    std::vector<RooStats::HistFactory::PreprocessFunction> fFunctionObjects;
+
+   /// Programmatic preprocess callbacks, executed during workspace creation.
+   /// Transient because std::function is not ROOT-streamable.
+   std::vector<PreprocessFunctionCallback> fPreprocessFunctionCallbacks; //!
 
    /// List of Asimov datasets to generate
    std::vector<RooStats::HistFactory::Asimov> fAsimovDatasets;

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -870,6 +870,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       proto.Print();
     }
 
+    measurement.ApplyPreprocessFunctionCallbacks(proto);
+
     RooArgSet likelihoodTerms("likelihoodTerms");
     RooArgSet constraintTerms("constraintTerms");
     vector<string> likelihoodTermNames;

--- a/roofit/histfactory/src/Measurement.cxx
+++ b/roofit/histfactory/src/Measurement.cxx
@@ -88,6 +88,22 @@ void Measurement::AddPreprocessFunction(std::string name, std::string expression
    AddFunctionObject(func);
 }
 
+void Measurement::AddPreprocessFunctionCallback(PreprocessFunctionCallback callback)
+{
+   if (callback) {
+      fPreprocessFunctionCallbacks.push_back(callback);
+   }
+}
+
+void Measurement::ApplyPreprocessFunctionCallbacks(RooWorkspace &ws) const
+{
+   for (const auto &callback : fPreprocessFunctionCallbacks) {
+      if (callback) {
+         callback(ws);
+      }
+   }
+}
+
 /// Returns a list of defined preprocess function expressions
 std::vector<std::string> Measurement::GetPreprocessFunctions() const
 {


### PR DESCRIPTION
# This Pull request is aimed to fix issue #21052 https://github.com/root-project/root/issues/21052:
Large HistFactory models can create many expression-based preprocess
functions. Constructing these through RooWorkspace::factory can cause crashes during workspace creation due to Cling/LLVM runtime.

Add an optional callback path to Measurement so callers can create
preprocess objects programmatically once the workspace is available. 
The existing string-based preprocess function path is unchanged. This is change is also meant to interface with changes to trex-fitter which will try to use this new callback functionality. 


## Checklist:

- [x] tested changes locally



