### PR TITLE
[cling] Disable pointer check for `Experimental` namespace

### DIFF
--- a/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
+++ b/interpreter/cling/lib/Interpreter/NullDerefProtectionTransformer.cpp
@@ -229,6 +229,11 @@ class PointerCheckInjector : public RecursiveASTVisitor<PointerCheckInjector> {
   static bool hasPtrCheckDisabledInContext(Sema *S, const Decl* D) {
     if (isa<TranslationUnitDecl>(D))
       return false;
+    if (auto *NS = dyn_cast<NamespaceDecl>(D)) {
+      if (NS->getName() == "Experimental") {
+        return true;
+      }
+    }
     for (const auto *Ann : D->specific_attrs<clang::AnnotateAttr>()) {
       if (Ann->getAnnotation() == "__cling__ptrcheck(off)")
         return true;


### PR DESCRIPTION
This also serves as a testbed for turning it off for the entire `ROOT` namespace.