### PR TITLE
[net] deprecate TSSLSocket

### DIFF
--- a/README/ReleaseNotes/v640/index.md
+++ b/README/ReleaseNotes/v640/index.md
@@ -59,7 +59,8 @@ The following people have contributed to this new version:
 * The `TFTP`, `TNetFile`, `TNetFileStager`, and `TNetSystem` classes are deprecated and will be removed in ROOT 6.42. These classes rely on **rootd**, which was removed in release 6.16.
 * The ROOT **auth** package together with `TVirtualAuth` and `TROOT::GetListOfSecContexts()`, and the **authenticated sockets** (`TSocket::CreateAuthSocket()`) feature are deprecated and will be remove in ROOT 6.42.
   The security assumtions in the current socket authentication implementation is not up to date anymore.
-  Secure communication should be provided by standard means, such as SSL sockets or SSH tunneling.
+  Secure communication should be provided by external means, such as SSH tunneling.
+* The `TSSLSocket` class is deprecated and should not be used in user code anymore. Secure communication should be provided by externals means, such as SSH tunneling.
 * The `builtin_davix` build option has been removed.
   The Davix I/O code in ROOT remains uneffected and is built as before provided that the Davix library is found on the system.
 * `RRealField::SetQuantized` now has a new overload and the existing signature has been deprecated. The new overload enforces proper ordering of the arguments.
