### PR TITLE
Remove Parallelism, http and ROOT7 doxygen groups

### DIFF
--- a/core/base/doc/index.md
+++ b/core/base/doc/index.md
@@ -13,5 +13,3 @@ plugin handler, run-config resource processor, etc. etc.
 
 \brief Extension classes within libCore to backport or complement missing std:: features
 
-\defgroup Parallelism Parallelized classes
-\brief Classes implement parallelism within ROOT

--- a/core/foundation/inc/ROOT/RLogger.hxx
+++ b/core/foundation/inc/ROOT/RLogger.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RLogger.hxx
-/// \ingroup Base ROOT7
 /// \author Axel Naumann <axel@cern.ch>
 /// \date 2015-03-29
 

--- a/core/foundation/src/RError.cxx
+++ b/core/foundation/src/RError.cxx
@@ -1,5 +1,4 @@
 /// \file RError.cxx
-/// \ingroup Base ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-12-11
 

--- a/core/foundation/src/RLogger.cxx
+++ b/core/foundation/src/RLogger.cxx
@@ -1,5 +1,4 @@
 /// \file RLogger.cxx
-/// \ingroup Base ROOT7
 /// \author Axel Naumann <axel@cern.ch>
 /// \date 2015-07-07
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/core/imt/inc/ROOT/TTaskGroup.hxx
+++ b/core/imt/inc/ROOT/TTaskGroup.hxx
@@ -26,7 +26,6 @@ namespace Experimental {
 class TTaskGroup {
    /**
    \class ROOT::Experimental::TTaskGroup
-   \ingroup Parallelism
    \brief A class to manage the asynchronous execution of work items.
 
    A TTaskGroup represents concurrent execution of a group of tasks. Tasks may be dynamically added to the group as it

--- a/core/imt/src/RTaskArena.cxx
+++ b/core/imt/src/RTaskArena.cxx
@@ -19,7 +19,6 @@
 //////////////////////////////////////////////////////////////////////////
 ///
 /// \class ROOT::Internal::RTaskArenaWrapper
-/// \ingroup Parallelism
 /// \brief Wrapper over tbb::task_arena
 ///
 /// This class is a wrapper over tbb::task_arena, in order to keep

--- a/core/imt/src/TTaskGroup.cxx
+++ b/core/imt/src/TTaskGroup.cxx
@@ -27,7 +27,6 @@
 
 /**
 \class ROOT::Experimental::TTaskGroup
-\ingroup Parallelism
 \brief A class to manage the asynchronous execution of work items.
 
 A TTaskGroup represents concurrent execution of a group of tasks.

--- a/core/imt/src/TThreadExecutor.cxx
+++ b/core/imt/src/TThreadExecutor.cxx
@@ -17,7 +17,6 @@
 //////////////////////////////////////////////////////////////////////////
 ///
 /// \class ROOT::TThreadExecutor
-/// \ingroup Parallelism
 /// \brief This class provides a simple interface to execute the same task
 /// multiple times in parallel threads, possibly with different arguments every
 /// time.

--- a/core/multiproc/src/TProcessExecutor.cxx
+++ b/core/multiproc/src/TProcessExecutor.cxx
@@ -15,7 +15,6 @@
 //////////////////////////////////////////////////////////////////////////
 ///
 /// \class ROOT::TProcessExecutor
-/// \ingroup Parallelism
 /// \brief This class provides a simple interface to execute the same task
 /// multiple times in parallel, possibly with different arguments every
 /// time.

--- a/core/thread/inc/ROOT/TSpinMutex.hxx
+++ b/core/thread/inc/ROOT/TSpinMutex.hxx
@@ -19,7 +19,6 @@ namespace ROOT {
    /**
     * \class ROOT::TSpinMutex
     * \brief A spin mutex class which respects the STL interface for mutexes.
-    * \ingroup Parallelism
     * This class allows to acquire spin locks also in combination with templates in the STL such as
     * <a href="http://en.cppreference.com/w/cpp/thread/unique_lock">std::unique_lock</a> or
     * <a href="http://en.cppreference.com/w/cpp/thread/condition_variable_any">std::condition_variable_any</a>.

--- a/core/thread/inc/ROOT/TThreadedObject.hxx
+++ b/core/thread/inc/ROOT/TThreadedObject.hxx
@@ -136,7 +136,6 @@ namespace ROOT {
     * \class ROOT::TThreadedObject
     * \brief A wrapper to make object instances thread private, lazily.
     * \tparam T Class of the object to be made thread private (e.g. TH1F)
-    * \ingroup Parallelism
     *
     * A wrapper which makes objects thread private. The methods of the underlying
     * object can be invoked via the arrow operator. The object is created in

--- a/gui/treemap/inc/ROOT/RTreeMapBase.hxx
+++ b/gui/treemap/inc/ROOT/RTreeMapBase.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RTreeMapBase.hxx
-/// \ingroup TreeMap ROOT7
 /// \author Patryk Tymoteusz Pilichowski <patryk.tymoteusz.pilichowski@cern.ch>
 /// \date 2025-08-21
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/gui/treemap/inc/ROOT/RTreeMapPainter.hxx
+++ b/gui/treemap/inc/ROOT/RTreeMapPainter.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RTreeMapPainter.hxx
-/// \ingroup TreeMap ROOT7
 /// \author Patryk Tymoteusz Pilichowski <patryk.tymoteusz.pilichowski@cern.ch>
 /// \date 2025-08-21
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/gui/treemap/src/RTreeMapBase.cxx
+++ b/gui/treemap/src/RTreeMapBase.cxx
@@ -1,5 +1,4 @@
 /// \file RTreeMapBase.cxx
-/// \ingroup TreeMap ROOT7
 /// \author Patryk Tymoteusz Pilichowski <patryk.tymoteusz.pilichowski@cern.ch>
 /// \date 2025-08-21
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/gui/treemap/src/RTreeMapPainter.cxx
+++ b/gui/treemap/src/RTreeMapPainter.cxx
@@ -1,5 +1,4 @@
 /// \file RTreeMapPainter.cxx
-/// \ingroup TreeMap ROOT7
 /// \author Patryk Tymoteusz Pilichowski <patryk.tymoteusz.pilichowski@cern.ch>
 /// \date 2025-08-21
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/io/io/inc/ROOT/RFile.hxx
+++ b/io/io/inc/ROOT/RFile.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RFile.hxx
-/// \ingroup Base ROOT7
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2025-03-19
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. Feedback

--- a/io/io/src/RFile.cxx
+++ b/io/io/src/RFile.cxx
@@ -1,5 +1,4 @@
 /// \file v7/src/RFile.cxx
-/// \ingroup Base ROOT7
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2025-03-19
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/net/doc/index.md
+++ b/net/doc/index.md
@@ -1,2 +1,0 @@
-\defgroup http HTTP server
-\brief THttpServer-related classes to provide HTTP protocol to ROOT application

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -507,7 +507,6 @@ static int begin_request_handler(struct mg_connection *conn, void *)
 }
 
 /** \class TCivetweb
-\ingroup http
 
 THttpEngine implementation, based on civetweb embedded server
 

--- a/net/http/src/TFastCgi.cxx
+++ b/net/http/src/TFastCgi.cxx
@@ -271,7 +271,6 @@ void run_single_thread(TFastCgi *engine)
 
 
 /** \class TFastCgi
-\ingroup http
 
 THttpEngine implementation, based on fastcgi package
 

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -17,7 +17,6 @@
 #include "THttpWSEngine.h"
 
 /** \class THttpCallArg
-\ingroup http
 
 Contains arguments for single HTTP call
 

--- a/net/http/src/THttpEngine.cxx
+++ b/net/http/src/THttpEngine.cxx
@@ -12,7 +12,6 @@
 #include "THttpEngine.h"
 
 /** \class THttpEngine
-\ingroup http
 
 Abstract class for implementing http protocol for THttpServer
 */

--- a/net/http/src/THttpLongPollEngine.cxx
+++ b/net/http/src/THttpLongPollEngine.cxx
@@ -18,7 +18,6 @@
 #include <cstdlib>
 
 /** \class THttpLongPollEngine
-\ingroup http
 
 Emulation of websocket with long poll requests
 

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -58,7 +58,6 @@ public:
 
 /**
 \class THttpServer
-\ingroup http
 \brief Online http server for arbitrary ROOT application
 \note This class provides HTTP access to ROOT objects. The user is entirely responsible for the security of the server.
 It is strongly recommended to use the server only within an isolated network

--- a/net/http/src/THttpWSHandler.cxx
+++ b/net/http/src/THttpWSHandler.cxx
@@ -19,7 +19,6 @@
 #include <chrono>
 
 /** \class THttpWSHandler
-\ingroup http
 
 Class for user-side handling of websocket with THttpServer
 

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -46,7 +46,6 @@ const char *item_prop_autoload = "_autoload";
 const char *item_prop_rootversion = "_root_version";
 
 /** \class TRootSnifferScanRec
-\ingroup http
 
 Structure used to scan hierarchies of ROOT objects
 
@@ -397,7 +396,6 @@ Bool_t TRootSnifferScanRec::GoInside(TRootSnifferScanRec &super, TObject *obj, c
 
 
 /** \class TRootSniffer
-\ingroup http
 
 Sniffer of ROOT objects, data provider for THttpServer
 

--- a/net/http/src/TRootSnifferStore.cxx
+++ b/net/http/src/TRootSnifferStore.cxx
@@ -13,7 +13,6 @@
 
 
 /** \class TRootSnifferStore
-\ingroup http
 
 Used to store different results of objects scanning by TRootSniffer
 */
@@ -34,7 +33,6 @@ void TRootSnifferStore::SetResult(void *_res, TClass *_rescl, TDataMember *_resm
 // =================================================================================
 
 /** \class TRootSnifferStoreXml
-\ingroup http
 
 Used to store scanned objects hierarchy in XML form
 */
@@ -98,7 +96,6 @@ void TRootSnifferStoreXml::CloseNode(Int_t lvl, Int_t numchilds)
 // ============================================================================
 
 /** \class TRootSnifferStoreJson
-\ingroup http
 
 Used to store scanned objects hierarchy in JSON form
 */

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -42,7 +42,6 @@
 #include <cstring>
 
 /** \class TRootSnifferFull
-\ingroup http
 
 Extends TRootSniffer for many ROOT classes
 

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -1,5 +1,4 @@
 /// \file RNTupleDS.hxx
-/// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Enrico Guiraud <enrico.guiraud@cern.ch>
 /// \date 2018-10-04

--- a/tree/ntuple/doc/README.md
+++ b/tree/ntuple/doc/README.md
@@ -75,5 +75,3 @@ These commands work both with TTree as well as RNTuple.
 
 ## Related classes
 
-\defgroup ROOT7 ROOT7 classes
-\brief Interfaces and classes designed for future ROOT version 7

--- a/tree/ntuple/inc/ROOT/RNTupleAttrWriting.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrWriting.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleAttrWriting.hxx
-/// \ingroup NTuple ROOT7
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-01-27
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/inc/ROOT/RNTupleExporter.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleExporter.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleExporter.hxx
-/// \ingroup NTuple ROOT7
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2024-12-10
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleImporter.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleImporter.hxx
-/// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2022-11-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleInspector.hxx
-/// \ingroup NTuple ROOT7
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2023-01-09
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/src/RNTupleExporter.cxx
+++ b/tree/ntupleutil/src/RNTupleExporter.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleExporter.cxx
-/// \ingroup NTuple ROOT7
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2024-12-10
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/src/RNTupleImporter.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleImporter.cxx
-/// \ingroup NTuple ROOT7
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2022-11-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntupleutil/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/src/RNTupleInspector.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleInspector.cxx
-/// \ingroup NTuple ROOT7
 /// \author Florine de Geus <florine.willemijn.de.geus@cern.ch>
 /// \date 2023-01-09
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/treeplayer/src/TTreeProcessorMP.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMP.cxx
@@ -20,7 +20,6 @@ static const std::thread::id MAIN_THREAD_ID = std::this_thread::get_id();
 //////////////////////////////////////////////////////////////////////////
 ///
 /// \class ROOT::TTreeProcessorMP
-/// \ingroup Parallelism
 /// \brief This class provides an interface to process a TTree dataset
 ///        in parallel with multi-process technology
 ///

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -10,7 +10,6 @@
  *************************************************************************/
 
 /** \class ROOT::TTreeProcessorMT
-    \ingroup Parallelism
     \brief A class to process the entries of a TTree in parallel.
 
 By means of its Process method, ROOT::TTreeProcessorMT provides a way to process the


### PR DESCRIPTION
# This Pull request:
Remove Parallelism, http and ROOT7 doxygen groups

