### PR TITLE
Clean up doxygen sidebar; fix parsing errors

### DIFF
--- a/documentation/doxygen/DoxygenLayout.xml
+++ b/documentation/doxygen/DoxygenLayout.xml
@@ -4,10 +4,10 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="user" visible="yes" title="Tutorials" url="group__Tutorials.html"/>
-    <tab type="topics" visible="yes" title="Functional Parts" intro=""/>
+    <tab type="topics" visible="yes" title="ROOT Components" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>
-      <tab type="namespacemembers" visible="yes" title="" intro=""/>
+      <tab type="namespacemembers" visible="no" title="" intro=""/>
     </tab>
     <tab type="classes" visible="yes" title="All Classes">
       <tab type="classlist" visible="yes" title="" intro=""/>
@@ -15,7 +15,7 @@
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="files" visible="yes" title="">
+    <tab type="files" visible="no" title="">
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -748,7 +748,7 @@ void RooDataSet::weightError(double& lo, double& hi, ErrorType etype) const
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// \copydoc RooAbsData::weightError(ErrorType)
+/// \copydoc RooAbsData::weightError(RooAbsData::ErrorType)
 /// \param etype error type
 double RooDataSet::weightError(ErrorType etype) const
 {

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -288,7 +288,7 @@ RooRealIntegral::RooRealIntegral()
 /// The other integrations are performed numerically. The optional
 /// config object prescribes how these numeric integrations are configured.
 ///
-/// \Note If pdf component selection was globally overridden to always include
+/// \note If pdf component selection was globally overridden to always include
 /// all components (either with RooAbsReal::globalSelectComp(bool) or a
 /// RooAbsReal::GlobalSelectComponentRAII), then any created integral will
 /// ignore component selections during its lifetime. This is especially useful

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -380,7 +380,7 @@ public:
 
    /// Thread-safe callback for RDataFrame.
    /// It will record elapsed times and event statistics, and print a progress bar every n seconds (set by the
-   /// fPrintInterval). \param slot Ignored. \param value Ignored.
+   /// fPrintInterval). The function arguments are ignored.
    template <typename T>
    void operator()(unsigned int /*slot*/, T & /*value*/)
    {


### PR DESCRIPTION
This is part of an effort to polish a bit how the documentation shows up on the web.