### PR TITLE
[Python] Inject `gClient` into facade without ROOT meta

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -155,6 +155,11 @@ class ROOTFacade(types.ModuleType):
         # calls). We reproduce their semantics here using LiveProxy.
         self.gDirectory = TDirectoryPythonAdapter()
 
+        def _gclient_resolver():
+            import ROOT
+
+            return ROOT.TGClient.Instance()
+
         def _gpad_resolver():
             import ROOT
 
@@ -165,6 +170,7 @@ class ROOTFacade(types.ModuleType):
 
             return ROOT.TVirtualX.Instance()
 
+        self.gClient = LiveProxy(_gclient_resolver)
         self.gPad = LiveProxy(_gpad_resolver)
         self.gVirtualX = LiveProxy(_gvirtualx_resolver)
 


### PR DESCRIPTION
Follows up on 5afaae763, applying the same procedure to yet another preprocessor macro: `gClient`.