### PR TITLE
[ntuple] Fixes for alignment

### DIFF
--- a/core/foundation/inc/ROOT/BitUtils.hxx
+++ b/core/foundation/inc/ROOT/BitUtils.hxx
@@ -41,6 +41,13 @@ inline constexpr T AlignUp(T value, T align) noexcept
    return (value + align - 1) & ~(align - 1);
 }
 
+/// Storage type whose alignment matches \a AlignT bytes.
+/// Used to instantiate std::vector specializations with guaranteed buffer alignment.
+template <std::size_t AlignT>
+struct alignas(AlignT) RAlignedStorage {
+   char data[AlignT] = {};
+};
+
 /// Given an integer `x`, returns the number of leading 0-bits starting at the most significant bit position.
 /// If `x` is 0, it returns the size of `x` in bits.
 ///

--- a/core/foundation/inc/ROOT/BitUtils.hxx
+++ b/core/foundation/inc/ROOT/BitUtils.hxx
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 #ifdef _MSC_VER
@@ -24,12 +25,17 @@
 namespace ROOT {
 namespace Internal {
 
+inline bool IsPowerOfTwo(std::uint64_t v)
+{
+   return (v & (v - 1)) == 0;
+}
+
 /// Return true if \p align is a valid C++ alignment value: strictly positive
 /// and a power of two.  This is the set of values accepted by
 /// `::operator new[](n, std::align_val_t(align))`.
 inline constexpr bool IsValidAlignment(std::size_t align) noexcept
 {
-   return align > 0 && (align & (align - 1)) == 0;
+   return align > 0 && IsPowerOfTwo(align);
 }
 
 /// Round \p value up to the next multiple of \p align.

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -23,27 +23,22 @@ class TEmulatedCollectionProxy : public TGenCollectionProxy  {
    friend class TCollectionProxy;
 
 public:
-   /// Storage type whose alignment matches \a Align bytes.
-   /// Used to instantiate std::vector specializations with guaranteed buffer alignment.
-   template <std::size_t Align>
-   struct alignas(Align) AlignedStorage {
-      char data[Align] = {};
-   };
-
    // Convenience vector aliases for each supported alignment.
-   using Cont1_t    = std::vector<AlignedStorage<   1>>;
-   using Cont2_t    = std::vector<AlignedStorage<   2>>;
-   using Cont4_t    = std::vector<AlignedStorage<   4>>;
-   using Cont8_t    = std::vector<AlignedStorage<   8>>;
-   using Cont16_t   = std::vector<AlignedStorage<  16>>;
-   using Cont32_t   = std::vector<AlignedStorage<  32>>;
-   using Cont64_t   = std::vector<AlignedStorage<  64>>;
-   using Cont128_t  = std::vector<AlignedStorage< 128>>;
-   using Cont256_t  = std::vector<AlignedStorage< 256>>;
-   using Cont512_t  = std::vector<AlignedStorage< 512>>;
-   using Cont1024_t = std::vector<AlignedStorage<1024>>;
-   using Cont2048_t = std::vector<AlignedStorage<2048>>;
-   using Cont4096_t = std::vector<AlignedStorage<4096>>;
+   // clang-format off
+   using Cont1_t    = std::vector<ROOT::Internal::RAlignedStorage<   1>>;
+   using Cont2_t    = std::vector<ROOT::Internal::RAlignedStorage<   2>>;
+   using Cont4_t    = std::vector<ROOT::Internal::RAlignedStorage<   4>>;
+   using Cont8_t    = std::vector<ROOT::Internal::RAlignedStorage<   8>>;
+   using Cont16_t   = std::vector<ROOT::Internal::RAlignedStorage<  16>>;
+   using Cont32_t   = std::vector<ROOT::Internal::RAlignedStorage<  32>>;
+   using Cont64_t   = std::vector<ROOT::Internal::RAlignedStorage<  64>>;
+   using Cont128_t  = std::vector<ROOT::Internal::RAlignedStorage< 128>>;
+   using Cont256_t  = std::vector<ROOT::Internal::RAlignedStorage< 256>>;
+   using Cont512_t  = std::vector<ROOT::Internal::RAlignedStorage< 512>>;
+   using Cont1024_t = std::vector<ROOT::Internal::RAlignedStorage<1024>>;
+   using Cont2048_t = std::vector<ROOT::Internal::RAlignedStorage<2048>>;
+   using Cont4096_t = std::vector<ROOT::Internal::RAlignedStorage<4096>>;
+   // clang-format on
 
    // Canonical container type (used for sizeof/typeid; actual alignment is
    // selected at runtime via the alignment switch in each method).

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -164,7 +164,6 @@ private:
    TClass *fClass;
    /// Additional information kept for each entry in `fSubfields`
    std::vector<RSubfieldInfo> fSubfieldsInfo;
-   std::size_t fMaxAlignment = 1;
 
    /// The staging area stores inputs to I/O rules according to the offsets given by the streamer info of
    /// "TypeName@@Version". The area is allocated depending on I/O rules resp. the source members of the I/O rules.
@@ -219,8 +218,8 @@ public:
    ~RClassField() override;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final;
-   size_t GetAlignment() const final { return fMaxAlignment; }
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
    std::uint32_t GetTypeVersion() const final;
    std::uint32_t GetTypeChecksum() const final;
    /// For polymorphic classes (that declare or inherit at least one virtual method), return the expected dynamic type

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -157,7 +157,7 @@ private:
       TClass *fClass;
 
    public:
-      explicit RClassDeleter(TClass *cl) : fClass(cl) {}
+      explicit RClassDeleter(TClass *cl);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
@@ -238,7 +238,7 @@ private:
       TClass *fClass;
 
    public:
-      explicit RStreamerFieldDeleter(TClass *cl) : fClass(cl) {}
+      explicit RStreamerFieldDeleter(TClass *cl);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -127,13 +127,9 @@ protected:
       RCollectionIterableOnce::RIteratorFuncs fIFuncsWrite;
 
    public:
-      explicit RProxiedCollectionDeleter(std::shared_ptr<TVirtualCollectionProxy> proxy) : fProxy(proxy) {}
+      explicit RProxiedCollectionDeleter(std::shared_ptr<TVirtualCollectionProxy> proxy);
       RProxiedCollectionDeleter(std::shared_ptr<TVirtualCollectionProxy> proxy, std::unique_ptr<RDeleter> itemDeleter,
-                                size_t itemSize)
-         : fProxy(proxy), fItemDeleter(std::move(itemDeleter)), fItemSize(itemSize)
-      {
-         fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
-      }
+                                size_t itemSize);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldProxiedCollection.hxx
@@ -175,8 +175,8 @@ public:
    ~RProxiedCollectionField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final { return fProxy->Sizeof(); }
-   size_t GetAlignment() const final { return alignof(std::max_align_t); }
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 };
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldRecord.hxx
@@ -58,8 +58,9 @@ class RRecordField : public RFieldBase {
       std::vector<std::size_t> fOffsets;
 
    public:
-      RRecordDeleter(std::vector<std::unique_ptr<RDeleter>> itemDeleters, const std::vector<std::size_t> &offsets)
-         : fItemDeleters(std::move(itemDeleters)), fOffsets(offsets)
+      RRecordDeleter(std::vector<std::unique_ptr<RDeleter>> itemDeleters, const std::vector<std::size_t> &offsets,
+                     std::size_t alignment)
+         : RDeleter(alignment), fItemDeleters(std::move(itemDeleters)), fOffsets(offsets)
       {
       }
       void operator()(void *objPtr, bool dtorOnly) final;

--- a/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -263,8 +263,8 @@ public:
    ~ROptionalField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final;
-   size_t GetAlignment() const final;
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
 };
 
 template <typename ItemT>
@@ -312,8 +312,8 @@ public:
    ~RUniquePtrField() override = default;
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final { return sizeof(std::unique_ptr<char>); }
-   size_t GetAlignment() const final { return alignof(std::unique_ptr<char>); }
+   std::size_t GetValueSize() const final { return sizeof(std::unique_ptr<char>); }
+   std::size_t GetAlignment() const final { return alignof(std::unique_ptr<char>); }
 };
 
 template <typename ItemT>
