### PR TITLE
[doxygen] Remove RNTuple source files from the corresponding doxygen group

### DIFF
--- a/tree/ntuple/inc/ROOT/RCluster.hxx
+++ b/tree/ntuple/inc/ROOT/RCluster.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RCluster.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2020-03-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/inc/ROOT/RClusterPool.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RClusterPool.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2020-03-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/inc/ROOT/RColumn.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RColumn.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RColumnElementBase.hxx
+++ b/tree/ntuple/inc/ROOT/RColumnElementBase.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RColumnElementBase.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RCreateFieldOptions.hxx
+++ b/tree/ntuple/inc/ROOT/RCreateFieldOptions.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RCreateFieldOptions.hxx
-/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2024-12-17
 

--- a/tree/ntuple/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RDaos.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RDaos.hxx
-/// \ingroup NTuple
 /// \author Javier Lopez-Gomez <j.lopez@cern.ch>
 /// \date 2020-11-14
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/REntry.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-07-19
 

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RField.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RFieldBase.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RFieldToken.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldToken.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RFieldToken.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2025-03-19
 

--- a/tree/ntuple/inc/ROOT/RFieldUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldUtils.hxx
@@ -1,5 +1,4 @@
 /// \file RFieldUtils.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 

--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RFieldVisitor.hxx
-/// \ingroup NTuple
 /// \author Simon Leisibach <simon.satoshi.rene.leisibach@cern.ch>
 /// \date 2019-06-11
 

--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RMiniFile.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-12-22
 

--- a/tree/ntuple/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/inc/ROOT/RNTuple.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTuple.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2023-09-19
 

--- a/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrReading.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleAttrReading.hxx
-/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-04-01
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleAttrUtils.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleAttrUtils.hxx
-/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-03-10
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleDescriptor.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>
 /// \date 2018-07-19

--- a/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleFillContext.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleFillContext.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 

--- a/tree/ntuple/inc/ROOT/RNTupleFillStatus.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleFillStatus.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleFillStatus.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-04-15
 

--- a/tree/ntuple/inc/ROOT/RNTupleImtTaskScheduler.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleImtTaskScheduler.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleImtTaskScheduler.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-19
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleJoinTable.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleJoinTable.hxx
-/// \ingroup NTuple
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2024-04-02
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMerger.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleMerger.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>, Max Orok <maxwellorok@gmail.com>, Alaettin Serhan Mete <amete@anl.gov>
 /// \date 2020-07-08
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleMetrics.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-08-27
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleModel.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleModel.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/inc/ROOT/RNTupleParallelWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleParallelWriter.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleParallelWriter.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-02-01
 

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleProcessor.hxx
-/// \ingroup NTuple
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2024-03-26
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleProcessor.hxx
-/// \ingroup NTuple
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2025-06-25
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleRange.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleRange.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleRange.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-05
 

--- a/tree/ntuple/inc/ROOT/RNTupleReadOptions.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReadOptions.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleReadOptions.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 

--- a/tree/ntuple/inc/ROOT/RNTupleReader.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleReader.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleReader.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-20
 

--- a/tree/ntuple/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleSerialize.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleSerialize.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>
 /// \date 2021-08-02

--- a/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleTypes.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleUtil.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleUtil.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2025-07-31
 

--- a/tree/ntuple/inc/ROOT/RNTupleUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleUtils.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleUtils.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2025-07-31
 

--- a/tree/ntuple/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleView.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleView.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-05
 

--- a/tree/ntuple/inc/ROOT/RNTupleWriteOptions.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriteOptions.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleWriteOptions.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 

--- a/tree/ntuple/inc/ROOT/RNTupleWriteOptionsDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriteOptionsDaos.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleWriteOptionsDaos.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleWriter.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleWriter.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-20
 

--- a/tree/ntuple/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleZip.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RNTupleZip.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-11-21
 

