### PR TITLE
[cppyy] Use `cppdef` for variable in test

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_fragile.py
@@ -544,13 +544,12 @@ class TestFRAGILE:
         assert "invaliddigit" in err
         assert "1aap=42;" in err
 
-    @mark.xfail(strict=True, condition=not IS_WINDOWS, reason="Fails on Windows")
     def test22_cppexec(self):
         """Interactive access to the Cling global scope"""
 
         import cppyy
 
-        cppyy.cppexec("int interactive_b = 4")
+        cppyy.cppdef("int interactive_b = 4;")
         assert cppyy.gbl.interactive_b == 4
 
         with raises(SyntaxError):


### PR DESCRIPTION
This fixes `test22_cppexec` which was marked as `xfail` if `not IS_WINDOWS`, which is the opposite of the given reason "Fails on Windows".