@@ -362,8 +362,8 @@ public:
    RField &operator=(RField &&other) = default;
    ~RField() final = default;
 
-   size_t GetValueSize() const final { return sizeof(std::string); }
-   size_t GetAlignment() const final { return std::alignment_of<std::string>(); }
+   std::size_t GetValueSize() const final { return sizeof(std::string); }
+   std::size_t GetAlignment() const final { return alignof(std::string); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 };
 
@@ -435,8 +435,8 @@ public:
    RVariantField &operator=(RVariantField &&other) = default;
    ~RVariantField() override = default;
 
-   size_t GetValueSize() const final;
-   size_t GetAlignment() const final;
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
 };
 
 template <typename... ItemTs>

--- a/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSTLMisc.hxx
@@ -232,8 +232,10 @@ class ROptionalField : public RNullableField {
       std::size_t fEngagementPtrOffset = 0;
 
    public:
-      ROptionalDeleter(std::unique_ptr<RDeleter> itemDeleter, std::size_t engagementPtrOffset)
-         : fItemDeleter(std::move(itemDeleter)), fEngagementPtrOffset(engagementPtrOffset) {}
+      ROptionalDeleter(std::unique_ptr<RDeleter> itemDeleter, std::size_t engagementPtrOffset, std::size_t alignment)
+         : RDeleter(alignment), fItemDeleter(std::move(itemDeleter)), fEngagementPtrOffset(engagementPtrOffset)
+      {
+      }
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
@@ -283,7 +285,10 @@ class RUniquePtrField : public RNullableField {
       std::unique_ptr<RDeleter> fItemDeleter;
 
    public:
-      explicit RUniquePtrDeleter(std::unique_ptr<RDeleter> itemDeleter) : fItemDeleter(std::move(itemDeleter)) {}
+      explicit RUniquePtrDeleter(std::unique_ptr<RDeleter> itemDeleter)
+         : RDeleter(alignof(std::unique_ptr<char>)), fItemDeleter(std::move(itemDeleter))
+      {
+      }
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
@@ -387,9 +392,12 @@ private:
       std::vector<std::unique_ptr<RDeleter>> fItemDeleters;
 
    public:
-      RVariantDeleter(std::size_t tagOffset, std::size_t variantOffset,
+      RVariantDeleter(std::size_t tagOffset, std::size_t variantOffset, std::size_t alignment,
                       std::vector<std::unique_ptr<RDeleter>> itemDeleters)
-         : fTagOffset(tagOffset), fVariantOffset(variantOffset), fItemDeleters(std::move(itemDeleters))
+         : RDeleter(alignment),
+           fTagOffset(tagOffset),
+           fVariantOffset(variantOffset),
+           fItemDeleters(std::move(itemDeleters))
       {
       }
       void operator()(void *objPtr, bool dtorOnly) final;

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -265,8 +265,8 @@ public:
    CreateUntyped(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField);
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
-   size_t GetValueSize() const final { return sizeof(std::vector<char>); }
-   size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 };
 
@@ -319,8 +319,8 @@ public:
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
 
-   size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
-   size_t GetAlignment() const final { return std::alignment_of<std::vector<bool>>(); }
+   std::size_t GetValueSize() const final { return sizeof(std::vector<bool>); }
+   std::size_t GetAlignment() const final { return alignof(std::vector<bool>); }
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;
 };
 
@@ -414,8 +414,8 @@ public:
    RArrayAsVectorField &operator=(RArrayAsVectorField &&other) = default;
    ~RArrayAsVectorField() final = default;
 
-   size_t GetValueSize() const final { return sizeof(std::vector<char>); }
-   size_t GetAlignment() const final { return std::alignment_of<std::vector<char>>(); }
+   std::size_t GetValueSize() const final;
+   std::size_t GetAlignment() const final;
 
    std::vector<RFieldBase::RValue> SplitValue(const RFieldBase::RValue &value) const final;
    void AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const final;

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -219,11 +219,12 @@ class RVectorField : public RFieldBase {
    class RVectorDeleter : public RDeleter {
    private:
       std::size_t fItemSize = 0;
+      std::size_t fItemAlignment = 0;
       std::unique_ptr<RDeleter> fItemDeleter;
 
    public:
-      RVectorDeleter();
-      RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter);
+      explicit RVectorDeleter(std::size_t itemAlignment);
+      RVectorDeleter(std::size_t itemSize, std::size_t itemAlignment, std::unique_ptr<RDeleter> itemDeleter);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 
@@ -248,7 +249,7 @@ protected:
    void GenerateColumns() final;
    void GenerateColumns(const ROOT::RNTupleDescriptor &desc) final;
 
-   void ConstructValue(void *where) const final { new (where) std::vector<char>(); }
+   void ConstructValue(void *where) const final;
    std::unique_ptr<RDeleter> GetDeleter() const final;
 
    std::size_t AppendImpl(const void *from) final;
@@ -402,7 +403,7 @@ protected:
    void GenerateColumns() final;
    using RFieldBase::GenerateColumns;
 
-   void ConstructValue(void *where) const final { new (where) std::vector<char>(); }
+   void ConstructValue(void *where) const final;
    /// Returns an RVectorField::RVectorDeleter
    std::unique_ptr<RDeleter> GetDeleter() const final;
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -54,8 +54,9 @@ private:
       std::unique_ptr<RDeleter> fItemDeleter;
 
    public:
-      RArrayDeleter(std::size_t itemSize, std::size_t arrayLength, std::unique_ptr<RDeleter> itemDeleter)
-         : fItemSize(itemSize), fArrayLength(arrayLength), fItemDeleter(std::move(itemDeleter))
+      RArrayDeleter(std::size_t itemSize, std::size_t arrayLength, std::size_t alignment,
+                    std::unique_ptr<RDeleter> itemDeleter)
+         : RDeleter(alignment), fItemSize(itemSize), fArrayLength(arrayLength), fItemDeleter(std::move(itemDeleter))
       {
       }
       void operator()(void *objPtr, bool dtorOnly) final;
@@ -130,9 +131,15 @@ class RRVecField : public RFieldBase {
       std::unique_ptr<RDeleter> fItemDeleter;
 
    public:
-      explicit RRVecDeleter(std::size_t itemAlignment) : fItemAlignment(itemAlignment) {}
+      explicit RRVecDeleter(std::size_t itemAlignment)
+         : RDeleter(ROOT::Internal::EvalRVecAlignment(itemAlignment)), fItemAlignment(itemAlignment)
+      {
+      }
       RRVecDeleter(std::size_t itemAlignment, std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
-         : fItemAlignment(itemAlignment), fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
+         : RDeleter(ROOT::Internal::EvalRVecAlignment(itemAlignment)),
+           fItemAlignment(itemAlignment),
+           fItemSize(itemSize),
+           fItemDeleter(std::move(itemDeleter))
       {
       }
       void operator()(void *objPtr, bool dtorOnly) final;
@@ -215,11 +222,8 @@ class RVectorField : public RFieldBase {
       std::unique_ptr<RDeleter> fItemDeleter;
 
    public:
-      RVectorDeleter() = default;
-      RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
-         : fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
-      {
-      }
+      RVectorDeleter();
+      RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 

--- a/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSequenceContainer.hxx
@@ -260,6 +260,9 @@ protected:
    void CommitClusterImpl() final { fNWritten = 0; }
 
 public:
+   /// Maximum alignment of the vector's value type
+   static constexpr std::size_t kMaxItemAlignment = 4096;
+
    RVectorField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField);
    RVectorField(RVectorField &&other) = default;
    RVectorField &operator=(RVectorField &&other) = default;

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -69,7 +69,6 @@ class RSoAField : public RFieldBase {
    std::vector<std::size_t> fSoAMemberOffsets;
    ///< A deleter returned by each record member's GetDeleter()
    std::vector<std::unique_ptr<RDeleter>> fRecordMemberDeleters;
-   std::size_t fMaxAlignment = 1;
    ROOT::Internal::RColumnIndex fNWritten;
 
    /// For reading and writing, the RVecs of the SoA class do not have a dedicated field. The in-memory RVecs of the
@@ -105,7 +104,7 @@ public:
 
    std::vector<RValue> SplitValue(const RValue &value) const final;
    size_t GetValueSize() const final;
-   size_t GetAlignment() const final { return fMaxAlignment; }
+   size_t GetAlignment() const final;
    std::uint32_t GetTypeVersion() const final;
    std::uint32_t GetTypeChecksum() const final;
    /// For polymorphic classes (that declare or inherit at least one virtual method), return the expected dynamic type

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -58,7 +58,7 @@ class RSoAField : public RFieldBase {
       TClass *fSoAClass;
 
    public:
-      explicit RSoADeleter(TClass *cl) : fSoAClass(cl) {}
+      explicit RSoADeleter(TClass *cl);
       void operator()(void *objPtr, bool dtorOnly) final;
    };
 

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -13,6 +13,7 @@
 #ifndef ROOT_RFieldBase
 #define ROOT_RFieldBase
 
+#include <ROOT/BitUtils.hxx>
 #include <ROOT/RColumn.hxx>
 #include <ROOT/RCreateFieldOptions.hxx>
 #include <ROOT/RError.hxx>
@@ -21,6 +22,7 @@
 #include <ROOT/RNTupleTypes.hxx>
 
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <functional>
 #include <iterator>
@@ -107,12 +109,22 @@ protected:
    /// The deleter is operational without the field object and thus can be used to destruct/release a value after
    /// the field has been destructed.
    class RDeleter {
+      std::size_t fAlignment;
+
    public:
+      explicit RDeleter(std::size_t align) : fAlignment(align) { assert(Internal::IsValidAlignment(align)); }
       virtual ~RDeleter() = default;
       virtual void operator()(void *objPtr, bool dtorOnly)
       {
-         if (!dtorOnly)
+         if (dtorOnly)
+            return;
+
+         // Match operator new in RFieldBase::CreateObjectRawPtr()
+         if (fAlignment <= sizeof(std::max_align_t)) {
             operator delete(objPtr);
+         } else {
+            operator delete(objPtr, std::align_val_t(fAlignment));
+         }
       }
    };
 
@@ -120,6 +132,7 @@ protected:
    template <typename T>
    class RTypedDeleter : public RDeleter {
    public:
+      RTypedDeleter() : RDeleter(alignof(T)) {}
       void operator()(void *objPtr, bool dtorOnly) final
       {
          std::destroy_at(static_cast<T *>(objPtr));
@@ -421,7 +434,7 @@ protected:
 
    /// Constructs value in a given location of size at least GetValueSize(). Called by the base class' CreateValue().
    virtual void ConstructValue(void *where) const = 0;
-   virtual std::unique_ptr<RDeleter> GetDeleter() const { return std::make_unique<RDeleter>(); }
+   virtual std::unique_ptr<RDeleter> GetDeleter() const { return std::make_unique<RDeleter>(GetAlignment()); }
    /// Allow derived classes to call ConstructValue(void *) and GetDeleter() on other (sub)fields.
    static void CallConstructValueOn(const RFieldBase &other, void *where) { other.ConstructValue(where); }
    static std::unique_ptr<RDeleter> GetDeleterOf(const RFieldBase &other) { return other.GetDeleter(); }
@@ -555,9 +568,6 @@ protected:
           const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 public:
-   /// Maximum supported alignment for field types, i.e. maximum returned by GetAlignment()
-   static constexpr std::size_t kMaxAlignment = 4096;
-
    template <bool IsConstT>
    class RSchemaIteratorTemplate;
    using RSchemaIterator = RSchemaIteratorTemplate<false>;
@@ -607,6 +617,8 @@ public:
    ///    auto ptr = field->CreateObject();
    ///    delete ptr.release();
    /// ~~~
+   /// Over-aligned types need to delete the returned pointer using the delete operator overload that specifies the
+   /// type's alignment.
    ///
    /// Note that CreateObject<void>() is supported. The returned `unique_ptr` has a custom deleter that reports an error
    /// if it is called. The intended use of the returned `unique_ptr<void>` is to call `release()`. In this way, the

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -110,6 +110,7 @@ protected:
    /// the field has been destructed.
    class RDeleter {
       std::size_t fAlignment;
+      void DeleteAligned(void *objPtr) const; // outlined to make Windows happy
 
    public:
       explicit RDeleter(std::size_t align) : fAlignment(align) { assert(Internal::IsValidAlignment(align)); }
@@ -123,7 +124,7 @@ protected:
          if (fAlignment <= sizeof(std::max_align_t)) {
             operator delete(objPtr);
          } else {
-            operator delete(objPtr, std::align_val_t(fAlignment));
+            DeleteAligned(objPtr);
          }
       }
    };

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -555,6 +555,9 @@ protected:
           const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 public:
+   /// Maximum supported alignment for field types, i.e. maximum returned by GetAlignment()
+   static constexpr std::size_t kMaxAlignment = 4096;
+
    template <bool IsConstT>
    class RSchemaIteratorTemplate;
    using RSchemaIterator = RSchemaIteratorTemplate<false>;
@@ -623,10 +626,9 @@ public:
    /// correct `std::variant` or all the elements of a collection. The default implementation assumes no subvalues
    /// and returns an empty vector.
    virtual std::vector<RValue> SplitValue(const RValue &value) const;
-   /// The number of bytes taken by a value of the appropriate type
+   /// What sizeof(T) for this type returns
    virtual size_t GetValueSize() const = 0;
-   /// As a rule of thumb, the alignment is equal to the size of the type. There are, however, various exceptions
-   /// to this rule depending on OS and CPU architecture. So enforce the alignment to be explicitly spelled out.
+   /// What alignof(T) for this type returns
    virtual size_t GetAlignment() const = 0;
    std::uint32_t GetTraits() const { return fTraits; }
    bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -730,7 +730,7 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RRecordField::GetDeleter() con
    for (const auto &f : fSubfields) {
       itemDeleters.emplace_back(GetDeleterOf(*f));
    }
-   return std::make_unique<RRecordDeleter>(std::move(itemDeleters), fOffsets);
+   return std::make_unique<RRecordDeleter>(std::move(itemDeleters), fOffsets, GetAlignment());
 }
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::RRecordField::SplitValue(const RValue &value) const
@@ -1168,7 +1168,7 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::ROptionalField::GetDeleter() c
 {
    return std::make_unique<ROptionalDeleter>(
       (fSubfields[0]->GetTraits() & kTraitTriviallyDestructible) ? nullptr : GetDeleterOf(*fSubfields[0]),
-      fSubfields[0]->GetValueSize());
+      fSubfields[0]->GetValueSize(), GetAlignment());
 }
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::ROptionalField::SplitValue(const RValue &value) const

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -96,6 +96,13 @@ ROOT::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::str
 
 //------------------------------------------------------------------------------
 
+void ROOT::RFieldBase::RDeleter::DeleteAligned(void *objPtr) const
+{
+   operator delete(objPtr, std::align_val_t(fAlignment));
+}
+
+//------------------------------------------------------------------------------
+
 ROOT::RFieldBase::RColumnRepresentations::RColumnRepresentations()
 {
    // A single representations with an empty set of columns

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -2,6 +2,7 @@
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 
+#include <ROOT/BitUtils.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
@@ -167,7 +168,7 @@ void ROOT::RFieldBase::RBulkValues::ReleaseValues()
       }
    }
 
-   operator delete(fValues);
+   operator delete(fValues, std::align_val_t(fField->GetAlignment()));
 }
 
 void ROOT::RFieldBase::RBulkValues::Reset(RNTupleLocalIndex firstIndex, std::size_t size)
@@ -177,7 +178,7 @@ void ROOT::RFieldBase::RBulkValues::Reset(RNTupleLocalIndex firstIndex, std::siz
          throw RException(R__FAIL("invalid attempt to bulk read beyond the adopted buffer"));
       }
       ReleaseValues();
-      fValues = operator new(size * fValueSize);
+      fValues = operator new(size * fValueSize, std::align_val_t(fField->GetAlignment()));
 
       if (!(fField->GetTraits() & RFieldBase::kTraitTriviallyConstructible)) {
          for (std::size_t i = 0; i < size; ++i) {
@@ -632,7 +633,15 @@ std::size_t ROOT::RFieldBase::ReadBulkImpl(const RBulkSpec &bulkSpec)
 
 void *ROOT::RFieldBase::CreateObjectRawPtr() const
 {
-   void *where = operator new(GetValueSize());
+   const auto align = GetAlignment();
+   void *where;
+   if (align <= sizeof(std::max_align_t)) {
+      // We use the normal operator new for regularly aligned types to not complicate the user code that
+      // deletes objects returned by CreateObject()
+      where = operator new(GetValueSize());
+   } else {
+      where = operator new(GetValueSize(), std::align_val_t(GetAlignment()));
+   }
    R__ASSERT(where != nullptr);
    ConstructValue(where);
    return where;

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -14,6 +14,7 @@
 //  - RField<TObject>
 //  - RVariantField
 
+#include <ROOT/BitUtils.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RFieldUtils.hxx>
@@ -116,6 +117,12 @@ TEnum *EnsureValidEnum(std::string_view enumName)
    return e;
 }
 
+void EnsureValidAlignment(std::size_t align)
+{
+   if (align == 0 || align > ROOT::RFieldBase::kMaxAlignment || !ROOT::Internal::IsPowerOfTwo(align))
+      throw ROOT::RException(R__FAIL(std::string("invalid alignment: ") + std::to_string(align)));
+}
+
 /// Create a comma-separated list of type names from the given fields. Uses either the real type names or the
 /// type aliases (if there are any, otherwise the actual type name). Used to construct template argument lists
 /// for templated types such as std::pair<...>, std::tuple<...>, std::variant<...>.
@@ -186,8 +193,7 @@ std::string BuildMapTypeName(ROOT::RMapField::EMapType mapType, const ROOT::RFie
 ROOT::RClassField::RClassField(std::string_view fieldName, const RClassField &source)
    : ROOT::RFieldBase(fieldName, source.GetTypeName(), ROOT::ENTupleStructure::kRecord, false /* isSimple */),
      fClass(source.fClass),
-     fSubfieldsInfo(source.fSubfieldsInfo),
-     fMaxAlignment(source.fMaxAlignment)
+     fSubfieldsInfo(source.fSubfieldsInfo)
 {
    for (const auto &f : source.GetConstSubfields()) {
       RFieldBase::Attach(f->Clone(f->GetFieldName()));
@@ -280,7 +286,6 @@ ROOT::RClassField::~RClassField()
 
 void ROOT::RClassField::Attach(std::unique_ptr<RFieldBase> child, RSubfieldInfo info)
 {
-   fMaxAlignment = std::max(fMaxAlignment, child->GetAlignment());
    fSubfieldsInfo.push_back(info);
    RFieldBase::Attach(std::move(child));
 }
@@ -622,9 +627,16 @@ std::vector<ROOT::RFieldBase::RValue> ROOT::RClassField::SplitValue(const RValue
    return result;
 }
 
-size_t ROOT::RClassField::GetValueSize() const
+std::size_t ROOT::RClassField::GetValueSize() const
 {
    return fClass->GetClassSize();
+}
+
+std::size_t ROOT::RClassField::GetAlignment() const
+{
+   const auto align = fClass->GetClassAlignment();
+   EnsureValidAlignment(align);
+   return align;
 }
 
 std::uint32_t ROOT::RClassField::GetTypeVersion() const
@@ -656,8 +668,7 @@ void ROOT::RClassField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) cons
 ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, const RSoAField &source)
    : ROOT::RFieldBase(fieldName, source.GetTypeName(), ROOT::ENTupleStructure::kCollection, false /* isSimple */),
      fSoAClass(source.fSoAClass),
-     fSoAMemberOffsets(source.fSoAMemberOffsets),
-     fMaxAlignment(source.fMaxAlignment)
+     fSoAMemberOffsets(source.fSoAMemberOffsets)
 {
    fTraits = source.GetTraits();
    Attach(source.fSubfields[0]->Clone(source.fSubfields[0]->GetFieldName()));
@@ -762,8 +773,6 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, TClass *clS
          throw RException(R__FAIL(std::string("SoA member type mismatch: ") + vecField->GetFieldName() + " (" +
                                   leftType + " vs. " + rightType + ")"));
       }
-
-      fMaxAlignment = std::max(fMaxAlignment, vecField->GetAlignment());
 
       assert(itr->second < fSoAMemberOffsets.size());
       fSoAMemberOffsets[itr->second] = dataMember->GetOffset();
@@ -910,7 +919,7 @@ std::vector<ROOT::RFieldBase::RValue> ROOT::Experimental::RSoAField::SplitValue(
    return values;
 }
 
-size_t ROOT::Experimental::RSoAField::GetValueSize() const
+std::size_t ROOT::Experimental::RSoAField::GetValueSize() const
 {
    return fSoAClass->GetClassSize();
 }
@@ -923,6 +932,13 @@ std::uint32_t ROOT::Experimental::RSoAField::GetTypeVersion() const
 std::uint32_t ROOT::Experimental::RSoAField::GetTypeChecksum() const
 {
    return fSoAClass->GetCheckSum();
+}
+
+std::size_t ROOT::Experimental::RSoAField::GetAlignment() const
+{
+   const auto align = fSoAClass->GetClassAlignment();
+   EnsureValidAlignment(align);
+   return align;
 }
 
 const std::type_info *ROOT::Experimental::RSoAField::GetPolymorphicTypeInfo() const
@@ -1250,6 +1266,18 @@ std::vector<ROOT::RFieldBase::RValue> ROOT::RProxiedCollectionField::SplitValue(
    return result;
 }
 
+std::size_t ROOT::RProxiedCollectionField::GetValueSize() const
+{
+   return fProxy->Sizeof();
+}
+
+std::size_t ROOT::RProxiedCollectionField::GetAlignment() const
+{
+   const auto align = fProxy->GetCollectionClass()->GetClassAlignment();
+   EnsureValidAlignment(align);
+   return align;
+}
+
 void ROOT::RProxiedCollectionField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitProxiedCollectionField(*this);
@@ -1457,7 +1485,9 @@ ROOT::RExtraTypeInfoDescriptor ROOT::RStreamerField::GetExtraTypeInfo() const
 
 std::size_t ROOT::RStreamerField::GetAlignment() const
 {
-   return std::min(alignof(std::max_align_t), GetValueSize()); // TODO(jblomer): fix me
+   const auto align = fClass->GetClassAlignment();
+   EnsureValidAlignment(align);
+   return align;
 }
 
 std::size_t ROOT::RStreamerField::GetValueSize() const

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -117,10 +117,10 @@ TEnum *EnsureValidEnum(std::string_view enumName)
    return e;
 }
 
-void EnsureValidAlignment(std::size_t align)
+void EnsureValidAlignment(std::size_t alignment)
 {
-   if (align == 0 || align > ROOT::RFieldBase::kMaxAlignment || !ROOT::Internal::IsPowerOfTwo(align))
-      throw ROOT::RException(R__FAIL(std::string("invalid alignment: ") + std::to_string(align)));
+   if (!ROOT::Internal::IsValidAlignment(alignment))
+      throw ROOT::RException(R__FAIL(std::string("invalid alignment: ") + std::to_string(alignment)));
 }
 
 /// Create a comma-separated list of type names from the given fields. Uses either the real type names or the
@@ -608,6 +608,8 @@ void ROOT::RClassField::ConstructValue(void *where) const
    fClass->New(where);
 }
 
+ROOT::RClassField::RClassDeleter::RClassDeleter(TClass *cl) : RDeleter(cl->GetClassAlignment()), fClass(cl) {}
+
 void ROOT::RClassField::RClassDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    fClass->Destructor(objPtr, true /* dtorOnly */);
@@ -884,6 +886,10 @@ void ROOT::Experimental::RSoAField::ReadGlobalImpl(ROOT::NTupleSize_t globalInde
 void ROOT::Experimental::RSoAField::ConstructValue(void *where) const
 {
    fSoAClass->New(where);
+}
+
+ROOT::Experimental::RSoAField::RSoADeleter::RSoADeleter(TClass *cl) : RDeleter(cl->GetClassAlignment()), fSoAClass(cl)
+{
 }
 
 void ROOT::Experimental::RSoAField::RSoADeleter::operator()(void *objPtr, bool dtorOnly)
@@ -1242,6 +1248,22 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RProxiedCollectionField::GetDe
    return std::make_unique<RProxiedCollectionDeleter>(fProxy);
 }
 
+ROOT::RProxiedCollectionField::RProxiedCollectionDeleter::RProxiedCollectionDeleter(
+   std::shared_ptr<TVirtualCollectionProxy> proxy)
+   : RDeleter(proxy->GetCollectionClass()->GetClassAlignment()), fProxy(proxy)
+{
+}
+
+ROOT::RProxiedCollectionField::RProxiedCollectionDeleter::RProxiedCollectionDeleter(
+   std::shared_ptr<TVirtualCollectionProxy> proxy, std::unique_ptr<RDeleter> itemDeleter, size_t itemSize)
+   : RDeleter(proxy->GetCollectionClass()->GetClassAlignment()),
+     fProxy(proxy),
+     fItemDeleter(std::move(itemDeleter)),
+     fItemSize(itemSize)
+{
+   fIFuncsWrite = RCollectionIterableOnce::GetIteratorFuncs(fProxy.get(), false /* readFromDisk */);
+}
+
 void ROOT::RProxiedCollectionField::RProxiedCollectionDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    if (fItemDeleter) {
@@ -1465,6 +1487,11 @@ void ROOT::RStreamerField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
 void ROOT::RStreamerField::ConstructValue(void *where) const
 {
    fClass->New(where);
+}
+
+ROOT::RStreamerField::RStreamerFieldDeleter::RStreamerFieldDeleter(TClass *cl)
+   : RDeleter(cl->GetClassAlignment()), fClass(cl)
+{
 }
 
 void ROOT::RStreamerField::RStreamerFieldDeleter::operator()(void *objPtr, bool dtorOnly)
@@ -1868,7 +1895,7 @@ std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RVariantField::GetDeleter() co
    for (const auto &f : fSubfields) {
       itemDeleters.emplace_back(GetDeleterOf(*f));
    }
-   return std::make_unique<RVariantDeleter>(fTagOffset, fVariantOffset, std::move(itemDeleters));
+   return std::make_unique<RVariantDeleter>(fTagOffset, fVariantOffset, GetAlignment(), std::move(itemDeleters));
 }
 
 size_t ROOT::RVariantField::GetAlignment() const

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -567,7 +567,41 @@ void ROOT::RVectorField::ResizeVector(void *vec, std::size_t nItems, std::size_t
          itemDeleter->operator()(typedValue->data() + (i * itemSize), true /* dtorOnly */);
       }
    }
-   typedValue->resize(nItems * itemSize);
+
+   // Resize the vector with correct alignment
+   const auto itemAlignment = itemField.GetAlignment();
+   const auto nbytes = nItems * itemSize;
+
+   auto fnAlignedResize = [](auto &vecOfAlignedStorage, std::size_t targetSize) {
+      constexpr auto valueTypeSize = sizeof(typename std::decay_t<decltype(vecOfAlignedStorage)>::value_type);
+      constexpr auto valueTypeAlignment = alignof(typename std::decay_t<decltype(vecOfAlignedStorage)>::value_type);
+      // Ensure that this function is used with RAlignedStorage as a template argument.
+      // In general, the actual (user-defined) item type may have larger size than alignment.
+      static_assert(valueTypeSize == valueTypeAlignment);
+      assert(targetSize % valueTypeAlignment == 0);
+      vecOfAlignedStorage.resize(targetSize / valueTypeSize);
+   };
+
+   static_assert(kMaxItemAlignment == 4096);
+   // clang-format off
+   switch (itemAlignment) {
+   case    1: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<   1>> *>(vec), nbytes); break;
+   case    2: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<   2>> *>(vec), nbytes); break;
+   case    4: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<   4>> *>(vec), nbytes); break;
+   case    8: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<   8>> *>(vec), nbytes); break;
+   case   16: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<  16>> *>(vec), nbytes); break;
+   case   32: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<  32>> *>(vec), nbytes); break;
+   case   64: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<  64>> *>(vec), nbytes); break;
+   case  128: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage< 128>> *>(vec), nbytes); break;
+   case  256: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage< 256>> *>(vec), nbytes); break;
+   case  512: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage< 512>> *>(vec), nbytes); break;
+   case 1024: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<1024>> *>(vec), nbytes); break;
+   case 2048: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<2048>> *>(vec), nbytes); break;
+   case 4096: fnAlignedResize(*static_cast<std::vector<Internal::RAlignedStorage<4096>> *>(vec), nbytes); break;
+   default: throw RException(R__FAIL(std::string("Unsupported alignment: ") + std::to_string(itemAlignment)));
+   }
+   // clang-format on
+
    if (!(itemField.GetTraits() & kTraitTriviallyConstructible)) {
       for (std::size_t i = allDeallocated ? 0 : oldNItems; i < nItems; ++i) {
          CallConstructValueOn(itemField, typedValue->data() + (i * itemSize));

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -2,6 +2,7 @@
 /// \author Jonas Hahnfeld <jonas.hahnfeld@cern.ch>
 /// \date 2024-11-19
 
+#include <ROOT/BitUtils.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldBase.hxx>
 #include <ROOT/RFieldVisitor.hxx>
@@ -27,6 +28,16 @@ std::vector<ROOT::RFieldBase::RValue> SplitVector(std::shared_ptr<void> valuePtr
       result.emplace_back(itemField.BindValue(std::shared_ptr<void>(valuePtr, vec->data() + (i * itemSize))));
    }
    return result;
+}
+
+std::size_t GetSizeOfVector()
+{
+   return sizeof(std::vector<char>);
+}
+
+std::size_t GetAlignOfVector()
+{
+   return alignof(std::vector<char>);
 }
 
 } // anonymous namespace