--- a/tree/ntuple/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/inc/ROOT/RPage.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPage.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RPageAllocator.hxx
+++ b/tree/ntuple/inc/ROOT/RPageAllocator.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageAllocator.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-06-25
 

--- a/tree/ntuple/inc/ROOT/RPageNullSink.hxx
+++ b/tree/ntuple/inc/ROOT/RPageNullSink.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageNullSink.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-01-31
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RPagePool.hxx
+++ b/tree/ntuple/inc/ROOT/RPagePool.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPagePool.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-09
 

--- a/tree/ntuple/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/inc/ROOT/RPageSinkBuf.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageSinkBuf.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Max Orok <maxwellorok@gmail.com>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageStorage.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-07-19
 

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageStorageDaos.hxx
-/// \ingroup NTuple
 /// \author Javier Lopez-Gomez <j.lopez@cern.ch>
 /// \date 2020-11-03
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RPageStorageFile.hxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-11-21
 

--- a/tree/ntuple/inc/ROOT/RRawPtrWriteEntry.hxx
+++ b/tree/ntuple/inc/ROOT/RRawPtrWriteEntry.hxx
@@ -1,5 +1,4 @@
 /// \file ROOT/RRawPtrWriteEntry.hxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2025-03-19
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RCluster.cxx
+++ b/tree/ntuple/src/RCluster.cxx
@@ -1,5 +1,4 @@
 /// \file RCluster.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2020-03-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RClusterPool.cxx
+++ b/tree/ntuple/src/RClusterPool.cxx
@@ -1,5 +1,4 @@
 /// \file RClusterPool.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2020-03-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RColumn.cxx
+++ b/tree/ntuple/src/RColumn.cxx
@@ -1,5 +1,4 @@
 /// \file RColumn.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/src/RColumnElement.cxx
+++ b/tree/ntuple/src/RColumnElement.cxx
@@ -1,5 +1,4 @@
 /// \file RColumnElement.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-08-11
 

--- a/tree/ntuple/src/RDaos.cxx
+++ b/tree/ntuple/src/RDaos.cxx
@@ -1,5 +1,4 @@
 /// \file RDaos.cxx
-/// \ingroup NTuple
 /// \author Javier Lopez-Gomez <j.lopez@cern.ch>
 /// \date 2020-11-14
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -1,5 +1,4 @@
 /// \file RField.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-15
 

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -1,5 +1,4 @@
 /// \file RFieldBase.cxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -1,5 +1,4 @@
 /// \file RFieldMeta.cxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -1,5 +1,4 @@
 /// \file RFieldSequenceContainer.cxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 

--- a/tree/ntuple/src/RFieldUtils.cxx
+++ b/tree/ntuple/src/RFieldUtils.cxx
@@ -1,5 +1,4 @@
 /// \file RFieldUtils.cxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -1,5 +1,4 @@
 /// \file RFieldVisitor.cxx
-/// \ingroup NTuple
 /// \author Simon Leisibach <simon.leisibach@gmail.com>
 /// \date 2019-06-11
 

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -1,5 +1,4 @@
 /// \file RMiniFile.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-12-22
 

--- a/tree/ntuple/src/RNTuple.cxx
+++ b/tree/ntuple/src/RNTuple.cxx
@@ -1,5 +1,4 @@
 /// \file RNTuple.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2023-09-19
 

--- a/tree/ntuple/src/RNTupleAttrReading.cxx
+++ b/tree/ntuple/src/RNTupleAttrReading.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleAttrReading.cxx
-/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-04-01
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleAttrWriting.cxx
+++ b/tree/ntuple/src/RNTupleAttrWriting.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleAttrWriting.cxx
-/// \ingroup NTuple
 /// \author Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2026-01-27
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/src/RNTupleDescriptor.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleDescriptor.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>
 /// \date 2018-10-04

--- a/tree/ntuple/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/src/RNTupleDescriptorFmt.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleDescriptorFmt.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-08-25
 

