### PR TITLE
[Python] Implicitly call SOFIE::RModel constructor in pythonization

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/parser.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/parser.py
@@ -321,7 +321,7 @@ class PyKeras:
         gmt_time = time.gmtime(ttime)
         parsetime = time.asctime(gmt_time)
 
-        rmodel = SOFIE.RModel.RModel(filename_nodir, parsetime)
+        rmodel = SOFIE.RModel(filename_nodir, parsetime)
 
         print("PyKeras: parsing model ", filename)
 


### PR DESCRIPTION
The RModel pythonization explicitly calls the constructor via cppyy with `SOFIE.RModel.RModel`, instead of `SOFIE.RModel(...`