### PR TITLE
[Python] Re-implement `TTree.SetBranchAddress` template call in Python

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_ttree.py
@@ -232,8 +232,7 @@ def _get_cpp_type_from_array_typecode(typecode):
 
 
 def _determine_data_type(addr):
-    """ Figure out data_type in case addr is a numpy.ndarray or array.array.
-    """
+    """Figure out data_type in case addr is a numpy.ndarray or array.array."""
 
     # For NumPy arrays
     if hasattr(addr, "__array_interface__"):
@@ -260,6 +259,8 @@ def _SetBranchAddress(self, bname, addr, *args, **kwargs):
     t.SetBranchAddress("my_vector_branch", v)
     ```
     """
+    import cppyy
+
     import ROOT
 
     branch = self.GetBranch(bname)
@@ -271,10 +272,37 @@ def _SetBranchAddress(self, bname, addr, *args, **kwargs):
     # Figure out data_type in case addr is a numpy.ndarray or array.array
     data_type = _determine_data_type(addr)
 
-    # We call the template specialization if we know the data type
-    func = self._OriginalSetBranchAddress if data_type is None else self._OriginalSetBranchAddress[data_type]
+    if data_type is None:
+        return self._OriginalSetBranchAddress(bname, addr, *args, **kwargs)
 
-    return func(bname, addr, *args, **kwargs)
+    # In the case the data_type is available, we would like to call the
+    # template overload of SetBranchAddress instantiatied for that type.
+    # However, there are two such overloads candidates:
+    #
+    #   template <class T> int TTree::SetBranchAddress(const char *bname, T **add, ...);
+    #   template <class T> int TTree::SetBranchAddress(const char *bname, T *add, ...);
+    #
+    # The cppyy bindings can't make a meaningful selection here as Python is
+    # lacking pointer semantics, so it considers both overloads as valid
+    # choices. In the past, we just happened to be lucky that it tried the T *
+    # overload first, which is the one we need. But as cppyy becomes more
+    # strict about overload resolution ambiguity errors, this won't work
+    # anymore. That's why we re-implement what happens in the template overload
+    # on the Python side.
+
+    cl = ROOT.TClass.GetClass[data_type]()
+    tp = ROOT.kOther_t
+    if not cl:
+        tp = ROOT.TDataType.GetType(cppyy.typeid(getattr(ROOT, data_type)))
+
+    # Extract the TBranch ptr argument if available
+    tbranch_ptr = ROOT.nullptr
+    if len(args) > 0:
+        tbranch_ptr = args[0]
+    elif "ptr" in kwargs:
+        tbranch_ptr = kwargs["ptr"]
+
+    return self._OriginalSetBranchAddress(bname, addr, ptr=tbranch_ptr, realClass=cl, datatype=tp, isptr=False)
 
 
 def _Branch(self, *args):
@@ -314,6 +342,7 @@ def _TTree__getattr__(self, key):
         out = ROOT._cppyy.ll.cast[cast_type](out)
     return out
 
+
 def _TTree_CloneTree(self, *args, **kwargs):
     """
     Forward the arguments to the C++ function and give up ownership if the
@@ -326,6 +355,7 @@ def _TTree_CloneTree(self, *args, **kwargs):
         ROOT.SetOwnership(out_tree, False)
 
     return out_tree
+
 
 @pythonization("TTree")
 def pythonize_ttree(klass, name):
@@ -379,6 +409,7 @@ def pythonize_tchain(klass):
     # SetBranchAddress
     klass._OriginalSetBranchAddress = klass.SetBranchAddress
     klass.SetBranchAddress = _SetBranchAddress
+
 
 @pythonization("TNtuple")
 def pythonize_tntuple(klass):


### PR DESCRIPTION
Previously, when the data type of the address argument could be determined (e.g. for NumPy arrays or `array.array` objects), we relied on cppyy to pick the right template overload of `SetBranchAddress` by indexing with the data type.

However, TTree::SetBranchAddress has two template overloads:

```c++
template <class T> int SetBranchAddress(const char *bname, T **add, ...);
template <class T> int SetBranchAddress(const char *bname, T  *add, ...);
```

Python lacks pointer semantics, so cppyy cannot meaningfully disambiguate between these two candidates and considers both valid. Until now, we happened to be lucky that cppyy tried the `T *` overload first, which is the one we need. As cppyy becomes stricter about overload resolution ambiguity, this will start failing.

To avoid relying on this accident, replicate on the Python side what the template overload does internally: look up the `TClass` for the given type, fall back to `TDataType::GetType` via `cppyy.typeid` otherwise, and then call the non-template `SetBranchAddress` overload directly with the resolved class and type arguments.

## Motivation for this PR

This fixes test failures that we see in the Cppyy upgrade PR (https://github.com/root-project/root/pull/21261), for example in [this test run on `alma10`](https://github.com/root-project/root/actions/runs/25723981162/job/75531885228?pr=21261):
```txt
 	 60 - pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-ttree-iterable (Failed)
 	 61 - pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-ttree-setbranchaddress (Failed)
```
The tests fail as follows:
```txt
972/3751 Test   #60: pyunittests-bindings-pyroot-pythonizations-pyroot-pyz-ttree-iterable ..............................***Failed    3.15 sec
test_array_branch (ttree_iterable.TTreeIterable.test_array_branch) ... ERROR
test_basic_type_branch (ttree_iterable.TTreeIterable.test_basic_type_branch) ... ERROR
test_ntuples (ttree_iterable.TTreeIterable.test_ntuples) ... ERROR
test_struct_branch (ttree_iterable.TTreeIterable.test_struct_branch) ... ok

======================================================================
ERROR: test_array_branch (ttree_iterable.TTreeIterable.test_array_branch)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/github/home/ROOT-CI/src/bindings/pyroot/pythonizations/test/ttree_iterable.py", line 83, in test_array_branch
    ds.SetBranchAddress('arrayb', a)
  File "/github/home/ROOT-CI/build/lib/ROOT/_pythonization/_ttree.py", line 277, in _SetBranchAddress
    return func(bname, addr, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Could not find "SetBranchAddress<double>" (set cppyy.set_debug() for C++ errors):
  Failed to instantiate "SetBranchAddress<double>(std::string,double*)"
```
So in case of the CppInterOp-based cppyy, it's selecting the other overload first, causing the tests to fail. This highlights that we should not rely on the "random first-try" overload selection, because the order in which the overloads are tried is not independent of the compiler/interpreter implementation.