### PR TITLE
[Python] Fix global directory setting in `root_module` test

### DIFF
--- a/bindings/pyroot/pythonizations/test/root_module.py
+++ b/bindings/pyroot/pythonizations/test/root_module.py
@@ -150,10 +150,10 @@ class ROOTModule(unittest.TestCase):
         self.assertEqual(gDirectory_1, gDirectory_2)
         self.assertNotEqual(gDirectory_1, ROOT.gROOT)
 
-        # If we re-assign the gDirectory now, it should be considered
-        ROOT.gDirectory = ROOT.nullptr
-        self.assertEqual(gDirectory_1, ROOT.nullptr)
-        self.assertEqual(gDirectory_2, ROOT.nullptr)
+        # If we reset the global directory to nullptr now, it should be considered
+        with ROOT.TDirectory.TContext(ROOT.nullptr):
+            self.assertEqual(gDirectory_1, ROOT.nullptr)
+            self.assertEqual(gDirectory_2, ROOT.nullptr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Doing `ROOT.gDirectory = ROOT.nullptr` is problematic because it replaces the `TDirectoryPythonAdapter` instance that makes `gDirectory` work as intended on the Python side, so this pattern can't be used.

Follows up on 2659fe33591e.