### PR TITLE
[ci] Invoke RN creation after publishing the binaries

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -649,3 +649,17 @@ jobs:
         kinit  -p ${{ secrets.KRB5USER }}@${{ secrets.KRB5REALM }} -kt ${KT_FILE_NAME}
         echo +++ Running the copy
         xrdcp -rf Binaries*/root_v* ${EOS_ENDPOINT}/${EOS_PATH}/
+
+
+  invoke_rn_creation:
+    # Create release notes
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.binaries}}
+    name: "Invoke the creation of the Release Notes"
+    needs: publish_binaries
+    uses: ./.github/workflows/root-rn-ci.yml
+    secrets:
+      RWEBEOS_KT: ${{ secrets.RWEBEOS_KT }}
+      KRB5REALM: ${{ secrets.KRB5REALM }}
+      KRB5USER: ${{ secrets.KRB5USER }}
+    with:
+      branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/root-rn-ci.yml
+++ b/.github/workflows/root-rn-ci.yml
@@ -8,7 +8,19 @@ on:
         type: string
         required: true
         default: "master"
-
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+    secrets:
+      RWEBEOS_KT:
+        required: true
+      KRB5REALM:
+        required: true
+      KRB5USER:
+        required: true
+      
 jobs:
   create_release_notes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
automatically. The generation of the RN continues to be callable independently in a stand-alone way.