@@ -647,6 +658,16 @@ std::vector<ROOT::RFieldBase::RValue> ROOT::RVectorField::SplitValue(const RValu
    return SplitVector(value.GetPtr<void>(), *fSubfields[0]);
 }
 
+std::size_t ROOT::RVectorField::GetValueSize() const
+{
+   return GetSizeOfVector();
+}
+
+std::size_t ROOT::RVectorField::GetAlignment() const
+{
+   return GetAlignOfVector();
+}
+
 void ROOT::RVectorField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitVectorField(*this);
@@ -971,6 +992,16 @@ void ROOT::RArrayAsVectorField::ReconcileOnDiskField(const RNTupleDescriptor &de
 std::vector<ROOT::RFieldBase::RValue> ROOT::RArrayAsVectorField::SplitValue(const ROOT::RFieldBase::RValue &value) const
 {
    return SplitVector(value.GetPtr<void>(), *fSubfields[0]);
+}
+
+std::size_t ROOT::RArrayAsVectorField::GetValueSize() const
+{
+   return GetSizeOfVector();
+}
+
+std::size_t ROOT::RArrayAsVectorField::GetAlignment() const
+{
+   return GetAlignOfVector();
 }
 
 void ROOT::RArrayAsVectorField::AcceptVisitor(ROOT::Detail::RFieldVisitor &visitor) const

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -146,8 +146,8 @@ void ROOT::RArrayField::RArrayDeleter::operator()(void *objPtr, bool dtorOnly)
 std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RArrayField::GetDeleter() const
 {
    if (!(fSubfields[0]->GetTraits() & kTraitTriviallyDestructible))
-      return std::make_unique<RArrayDeleter>(fItemSize, fArrayLength, GetDeleterOf(*fSubfields[0]));
-   return std::make_unique<RDeleter>();
+      return std::make_unique<RArrayDeleter>(fItemSize, fArrayLength, GetAlignment(), GetDeleterOf(*fSubfields[0]));
+   return std::make_unique<RDeleter>(GetAlignment());
 }
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::RArrayField::SplitValue(const RValue &value) const
@@ -175,6 +175,11 @@ ROOT::RRVecField::RRVecField(std::string_view fieldName, std::unique_ptr<RFieldB
      fItemSize(itemField->GetValueSize()),
      fNWritten(0)
 {
+   if (itemField->GetAlignment() > sizeof(std::max_align_t)) {
+      // RVec uses malloc() and free()
+      throw RException(R__FAIL("RVec does not support over-aligned types"));
+   }
+
    if (!(itemField->GetTraits() & kTraitTriviallyDestructible))
       fItemDeleter = GetDeleterOf(*itemField);
    if (!itemField->GetTypeAlias().empty())
@@ -549,9 +554,11 @@ void ROOT::RVectorField::ResizeVector(void *vec, std::size_t nItems, std::size_t
    auto typedValue = static_cast<std::vector<char> *>(vec);
 
    // See "semantics of reading non-trivial objects" in RNTuple's Architecture.md
-   R__ASSERT(itemSize > 0);
+   assert(itemSize > 0);
    const auto oldNItems = typedValue->size() / itemSize;
    const auto availNItems = typedValue->capacity() / itemSize;
+   assert((typedValue->size() % itemSize == 0) && (typedValue->capacity() % itemSize == 0));
+
    const bool canRealloc = availNItems < nItems;
    bool allDeallocated = false;
    if (itemDeleter) {
@@ -629,6 +636,13 @@ std::unique_ptr<ROOT::RFieldBase> ROOT::RVectorField::BeforeConnectPageSource(In
 void ROOT::RVectorField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
 {
    EnsureMatchingOnDiskCollection(desc).ThrowOnError();
+}
+
+ROOT::RVectorField::RVectorDeleter::RVectorDeleter() : RDeleter(GetAlignOfVector()) {}
+
+ROOT::RVectorField::RVectorDeleter::RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
+   : RDeleter(GetAlignOfVector()), fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
+{
 }
 
 void ROOT::RVectorField::RVectorDeleter::operator()(void *objPtr, bool dtorOnly)

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -516,6 +516,11 @@ ROOT::RVectorField::RVectorField(std::string_view fieldName, std::unique_ptr<RFi
      fItemSize(itemField->GetValueSize()),
      fNWritten(0)
 {
+   if (itemField->GetAlignment() > kMaxItemAlignment) {
+      throw RException(
+         R__FAIL(std::string("Unsupported vector item alignment: ") + std::to_string(itemField->GetAlignment())));
+   }
+
    if (emulatedFromType && !emulatedFromType->empty())
       fTraits |= kTraitEmulatedField;
 

--- a/tree/ntuple/src/RFieldSequenceContainer.cxx
+++ b/tree/ntuple/src/RFieldSequenceContainer.cxx
@@ -40,6 +40,29 @@ std::size_t GetAlignOfVector()
    return alignof(std::vector<char>);
 }
 
+void ConstructVector(void *where, std::size_t alignOfValue)
+{
+   static_assert(ROOT::RVectorField::kMaxItemAlignment == 4096);
+   // clang-format off
+   switch (alignOfValue) {
+   case    1: new (where) std::vector<ROOT::Internal::RAlignedStorage<   1>>(); break;
+   case    2: new (where) std::vector<ROOT::Internal::RAlignedStorage<   2>>(); break;
+   case    4: new (where) std::vector<ROOT::Internal::RAlignedStorage<   4>>(); break;
+   case    8: new (where) std::vector<ROOT::Internal::RAlignedStorage<   8>>(); break;
+   case   16: new (where) std::vector<ROOT::Internal::RAlignedStorage<  16>>(); break;
+   case   32: new (where) std::vector<ROOT::Internal::RAlignedStorage<  32>>(); break;
+   case   64: new (where) std::vector<ROOT::Internal::RAlignedStorage<  64>>(); break;
+   case  128: new (where) std::vector<ROOT::Internal::RAlignedStorage< 128>>(); break;
+   case  256: new (where) std::vector<ROOT::Internal::RAlignedStorage< 256>>(); break;
+   case  512: new (where) std::vector<ROOT::Internal::RAlignedStorage< 512>>(); break;
+   case 1024: new (where) std::vector<ROOT::Internal::RAlignedStorage<1024>>(); break;
+   case 2048: new (where) std::vector<ROOT::Internal::RAlignedStorage<2048>>(); break;
+   case 4096: new (where) std::vector<ROOT::Internal::RAlignedStorage<4096>>(); break;
+   default: throw ROOT::RException(R__FAIL(std::string("Unsupported alignment: ") + std::to_string(alignOfValue)));
+   }
+   // clang-format on
+}
+
 } // anonymous namespace
 
 ROOT::RArrayField::RArrayField(std::string_view fieldName, std::unique_ptr<RFieldBase> itemField,
@@ -672,10 +695,22 @@ void ROOT::RVectorField::ReconcileOnDiskField(const RNTupleDescriptor &desc)
    EnsureMatchingOnDiskCollection(desc).ThrowOnError();
 }
 
-ROOT::RVectorField::RVectorDeleter::RVectorDeleter() : RDeleter(GetAlignOfVector()) {}
+void ROOT::RVectorField::ConstructValue(void *where) const
+{
+   ConstructVector(where, fSubfields[0]->GetAlignment());
+}
 
-ROOT::RVectorField::RVectorDeleter::RVectorDeleter(std::size_t itemSize, std::unique_ptr<RDeleter> itemDeleter)
-   : RDeleter(GetAlignOfVector()), fItemSize(itemSize), fItemDeleter(std::move(itemDeleter))
+ROOT::RVectorField::RVectorDeleter::RVectorDeleter(std::size_t itemAlignment)
+   : RDeleter(GetAlignOfVector()), fItemAlignment(itemAlignment)
+{
+}
+
+ROOT::RVectorField::RVectorDeleter::RVectorDeleter(std::size_t itemSize, std::size_t itemAlignment,
+                                                   std::unique_ptr<RDeleter> itemDeleter)
+   : RDeleter(GetAlignOfVector()),
+     fItemSize(itemSize),
+     fItemAlignment(itemAlignment),
+     fItemDeleter(std::move(itemDeleter))
 {
 }
 
@@ -683,22 +718,42 @@ void ROOT::RVectorField::RVectorDeleter::operator()(void *objPtr, bool dtorOnly)
 {
    auto vecPtr = static_cast<std::vector<char> *>(objPtr);
    if (fItemDeleter) {
-      R__ASSERT(fItemSize > 0);
-      R__ASSERT((vecPtr->size() % fItemSize) == 0);
+      assert(fItemSize > 0);
       auto nItems = vecPtr->size() / fItemSize;
+      assert((vecPtr->size() % fItemSize) == 0);
       for (std::size_t i = 0; i < nItems; ++i) {
          fItemDeleter->operator()(vecPtr->data() + (i * fItemSize), true /* dtorOnly */);
       }
    }
-   std::destroy_at(vecPtr);
+
+   static_assert(kMaxItemAlignment == 4096);
+   // clang-format off
+   switch (fItemAlignment) {
+   case    1: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<   1>> *>(objPtr)); break;
+   case    2: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<   2>> *>(objPtr)); break;
+   case    4: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<   4>> *>(objPtr)); break;
+   case    8: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<   8>> *>(objPtr)); break;
+   case   16: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<  16>> *>(objPtr)); break;
+   case   32: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<  32>> *>(objPtr)); break;
+   case   64: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<  64>> *>(objPtr)); break;
+   case  128: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage< 128>> *>(objPtr)); break;
+   case  256: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage< 256>> *>(objPtr)); break;
+   case  512: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage< 512>> *>(objPtr)); break;
+   case 1024: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<1024>> *>(objPtr)); break;
+   case 2048: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<2048>> *>(objPtr)); break;
+   case 4096: std::destroy_at(static_cast<std::vector<Internal::RAlignedStorage<4096>> *>(objPtr)); break;
+   default: throw ROOT::RException(R__FAIL(std::string("Unsupported alignment: ") + std::to_string(fItemAlignment)));
+   }
+   // clang-format on
+
    RDeleter::operator()(objPtr, dtorOnly);
 }
 
 std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RVectorField::GetDeleter() const
 {
    if (fItemDeleter)
-      return std::make_unique<RVectorDeleter>(fItemSize, GetDeleterOf(*fSubfields[0]));
-   return std::make_unique<RVectorDeleter>();
+      return std::make_unique<RVectorDeleter>(fItemSize, fSubfields[0]->GetAlignment(), GetDeleterOf(*fSubfields[0]));
+   return std::make_unique<RVectorDeleter>(fSubfields[0]->GetAlignment());
 }
 
 std::vector<ROOT::RFieldBase::RValue> ROOT::RVectorField::SplitValue(const RValue &value) const
