### PR TITLE
[ntuple] Remove width limit in `PrintInfo()`

### DIFF
--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -133,51 +133,38 @@ class RPrintSchemaVisitor : public Detail::RFieldVisitor {
 private:
    /// Where to write the printout to
    std::ostream &fOutput;
-   /// To render the output, use an asterix (*) by default to draw table lines and boundaries
-   char fFrameSymbol;
-   /// Indicates maximal number of allowed characters per line
-   int fWidth;
    int fDeepestLevel;
    int fNumFields;
    int fAvailableSpaceKeyString;
-   int fAvailableSpaceValueString;
    int fFieldNo = 1;
    std::string fTreePrefix;
    std::string fFieldNoPrefix;
 
 public:
-   RPrintSchemaVisitor(std::ostream &out = std::cout, char frameSymbol = '*', int width = 80, int deepestLevel = 1,
-                       int numFields = 1)
-      : fOutput{out}, fFrameSymbol{frameSymbol}, fWidth{width}, fDeepestLevel{deepestLevel}, fNumFields{numFields}
+   RPrintSchemaVisitor(std::ostream &out = std::cout, int deepestLevel = 1, int numFields = 1)
+      : fOutput{out}, fDeepestLevel{deepestLevel}, fNumFields{numFields}
    {
       SetAvailableSpaceForStrings();
    }
    /// Prints summary of Field
    void VisitField(const ROOT::RFieldBase &field) final;
    void VisitFieldZero(const ROOT::RFieldZero &fieldZero) final;
-   void SetFrameSymbol(char s) { fFrameSymbol = s; }
-   void SetWidth(int w) { fWidth = w; }
    void SetDeepestLevel(int d);
    void SetNumFields(int n);
    /// Computes how many characters should be placed between the frame symbol and ':' for left and right side of ':' for
    /// visually pleasing output.
    // E.g.
-   // * Field 1       : vpx (std::vector<float>)                                     *
-   // * |__Field 1.1  : vpx/vpx (float)                                              *
-   // int fAvailableSpaceKeyString (num characters on left side between "* " and " : ")
+   // Field 1      : vpx (std::vector<float>)
+   //   Field 1.1  : vpx/vpx (float)
+   // int fAvailableSpaceKeyString (num characters on left side before " : ")
    //    deepestlevel here is 2 (1.1 is deepest and has 2 numbers).
-   //    For every additional level an additional "|_" and ".1" (4 characters) is added, so the number of required
+   //    For every additional level an additional "  " and ".1" (4 characters) is added, so the number of required
    //    additional characters is 4 * fDeepestLevel. For level 1, 8 characters are required ("Field 1 "), so an
    //    additional + 4 is added. To account for cases where the total number of fields is not a single digit number and
-   //    more space is required to output big numbers, fNumFields is incorporated into the calculation. To make sure
-   //    that there is still enough space for the right side of " : ", an std::min comparision with fWidth - 15 is done.
-   // int fAvailableSpaceValueString(num characters on right side between " : " and '*')
-   //    The 6 subtracted characters are "* " (2) in the beginning,  " : " (3) and '*' (1) on the far right.
+   //    more space is required to output big numbers, fNumFields is incorporated into the calculation.
    void SetAvailableSpaceForStrings()
    {
-      fAvailableSpaceKeyString =
-         std::min(4 * fDeepestLevel + 4 + static_cast<int>(std::to_string(fNumFields).size()), fWidth - 15);
-      fAvailableSpaceValueString = fWidth - 6 - fAvailableSpaceKeyString;
+      fAvailableSpaceKeyString = 4 * fDeepestLevel + 4 + static_cast<int>(std::to_string(fNumFields).size());
    }
 };
 

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -62,8 +62,6 @@ void ROOT::Internal::RPrintSchemaVisitor::SetNumFields(int n)
 
 void ROOT::Internal::RPrintSchemaVisitor::VisitField(const ROOT::RFieldBase &field)
 {
-   fOutput << fFrameSymbol << ' ';
-
    std::string key = fTreePrefix;
    key += "Field " + fFieldNoPrefix + std::to_string(fFieldNo);
    fOutput << RNTupleFormatter::FitString(key, fAvailableSpaceKeyString);
@@ -72,8 +70,7 @@ void ROOT::Internal::RPrintSchemaVisitor::VisitField(const ROOT::RFieldBase &fie
    std::string value = field.GetFieldName();
    if (!field.GetTypeName().empty())
       value += " (" + field.GetTypeName() + ")";
-   fOutput << RNTupleFormatter::FitString(value, fAvailableSpaceValueString);
-   fOutput << fFrameSymbol << std::endl;
+   fOutput << value << '\n';
 
    auto subfields = field.GetConstSubfields();
    auto fieldNo = 1;

--- a/tree/ntuple/src/RNTupleReader.cxx
+++ b/tree/ntuple/src/RNTupleReader.cxx
@@ -249,16 +249,6 @@ void ROOT::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output
 {
    using namespace ROOT::Internal;
 
-   // TODO(lesimon): In a later version, these variables may be defined by the user or the ideal width may be read out
-   // from the terminal.
-   char frameSymbol = '*';
-   int width = 80;
-   /*
-   if (width < 30) {
-      output << "The width is too small! Should be at least 30." << std::endl;
-      return;
-   }
-   */
    switch (what) {
    case ENTupleInfo::kSummary: {
       std::string name;
@@ -274,17 +264,9 @@ void ROOT::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output
          fullModel = descriptorGuard->CreateModel(opts);
       }
 
-      for (int i = 0; i < (width / 2 + width % 2 - 4); ++i)
-         output << frameSymbol;
-      output << " NTUPLE ";
-      for (int i = 0; i < (width / 2 - 4); ++i)
-         output << frameSymbol;
-      output << "\n";
       // FitString defined in RFieldVisitor.cxx
-      output << frameSymbol << " N-Tuple : " << RNTupleFormatter::FitString(name, width - 13) << frameSymbol
-             << "\n"; // prints line with name of ntuple
-      output << frameSymbol << " Entries : " << RNTupleFormatter::FitString(std::to_string(GetNEntries()), width - 13)
-             << frameSymbol << "\n"; // prints line with number of entries
+      output << "RNTuple : " << name << "\n";
+      output << "Entries : " << GetNEntries() << "\n\n";
 
       // Traverses through all fields to gather information needed for printing.
       RPrepareVisitor prepVisitor;
@@ -294,18 +276,11 @@ void ROOT::RNTupleReader::PrintInfo(const ENTupleInfo what, std::ostream &output
       // Note that we do not need to connect the model, we are only looking at its tree of fields
       fullModel->GetConstFieldZero().AcceptVisitor(prepVisitor);
 
-      printVisitor.SetFrameSymbol(frameSymbol);
-      printVisitor.SetWidth(width);
       printVisitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
       printVisitor.SetNumFields(prepVisitor.GetNumFields());
 
-      for (int i = 0; i < width; ++i)
-         output << frameSymbol;
-      output << "\n";
       fullModel->GetConstFieldZero().AcceptVisitor(printVisitor);
-      for (int i = 0; i < width; ++i)
-         output << frameSymbol;
-      output << std::endl;
+      output << std::flush;
       break;
    }
    case ENTupleInfo::kStorageDetails: fSource->GetSharedDescriptorGuard()->PrintInfo(output); break;

--- a/tree/ntuple/test/ntuple_print.cxx
+++ b/tree/ntuple/test/ntuple_print.cxx
@@ -19,15 +19,15 @@ TEST(RNtuplePrint, FullString)
    auto reader = RNTupleReader::Open("ntpl", fileGuard.GetPath());
    std::ostringstream osSummary;
    reader->PrintInfo(ROOT::ENTupleInfo::kSummary, osSummary);
+   // clang-format off
    std::string reference{std::string("")
-       + "************************************ NTUPLE ************************************\n"
-       + "* N-Tuple : ntpl                                                               *\n"
-       + "* Entries : 1                                                                  *\n"
-       + "********************************************************************************\n"
-       + "* Field 1   : px (float)                                                       *\n"
-       + "* Field 2   : py (float)                                                       *\n"
-       + "* Field 3   : proj (float)                                                     *\n"
-       + "********************************************************************************\n"};
+       + "RNTuple : ntpl\n"
+       + "Entries : 1\n"
+       + "\n"
+       + "Field 1   : px (float)\n"
+       + "Field 2   : py (float)\n"
+       + "Field 3   : proj (float)\n"};
+   // clang-format on
    EXPECT_EQ(reference, osSummary.str());
 
    std::ostringstream osDetails;
@@ -82,19 +82,17 @@ TEST(RNtuplePrint, Int)
    RPrintSchemaVisitor visitor(os);
    RField<int> testField("intTest");
    testField.AcceptVisitor(visitor);
-   std::string expected{std::string("")
-       + "* Field 1   : intTest (std::int32_t)                                           *\n"};
+   std::string expected{"Field 1   : intTest (std::int32_t)\n"};
    EXPECT_EQ(expected, os.str());
 }
 
 TEST(RNtuplePrint, Float)
 {
    std::stringstream os;
-   RPrintSchemaVisitor visitor(os, 'a');
+   RPrintSchemaVisitor visitor(os);
    RField<float> testField("floatTest");
    testField.AcceptVisitor(visitor);
-   std::string expected{std::string("")
-       + "a Field 1   : floatTest (float)                                                a\n"};
+   std::string expected{"Field 1   : floatTest (float)\n"};
    EXPECT_EQ(expected, os.str());
 }
 
@@ -104,13 +102,15 @@ TEST(RNtuplePrint, Vector)
    RPrepareVisitor prepVisitor;
    RField<std::vector<float>> testField("floatVecTest");
    testField.AcceptVisitor(prepVisitor);
-   RPrintSchemaVisitor visitor(os, '$');
+   RPrintSchemaVisitor visitor(os);
    visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
    visitor.SetNumFields(prepVisitor.GetNumFields());
    testField.AcceptVisitor(visitor);
+   // clang-format off
    std::string expected{std::string("")
-       + "$ Field 1       : floatVecTest (std::vector<float>)                            $\n"
-       + "$   Field 1.1   : _0 (float)                                                   $\n"};
+       + "Field 1       : floatVecTest (std::vector<float>)\n"
+       + "  Field 1.1   : _0 (float)\n"};
+   // clang-format on
    EXPECT_EQ(expected, os.str());
 }
 
