### PR TITLE
Re-enable exception tests on macOS arm64

### DIFF
--- a/bindings/distrdf/test/test_headnode.py
+++ b/bindings/distrdf/test/test_headnode.py
@@ -99,13 +99,9 @@ class DataFrameConstructorTests(unittest.TestCase):
             x[0] = i
             tree.Fill()
 
-        # See https://github.com/root-project/root/issues/7541 and
-        # https://bugs.llvm.org/show_bug.cgi?id=49692 :
-        # llvm JIT fails to catch exceptions on M1, so we disable their testing
-        if platform.processor() != "arm" or platform.mac_ver()[0] == '':
-            with self.assertRaises(ROOT.std.runtime_error):
-                # Trees with no associated files are not supported
-                create_dummy_headnode(tree)
+        with self.assertRaises(ROOT.std.runtime_error):
+            # Trees with no associated files are not supported
+            create_dummy_headnode(tree)
 
     def assertArgs(self, args_list1, args_list2):
         """
@@ -231,31 +227,27 @@ class DataFrameConstructorTests(unittest.TestCase):
 
     def test_tree_with_friends_and_treeindex(self):
         """TTreeIndex is not supported in distributed mode."""
-        # See https://github.com/root-project/root/issues/7541 and
-        # https://bugs.llvm.org/show_bug.cgi?id=49692 :
-        # llvm JIT fails to catch exceptions on M1, so we disable their testing
-        if platform.processor() != "arm" or platform.mac_ver()[0] == '':
-            main_file = "distrdf_indexed_friend_main.root"
-            aux_file = "distrdf_indexed_friend_aux.root"
-            fill_main_tree_and_indexed_friend(main_file, aux_file)
+        main_file = "distrdf_indexed_friend_main.root"
+        aux_file = "distrdf_indexed_friend_aux.root"
+        fill_main_tree_and_indexed_friend(main_file, aux_file)
 
-            main_chain = ROOT.TChain("mainTree", "mainTree")
-            main_chain.Add(main_file)
-            aux_chain = ROOT.TChain("auxTree", "auxTree")
-            aux_chain.Add(aux_file)
+        main_chain = ROOT.TChain("mainTree", "mainTree")
+        main_chain.Add(main_file)
+        aux_chain = ROOT.TChain("auxTree", "auxTree")
+        aux_chain.Add(aux_file)
 
-            aux_chain.BuildIndex("idx")
-            main_chain.AddFriend(aux_chain)
+        aux_chain.BuildIndex("idx")
+        main_chain.AddFriend(aux_chain)
 
-            with self.assertRaises(ValueError) as context:
-                create_dummy_headnode(main_chain)
+        with self.assertRaises(ValueError) as context:
+            create_dummy_headnode(main_chain)
 
-            self.assertEqual(str(context.exception),
-                             "Friend tree 'auxTree' has a TTreeIndex. This is not supported in distributed mode.")
+        self.assertEqual(str(context.exception),
+                         "Friend tree 'auxTree' has a TTreeIndex. This is not supported in distributed mode.")
 
-            # Remove unnecessary .root files
-            os.remove(main_file)
-            os.remove(aux_file)
+        # Remove unnecessary .root files
+        os.remove(main_file)
+        os.remove(aux_file)
 
 
 class NumEntriesTest(unittest.TestCase):

--- a/bindings/pyroot/cppyy/cppyy/test/test_regression.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_regression.py
@@ -1414,14 +1414,11 @@ class TestREGRESSION:
         assert out == ""
         assert err == ""
 
-    @mark.xfail(run=False, condition=IS_MAC_ARM or IS_WINDOWS == 64, reason="LLVM JIT fails to catch exceptions")
+    @mark.xfail(run=False, condition=IS_WINDOWS == 64, reason="LLVM JIT fails to catch exceptions")
     def test49_overloads_with_runtime_errors(self):
         """Regression test for https://github.com/root-project/root/issues/17497
 
