### PR TITLE
[v636][core] Allow custom path for .rootrc instead of $HOME

### DIFF
--- a/core/base/src/TEnv.cxx
+++ b/core/base/src/TEnv.cxx
@@ -389,14 +389,20 @@ ClassImp(TEnv);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a resource table and read the (possibly) three resource files,
-/// i.e.\ `$ROOTSYS/etc/system<name>` (or `ROOTETCDIR/system<name>`),
-/// `$HOME/<name>` and `$PWD/<name>`.
+/// i.e.\ `$ROOTSYS/etc/system<name>` or `ROOTETCDIR/system<name>` 
+/// (kEnvGlobal), `$HOME/<name>` or (kEnvUser),  and `$PWD/<name>` (kEnvLocal).
 /// ROOT always reads ".rootrc" (in TROOT::InitSystem()). You can
 /// read additional user defined resource files by creating additional TEnv
 /// objects. By setting the shell variable ROOTENV_NO_HOME=1 the reading of
 /// the `$HOME/<name>` resource file will be skipped. This might be useful in
 /// case the home directory resides on an auto-mounted remote file system
 /// and one wants to avoid the file system from being mounted.
+/// In case the environment variable ROOTENV_USER_PATH is specified, 
+/// and ROOTENV_NO_HOME is not set, then `$ROOTENV_USER_PATH/<name>` 
+/// is considered instead of `$HOME/<name>`.
+/// If environment variables have to be avoided, a `rootlogon.C` script 
+/// can be created where where the environment can be set through an
+/// invocation of TEnv::ReadFile.
 
 TEnv::TEnv(const char *name)
 {
@@ -413,14 +419,23 @@ TEnv::TEnv(const char *name)
       char *s = gSystem->ConcatFileName(TROOT::GetEtcDir(), sname);
       ReadFile(s, kEnvGlobal);
       delete [] s;
+
       if (!gSystem->Getenv("ROOTENV_NO_HOME")) {
-         s = gSystem->ConcatFileName(gSystem->HomeDirectory(), name);
-         ReadFile(s, kEnvUser);
-         delete [] s;
-         if (strcmp(gSystem->HomeDirectory(), gSystem->WorkingDirectory()))
+         if (const auto rootrcPath = gSystem->Getenv("ROOTENV_USER_PATH")) {
+            s = gSystem->ConcatFileName(rootrcPath, name);
+            ReadFile(s, kEnvUser);
+            delete[] s;
+         } else {
+            s = gSystem->ConcatFileName(gSystem->HomeDirectory(), name);
+            ReadFile(s, kEnvUser);
+            delete[] s;
+         }
+         if (strcmp(gSystem->HomeDirectory(), gSystem->WorkingDirectory())) {
             ReadFile(name, kEnvLocal);
-      } else
+         }
+      } else {
          ReadFile(name, kEnvLocal);
+      }
    }
 }
 


### PR DESCRIPTION
via environment variable ROOTENV_USER_PATH.

Backport of https://github.com/root-project/root/pull/20202, as requested by @HealthyPear.

This new feature remains undocumented for ROOT versions before 6.38, but it's still convenient for code portability if this harmless feature works in all actively-maintained ROOT 6 branches.