### PR TITLE
[Python][roottest] Don't rely on `__name__` attribute for template test

### DIFF
--- a/roottest/python/regression/LoKiNamespace.C
+++ b/roottest/python/regression/LoKiNamespace.C
@@ -1,15 +1,25 @@
+#include <type_traits>
+
 namespace LHCb {
 
-   class Particle {};
+class Particle {};
 
-} // namespace Particle
+} // namespace LHCb
 
 namespace LoKi {
 
-   template< typename T > class Constant {};
-   template< typename T > class BooleanConstant{};
+template <typename T>
+class Constant {
+public:
+   static constexpr bool isConstParticlePtr() { return std::is_same_v<T, LHCb::Particle const *>; }
+};
+template <typename T>
+class BooleanConstant {
+public:
+   static constexpr bool isConstParticlePtr() { return std::is_same_v<T, LHCb::Particle const *>; }
+};
 
-} // namespace Loki
+} // namespace LoKi
 
 #ifdef __CLING__
 #pragma link C++ class LoKi::Constant< const LHCb::Particle* >;

--- a/roottest/python/regression/PyROOT_regressiontests.py
+++ b/roottest/python/regression/PyROOT_regressiontests.py
@@ -229,9 +229,8 @@ class Regression05LoKiNamespace( MyTestCase ):
       gROOT.LoadMacro( 'LoKiNamespace.C+' )
       LoKi = ROOT.LoKi
 
-      self.assertEqual( LoKi.Constant( rcp ).__name__, 'Constant<%s>' % rcp )
-      self.assertEqual(
-         LoKi.BooleanConstant( rcp ).__name__, 'BooleanConstant<%s>' % rcp )
+      self.assertTrue(LoKi.Constant( rcp ).isConstParticlePtr())
+      self.assertTrue(LoKi.BooleanConstant( rcp ).isConstParticlePtr())
 
    def test2TemplateWithNamespaceReturnValue(self):
       """Test the return value of a templated function in a namespace"""


### PR DESCRIPTION
The regression test for template arguments in namespaces uses the `__name__` attribute of the template instance as a witness that the instantiation succeeded. However, this will cause problems when we update the pretty-printing in cppyy to rightfully include template arguments:
```txt
======================================================================
FAIL: Test name resolution of template with namespace parameter
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rembserj/code/root/root_src/roottest/python/regression/PyROOT_regressiontests.py", line 232, in test1TemplateWithNamespaceParameter
    self.assertEqual( LoKi.Constant( rcp ).__name__, 'Constant<%s>' % rcp )
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 'Constant<const Particle *>' != 'Constant<const LHCb::Particle*>'
- Constant<const Particle *>
?                        -
+ Constant<const LHCb::Particle*>
?                ++++++
```

The solution to this problem that this commit suggests is to avoid string matching in the test, moving the burden to checking if the template instantiation succeeded to well-defined C++.

Some historical context: this test was introduced 20 years ago:
https://github.com/root-project/roottest/commit/8654ef9eead1c23d522e897dc4fea2caeb71a260