@@ -985,11 +1040,18 @@ void ROOT::RArrayAsVectorField::GenerateColumns()
    throw RException(R__FAIL("RArrayAsVectorField fields must only be used for reading"));
 }
 
+void ROOT::RArrayAsVectorField::ConstructValue(void *where) const
+{
+   ConstructVector(where, fSubfields[0]->GetAlignment());
+}
+
 std::unique_ptr<ROOT::RFieldBase::RDeleter> ROOT::RArrayAsVectorField::GetDeleter() const
 {
-   if (fItemDeleter)
-      return std::make_unique<RVectorField::RVectorDeleter>(fItemSize, GetDeleterOf(*fSubfields[0]));
-   return std::make_unique<RVectorField::RVectorDeleter>();
+   if (fItemDeleter) {
+      return std::make_unique<RVectorField::RVectorDeleter>(fItemSize, fSubfields[0]->GetAlignment(),
+                                                            GetDeleterOf(*fSubfields[0]));
+   }
+   return std::make_unique<RVectorField::RVectorDeleter>(fSubfields[0]->GetAlignment());
 }
 
 void ROOT::RArrayAsVectorField::ReadGlobalImpl(ROOT::NTupleSize_t globalIndex, void *to)

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -11,7 +11,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/CustomStruct.hxx
                               SOURCES CustomStruct.cxx
                               LINKDEF CustomStructLinkDef.h
