### PR TITLE
Allow I/O of interpreted class if the underlying data format allows

### DIFF
--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -172,11 +172,20 @@ const std::type_info &TypeName2TypeID(const std::string &name)
    if (auto it = typeName2TypeIDMap.find(name); it != typeName2TypeIDMap.end())
       return it->second.get();
 
-   if (auto c = TClass::GetClass(name.c_str())) {
-      if (!c->GetTypeInfo()) {
-         throw std::runtime_error("Cannot extract type_info of type " + name + ".");
-      }
+   if (auto c = TClass::GetClass(name.c_str()); c && c->GetTypeInfo()) {
       return *c->GetTypeInfo();
+   }
+
+   // When the type_info cannot be retrieved with TClass, it might be that the interpreter still knows about it. This
+   // happens for example when a class has been declared to the interpreter in the same program where this
+   // RDataFrame is running, but has no dictionary. We attempt to retrieve the type_info via the interpreter before
+   // giving up.
+   std::unique_ptr<TInterpreterValue> v = gInterpreter->MakeInterpreterValue();
+   if (gInterpreter->Evaluate(("typeid(" + name + ')').c_str(), *v)) {
+      auto *typeIdAsVoidPtr = v->GetAsPointer();
+      const std::type_info *ti = reinterpret_cast<const std::type_info *>(typeIdAsVoidPtr);
+      if (ti)
+         return *ti;
    }
 
    throw std::runtime_error("Cannot extract type_info of type " + name + ".");

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -173,3 +173,19 @@ if(pyroot)
 endif()
 
 configure_file(.rootrc . COPYONLY)
+
+# This test writes a column of an interpreted type to disk and checks its contents
+ROOT_ADD_GTEST(
+  dataframe_snapshot_interpreted_class_write
+  dataframe_snapshot_interpreted_class_write.cxx
+  LIBRARIES ROOTDataFrame
+  FIXTURES_SETUP dataframe_snapshot_interpreted_class_fixture)
+
+# Here we read back from disk the contents of that column in a different process
+# to avoid having the interpreter know about the definition of that class. Since
+# there is no dictionary, only the data members of the class can be accessed
+ROOT_ADD_GTEST(
+  dataframe_snapshot_interpreted_class_read
+  dataframe_snapshot_interpreted_class_read.cxx
+  LIBRARIES ROOTDataFrame
+  FIXTURES_REQUIRED dataframe_snapshot_interpreted_class_fixture)

--- a/tree/dataframe/test/dataframe_snapshot_interpreted_class_read.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_interpreted_class_read.cxx
@@ -1,0 +1,53 @@
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/TestSupport.hxx>
+
+#include <gtest/gtest.h>
+
+class RDFSnapshotInterpretedClassRead : public ::testing::Test {
+protected:
+   inline constexpr static auto fgRNTupleFile{"RDFSnapshotInterpretedClassWriteRNTuple.root"};
+   inline constexpr static auto fgRNTupleName{"RDFSnapshotInterpretedClassWriteRNTuple"};
+   inline constexpr static auto fgTTreeFile{"RDFSnapshotInterpretedClassWriteTTree.root"};
+   inline constexpr static auto fgTTreeName{"RDFSnapshotInterpretedClassWriteTTree"};
+
+   static void TearDownTestSuite()
+   {
+      std::remove(fgRNTupleFile);
+      std::remove(fgTTreeFile);
+   }
+};
+
+TEST_F(RDFSnapshotInterpretedClassRead, ReadTTree)
+{
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.requiredDiag(kWarning, "TClass::Init",
+                      "no dictionary for class RDFSnapshotInterpretedClassWriteClass is available");
+   ROOT::RDataFrame df{fgTTreeName, fgTTreeFile};
+
+   auto s_evtId = df.Sum("evt.evtId");
+   auto s_charge = df.Sum("evt.charge");
+   auto s_pt = df.Sum("evt.pt");
+   auto s_eta = df.Sum("evt.eta");
+
+   EXPECT_EQ(*s_evtId, 42);
+   EXPECT_EQ(*s_charge, 1);
+   EXPECT_FLOAT_EQ(*s_pt, 30);
+   EXPECT_FLOAT_EQ(*s_eta, 3);
+}
+
+TEST_F(RDFSnapshotInterpretedClassRead, ReadRNTuple)
+{
+   // We would normally also get the TClass::Init warning for the RNTuple case, but since we read the TTree first,
+   // the TClass is already initialized and we don't get the warning again.
+   ROOT::RDataFrame df{fgRNTupleName, fgRNTupleFile};
+
+   auto s_evtId = df.Sum("evt.evtId");
+   auto s_charge = df.Sum("evt.charge");
+   auto s_pt = df.Sum("evt.pt");
+   auto s_eta = df.Sum("evt.eta");
+
+   EXPECT_EQ(*s_evtId, 42);
+   EXPECT_EQ(*s_charge, 1);
+   EXPECT_FLOAT_EQ(*s_pt, 30);
+   EXPECT_FLOAT_EQ(*s_eta, 3);
+}

--- a/tree/dataframe/test/dataframe_snapshot_interpreted_class_write.cxx
+++ b/tree/dataframe/test/dataframe_snapshot_interpreted_class_write.cxx
@@ -1,0 +1,89 @@
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RFieldBase.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+#include <ROOT/RNTupleReader.hxx>
+
+#include <TInterpreter.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+// The files are intentionally not deleted
+class RDFSnapshotInterpretedClassWrite : public ::testing::Test {
+protected:
+   inline constexpr static auto fgRNTupleFile{"RDFSnapshotInterpretedClassWriteRNTuple.root"};
+   inline constexpr static auto fgRNTupleName{"RDFSnapshotInterpretedClassWriteRNTuple"};
+   inline constexpr static auto fgTTreeFile{"RDFSnapshotInterpretedClassWriteTTree.root"};
+   inline constexpr static auto fgTTreeName{"RDFSnapshotInterpretedClassWriteTTree"};
+
+   static void WriteTTree(const char *datasetname, const char *filename)
+   {
+      auto f = std::make_unique<TFile>(filename, "recreate");
+      auto t = std::make_unique<TTree>(datasetname, datasetname);
+
+      gInterpreter->ProcessLine("RDFSnapshotInterpretedClassWriteClass myEvt{};");
+      std::unique_ptr<TInterpreterValue> v = gInterpreter->MakeInterpreterValue();
+      gInterpreter->Evaluate("myEvt", *v);
+      void *voidPtr = v->GetAsPointer();
+      t->Branch("evt", "RDFSnapshotInterpretedClassWriteClass", &voidPtr);
+      t->Fill();
+      f->Write();
+   }
+
+   static void WriteRNTuple(const char *datasetname, const char *filename)
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      model->AddField(ROOT::RFieldBase::Create("evt", "RDFSnapshotInterpretedClassWriteClass").Unwrap());
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), datasetname, filename);
+      writer->Fill();
+   }
+
+   static void SetUpTestSuite()
+   {
+      gInterpreter->Declare(R"(
+        struct RDFSnapshotInterpretedClassWriteClass{
+            int evtId{42};
+            std::vector<int> charge{1,-1,1};
+            std::vector<float> pt{5,10,15};
+            std::vector<float> eta{0, 1, 2};
+        };
+        )");
+
+      WriteRNTuple(fgRNTupleName, fgRNTupleFile);
+
+      WriteTTree(fgTTreeName, fgTTreeFile);
+   }
+};
+
+TEST_F(RDFSnapshotInterpretedClassWrite, ReadTTree)
+{
+   ROOT::RDataFrame df{fgTTreeName, fgTTreeFile};
+
+   auto s_evtId = df.Sum("evt.evtId");
+   auto s_charge = df.Sum("evt.charge");
+   auto s_pt = df.Sum("evt.pt");
+   auto s_eta = df.Sum("evt.eta");
+
+   EXPECT_EQ(*s_evtId, 42);
+   EXPECT_EQ(*s_charge, 1);
+   EXPECT_FLOAT_EQ(*s_pt, 30);
+   EXPECT_FLOAT_EQ(*s_eta, 3);
+}
+
+TEST_F(RDFSnapshotInterpretedClassWrite, ReadRNTuple)
+{
+   ROOT::RDataFrame df{fgRNTupleName, fgRNTupleFile};
+   auto s_evtId = df.Sum("evt.evtId");
+   auto s_charge = df.Sum("evt.charge");
+   auto s_pt = df.Sum("evt.pt");
+   auto s_eta = df.Sum("evt.eta");
+
+   EXPECT_EQ(*s_evtId, 42);
+   EXPECT_EQ(*s_charge, 1);
+   EXPECT_FLOAT_EQ(*s_pt, 30);
+   EXPECT_FLOAT_EQ(*s_eta, 3);
+}

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -235,8 +235,6 @@ TEST(RDataFrameUtils, TypeName2TypeID)
    EXPECT_EQ(typeid(float), RDFInt::TypeName2TypeID("float"));
    EXPECT_EQ(typeid(std::vector<float>), RDFInt::TypeName2TypeID("std::vector<float>"));
    EXPECT_EQ(typeid(std::vector<std::vector<float>>), RDFInt::TypeName2TypeID("std::vector<std::vector<float>>"));
