### PR TITLE
[RF] Bugfix: Change min limit check to use strict inequality

### DIFF
--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -520,7 +520,7 @@ void RooRealVar::setMin(const char* name, double value, bool shared)
   RooAbsBinning& binning = getBinning(name,true,true,shared) ;
 
   // Check if new limit is consistent
-  if (value >= getMax()) {
+  if (value > getMax()) {
     coutW(InputArguments) << "RooRealVar::setMin(" << GetName()
            << "): Proposed new fit min. larger than max., setting min. to max." << std::endl ;
     binning.setMin(getMax()) ;


### PR DESCRIPTION
RooRealVar::setMin() limit check raised a warning of value being larger than getMax(). The check used ">=" instead of ">".