### PR TITLE
[http] reduce size of `file.root` request

### DIFF
--- a/net/http/test/test_server.cxx
+++ b/net/http/test/test_server.cxx
@@ -108,7 +108,7 @@ TEST(THttpServer, main)
    // check ROOT file creation
    res = execute_request("/obj1/file.root");
    // TODO: anlyze why so big size for small object
-   EXPECT_NEAR(res.length(), 2097152, 10000);
+   EXPECT_NEAR(res.length(), 1024, 100);
 
    // check item request hierarchy request
    res = execute_request("/obj1/item.json");

--- a/net/http/test/test_server.cxx
+++ b/net/http/test/test_server.cxx
@@ -87,7 +87,7 @@ TEST(THttpServer, main)
                   "  \"fBits\" : 8,\n"
                   "  \"fName\" : \"obj1\",\n"
                   "  \"fTitle\" : \"title1\"\n"
-                  "}");
+                  "}") << "result of root.json request";
 
    // check XML representation for the object
    res = execute_request("/obj1/root.xml");
@@ -97,18 +97,18 @@ TEST(THttpServer, main)
                   "    <fName str=\"obj1\"/>\n"
                   "    <fTitle str=\"title1\"/>\n"
                   "  </TNamed>\n"
-                  "</Object>\n");
+                  "</Object>\n") << "result of root.xml request";
 
 
    // check BINARY representation for the object
    res = execute_request("/obj1/root.bin");
    // keep minimal margin for binary format change
-   EXPECT_NEAR(res.length(), 28, 4);
+   EXPECT_NEAR(res.length(), 28, 4) << "size of root.bin request";
 
    // check ROOT file creation
    res = execute_request("/obj1/file.root");
    // TODO: anlyze why so big size for small object
-   EXPECT_NEAR(res.length(), 1024, 100);
+   EXPECT_NEAR(res.length(), 1024, 100) << "size of file.root request";
 
    // check item request hierarchy request
    res = execute_request("/obj1/item.json");
@@ -118,7 +118,7 @@ TEST(THttpServer, main)
                   "  \"_root_version\" : " + std::to_string(gROOT->GetVersionCode()) + ",\n"
                   "  \"_kind\" : \"ROOT.TNamed\",\n"
                   "  \"_title\" : \"title1\"\n"
-                  "}");
+                  "}") << "result of item.json request";
 
 
    // check multi request to several objects
@@ -135,12 +135,12 @@ TEST(THttpServer, main)
                   "  \"fBits\" : 8,\n"
                   "  \"fName\" : \"obj2\",\n"
                   "  \"fTitle\" : \"title2\"\n"
-                  "}]");
+                  "}]") << "result of multi.json request";
 
 
    // by default methods execution is not allowed
    res = execute_request("/obj1/exe.json?method=GetTitle");
-   EXPECT_EQ(res, "");
+   EXPECT_EQ(res, "") << "exe.json should be empty in readonly";
 
 
    // disable readonly to get extra functionality
@@ -148,10 +148,10 @@ TEST(THttpServer, main)
 
    // only now one can execute method
    res = execute_request("/obj1/exe.json?method=GetTitle");
-   EXPECT_EQ(res, "\"title1\"");
+   EXPECT_EQ(res, "\"title1\"") << "result of exe.json with object title";
 
    res = execute_request("/obj1/exe.json?method=SetTitle&title=NewTitle");
-   EXPECT_EQ(res, "null");
-   EXPECT_EQ(std::string("NewTitle"), obj1.GetTitle());
+   EXPECT_EQ(res, "null") << "returns null when executes void method";
+   EXPECT_EQ(std::string("NewTitle"), obj1.GetTitle()) << "title must match with submitted value";
    obj1.SetTitle("title1");
 }

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -347,7 +347,9 @@ Bool_t TRootSnifferFull::ProduceRootFile(const std::string &path, const std::str
    } restoreGFile;
 
    {
-      TMemFile memfile("dummy.file", "RECREATE", "", ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault, 1024);
+      TMemFile memfile("dummy.file", "RECREATE",
+                        TString::Format("Object %s", path.c_str()),
+                        ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault, 1024);
       gROOT->GetListOfFiles()->Remove(&memfile);
 
       memfile.WriteObjectAny(obj_ptr, obj_cl, store_name);

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -347,7 +347,7 @@ Bool_t TRootSnifferFull::ProduceRootFile(const std::string &path, const std::str
    } restoreGFile;
 
    {
-      TMemFile memfile("dummy.file", "RECREATE");
+      TMemFile memfile("dummy.file", "RECREATE", "", ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault, 1024);
       gROOT->GetListOfFiles()->Remove(&memfile);
 
       memfile.WriteObjectAny(obj_ptr, obj_cl, store_name);

--- a/net/httpsniff/test/test_sniffer.cxx
+++ b/net/httpsniff/test/test_sniffer.cxx
@@ -127,7 +127,7 @@ TEST(TRootSniffer, file_root)
 
    std::string res;
    sniffer.Produce("/obj", "file.root", "", res);
-   EXPECT_NEAR(res.length(), 2097152, 10000) << "size of file.root request";
+   EXPECT_NEAR(res.length(), 1024, 100) << "size of file.root request";
 }
 
 // check hierarchy request


### PR DESCRIPTION
Any object from `THttpServer` can be requested with `file.root` request
Internally `TMemFile` used - which has very large default buffer size.
Therefore default file size is 2MB - which is too much.
Reduce this to 1K, adjust already provided testing

Also add text output to `EXPECT_EQ` macros - to get idea that value is compared.
Simplify debugging afterwards