--- a/tree/ntuple/src/RNTupleFillContext.cxx
+++ b/tree/ntuple/src/RNTupleFillContext.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleFillContext.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 

--- a/tree/ntuple/src/RNTupleJoinTable.cxx
+++ b/tree/ntuple/src/RNTupleJoinTable.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleJoinTable.cxx
-/// \ingroup NTuple
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2024-04-02
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleMerger.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>, Max Orok <maxwellorok@gmail.com>, Alaettin Serhan Mete <amete@anl.gov>,
 /// Giacomo Parolini <giacomo.parolini@cern.ch>
 /// \date 2020-07-08

--- a/tree/ntuple/src/RNTupleMetrics.cxx
+++ b/tree/ntuple/src/RNTupleMetrics.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleMetrics.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-08-27
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleModel.cxx
+++ b/tree/ntuple/src/RNTupleModel.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleModel.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-15
 

--- a/tree/ntuple/src/RNTupleParallelWriter.cxx
+++ b/tree/ntuple/src/RNTupleParallelWriter.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleParallelWriter.cxx
-/// \ingroup NTuple
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-02-01
 

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleProcessor.cxx
-/// \ingroup NTuple
 /// \author Florine de Geus <florine.de.geus@cern.ch>
 /// \date 2024-03-26
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RNTupleReader.cxx
+++ b/tree/ntuple/src/RNTupleReader.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleReader.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-20
 

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleSerialize.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>
 /// \date 2021-08-02

--- a/tree/ntuple/src/RNTupleTypes.cxx
+++ b/tree/ntuple/src/RNTupleTypes.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleTypes.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2026-02-00
 

--- a/tree/ntuple/src/RNTupleUtils.cxx
+++ b/tree/ntuple/src/RNTupleUtils.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleUtils.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch> & Max Orok <maxwellorok@gmail.com>
 /// \date 2020-07-14
 /// \author Vincenzo Eduardo Padulano, CERN

--- a/tree/ntuple/src/RNTupleView.cxx
+++ b/tree/ntuple/src/RNTupleView.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleView.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-10-28
 

--- a/tree/ntuple/src/RNTupleWriteOptions.cxx
+++ b/tree/ntuple/src/RNTupleWriteOptions.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleWriteOptions.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-22
 

--- a/tree/ntuple/src/RNTupleWriter.cxx
+++ b/tree/ntuple/src/RNTupleWriter.cxx
@@ -1,5 +1,4 @@
 /// \file RNTupleReader.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2024-02-20
 

--- a/tree/ntuple/src/RPage.cxx
+++ b/tree/ntuple/src/RPage.cxx
@@ -1,5 +1,4 @@
 /// \file RPage.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/src/RPageAllocator.cxx
+++ b/tree/ntuple/src/RPageAllocator.cxx
@@ -1,5 +1,4 @@
 /// \file RPageAllocator.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-06-25
 

--- a/tree/ntuple/src/RPagePool.cxx
+++ b/tree/ntuple/src/RPagePool.cxx
@@ -1,5 +1,4 @@
 /// \file RPagePool.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/src/RPageSinkBuf.cxx
@@ -1,5 +1,4 @@
 /// \file RPageSinkBuf.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \author Max Orok <maxwellorok@gmail.com>
 /// \author Javier Lopez-Gomez <javier.lopez.gomez@cern.ch>

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1,5 +1,4 @@
 /// \file RPageStorage.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2018-10-04
 

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -1,5 +1,4 @@
 /// \file RPageStorageDaos.cxx
-/// \ingroup NTuple
 /// \author Javier Lopez-Gomez <j.lopez@cern.ch>
 /// \date 2020-11-03
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -1,5 +1,4 @@
 /// \file RPageStorageFile.cxx
-/// \ingroup NTuple
 /// \author Jakob Blomer <jblomer@cern.ch>
 /// \date 2019-11-25
 


### PR DESCRIPTION
Listing files on the doxygen page doesn't have a lot of benefit. Instead, we will list the contained classes.