### PR TITLE
[ntuple] Add kTypeS3 locator type for S3 storage backend

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleTypes.hxx
@@ -236,6 +236,7 @@ public:
       // if the size of the referenced data block is >2GB
       kTypeFile = 0x00,
       kTypeDAOS = 0x02,
+      kTypeS3 = 0x03,
 
       kLastSerializableType = 0x7f,
       kTypePageZero = kLastSerializableType + 1,

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -506,7 +506,7 @@ ROOT::RResult<void> DeserializeLocatorPayloadObject64(const unsigned char *buffe
       locator.SetNBytesOnStorage(nBytesOnStorage);
       RNTupleSerializer::DeserializeUInt64(buffer + sizeof(std::uint64_t), location);
    } else {
-      return R__FAIL("invalid DAOS locator payload size: " + std::to_string(sizeofLocatorPayload));
+      return R__FAIL("invalid Object64 locator payload size: " + std::to_string(sizeofLocatorPayload));
    }
    locator.SetPosition(ROOT::RNTupleLocatorObject64{location});
    return ROOT::RResult<void>::Success();
@@ -1091,6 +1091,10 @@ ROOT::Internal::RNTupleSerializer::SerializeLocator(const RNTupleLocator &locato
       size += SerializeLocatorPayloadObject64(locator, payloadp);
       locatorType = 0x02;
       break;
+   case RNTupleLocator::kTypeS3:
+      size += SerializeLocatorPayloadObject64(locator, payloadp);
+      locatorType = 0x03;
+      break;
    default:
       if (locator.GetType() == ROOT::Internal::kTestLocatorType) {
          // For the testing locator, use the same payload format as Object64. We won't read it back anyway.
@@ -1137,6 +1141,10 @@ ROOT::RResult<std::uint32_t> ROOT::Internal::RNTupleSerializer::DeserializeLocat
          break;
       case 0x02:
          locator.SetType(RNTupleLocator::kTypeDAOS);
+         DeserializeLocatorPayloadObject64(bytes, payloadSize, locator);
+         break;
+      case 0x03:
+         locator.SetType(RNTupleLocator::kTypeS3);
          DeserializeLocatorPayloadObject64(bytes, payloadSize, locator);
          break;
       default: locator.SetType(RNTupleLocator::kTypeUnknown);

--- a/tree/ntuple/src/RNTupleTypes.cxx
+++ b/tree/ntuple/src/RNTupleTypes.cxx
@@ -45,7 +45,8 @@ ROOT::RNTupleLocator::ELocatorType ROOT::RNTupleLocator::GetType() const
    case 1: return kTypeDAOS;
    case 2: return kTypePageZero;
    case 3: return kTypeUnknown;
-   case 4: return Internal::kTestLocatorType;
+   case 4: return kTypeS3;
+   case 5: return Internal::kTestLocatorType;
    default: break;
    }
    R__ASSERT(false);
@@ -60,9 +61,10 @@ void ROOT::RNTupleLocator::SetType(ELocatorType type)
    case kTypeDAOS: compactType = 1; break;
    case kTypePageZero: compactType = 2; break;
    case kTypeUnknown: compactType = 3; break;
+   case kTypeS3: compactType = 4; break;
    default:
       if (type == Internal::kTestLocatorType)
-         compactType = 4;
+         compactType = 5;
       else
          throw RException(R__FAIL("invalid locator type: " + std::to_string(type)));
    }
@@ -79,7 +81,7 @@ void ROOT::RNTupleLocator::SetPosition(std::uint64_t position)
 
 void ROOT::RNTupleLocator::SetPosition(RNTupleLocatorObject64 position)
 {
-   if (GetType() != kTypeDAOS)
+   if (GetType() != kTypeDAOS && GetType() != kTypeS3)
       throw RException(R__FAIL("cannot set position as 64bit object for type " + std::to_string(GetType())));
    fPosition = position.GetLocation();
 }
