### PR TITLE
[6.40] [hist] Protect conversion of disabled `RHistStats` dimension

### DIFF
--- a/hist/histv7util/src/ConvertToTH1.cxx
+++ b/hist/histv7util/src/ConvertToTH1.cxx
@@ -78,9 +78,13 @@ void ConvertGlobalStatistics(Hist &h, const RHistStats &stats)
    Double_t hStats[4] = {
       stats.GetSumW(),
       stats.GetSumW2(),
-      stats.GetDimensionStats(0).fSumWX,
-      stats.GetDimensionStats(0).fSumWX2,
+      0,
+      0,
    };
+   if (stats.IsEnabled(0)) {
+      hStats[2] = stats.GetDimensionStats(0).fSumWX;
+      hStats[3] = stats.GetDimensionStats(0).fSumWX2;
+   }
    h.PutStats(hStats);
 }
 } // namespace

--- a/hist/histv7util/test/hist_convert_TH1.cxx
+++ b/hist/histv7util/test/hist_convert_TH1.cxx
@@ -121,6 +121,29 @@ TEST(ConvertToTH1I, RHistSetBinContentTainted)
    EXPECT_EQ(stats[3], 0);
 }
 
+TEST(ConvertToTH1I, RHistCategoricalAxis)
+{
+   const std::vector<std::string> categories = {"a", "b", "c"};
+   const RCategoricalAxis axis(categories);
+   RHist<int> hist(axis);
+   ASSERT_FALSE(hist.GetStats().IsEnabled(0));
+
+   hist.Fill("a");
+
+   auto th1i = ConvertToTH1I(hist);
+   ASSERT_TRUE(th1i);
+
+   EXPECT_EQ(th1i->GetBinContent(1), 1);
+
+   EXPECT_EQ(th1i->GetEntries(), 1);
+   Double_t stats[4];
+   th1i->GetStats(stats);
+   EXPECT_EQ(stats[0], 1);
+   EXPECT_EQ(stats[1], 1);
+   EXPECT_EQ(stats[2], 0);
+   EXPECT_EQ(stats[3], 0);
+}
+
 TEST(ConvertToTH1C, RHistEngine)
 {
    static constexpr std::size_t Bins = 20;


### PR DESCRIPTION
(cherry picked from commit 177b9c98af7634a2396b77e8c922cf2fe4c769ed)