-        See https://github.com/root-project/root/issues/7541 and
-        https://bugs.llvm.org/show_bug.cgi?id=49692 :
-        llvm JIT fails to catch exceptions on MacOS ARM, so we disable their testing
-        Also fails on Windows 64bit for the same reason
+        LLVM JIT failes to catch exceptions on Windows 64bit, so we disable their testing
         """
         import cppyy
 

--- a/bindings/pyroot/pythonizations/test/rdataframe_misc.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_misc.py
@@ -51,11 +51,8 @@ class RDataFrameMisc(unittest.TestCase):
         """
         An empty list of filenames should be detected and the user should be informed
         """
-        # See https://github.com/root-project/root/issues/7541 and
-        # https://bugs.llvm.org/show_bug.cgi?id=49692 :
-        # llvm JIT fails to catch exceptions on MacOS ARM, so we disable their testing
-        # Also fails on Windows for the same reason
-        if (platform.processor() != "arm" or platform.mac_ver()[0] == "") and not platform.system() == "Windows":
+        # LLVM JIT fails to catch exceptions on Windows, so we disable their testing
+        if not platform.system() == "Windows":
             # With implicit conversions, cppyy also needs to try dispatching to the various
             # constructor overloads. The C++ exception will be thrown, but will be incapsulated
             # in a more generic TypeError telling the user that none of the overloads worked

--- a/interpreter/cling/lib/Interpreter/Exception.cpp
+++ b/interpreter/cling/lib/Interpreter/Exception.cpp
@@ -32,14 +32,6 @@ CLING_LIB_EXPORT
 void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
                                                    const void* Arg) {
 
-#if defined(__APPLE__) && defined(__arm64__)
-  // See https://github.com/root-project/root/issues/7541 and
-  // https://bugs.llvm.org/show_bug.cgi?id=49692 :
-  // llvm JIT fails to catch exceptions on M1, so let's throw less.
-  // This might still better than `terminate`...
-  (void)Interp;
-  (void)Expr;
-#else
   const clang::Expr* const E = (const clang::Expr*)Expr;
 
   // The isValidAddress function return true even when the pointer is
@@ -62,7 +54,6 @@ void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
     throw cling::InvalidDerefException(&S, E,
           cling::InvalidDerefException::DerefType::INVALID_MEM);
   }
-#endif
   return const_cast<void*>(Arg);
 }
 }
@@ -112,11 +103,7 @@ namespace cling {
   void CompilationException::throwingHandler(void * /*user_data*/,
                                              const char* reason,
                                              bool /*gen_crash_diag*/) {
-    // See https://github.com/root-project/root/issues/7541 and
-    // https://bugs.llvm.org/show_bug.cgi?id=49692 :
-    // We cannot catch exceptions that traverse JITted code on M1, so let's throw less.
-    // This might still better than `terminate`...
-#if !defined(_MSC_VER) && (!defined(__APPLE__) || !defined(__arm64__))
+#if !defined(_MSC_VER)
     throw cling::CompilationException(reason);
 #endif
   }

--- a/roottest/python/regression/PyROOT_regressiontests.py
+++ b/roottest/python/regression/PyROOT_regressiontests.py
@@ -70,19 +70,15 @@ class Regression01TwiceImportStar( MyTestCase ):
 class Regression02PyException(MyTestCase):
    def test1RaiseAndTrapPyException(self):
       """Test thrown TPyException object processing"""
-      # See https://github.com/root-project/root/issues/7541 and
-      # https://bugs.llvm.org/show_bug.cgi?id=49692 :
-      # llvm JIT fails to catch exceptions on M1, so we disable their testing
-      if platform.processor() != "arm" or platform.mac_ver()[0] == '':
-         gROOT.LoadMacro("ScottCppyy.C+")
+      gROOT.LoadMacro("ScottCppyy.C+")
 
-         # test of not overloaded global function
-         with self.assertRaisesRegex(SyntaxError, "test error message"):
-            ROOT.ThrowPyException()
+      # test of not overloaded global function
+      with self.assertRaisesRegex(SyntaxError, "test error message"):
+         ROOT.ThrowPyException()
 
-         # test of overloaded function
-         with self.assertRaisesRegex(SyntaxError, "overloaded int test error message"):
-            ROOT.MyThrowingClass.ThrowPyException(1)
+      # test of overloaded function
+      with self.assertRaisesRegex(SyntaxError, "overloaded int test error message"):
+         ROOT.MyThrowingClass.ThrowPyException(1)
 
 
 ### Several tests that used to cause crashes =================================


### PR DESCRIPTION
Catching exceptions from and through interpreted code works since the upgrade to LLVM 20.

Closes #7541