-   EXPECT_THROW(RDFInt::TypeName2TypeID("float *"), std::runtime_error);
-   EXPECT_THROW(RDFInt::TypeName2TypeID("float &"), std::runtime_error);
 }
 
 TEST(RDataFrameUtils, GetClusterRanges)


### PR DESCRIPTION
RDataFrame needs the type_info of input column types to create the column readers. This is searched first in a map of known simple types, then through TClass. Sometimes TClass might not know about a type_info even though it's available to the interpreter. This is the case for example of runtime-generated classes that are declared to the interpreter but do not have a dictionary, in which case `tclass->IsLoaded()` will return false and the TClass will not expose the type_info but the interpreter knows about it.

This commit proposes to extend the search in RDataFrame to include also a call to the interpreter in case the RTTI cannot be found through TClass.

This removes a long-standing safeguard introduced in RDataFrame that would prevent users from trying to Snapshot a column if the type had no dictionary. But both TTree and RNTuple support this to different degrees. By removing the safeguard and querying the interpreter for the RTTI RDataFrame delegates responsability to the underlying I/O technology.

As a side effect, this also helps in the integration with awkward arrays, where a C++ type is generated per different awkward array layout at runtime in the Python application. The awkward data source is still responsible to communicate correctly to TTree or RNTuple what they should store to disk when a Snapshot is called.

FYI @ianna 

Fixes https://github.com/root-project/root/issues/22233