### PR TITLE
[svg] fix missing math symbols

### DIFF
--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1493,7 +1493,7 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 815) ichar =  8659; // DOWNWARDS DOUBLE ARROW
       if (ic == 811) ichar =  8660; // LEFT RIGHT DOUBLE ARROW
       if (ic == 826) ichar =  124;  // VERTICAL LINE
-      if (ic == 818) ichar =  9145; // CIRCLED LATIN CAPITAL LETTER R
+      if (ic == 818) ichar =  9415; // CIRCLED LATIN CAPITAL LETTER R
       if (ic == 820) ichar =  8482; // TRADEMARK SIGN
 
       // Greek characters

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1488,6 +1488,11 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 786) ichar =  8476;
       if (ic == 785) ichar =  8465;
       if (ic == 787) ichar =  8472;
+      if (ic == 882) ichar =  8704; // FOR ALL
+      if (ic == 884) ichar =  8707; // THERE EXISTS
+      if (ic == 815) ichar =  8659; // DOWNWARDS DOUBLE ARROW
+      if (ic == 811) ichar =  8660; // LEFT RIGHT DOUBLE ARROW
+      if (ic == 826) ichar =  124;  // Vertical bar
 
       // Greek characters
       if (ic == 918) ichar = 934;

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1492,7 +1492,10 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 884) ichar =  8707; // THERE EXISTS
       if (ic == 815) ichar =  8659; // DOWNWARDS DOUBLE ARROW
       if (ic == 811) ichar =  8660; // LEFT RIGHT DOUBLE ARROW
-      if (ic == 826) ichar =  124;  // Vertical bar
+      if (ic == 826) ichar =  124;  // VERTICAL LINE
+      if (ic == 818) ichar =  9145; // CIRCLED LATIN CAPITAL LETTER R
+      if (ic == 820) ichar =  8482; // TRADEMARK SIGN
+        
 
       // Greek characters
       if (ic == 918) ichar = 934;

--- a/graf2d/postscript/src/TSVG.cxx
+++ b/graf2d/postscript/src/TSVG.cxx
@@ -1495,7 +1495,6 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 826) ichar =  124;  // VERTICAL LINE
       if (ic == 818) ichar =  9145; // CIRCLED LATIN CAPITAL LETTER R
       if (ic == 820) ichar =  8482; // TRADEMARK SIGN
-        
 
       // Greek characters
       if (ic == 918) ichar = 934;
@@ -1513,7 +1512,7 @@ void TSVG::Text(Double_t xx, Double_t yy, const char *chars)
       if (ic == 935) ichar = 937;
       if (ic == 938) ichar = 918;
       if (ic == 951) ichar = 947;
-      if (ic == 798) ichar = 949;
+      if (ic == 798) ichar = 8712; // ELEMENT OF, TeX traditionally assigns \epsilon to GREEK LUNATE EPSILON SYMBOL (ϵ), compared to the curly \varepsilon to the GREEK SMALL LETTER EPSILON (Ɛ)
       if (ic == 970) ichar = 950;
       if (ic == 952) ichar = 951;
       if (ic == 961) ichar = 952;

--- a/test/svg_ref/tefficiency.svg
+++ b/test/svg_ref/tefficiency.svg
@@ -51,7 +51,7 @@ tefficiency.svg
 <text xml:space="preserve" x="27" y="66" fill="black" font-size="10" font-family="Helvetica" font-weight="bold">1
 </text>
 <g transform="rotate(-90,20,44)">
-<text xml:space="preserve" x="20" y="44" fill="black" font-size="10" font-family="Times">&#0949;
+<text xml:space="preserve" x="20" y="44" fill="black" font-size="10" font-family="Times">&#8712;
 </text>
 </g>
 <rect x="8.9" y="5.3" width="161" height="17" fill="#f2f2f2"/>
@@ -192,7 +192,7 @@ tefficiency.svg
 <text xml:space="preserve" x="311" y="66" fill="black" font-size="10" font-family="Helvetica" font-weight="bold">1
 </text>
 <g transform="rotate(-90,303,44)">
-<text xml:space="preserve" x="303" y="44" fill="black" font-size="10" font-family="Times">&#0949;
+<text xml:space="preserve" x="303" y="44" fill="black" font-size="10" font-family="Times">&#8712;
 </text>
 </g>
 <rect x="292" y="5.3" width="153" height="17" fill="#f2f2f2"/>

--- a/test/svg_ref/tlatex2.svg
+++ b/test/svg_ref/tlatex2.svg
@@ -76,7 +76,7 @@ tlatex2.svg
 <path d="M350,208v 17" fill="none" stroke="black" stroke-width="2.0"/>
 <text xml:space="preserve" x="337" y="225" fill="black" font-size="36" font-family="Helvetica" font-weight="bold">(
 </text>
-<text xml:space="preserve" x="299" y="225" fill="black" font-size="36" font-family="Times">&#0811;
+<text xml:space="preserve" x="299" y="225" fill="black" font-size="36" font-family="Times">&#8660;
 </text>
 <text xml:space="preserve" x="247" y="225" fill="black" font-size="36" font-family="Helvetica" font-weight="bold">)=0
 </text>