-                              DEPENDENCIES RIO)
+                              DEPENDENCIES RIO ROOTVecOps)
 configure_file(CustomStruct.hxx . COPYONLY)
 if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
   add_custom_command(TARGET CustomStruct POST_BUILD

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -1,11 +1,14 @@
 #ifndef ROOT_RNTuple_Test_CustomStruct
 #define ROOT_RNTuple_Test_CustomStruct
 
+#include <ROOT/RVec.hxx>
+
 #include <RtypesCore.h> // for Double32_t
 #include <TObject.h>
 #include <TRootIOCtor.h>
 #include <TVirtualCollectionProxy.h>
 
+#include <array>
 #include <chrono>
 #include <stdexcept>
 #include <cstddef>
@@ -476,6 +479,22 @@ struct MemberWithCustomStreamer {
    int fNormal = 0;
    int fCustom = 0;
    ClassDefNV(MemberWithCustomStreamer, 2);
+};
+
+struct AlignmentDeterminedByTransientMember {
+   short int fA;
+   float fTransient; ///<!
+};
+
+struct alignas(8) AlignedAs {};
+
+struct alignas(64) OverAligned {
+   std::uint32_t fA;
+};
+
+struct AlignmentEnvelope {
+   ROOT::RVec<OverAligned> fVec;
+   std::array<OverAligned, 2> fArr;
 };
 
 #endif

--- a/tree/ntuple/test/CustomStruct.hxx
+++ b/tree/ntuple/test/CustomStruct.hxx
@@ -493,7 +493,7 @@ struct alignas(64) OverAligned {
 };
 
 struct AlignmentEnvelope {
-   ROOT::RVec<OverAligned> fVec;
+   std::vector<OverAligned> fVec;
    std::array<OverAligned, 2> fArr;
 };
 

--- a/tree/ntuple/test/CustomStructLinkDef.h
+++ b/tree/ntuple/test/CustomStructLinkDef.h
@@ -181,4 +181,9 @@
 
 #pragma link C++ class MemberWithCustomStreamer+;
 
+#pragma link C++ class AlignmentDeterminedByTransientMember+;
+#pragma link C++ class AlignedAs+;
+#pragma link C++ class OverAligned+;
+#pragma link C++ class AlignmentEnvelope+;
+
 #endif

--- a/tree/ntuple/test/ntuple_compat.cxx
+++ b/tree/ntuple/test/ntuple_compat.cxx
@@ -452,8 +452,8 @@ class RFutureField : public RFieldBase {
 public:
    RFutureField(std::string_view name) : RFieldBase(name, "Future", ROOT::Internal::kTestFutureFieldStructure, false) {}
 
-   std::size_t GetValueSize() const final { return 0; }
-   std::size_t GetAlignment() const final { return 0; }
+   std::size_t GetValueSize() const final { return 1; }
+   std::size_t GetAlignment() const final { return 1; }
 };
 
 TEST(RNTupleCompat, FutureFieldStructuralRole)

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -502,3 +502,22 @@ TEST(RNTuple, MemberWithCustomStreamer)
    // After setting member streamer: field creation should throw
    EXPECT_THROW(RFieldBase::Create("f", "MemberWithCustomStreamer").Unwrap(), ROOT::RException);
 }