@@ -802,4 +803,3 @@ More than 130 items were addressed for this release:
   * [[ROOT-7499](https://its.cern.ch/jira/browse/ROOT-7499)] - ExpectedData generated from RooSimultaneous does not have non-integer weights
   * [[ROOT-5306](https://its.cern.ch/jira/browse/ROOT-5306)] - Read a file with a versioned class layout fails if the current class layout is unversioned
   * [[ROOT-5174](https://its.cern.ch/jira/browse/ROOT-5174)] - rootcling without linkdef
-

--- a/gui/guihtml/src/TGHtmlBrowser.cxx
+++ b/gui/guihtml/src/TGHtmlBrowser.cxx
@@ -268,7 +268,7 @@ Ssiz_t ReadSize(const char *url)
       return 0;
    if (uri.BeginsWith("https://")) {
 #ifdef R__SSL
-      s = new TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
+      s = new ROOT::Deprecated::TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
 #else
       ::Error("ReadSize", "library compiled without SSL, https not supported");
       return 0;
@@ -328,7 +328,7 @@ static char *ReadRemote(const char *url)
       return 0;
    if (uri.BeginsWith("https://")) {
 #ifdef R__SSL
-      s = new TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
+      s = new ROOT::Deprecated::TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
 #else
       ::Error("ReadRemote", "library compiled without SSL, https not supported");
      return 0;
@@ -699,4 +699,3 @@ Bool_t TGHtmlBrowser::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t)
    }
    return kTRUE;
 }
-

--- a/gui/guihtml/src/TGHtmlImage.cxx
+++ b/gui/guihtml/src/TGHtmlImage.cxx
@@ -236,7 +236,7 @@ static TImage *ReadRemoteImage(const char *url)
    TSocket *s;
    if (uri.BeginsWith("https://")) {
 #ifdef R__SSL
-      s = new TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
+      s = new ROOT::Deprecated::TSSLSocket(fUrl.GetHost(), fUrl.GetPort());
 #else
       ::Error("ReadRemoteImage", "library compiled without SSL, https not supported");
       return 0;

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -34,7 +34,7 @@
 #pragma link C++ class TParallelMergingFile+;
 
 #ifdef R__SSL
-#pragma link C++ class TSSLSocket;
+#pragma link C++ class ROOT::Deprecated::TSSLSocket;
 #endif
 
 #endif

--- a/net/net/inc/TSSLSocket.h
+++ b/net/net/inc/TSSLSocket.h
@@ -22,6 +22,8 @@
 
 #include "TSocket.h"
 
+namespace ROOT::Deprecated {
+
 typedef struct ssl_st     SSL;
 typedef struct ssl_ctx_st SSL_CTX;
 
@@ -77,5 +79,11 @@ public:
 
    ClassDefOverride(TSSLSocket,0)  // SSL wrapped socket
 };
+
+} // namespace ROOT::Deprecated
+
+using TSSLSocket R__DEPRECATED(6, 42,
+                               "ROOT is not providing an SSL socket API anymore. "
+                               "Consider using SSH tunneling for secure channels.") = ROOT::Deprecated::TSSLSocket;
 
 #endif

--- a/net/net/src/TSSLSocket.cxx
+++ b/net/net/src/TSSLSocket.cxx
@@ -26,15 +26,15 @@ not limited to, the management of the connections to said sockets.
 #include "strlcpy.h"
 
 // Static properties
-char TSSLSocket::fgSSLCAFile[FILENAME_MAX] = "";
-char TSSLSocket::fgSSLCAPath[FILENAME_MAX] = "";
-char TSSLSocket::fgSSLUCert[FILENAME_MAX]  = "";
-char TSSLSocket::fgSSLUKey[FILENAME_MAX]   = "";
+char ROOT::Deprecated::TSSLSocket::fgSSLCAFile[FILENAME_MAX] = "";
+char ROOT::Deprecated::TSSLSocket::fgSSLCAPath[FILENAME_MAX] = "";
+char ROOT::Deprecated::TSSLSocket::fgSSLUCert[FILENAME_MAX] = "";
+char ROOT::Deprecated::TSSLSocket::fgSSLUKey[FILENAME_MAX] = "";
 
 ////////////////////////////////////////////////////////////////////////////////
 // SSL debugging
 
-void ssl_info_callback(const SSL* ssl, int where, int ret)
+static void ssl_info_callback(const SSL *ssl, int where, int ret)
 {
    if (ret == 0) {
       std::cout << "-- ssl_info_callback: error occurred.\n";
@@ -50,7 +50,7 @@ void ssl_info_callback(const SSL* ssl, int where, int ret)
 ////////////////////////////////////////////////////////////////////////////////
 /// Wraps the socket with OpenSSL.
 
-void TSSLSocket::WrapWithSSL(void)
+void ROOT::Deprecated::TSSLSocket::WrapWithSSL(void)
 {
    SSL_library_init();
 
@@ -108,7 +108,7 @@ wrapFailed:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(TInetAddress addr, const char *service, Int_t tcpwindowsize)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(TInetAddress addr, const char *service, Int_t tcpwindowsize)
    : TSocket(addr, service, tcpwindowsize)
 {
    WrapWithSSL();
@@ -116,7 +116,7 @@ TSSLSocket::TSSLSocket(TInetAddress addr, const char *service, Int_t tcpwindowsi
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
    : TSocket(addr, port, tcpwindowsize)
 {
    WrapWithSSL();
@@ -124,7 +124,7 @@ TSSLSocket::TSSLSocket(TInetAddress addr, Int_t port, Int_t tcpwindowsize)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(const char *host, const char *service, Int_t tcpwindowsize)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(const char *host, const char *service, Int_t tcpwindowsize)
    : TSocket(host, service, tcpwindowsize)
 {
    WrapWithSSL();
@@ -132,7 +132,7 @@ TSSLSocket::TSSLSocket(const char *host, const char *service, Int_t tcpwindowsiz
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(const char *url, Int_t port, Int_t tcpwindowsize)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(const char *url, Int_t port, Int_t tcpwindowsize)
    : TSocket(url, port, tcpwindowsize)
 {
    WrapWithSSL();
@@ -140,28 +140,28 @@ TSSLSocket::TSSLSocket(const char *url, Int_t port, Int_t tcpwindowsize)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(const char *sockpath) : TSocket(sockpath)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(const char *sockpath) : TSocket(sockpath)
 {
    WrapWithSSL();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(Int_t desc) : TSocket(desc)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(Int_t desc) : TSocket(desc)
 {
    WrapWithSSL();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(Int_t desc, const char *sockpath) : TSocket(desc, sockpath)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(Int_t desc, const char *sockpath) : TSocket(desc, sockpath)
 {
    WrapWithSSL();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TSSLSocket::TSSLSocket(const TSSLSocket &s) : TSocket(s)
+ROOT::Deprecated::TSSLSocket::TSSLSocket(const TSSLSocket &s) : TSocket(s)
 {
    WrapWithSSL();
 }
@@ -169,7 +169,7 @@ TSSLSocket::TSSLSocket(const TSSLSocket &s) : TSocket(s)
 ////////////////////////////////////////////////////////////////////////////////
 /// Close gracefully the connection, and free SSL structures.
 
-TSSLSocket::~TSSLSocket()
+ROOT::Deprecated::TSSLSocket::~TSSLSocket()
 {
    Close();
    if (fSSL)
@@ -181,7 +181,7 @@ TSSLSocket::~TSSLSocket()
 ////////////////////////////////////////////////////////////////////////////////
 /// Close the SSL connection.
 
-void TSSLSocket::Close(Option_t *option)
+void ROOT::Deprecated::TSSLSocket::Close(Option_t *option)
 {
    if (fSSL)
       SSL_shutdown(fSSL);
@@ -191,8 +191,7 @@ void TSSLSocket::Close(Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Set up the static configuration variables.
 
-void TSSLSocket::SetUpSSL(const char *cafile, const char *capath,
-                          const char *ucert,  const char *ukey)
+void ROOT::Deprecated::TSSLSocket::SetUpSSL(const char *cafile, const char *capath, const char *ucert, const char *ukey)
 {
    if (cafile)
       strlcpy(fgSSLCAFile, cafile, FILENAME_MAX);
@@ -206,7 +205,7 @@ void TSSLSocket::SetUpSSL(const char *cafile, const char *capath,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t TSSLSocket::Recv(TMessage *& /*mess */)
+Int_t ROOT::Deprecated::TSSLSocket::Recv(TMessage *& /*mess */)
 {
    Error("Recv", "not implemented");
    return -1;
@@ -215,7 +214,7 @@ Int_t TSSLSocket::Recv(TMessage *& /*mess */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Receive a raw buffer of specified length bytes.
 
-Int_t TSSLSocket::RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt)
+Int_t ROOT::Deprecated::TSSLSocket::RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt)
 {
    TSystem::ResetErrno();
 
@@ -271,7 +270,7 @@ Int_t TSSLSocket::RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t TSSLSocket::Send(const TMessage & /* mess */)
+Int_t ROOT::Deprecated::TSSLSocket::Send(const TMessage & /* mess */)
 {
    Error("Send", "not implemented");
    return -1;
@@ -280,7 +279,7 @@ Int_t TSSLSocket::Send(const TMessage & /* mess */)
 ////////////////////////////////////////////////////////////////////////////////
 /// Send a raw buffer of specified length.
 
-Int_t TSSLSocket::SendRaw(const void *buffer, Int_t length, ESendRecvOptions /* opt */)
+Int_t ROOT::Deprecated::TSSLSocket::SendRaw(const void *buffer, Int_t length, ESendRecvOptions /* opt */)
 {
    TSystem::ResetErrno();
 


### PR DESCRIPTION
My suggestion is to backport this to 6.40.

For 6.42, we can make it an internal class and then decide about its further internal use.