--- a/test/svg_ref/tlatex4.svg
+++ b/test/svg_ref/tlatex4.svg
@@ -30,7 +30,7 @@ tlatex4.svg
 </text>
 <text xml:space="preserve" x="40" y="165" fill="black" font-size="16" font-family="Helvetica" font-weight="bold">epsilon : 
 </text>
-<text xml:space="preserve" x="154" y="165" fill="black" font-size="16" font-family="Times">&#0949;
+<text xml:space="preserve" x="154" y="165" fill="black" font-size="16" font-family="Times">&#8712;
 </text>
 <text xml:space="preserve" x="40" y="190" fill="black" font-size="16" font-family="Helvetica" font-weight="bold">zeta : 
 </text>

--- a/test/svg_ref/tlatex5.svg
+++ b/test/svg_ref/tlatex5.svg
@@ -22,7 +22,7 @@ tlatex5.svg
 </text>
 <text xml:space="preserve" x="35" y="101" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#approx
 </text>
-<text xml:space="preserve" x="12" y="122" fill="black" font-size="15" font-family="Times">&#0949;
+<text xml:space="preserve" x="12" y="122" fill="black" font-size="15" font-family="Times">&#8712;
 </text>
 <text xml:space="preserve" x="35" y="125" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#in
 </text>
@@ -74,15 +74,15 @@ tlatex5.svg
 </text>
 <text xml:space="preserve" x="35" y="413" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#leftrightarrow
 </text>
-<text xml:space="preserve" x="12" y="437" fill="black" font-size="15" font-family="Times">&#0815;
+<text xml:space="preserve" x="12" y="437" fill="black" font-size="15" font-family="Times">&#8659;
 </text>
 <text xml:space="preserve" x="35" y="436" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#Downarrow
 </text>
-<text xml:space="preserve" x="12" y="457" fill="black" font-size="15" font-family="Times">&#0811;
+<text xml:space="preserve" x="12" y="457" fill="black" font-size="15" font-family="Times">&#8660;
 </text>
 <text xml:space="preserve" x="35" y="460" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#Leftrightarrow
 </text>
-<text xml:space="preserve" x="12" y="484" fill="black" font-size="15" font-family="Times">&#0826;
+<text xml:space="preserve" x="12" y="484" fill="black" font-size="15" font-family="Times">&#0124;
 </text>
 <text xml:space="preserve" x="35" y="484" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#void8
 </text>
@@ -91,7 +91,7 @@ tlatex5.svg
 <path d="M12,499l 6.1, -1.6" fill="none" stroke="black" stroke-width="2.0"/>
 <text xml:space="preserve" x="35" y="508" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#hbar
 </text>
-<text xml:space="preserve" x="12" y="531" fill="black" font-size="15" font-family="Times">&#0882;
+<text xml:space="preserve" x="12" y="531" fill="black" font-size="15" font-family="Times">&#8704;
 </text>
 <text xml:space="preserve" x="35" y="532" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#forall
 </text>
@@ -127,7 +127,7 @@ tlatex5.svg
 </text>
 <text xml:space="preserve" x="176" y="197" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#copyright
 </text>
-<text xml:space="preserve" x="154" y="218" fill="black" font-size="15" font-family="Times">&#0820;
+<text xml:space="preserve" x="154" y="218" fill="black" font-size="15" font-family="Times">&#8482;
 </text>
 <text xml:space="preserve" x="176" y="221" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#void3
 </text>
@@ -181,7 +181,7 @@ tlatex5.svg
 <path d="M159,511v -15" fill="none" stroke="black" stroke-width="2.0"/>
 <text xml:space="preserve" x="176" y="508" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#parallel
 </text>
-<text xml:space="preserve" x="154" y="531" fill="black" font-size="15" font-family="Times">&#0884;
+<text xml:space="preserve" x="154" y="531" fill="black" font-size="15" font-family="Times">&#8707;
 </text>
 <text xml:space="preserve" x="176" y="532" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#exists
 </text>
@@ -297,7 +297,7 @@ tlatex5.svg
 </text>
 <text xml:space="preserve" x="460" y="173" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#vee
 </text>
-<text xml:space="preserve" x="437" y="195" fill="black" font-size="15" font-family="Times">&#0818;
+<text xml:space="preserve" x="437" y="195" fill="black" font-size="15" font-family="Times">&#9415;
 </text>
 <text xml:space="preserve" x="460" y="197" fill="black" font-size="15" font-family="Helvetica" font-weight="bold">#void1
 </text>


### PR DESCRIPTION
from latex5 tutorial

as found out in https://github.com/root-project/root/pull/22317#pullrequestreview-4308026542