+
+TEST(RNTuple, AlignmentCornerCases)
+{
+   // Alignment determined by transient member
+   EXPECT_EQ(alignof(AlignmentDeterminedByTransientMember),
+             RFieldBase::Create("", "AlignmentDeterminedByTransientMember").Unwrap()->GetAlignment());
+
+   // Respect custom alignment
+   EXPECT_EQ(alignof(AlignedAs), RFieldBase::Create("", "AlignedAs").Unwrap()->GetAlignment());
+   EXPECT_EQ(sizeof(AlignedAs), RFieldBase::Create("", "AlignedAs").Unwrap()->GetValueSize());
+   EXPECT_EQ(8u, RFieldBase::Create("", "AlignedAs").Unwrap()->GetValueSize());
+
+   // Handling of over-aligned types
+   auto f = RFieldBase::Create("", "AlignmentEnvelope").Unwrap();
+   EXPECT_GT(alignof(AlignmentEnvelope), sizeof(std::max_align_t));
+   EXPECT_EQ(alignof(AlignmentEnvelope), f->GetAlignment());
+   EXPECT_EQ(alignof(ROOT::RVec<OverAligned>),
+             RFieldBase::Create("", "ROOT::RVec<OverAligned>").Unwrap()->GetAlignment());
+}

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -540,6 +540,5 @@ TEST(RNTuple, AlignmentCornerCases)
 
    auto view = reader->GetView<AlignmentEnvelope>("f");
    EXPECT_EQ(1u, view(0).fVec.size());