@@ -120,13 +120,15 @@ TEST(RNtuplePrint, ArrayAsRVec)
    RPrepareVisitor prepVisitor;
    ROOT::RArrayAsRVecField testField("arrayasrvecfield", std::make_unique<ROOT::RField<float>>("_0"), 0);
    testField.AcceptVisitor(prepVisitor);
-   RPrintSchemaVisitor visitor(os, '$');
+   RPrintSchemaVisitor visitor(os);
    visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
    visitor.SetNumFields(prepVisitor.GetNumFields());
    testField.AcceptVisitor(visitor);
-   std::string expected{std::string("") +
-                        "$ Field 1       : arrayasrvecfield (ROOT::VecOps::RVec<float>)                 $\n" +
-                        "$   Field 1.1   : _0 (float)                                                   $\n"};
+   // clang-format off
+   std::string expected{std::string("")
+       + "Field 1       : arrayasrvecfield (ROOT::VecOps::RVec<float>)\n" +
+       + "  Field 1.1   : _0 (float)\n"};
+   // clang-format on
    EXPECT_EQ(expected, os.str());
 }
 
@@ -136,47 +138,15 @@ TEST(RNtuplePrint, VectorNested)
    RPrepareVisitor prepVisitor;
    RField<std::vector<std::vector<float>>> testField("floatVecVecTest");
    testField.AcceptVisitor(prepVisitor);