@@ -94,7 +96,7 @@ std::uint64_t ROOT::Internal::RNTupleLocatorHelper<std::uint64_t>::Get(const RNT
 ROOT::RNTupleLocatorObject64
 ROOT::Internal::RNTupleLocatorHelper<ROOT::RNTupleLocatorObject64>::Get(const RNTupleLocator &loc)
 {
-   if (loc.GetType() != ROOT::RNTupleLocator::kTypeDAOS)
+   if (loc.GetType() != ROOT::RNTupleLocator::kTypeDAOS && loc.GetType() != ROOT::RNTupleLocator::kTypeS3)
       throw RException(R__FAIL("cannot retrieve position as 64bit object for type " + std::to_string(loc.GetType())));
    return RNTupleLocatorObject64{loc.fPosition};
 }

--- a/tree/ntuple/test/ntuple_serialize.cxx
+++ b/tree/ntuple/test/ntuple_serialize.cxx
@@ -399,6 +399,31 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(locator.GetReserved(), 1);
    EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
 
+   // S3 locator round-trip with 32-bit nBytesOnStorage
+   locator = RNTupleLocator{};
+   locator.SetType(RNTupleLocator::kTypeS3);
+   locator.SetPosition(RNTupleLocatorObject64{42U});
+   locator.SetNBytesOnStorage(1024U);
+   locator.SetReserved(0);
+   EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer).Unwrap());
+   locator = RNTupleLocator{};
+   EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
+   EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeS3);
+   EXPECT_EQ(locator.GetNBytesOnStorage(), 1024U);
+   EXPECT_EQ(locator.GetReserved(), 0);
+   EXPECT_EQ(42U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
+
+   // S3 locator round-trip with 64-bit nBytesOnStorage and reserved bit
+   locator.SetNBytesOnStorage(static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
+   locator.SetReserved(1);
+   EXPECT_EQ(20u, RNTupleSerializer::SerializeLocator(locator, buffer).Unwrap());
+   locator = RNTupleLocator{};
+   EXPECT_EQ(20u, RNTupleSerializer::DeserializeLocator(buffer, 20, locator).Unwrap());
+   EXPECT_EQ(locator.GetType(), RNTupleLocator::kTypeS3);
+   EXPECT_EQ(locator.GetNBytesOnStorage(), static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1);
+   EXPECT_EQ(locator.GetReserved(), 1);
+   EXPECT_EQ(42U, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
+
    std::int32_t *head = reinterpret_cast<std::int32_t *>(buffer);
 #ifndef R__BYTESWAP
    // on big endian system


### PR DESCRIPTION
# This Pull Request 
(Is a part of the GSoC 2026 project `S3 Backend for RNTuple.`)

The S3 backend supports two addressing modes: Mode A packs multiple pages into a single S3 object and uses a new locator type to encode both the object ID and byte offset, while Mode B stores one page per object and reuses the existing Object64 locator. This PR adds the on-disk format support needed for Mode A.

This PR:

* Adds `kTypeS3 = 0x03` to the `ELocatorType` enum in `RNTupleTypes.hxx`
* Wires the new type code into `SerializeLocator()` and `DeserializeLocator()` in `RNTupleSerialize.cxx`, reusing the existing `SerializeLocatorPayloadObject64` / `DeserializeLocatorPayloadObject64`
* Adds round-trip serialization tests for the new locator type, verifying that the 64-bit payload passes the serialize-deserialize cycle with the correct type code

The 64-bit payload is interpreted differently depending on the locator type: `0x03` (Mode A) bit-splices upper 32 bits as object ID and lower 32 bits as byte offset, while `0x02` (Mode B) uses the full value as a plain object ID. The interpretation is handled by the backend, not the serializer. The serializer just stores and retrieves the raw 64-bit value.

### Checklist

- [x] Tested changes locally
- [x] Locator round-trip tests pass for both `kTypeS3` (0x03) and `kTypeDAOS` (0x02), locally.