### PR TITLE
[gpad] make canvas size consistent in batch vs non-batch

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -602,8 +602,8 @@ void TCanvas::Build()
 
    if (IsBatch()) {
       // Make sure that batch interactive canvas sizes are the same
-      fCw -= 4;
-      fCh -= 28;
+      fCw -= 2;
+      fCh -= 24;
    } else if (IsWeb()) {
       // mark canvas as batch - avoid gVirtualX in many places
       SetBatch(kTRUE);


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/11004

Explores alternative solution to https://github.com/root-project/root/pull/22226

fyi @rlalik

TODO:
- [ ] Test if this offset is platform-dependent or not. Maybe we need `if MACOS -= 4 else -=2`
- [ ] Not sure if lines 234 and 880 need to be adapted, too.
- [ ] Maybe create ctest

Reproducer:

```
// Run either as root -l test_pixels.cpp -b -q
// Or as xvfb-run root -l test_pixels.cpp -q
#include <TCanvas.h>
#include <TROOT.h>
#include <iostream>
void test_pixels() {
    for(Int_t w=500;w<=900;w++) {
        for(Int_t h=500;h<=600;h++) {
            TCanvas *c = new TCanvas("c1","c1",w,h);
            Int_t diffw = w-c->GetWw();
            Int_t diffh = h-c->GetWh();
            if(!gROOT->IsBatch()) {
                if (diffw !=2 || diffh !=24)
                    std::cout << diffw << " " << diffh << " " << w << " " << h << std::endl;
            }
            else {
                if (diffw !=2 || diffh !=24)
                    std::cout << diffw << " " << diffh << " " << w << " " << h << std::endl;
            }
            delete c;
        }
    }
}

```