### PR TITLE
TCanvas drawing area size

### DIFF
--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -89,6 +89,7 @@ private:
    Int_t         fCanvasDefW;        ///< Default canvas width
    Int_t         fCanvasDefX;        ///< Default canvas top X position
    Int_t         fCanvasDefY;        ///< Default canvas top Y position
+   Bool_t        fCanvasSizeIsDrawingArea; ///< If true, TCanvas ctor sizes define the drawing area instead of the window size. Default is false.
    Color_t       fPadColor;          ///< Pad color
    Width_t       fPadBorderSize;     ///< Pad border size
    Int_t         fPadBorderMode;     ///< Pad border mode
@@ -194,6 +195,7 @@ public:
    Int_t            GetCanvasDefW() const      {return fCanvasDefW;}
    Int_t            GetCanvasDefX() const      {return fCanvasDefX;}
    Int_t            GetCanvasDefY() const      {return fCanvasDefY;}
+   Bool_t           GetCanvasSizeIsDrawingArea() const   {return fCanvasSizeIsDrawingArea;}
    Int_t            GetColorPalette(Int_t i) const;
    Int_t            GetColorModelPS() const    {return fColorModelPS;}
    Float_t          GetDateX() const           {return fDateX;}
@@ -351,6 +353,7 @@ public:
    void             SetCanvasDefW(Int_t w=700) {fCanvasDefW = w;}
    void             SetCanvasDefX(Int_t topx=10) {fCanvasDefX = topx;}
    void             SetCanvasDefY(Int_t topy=10) {fCanvasDefY = topy;}
+   void             SetCanvasSizeIsDrawingArea(Int_t da =kFALSE) {fCanvasSizeIsDrawingArea = da;}
    void             SetLegendBorderSize(Width_t size=4) {fLegendBorderSize = size;}
    void             SetLegendFillColor(Color_t color=0) {fLegendFillColor = color;}
    void             SetLegendFillStyle(Style_t style=1001) {fLegendFillStyle = style;}
@@ -435,7 +438,7 @@ public:
    void             SavePrimitive(std::ostream &out, Option_t * = "") override;
    void             SaveSource(const char *filename, Option_t *option = nullptr);
 
-   ClassDefOverride(TStyle, 24);  //A collection of all graphics attributes
+   ClassDefOverride(TStyle, 25);  //A collection of all graphics attributes
 };
 
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -567,6 +567,7 @@ void TStyle::Copy(TObject &obj) const
    ((TStyle&)obj).fCanvasDefW       = fCanvasDefW;
    ((TStyle&)obj).fCanvasDefX       = fCanvasDefX;
    ((TStyle&)obj).fCanvasDefY       = fCanvasDefY;
+   ((TStyle&)obj).fCanvasSizeIsDrawingArea = fCanvasSizeIsDrawingArea;
    ((TStyle&)obj).fPadColor         = fPadColor;
    ((TStyle&)obj).fPadBorderSize    = fPadBorderSize;
    ((TStyle&)obj).fPadBorderMode    = fPadBorderMode;
@@ -713,6 +714,7 @@ void TStyle::Reset(Option_t *opt)
    fCanvasDefW     = 700;
    fCanvasDefX     = 10;
    fCanvasDefY     = 10;
+   fCanvasSizeIsDrawingArea = kFALSE;
    fPadColor       = fCanvasColor;
    fPadBorderSize  = fCanvasBorderSize;
    fPadBorderMode  = fCanvasBorderMode;
@@ -2149,6 +2151,7 @@ void TStyle::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out << prefix << "SetCanvasDefW(" << GetCanvasDefW() << ");\n";
    out << prefix << "SetCanvasDefX(" << GetCanvasDefX() << ");\n";
    out << prefix << "SetCanvasDefY(" << GetCanvasDefY() << ");\n";
+   out << prefix << "SetCanvasSizeIsDrawingArea(" << GetCanvasSizeIsDrawingArea() << ");\n";
    out << prefix << "SetPadColor(" << TColor::SavePrimitiveColor(GetPadColor()) << ");\n";
    out << prefix << "SetPadBorderSize(" << GetPadBorderSize() << ");\n";
    out << prefix << "SetPadBorderMode(" << GetPadBorderMode() << ");\n";

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -138,6 +138,27 @@ Following example shows how to proceed.
       c->SetWindowSize(500, 500);
    }
 ~~~
+
+\since **ROOT version 6.41/02:**
+
+When SetCanvasSizeIsDrawingArea(kTRUE) is enabled, the width and height passed to the TCanvas
+constructor define the size of the drawable area, rather than the full window size.
+
+Enabling this option makes the canvas behave consistently with typical image/output use cases,
+where the requested size should match the final rendered content.
+
+Example:
+~~~ {.cpp}
+{
+   gStyle->SetCanvasSizeIsDrawingArea(kTRUE);
+   Double_t w = 600;
+   Double_t h = 600;
+   auto c = new TCanvas("c", "c", w, h);
+   c->SaveAs("c.png");
+}
+~~~
+
+In this example, the saved PNG will have exactly 600×600 pixels of drawable content.
 */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -665,6 +686,10 @@ void TCanvas::Build()
       if (TestBit(kShowToolBar))     fCanvasImp->ShowToolBar(kTRUE);
       if (TestBit(kShowEditor))      fCanvasImp->ShowEditor(kTRUE);
       if (TestBit(kShowToolTips))    fCanvasImp->ShowToolTips(kTRUE);
+   }
+   if (gStyle->GetCanvasSizeIsDrawingArea()) {
+      SetWindowSize(fWindowWidth  + (fWindowWidth  - GetWw()),
+                    fWindowHeight + (fWindowHeight - GetWh()));
    }
 }
 


### PR DESCRIPTION
This change introduces a new setting `gStyle->SetCanvasSizeIsDrawingArea(kTRUE)` 
controlling how the TCanvas constructor interprets its width and height parameters.

By default, the constructor arguments correspond to the full window size, including window decorations (borders and title bar), which results in a smaller actual drawing area.

When this option is enabled, the constructor dimensions instead define the drawable area directly, ensuring that the rendered content (e.g. saved images) matches the requested size exactly.

Example usage:
```
void pngsize() {
   gStyle->SetCanvasSizeIsDrawingArea(kTRUE);
   Double_t w = 600;
   Double_t h = 600;
   auto c = new TCanvas("c", "c", w, h);
   c->SaveAs("c.png");
}
```
This is particularly useful for producing reproducible image outputs where the canvas size must match the final pixel dimensions.

This PR intend to give a solution to this issue: https://github.com/root-project/root/issues/11004#issuecomment-1471869803