-   // TODO(jblomer): FIXME
-   // EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(view(0).fVec.data()) % alignof(OverAligned));
+   EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(view(0).fVec.data()) % alignof(OverAligned));
 }

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -518,6 +518,28 @@ TEST(RNTuple, AlignmentCornerCases)
    auto f = RFieldBase::Create("", "AlignmentEnvelope").Unwrap();
    EXPECT_GT(alignof(AlignmentEnvelope), sizeof(std::max_align_t));
    EXPECT_EQ(alignof(AlignmentEnvelope), f->GetAlignment());
-   EXPECT_EQ(alignof(ROOT::RVec<OverAligned>),
-             RFieldBase::Create("", "ROOT::RVec<OverAligned>").Unwrap()->GetAlignment());
+   auto res = RFieldBase::Create("", "ROOT::RVec<OverAligned>");
+   EXPECT_FALSE(res);
+   EXPECT_THAT(res.GetError()->GetReport(), ::testing::HasSubstr("RVec does not support over-aligned types"));
+
+   std::unique_ptr<AlignmentEnvelope> ptr(f->CreateObject<AlignmentEnvelope>().release());
+   EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(ptr.get()) % alignof(AlignmentEnvelope));
+
+   FileRaii fileGuard("test_ntuple_alignment_corner_cases.root");
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto p = model->MakeField<AlignmentEnvelope>("f");
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
+      p->fVec.push_back(OverAligned{1});
+      writer->Fill();
+   }
+   auto reader = ROOT::RNTupleReader::Open("ntpl", fileGuard.GetPath());
+   auto bulk = reader->GetModel().CreateBulk("f");
+   auto bulkPtr = bulk.ReadBulk(ROOT::RNTupleLocalRange(0, 0, 1));
+   EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(bulkPtr) % alignof(AlignmentEnvelope));
+
+   auto view = reader->GetView<AlignmentEnvelope>("f");
+   EXPECT_EQ(1u, view(0).fVec.size());
+   // TODO(jblomer): FIXME
+   // EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(view(0).fVec.data()) % alignof(OverAligned));
 }

