### PR TITLE
Fix typo in TAttText::GetTextSizePercent

### DIFF
--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -316,7 +316,7 @@ void TAttText::Copy(TAttText &atttext) const
 
 Float_t TAttText::GetTextSizePercent(Float_t size)
 {
-   if ((GetTextFont() % 2 < 3) || !gPad)
+   if ((GetTextFont() % 10 < 3) || !gPad)
       return size;
 
    auto size0 = fTextSize;


### PR DESCRIPTION
Returns wrong size for the font with pixel size.

Fixes #22195
