### PR TITLE
[Python] Delete TBrowser instances at exit

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import atexit
 import builtins
 import os
 import platform
@@ -188,3 +189,28 @@ if _is_ipython:
         from . import _jupyroot  # noqa: F401  # imported the side effect of setting up JupyROOT
 
         # from . import JsMVA
+
+
+def _cleanup():
+    # Delete TBrowser instances while the GUI event loop is still alive,
+    # which fixed https://github.com/root-project/root/issues/21912.
+    #
+    # The cleanup is kept tight on purpose. A previous version called
+    # TROOT::EndOfProcessCleanups() outright (removed in commit e9d2803), which
+    # also ran gInterpreter->ResetGlobals() and ShutDown() and interfered with
+    # Python objects still alive at exit time, by cleaning up objects that
+    # might be referenced by other Python proxies outside the control of gROOT.
+    facade = sys.modules[__name__]
+
+    # Skip if the C++ runtime was never initialized (i.e. _finalSetup did
+    # not run): nothing to clean up, and we don't want to drag cppyy in.
+    if "_cppyy" not in facade.__dict__:
+        return
+
+    if not getattr(facade.PyConfig, "ShutDown", True):
+        return
+
+    facade.gROOT.GetListOfBrowsers().Delete()
+
+
+atexit.register(_cleanup)


### PR DESCRIPTION
Closes #21912, which reported that a Python session that constructs a TRootBrowser segfaults at exit inside `TROOT::EndOfProcessCleanups()`.

To fix this, register an atexit hook that calls
`gROOT->GetListOfBrowsers()->Delete()` while the Python interpreter is still alive. This is the same workaround suggested in the issue, just made automatic. Honors `PyConfig.ShutDown`, and short-circuits if `_finalSetup()` never ran (no ROOT C++ runtime means nothing to clean up, and we do not want to drag cppyy in).

Why we cannot just call `EndOfProcessCleanups()` from atexit? That was the previous behaviour, removed in commit e9d2803 ("[python] Avoid interfering with gc at exit time"). Doing this would re-introduce test failures that the removal commit as fixed:

```
  pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-tdirectory-attrsyntax
  pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-tdirectoryfile-attrsyntax-get
```

`EndOfProcessCleanups()` tears down C++ objects that the TestCase classes still hold via CPyCppyy proxies (TFile / TDirectory). When CPython's gc walks those classes, it deallocates the proxies and reads memory ROOT just freed. Limiting the exit-time work to `TROOT::fBrowsers` leaves such objects untouched, so those tests stay green.