--- a/tree/ntuple/test/rfield_class.cxx
+++ b/tree/ntuple/test/rfield_class.cxx
@@ -518,12 +518,17 @@ TEST(RNTuple, AlignmentCornerCases)
    auto f = RFieldBase::Create("", "AlignmentEnvelope").Unwrap();
    EXPECT_GT(alignof(AlignmentEnvelope), sizeof(std::max_align_t));
    EXPECT_EQ(alignof(AlignmentEnvelope), f->GetAlignment());
+   std::unique_ptr<AlignmentEnvelope> ptr(f->CreateObject<AlignmentEnvelope>().release());
+   EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(ptr.get()) % alignof(AlignmentEnvelope));
+
+   f = RFieldBase::Create("", "std::vector<AlignmentEnvelope>").Unwrap();
+   auto vecPtr = f->CreateObject<std::vector<AlignmentEnvelope>>().release();
+   EXPECT_TRUE(vecPtr->data() == nullptr ||
+               reinterpret_cast<std::uintptr_t>(vecPtr->data()) % alignof(AlignmentEnvelope) == 0);
+
    auto res = RFieldBase::Create("", "ROOT::RVec<OverAligned>");
    EXPECT_FALSE(res);
    EXPECT_THAT(res.GetError()->GetReport(), ::testing::HasSubstr("RVec does not support over-aligned types"));
-
-   std::unique_ptr<AlignmentEnvelope> ptr(f->CreateObject<AlignmentEnvelope>().release());
-   EXPECT_EQ(0, reinterpret_cast<std::uintptr_t>(ptr.get()) % alignof(AlignmentEnvelope));
 
    FileRaii fileGuard("test_ntuple_alignment_corner_cases.root");
    {

--- a/tree/ntuple/test/rfield_vector.cxx
+++ b/tree/ntuple/test/rfield_vector.cxx
@@ -549,3 +549,16 @@ TEST(RNTuple, RVecAdopted)
    EXPECT_FLOAT_EQ(2.0, buf[1]);
    EXPECT_FLOAT_EQ(0.0, buf[2]);
 }
+
+TEST(RNTuple, OverAligned)
+{
+   auto res = RFieldBase::Create("f", "std::vector<ROOT::Internal::RAlignedStorage<4096>>");
+   if (!res)
+      FAIL() << "Createing a vector of a 4096B aligned type should work";
+
+   res = RFieldBase::Create("f", "std::vector<ROOT::Internal::RAlignedStorage<8192>>");
+   if (res)
+      FAIL() << "Createing a vector of a 8192B aligned type should fail";
+
+   EXPECT_THAT(res.GetError()->GetReport(), ::testing::HasSubstr("Unsupported vector item alignment: 8192"));
+}


### PR DESCRIPTION
Use the new `TClass` alignment information where applicable. This fixes

- Alignment of classes whose alignment is defined by a transient member
- Alignment of certain streamer fields

Additionally, use the `new` and `delete` operators with alignment info. This ensures correct memory allocation for over-aligned types.

Fixes #16765