### PR TITLE
[6.40] fix GL box painting, marker size in quartz

### DIFF
--- a/graf2d/cocoa/src/TGQuartz.mm
+++ b/graf2d/cocoa/src/TGQuartz.mm
@@ -433,7 +433,7 @@ void  TGQuartz::DrawPolyMarkerW(WinContext_t wctxt, Int_t n, TPoint *xy)
        CGContextSetLineCap(ctx, kCGLineCapRound);
    }
 
-   Float_t MarkerSizeReduced = GetMarkerSize() - TMath::Floor(TAttMarker::GetMarkerLineWidth(attmark.GetMarkerStyle())/2.)/4.;
+   Float_t MarkerSizeReduced = attmark.GetMarkerSize() - TMath::Floor(TAttMarker::GetMarkerLineWidth(attmark.GetMarkerStyle())/2.)/4.;
    Quartz::DrawPolyMarker(ctx, n, &fConvertedPoints[0], MarkerSizeReduced * drawable.fScaleFactor, markerstyle);
 
    CGContextSetLineJoin(ctx, kCGLineJoinMiter);

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -457,11 +457,12 @@ void TGLPadPainter::DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, 
 
    if (mode == kHollow) {
       const Rgl::Pad::LineAttribSet lineAttribs(kTRUE, 0, fLimits.GetMaxLineWidth(), kTRUE, &GetAttLine());
-      //
-      glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-      glRectd(x1, y1, x2, y2);
-      glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
-      glLineWidth(1.f);
+      glBegin(GL_LINE_LOOP);
+      glVertex2d(x1, y1);
+      glVertex2d(x2, y1);
+      glVertex2d(x2, y2);
+      glVertex2d(x1, y2);
+      glEnd();
    } else {
       const Rgl::Pad::FillAttribSet fillAttribs(fSSet, kFALSE, &fGlFillAtt);//Set filling parameters.
       glRectd(x1, y1, x2, y2);


### PR DESCRIPTION
1. In `TGLPadPainter` use line drawing for painting box border. `glRectd()` partially depends on previous state.
2. Fix marker size usage in `TGQuartz`. One have to use marker attributes to get marker size

These are backported fixes from https://github.com/root-project/root/pull/22222