### PR TITLE
[skip-ci][NFC] Fix typos and improve UNU.RAN documentation

### DIFF
--- a/core/dictgen/src/BaseSelectionRule.cxx
+++ b/core/dictgen/src/BaseSelectionRule.cxx
@@ -45,7 +45,7 @@ static const char *R__GetDeclSourceFileName(const clang::Decl* D)
    clang::SourceLocation SL = D->getLocation();
    // If the class decl is the result of a macpo expansion, take the location
    // where the macro is "invoked" i.e. expanded at (ExpansionLoc), not the
-   // spelling location (where the delc's tokens come from).
+   // spelling location (where the decl's tokens come from).
    if (SL.isMacroID())
       SL = SM.getExpansionLoc(SL);
 
@@ -555,5 +555,4 @@ void BaseSelectionRule::FillCache()
    }
 
 }
-
 

--- a/core/dictgen/src/XMLReader.cxx
+++ b/core/dictgen/src/XMLReader.cxx
@@ -65,7 +65,7 @@ void XMLReader::PopulateMap(){
 }
 
 /*
- This function Gets the next tag from teh input file stream
+ This function Gets the next tag from the input file stream
  file - the open input stream
  out - we return the tag through that parameter
  lineCount - we are counting the line numbers here in order to print error messages in case of an error

--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -64,7 +64,7 @@ static struct ForbidDiagnostics {
          return;
       }
 
-      // FIXME: DOAS backend is exprimental.
+      // FIXME: DOAS backend is experimental.
       if (level == kWarning
           && strstr(msg, "The DAOS backend is experimental and still under development") != nullptr) {
         std::cerr << "Warning in " << location << " " << msg << std::endl;

--- a/hist/hist/test/test_THBinIterator.cxx
+++ b/hist/hist/test/test_THBinIterator.cxx
@@ -187,7 +187,7 @@ TH1 *createTH3()
    return h1;
 }
 
-// create a TH2Poly using teh TKDTree binning class
+// create a TH2Poly using the TKDTree binning class
 TH1 * createTH2Poly() {
    // generate multidim data
    const int n = nEvents;

--- a/hist/unfold/src/TUnfoldBinning.cxx
+++ b/hist/unfold/src/TUnfoldBinning.cxx
@@ -1001,7 +1001,7 @@ Int_t TUnfoldBinning::GetTHxxBinningSingleNode
 }
 
 ////////////////////////////////////////////////////////////////////////
-/// calculate number of bins required to store this binning with teh
+/// calculate number of bins required to store this binning with the
 /// given axisSteering
 ///
 /// \param[in] axisSteering see method CreateHistogram()
@@ -2132,4 +2132,3 @@ void TUnfoldBinning::DecodeAxisSteering
      }
   }
 }
-

--- a/math/unuran/doc/index.md
+++ b/math/unuran/doc/index.md
@@ -3,20 +3,20 @@
 \brief Universal Non Uniform Random number generator for generating non uniform pseudo-random numbers.
 
 
-UNU.RAN, (Universal Non Uniform Random number generator for generating non uniform pseudo-random numbers)
+UNU.RAN (Universal Non-Uniform Random number generator for generating non-uniform pseudo-random numbers)
 is an ANSI C library licensed under GPL.<br>
 It contains universal (also called automatic or black-box) algorithms that can generate random numbers from
 large classes of continuous or discrete distributions, and also from practically all standard distributions.
-An extensive online documentation are available at the (UNU.RAN Web Site)[http://statistik.wu-wien.ac.at/unuran/]
+Extensive online documentation is available at the [UNU.RAN Web Site](http://statistik.wu-wien.ac.at/unuran/).
 
-New classes have been introduced to use the UNU.RAN C library from ROOT and C++ from ROOT and using C++ objects.
-To use UNU.RAN one needs always an instance of the class **TUnuran**.
+New classes have been introduced to use the UNU.RAN C library from ROOT and C++ objects.
+To use UNU.RAN, one always needs an instance of the class **TUnuran**.
 It can then be used in two distinct ways:
-- using the UNU.RAN native string API for pre-defined distributions (see<a href="http://statistik.wu-wien.ac.at/unuran/doc/unuran.html#StringAPI"> UNU.RAN documentation</a> for the string API):
+- Using the UNU.RAN native string API for pre-defined distributions (see the <a href="http://statistik.wu-wien.ac.at/unuran/doc/unuran.html#StringAPI">UNU.RAN documentation</a> for the string API):
 
 ~~~{.cpp}
           TUnuran unr;
-          //initialize unuran to generate normal random numbers using a "arou" method
+          // initialize unuran to generate normal random numbers using an "arou" method
           unr.Init("normal()","method=arou");
           //......
           // sample distributions N times (generate N random numbers)
@@ -26,9 +26,9 @@ It can then be used in two distinct ways:
 ~~~
 
 
-- Using a distribution object. We have then the following cases depending on the dimension and the distribution object.
+- Using a distribution object. The following cases depend on the dimension and the distribution object.
 
-- For 1D distribution the class **TUnuranContDist** must be used.
+- For 1D distributions, the class **TUnuranContDist** must be used.
     - A **TUnuranContDist** object can be created from a function
     providing the pdf (probability density function) and optionally one providing the derivative of the pdf.
     - If the derivative is not provided and the generation method requires it, then it is estimated numerically.
@@ -50,8 +50,8 @@ Some of this information is required depending on the chosen UNURAN generation m
           double x = unr.Sample();
 ~~~~
 
-- For multi-dimensional distribution the class **TUnuranMultiContDist** must be used.
-In this case only the multi-dimensional pdf is required
+- For multi-dimensional distributions, the class **TUnuranMultiContDist** must be used.
+In this case, only the multi-dimensional pdf is required.
 
 ~~~~{.cpp}
       //Multi-Dim case from a TF1 (or TF2 or TF3) object describing a multi-dimensional function
@@ -64,7 +64,7 @@ In this case only the multi-dimensional pdf is required
       unr.SampleMulti(x);
 ~~~~
 
-- For discrete distribution the class **TUnuranDiscrDist** must be used.
+- For discrete distributions, the class **TUnuranDiscrDist** must be used.
    The distribution can be initialized from a TF1 or from a vector of probabilities.
 
 ~~~~{.cpp}
@@ -78,10 +78,10 @@ In this case only the multi-dimensional pdf is required
          int k = unr.SampleDiscr();
 ~~~~
 
-- For empirical distribution the class **TUnuranEmpDist** must be used.
-  In this case one can generate random numbers from a set of data (un-binned)  in one or multi-dimension or
+- For empirical distributions, the class **TUnuranEmpDist** must be used.
+  In this case, one can generate random numbers from a set of data (un-binned) in one or more dimensions or
   from a set of binned data in one dimension (similar to TH1::GetRandom() ).
-  - For unbin data the parent distribution is estimated by UNU.RAN using a gaussian kernel smoothing algorithm.
+  - For unbinned data, the parent distribution is estimated by UNU.RAN using a Gaussian kernel smoothing algorithm.
    One can create the distribution class directly from a vector of data or from the buffer of TH1.
 
 ~~~~{.cpp}
@@ -94,12 +94,12 @@ In this case only the multi-dimensional pdf is required
          double x = unr.Sample();
 ~~~~
 
-- In the case of multi-dimension empirical distributions one needs to pass in addition to the iterators, the data dimension. It is assumed that the data are stored in the vector in this order : `(x0,y0,...),(x1,y1,....)`.
+- In the case of multi-dimensional empirical distributions, one needs to pass the data dimension in addition to the iterators. It is assumed that the data are stored in the vector in this order: `(x0,y0,...),(x1,y1,....)`.
 
-- For binned data (only one dimensional data are supported) one uses directly the histogram
+- For binned data (only one-dimensional data are supported), one uses the histogram directly.
 
 ~~~{.cpp}
-      // create an empirical distribution from an histogram
+      // create an empirical distribution from a histogram
       // if the histogram has a buffer one must use TUnuranEmpDist(h1,false)
       TH1 * h1 = ... // histogram pointer
       TUnuranEmpDist  binDist( h1);
@@ -115,5 +115,5 @@ In this case only the multi-dimensional pdf is required
 Functionality is also provided via the C++ classes for using a different random number generator by passing a
 TRandom pointer when constructing the TUnuran class (by default the ROOT gRandom is passed to UNURAN).
 
-The (UNU.RAN documentation)[http://statistik.wu-wien.ac.at/unuran/doc/unuran.html#Top] provides a detailed
-description of all the available methods and the possible options which one can pass to UNU.RAN for the various distributions.
+The [UNU.RAN documentation](http://statistik.wu-wien.ac.at/unuran/doc/unuran.html#Top) provides a detailed
+description of all the available methods and the possible options that one can pass to UNU.RAN for the various distributions.


### PR DESCRIPTION
Summary

This PR fixes several typos in comments and improves UNU.RAN documentation formatting and grammar.

Changes
fixed comment typos in core, hist, and dictgen
corrected Markdown link syntax in math/unuran/doc/index.md
improved wording/grammar in UNU.RAN documentation

No functional code changes were made.