### PR TITLE
[reve] Add chek for empty REveGeoPolyShape and REvePolygonSetProjected

### DIFF
--- a/graf3d/eve7/src/REveGluTess.cxx
+++ b/graf3d/eve7/src/REveGluTess.cxx
@@ -178,6 +178,9 @@ void ROOT::Experimental::EveGlu::TriangleCollector::ProcessData(const std::vecto
                                     const std::vector<UInt_t>  & polys,
                                     const Int_t                  n_polys)
 {
+   if (verts.empty() || polys.empty())
+      return;
+
    const Double_t *pnts = &verts[0];
    const UInt_t   *pols = &polys[0];
 


### PR DESCRIPTION
In some cases of REveGeoShapeExtract, an empty REveGeoShape holder is created for the directory structure.

Example:
```
   auto all = new  ("CMS");
   all->SetRnrSelf(false);
   all->AddElement(tracker);
   all->AddElement(muon);
   all->AddElement(ecal);
   all->AddElement(hcal);
```
For this case, EveGlu::TriangleCollector::ProcessData() needs the check before accessing the first element.