### PR TITLE
[hist] Annotate RHist with R__CLING_PTRCHECK(off).

### DIFF
--- a/hist/histv7/inc/ROOT/RAxes.hxx
+++ b/hist/histv7/inc/ROOT/RAxes.hxx
@@ -10,6 +10,7 @@
 #include "RBinIndexMultiDimRange.hxx"
 #include "RBinIndexRange.hxx"
 #include "RCategoricalAxis.hxx"
+#include "RHistUtils.hxx"
 #include "RLinearizedIndex.hxx"
 #include "RRegularAxis.hxx"
 #include "RVariableBinAxis.hxx"
@@ -38,7 +39,7 @@ namespace Internal {
 /**
 Bin configurations for all dimensions of a histogram.
 */
-class RAxes final {
+class R__CLING_PTRCHECK(off) RAxes final {
    template <typename T>
    friend class ::ROOT::Experimental::RHistEngine;
 

--- a/hist/histv7/inc/ROOT/RHistFillContext.hxx
+++ b/hist/histv7/inc/ROOT/RHistFillContext.hxx
@@ -28,7 +28,7 @@ A context to concurrently fill an RHist.
 Feedback is welcome!
 */
 template <typename BinContentType>
-class RHistFillContext final {
+class R__CLING_PTRCHECK(off) RHistFillContext final {
    friend class RHistConcurrentFiller<BinContentType>;
 
 private:

--- a/hist/histv7/inc/ROOT/RHistUtils.hxx
+++ b/hist/histv7/inc/ROOT/RHistUtils.hxx
@@ -12,6 +12,14 @@
 #include <intrin.h>
 #endif
 
+#ifdef __CLING__
+// This attribute can significantly speed up JIT-compiled code in CLING
+// It is also defined in ROOT, so keep the definitions the same.
+#define R__CLING_PTRCHECK(ONOFF) __attribute__((annotate("__cling__ptrcheck(" #ONOFF ")")))
+#else
+#define R__CLING_PTRCHECK(ONOFF)
+#endif
+
 namespace ROOT {
 namespace Experimental {
 namespace Internal {


### PR DESCRIPTION
In JITted RDF nodes, cling added an unnecessary pointer check, which significantly slows down execution.

