### PR TITLE
[ML][Python] Fix udnersampling test - rounding below min sampling ratio

### DIFF
--- a/bindings/pyroot/pythonizations/test/ml_dataloader.py
+++ b/bindings/pyroot/pythonizations/test/ml_dataloader.py
@@ -1,3 +1,4 @@
+import math
 import os
 import unittest
 from random import randrange, uniform
@@ -5779,7 +5780,7 @@ class DataLoaderRandomUndersampling(unittest.TestCase):
         entries_in_rdf_minor = randrange(8000, 9999)
         batch_size = randrange(100, 501)
         min_allowed_sampling_ratio = entries_in_rdf_minor / entries_in_rdf_major
-        sampling_ratio = round(uniform(min_allowed_sampling_ratio, 2), 2)
+        sampling_ratio = math.ceil(uniform(min_allowed_sampling_ratio, 2) * 100) / 100
 
         error_message = f"\n Batch size: {batch_size}\
             Number of major entries: {entries_in_rdf_major} \


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`test14_big_data_replacement_false` was occasionally failing with `invalid_argument: The sampling_ratio is too low` because `round(uniform(min_allowed_sampling_ratio, 2), 2)` could round the randomly generated ratio down below `min_allowed_sampling_ratio`. The fix makes sure to always round up so that the sampling ratio is always at or above the minimum valid value.


## Checklist:

- [x] tested changes locally


