### PR TITLE
[Python] Release Python ownership of TCanvas registered to gROOT

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcanvas.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcanvas.py
@@ -72,6 +72,21 @@ if __name__ == "__main__":
 from . import _run_root_event_loop, pythonization
 
 
+def _TCanvas_init_releasing_ownership(self, *args, **kwargs):
+    """
+    Forward the arguments to the C++ constructor and give up Python ownership
+    if the canvas registered itself to gROOT's list of canvases (which is
+    the case for any non-default constructor). This avoids for example double deletes when a subsequent TCanvas with the same name
+    triggers gROOT to delete the old canvas while the previous Python
+    proxy is still alive somewhere.
+    """
+    import ROOT
+
+    self._cpp_constructor(*args, **kwargs)
+    if ROOT.gROOT.GetListOfCanvases().FindObject(self):
+        ROOT.SetOwnership(self, False)
+
+
 def _TCanvas_Update(self, block=False):
     """
     Updates the canvas.
@@ -116,3 +131,6 @@ def pythonize_tcanvas(klass):
     klass._Draw = klass.Draw
     klass.Update = _TCanvas_Update
     klass.Draw = _TCanvas_Draw
+
+    klass._cpp_constructor = klass.__init__
+    klass.__init__ = _TCanvas_init_releasing_ownership

--- a/bindings/pyroot/pythonizations/test/memory.py
+++ b/bindings/pyroot/pythonizations/test/memory.py
@@ -4,6 +4,8 @@ import unittest
 
 import ROOT
 
+ROOT.gROOT.SetBatch(True)
+
 
 def _leak(obj):
     gc.collect()
@@ -123,8 +125,7 @@ class MemoryStlString(unittest.TestCase):
         Test that registering manually an object with a directory also triggers
         a release of ownership from Python to C++.
         """
-        f1 = ROOT.TMemFile(
-            "_check_object_setdirectory_in_memory_file_begin", "recreate")
+        f1 = ROOT.TMemFile("_check_object_setdirectory_in_memory_file_begin", "recreate")
 
         x = klass(*args)
         # Register the object to the directory in case this hasn't been done:
@@ -170,5 +171,58 @@ class MemoryStlString(unittest.TestCase):
                 self._check_object_setdirectory(getattr(ROOT, classname), classname, args)
 
 
-if __name__ == '__main__':
+class TCanvasOwnership(unittest.TestCase):
+    """
+    Tests that the TCanvas pythonization releases Python ownership for canvases
+    that register themselves with gROOT's list of canvases.
+
+    This avoids a double delete when a subsequent TCanvas is constructed with
+    the same name. This triggers a cleanup of the previous canvas in gROOT
+    while the previous Python proxy can still be alive somewhere.
+
+    See https://github.com/root-project/root/issues/21942 for the original bug
+    report, describing a Jupyter kernel crash when re-executing a cell that
+    creates a TCanvas.
+    """
+
+    def test_canvas_loses_python_ownership(self):
+        c = ROOT.TCanvas("test_canvas_ownership", "title", 100, 100)
+        self.assertFalse(
+            c.__python_owns__,
+            "TCanvas Python proxy should not own the C++ object once it is registered in gROOT's list of canvases",
+        )
+        c.Close()
+
+    def test_recreate_with_same_name_does_not_crash(self):
+        canvas_name = "test_canvas_recreate"
+        canvas_title = "title"
+
+        # First proxy: create and keep an extra reference around to simulate
+        # the situation where for example the IPython user namespace holds on
+        # to the proxy after C++ has already deleted the object.
+        c_old = ROOT.TCanvas(canvas_name, canvas_title, 100, 100)
+        held_reference = c_old  # noqa: F841
+
+        # Creating a new canvas with the same name causes the C++ constructor
+        # to delete the previous canvas. With the fix, c_old does not own the
+        # underlying object and so will not double-delete it when it is finally
+        # garbage-collected.
+        c_new = ROOT.TCanvas(canvas_name, canvas_title, 100, 100)
+
+        # Used to cause double-deletes.
+        del c_old
+        del held_reference
+        gc.collect()
+
+        # Force another rebinding to exercise the cell re-running path that was
+        # the original reproducer, i.g. assign the new canvas to the same
+        # Python variable name.
+        c_new = ROOT.TCanvas(canvas_name, canvas_title, 100, 100)  # noqa: F841
+
+        # Sanity check: there should be exactly one canvas with this name.
+        canvases = [c.GetName() for c in ROOT.gROOT.GetListOfCanvases() if c.GetName() == canvas_name]
+        self.assertEqual(len(canvases), 1)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Following the pattern already used for TH1/TFile/etc., drop Python ownership in the TCanvas constructor pythonization once the canvas is in `gROOT`'s list of canvases.

This fixes a Jupyter kernel crash where re-running a cell that creates a TCanvas with the same name would double-delete the C++ object: The TCanvas constructor triggers deletion of the old same-name canvas, but the previous Python proxy still thought it owned the object and tried to delete it again on finalization.

Close #21942.