-   RPrintSchemaVisitor visitor(os, 'x');
+   RPrintSchemaVisitor visitor(os);
    visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
    visitor.SetNumFields(prepVisitor.GetNumFields());
    testField.AcceptVisitor(visitor);
+   // clang-format off
    std::string expected{std::string("")
-       + "x Field 1           : floatVecVecTest (std::vector<std::vector<float>>)        x\n"
-       + "x   Field 1.1       : _0 (std::vector<float>)                                  x\n"
-       + "x     Field 1.1.1   : _0 (float)                                               x\n"};
+       + "Field 1           : floatVecVecTest (std::vector<std::vector<float>>)\n"
+       + "  Field 1.1       : _0 (std::vector<float>)\n"
+       + "    Field 1.1.1   : _0 (float)\n"};
+   // clang-format on
    EXPECT_EQ(expected, os.str());
 }
-
-TEST(RNtuplePrint, NarrowManyEntriesVecVecTraverse)
-{
-   std::stringstream os;
-   RPrepareVisitor prepVisitor;
-   RField<std::vector<std::vector<float>>> testField("floatVecVecTest");
-   testField.AcceptVisitor(prepVisitor);
-   RPrintSchemaVisitor visitor(os, ' ', 25);
-   visitor.SetDeepestLevel(prepVisitor.GetDeepestLevel());
-   visitor.SetNumFields(prepVisitor.GetNumFields());
-   testField.AcceptVisitor(visitor);
-   std::string expected{std::string("")
-       + "  Field 1    : floatV... \n"
-       + "    Field... : _0 (st... \n"
-       + "      Fie... : _0 (fl... \n"};
-   EXPECT_EQ(expected, os.str());
-}
-
-/* Currently the width can't be set by PrintInfo(). This test will be enabled when this feature is added.
-TEST(RNTuplePrint, TooShort)
-{
-FileRaii fileGuard("test.root");
-{
-   auto model = RNTupleModel::Create();
-   auto fieldPt = model->MakeField<float>("pt");
-   auto ntuple = RNTupleWriter::Recreate(std::move(model), "Staff", "test.root");
-}
-auto ntuple2 = RNTupleReader::Open("Staff", "test.root");
-std::ostringstream os;
-ntuple2->PrintInfo(ROOT::ENTupleInfo::kSummary, os, '+', 29);
-std::string fString{"The width is too small! Should be at least 30.\n"};
-EXPECT_EQ(fString, os.str());
-}
-*/

--- a/tree/ntuple/test/ntuple_show.cxx
+++ b/tree/ntuple/test/ntuple_show.cxx
@@ -390,22 +390,6 @@ R"({
 )" };
    // clang-format on
    EXPECT_EQ(outputData, osData.str());
-
-   std::ostringstream osFields;
-   reader->PrintInfo(ROOT::ENTupleInfo::kSummary, osFields);
-   // clang-format off
-   std::string outputFields{
-      "************************************ NTUPLE ************************************\n"
-      "* N-Tuple : Collections                                                        *\n"
-      "* Entries : 1                                                                  *\n"
-      "********************************************************************************\n"
-      "* Field 1           : myCollection                                             *\n"
-      "*   Field 1.1       : _0                                                       *\n"
-      "*     Field 1.1.1   : myShort (std::int16_t)                                   *\n"
-      "*     Field 1.1.2   : myFloat (float)                                          *\n"
-      "********************************************************************************\n" };
-   // clang-format on
-   EXPECT_EQ(outputFields, osFields.str());
 }
 
 TEST(RNTupleShow, RVec)


### PR DESCRIPTION
This is generally not useful for large EDMs with long type names, for example in the presence of templates. In that case, it is preferable to show long lines instead of cutting information.