### PR TITLE
[tree] fix I/O rule for vector<T> with nested split source

### DIFF
--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -213,6 +213,13 @@ namespace TStreamerInfoActions {
       void AddToOffset(Int_t delta);
       void SetMissing();
 
+      /// Replace each action with `UseCacheVectorLoop` wrapping the original
+      /// action.  Used by TBranchElement when a sub-branch must read its data
+      /// into the parent's on-file staging area (e.g. a split branch supplying
+      /// the source of a schema-evolution rule whose source is a nested
+      /// struct member).
+      void WrapAllActionsWithUseCacheVectorLoop(TVirtualStreamerInfo *info);
+
       TActionSequence *CreateCopy();
       static TActionSequence *CreateReadMemberWiseActions(TVirtualStreamerInfo *info, TVirtualCollectionProxy &proxy);
       static TActionSequence *CreateReadMemberWiseActions(TVirtualStreamerInfo &info, std::unique_ptr<TLoopConfiguration> loopConfig);

--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -5416,6 +5416,21 @@ void TStreamerInfoActions::TActionSequence::AddToOffset(Int_t delta)
    }
 }
 
+void TStreamerInfoActions::TActionSequence::WrapAllActionsWithUseCacheVectorLoop(TVirtualStreamerInfo *info)
+{
+   // Replace each action in the sequence with a UseCacheVectorLoop wrapping
+   // the original action.  After this call, the actions iterate over the
+   // staging area pushed onto the buffer's data cache stack rather than the
+   // original (user) iteration range.  The element offsets stored on the
+   // inner actions therefore must be relative to the staging element layout.
+
+   for (auto &configured : fActions) {
+      TConfiguredAction inner(configured);
+      configured.fLoopAction = UseCacheVectorLoop;
+      configured.fConfiguration = new TConfigurationUseCache(info, inner, /*repeat*/ kFALSE);
+   }
+}
+
 void TStreamerInfoActions::TActionSequence::SetMissing()
 {
    // Add the (potentially negative) delta to all the configuration's offset.  This is used by

--- a/roottest/root/io/datamodelevolution/stl/CMakeLists.txt
+++ b/roottest/root/io/datamodelevolution/stl/CMakeLists.txt
@@ -39,3 +39,4 @@ ROOTTEST_ADD_TEST(ReadFile
                   FIXTURES_REQUIRED root-io-datamodelevolution-stl-WriteFile-fixture
                                     root-io-datamodelevolution-stl-readFile-compile-fixture)
 
+ROOTTEST_ADD_TESTDIRS()

--- a/roottest/root/io/datamodelevolution/stl/nestedsource/CMakeLists.txt
+++ b/roottest/root/io/datamodelevolution/stl/nestedsource/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Reading a split TTree branch holding a vector<T>, where an I/O rule for T
+# sources a member nested inside a struct.
+# See https://github.com/root-project/root/issues/19773
+
+ROOTTEST_COMPILE_MACRO(execWriteNestedSource.cxx
+                  FIXTURES_SETUP root-io-datamodelevolution-stl-nestedsource-WriteNestedSource-compile-fixture)
+
+ROOTTEST_COMPILE_MACRO(execReadNestedSource.cxx
+                  FIXTURES_SETUP root-io-datamodelevolution-stl-nestedsource-ReadNestedSource-compile-fixture)
+
+ROOTTEST_ADD_TEST(WriteNestedSource
+                  MACRO execWriteNestedSource.cxx+
+                  OUTREF execWriteNestedSource.ref
+                  LABELS longtest
+                  FIXTURES_REQUIRED root-io-datamodelevolution-stl-nestedsource-WriteNestedSource-compile-fixture
+                  FIXTURES_SETUP root-io-datamodelevolution-stl-nestedsource-WriteNestedSource-fixture)
+
+ROOTTEST_ADD_TEST(ReadNestedSource
+                  MACRO execReadNestedSource.cxx+
+                  OUTREF execReadNestedSource.ref
+                  LABELS longtest
+                  FIXTURES_REQUIRED root-io-datamodelevolution-stl-nestedsource-ReadNestedSource-compile-fixture
+                                    root-io-datamodelevolution-stl-nestedsource-WriteNestedSource-fixture)

--- a/roottest/root/io/datamodelevolution/stl/nestedsource/execReadNestedSource.cxx
+++ b/roottest/root/io/datamodelevolution/stl/nestedsource/execReadNestedSource.cxx
@@ -1,0 +1,82 @@
+// Read the file written by execWriteNestedSource.cxx with a data model in
+// which the members of the nested `Deep` struct have been moved to the top
+// level of `Event`, where they are filled by an I/O rule whose source is the
+// nested struct.
+//
+// All four cases below must report the same values; before the fix for issue
+// https://github.com/root-project/root/issues/19773 the elements read from the
+// split TTree branch were left with the default values because the on-file
+// staging area the rule reads from was never filled.
+
+#include <Rtypes.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <vector>
+
+struct Deep {
+   float fDeepMember = 0.;
+   int fDeepInt = 0;
+
+   ClassDefNV(Deep, 1)
+};
+
+struct Event {
+   int fId = 0;
+   float fMember = 0.;
+   int fIntMember = 0;
+
+   ClassDefNV(Event, 2)
+};
+
+#ifdef __ROOTCLING__
+#pragma link C++ class Deep+;
+#pragma link C++ class Event+;
+#pragma link C++ class std::vector<Event>+;
+
+#pragma read sourceClass = "Event" source = "Deep fDeep" version = "[1]" targetClass = "Event" \
+   target = "fMember,fIntMember" code = "{ fMember = onfile.fDeep.fDeepMember; fIntMember = onfile.fDeep.fDeepInt; }"
+#endif
+
+void Print(const char *what, const Event &event)
+{
+   std::cout << what << ": fId=" << event.fId << " fMember=" << event.fMember << " fIntMember=" << event.fIntMember
+             << "\n";
+}
+
+void Print(const char *what, const std::vector<Event> &events)
+{
+   for (unsigned int i = 0; i < events.size(); ++i) {
+      std::cout << what << " i=" << i;
+      std::cout << ": fId=" << events[i].fId;
+      std::cout << " fMember=" << events[i].fMember;
+      std::cout << " fIntMember=" << events[i].fIntMember;
+      std::cout << "\n";
+   }
+}
+
+int execReadNestedSource()
+{
+   TFile file("nestedsource.root", "READ");
+
+   auto *single = file.Get<Event>("e");
+   Print("Plain object", *single);
+
+   auto *vec = file.Get<std::vector<Event>>("ve");
+   Print("Plain vector", *vec);
+
+   auto *tree = file.Get<TTree>("t");
+
+   std::vector<Event> *ve0 = nullptr;
+   std::vector<Event> *ve99 = nullptr;
+   tree->SetBranchAddress("ve0", &ve0);
+   tree->SetBranchAddress("ve99", &ve99);
+
+   tree->GetEntry(0);
+
+   Print("Tree (splitlevel 0)", *ve0);
+   Print("Tree (splitlevel 99)", *ve99);
+
+   return 0;
+}

--- a/roottest/root/io/datamodelevolution/stl/nestedsource/execReadNestedSource.ref
+++ b/roottest/root/io/datamodelevolution/stl/nestedsource/execReadNestedSource.ref
@@ -1,0 +1,12 @@
+Processing execReadNestedSource.cxx+...
+Plain object: fId=1 fMember=10 fIntMember=100
+Plain vector i=0: fId=1 fMember=10 fIntMember=100
+Plain vector i=1: fId=2 fMember=20 fIntMember=200
+Plain vector i=2: fId=3 fMember=30 fIntMember=300
+Tree (splitlevel 0) i=0: fId=1 fMember=10 fIntMember=100
+Tree (splitlevel 0) i=1: fId=2 fMember=20 fIntMember=200
+Tree (splitlevel 0) i=2: fId=3 fMember=30 fIntMember=300
+Tree (splitlevel 99) i=0: fId=1 fMember=10 fIntMember=100
+Tree (splitlevel 99) i=1: fId=2 fMember=20 fIntMember=200
+Tree (splitlevel 99) i=2: fId=3 fMember=30 fIntMember=300
+(int) 0

--- a/roottest/root/io/datamodelevolution/stl/nestedsource/execWriteNestedSource.cxx
+++ b/roottest/root/io/datamodelevolution/stl/nestedsource/execWriteNestedSource.cxx
@@ -1,0 +1,65 @@
+// Write a file with the old data model, where the interesting values are
+// stored inside the nested `Deep` struct.  They are read back by
+// execReadNestedSource.cxx with a data model in which those values have been
+// moved to the top level of `Event`.
+// See https://github.com/root-project/root/issues/19773
+
+#include <Rtypes.h>
+#include <TFile.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <vector>
+
+struct Deep {
+   float fDeepMember = 0.;
+   int fDeepInt = 0;
+
+   ClassDefNV(Deep, 1)
+};
+
+struct Event {
+   int fId = 0;
+   Deep fDeep;
+
+   ClassDefNV(Event, 1)
+};
+
+#ifdef __ROOTCLING__
+#pragma link C++ class Deep+;
+#pragma link C++ class Event+;
+#pragma link C++ class std::vector<Event>+;
+#endif
+
+int execWriteNestedSource()
+{
+   TFile file("nestedsource.root", "RECREATE");
+
+   Event single;
+   single.fId = 1;
+   single.fDeep.fDeepMember = 10.;
+   single.fDeep.fDeepInt = 100;
+   file.WriteObject(&single, "e");
+
+   std::vector<Event> vec;
+   for (int i = 1; i <= 3; ++i) {
+      Event event;
+      event.fId = i;
+      event.fDeep.fDeepMember = 10. * i;
+      event.fDeep.fDeepInt = 100 * i;
+      vec.push_back(event);
+   }
+   auto *vecPtr = &vec;
+   file.WriteObject(vecPtr, "ve");
+
+   TTree tree("t", "");
+   tree.Branch("ve0", "std::vector<Event>", &vecPtr, 32000, 0);
+   tree.Branch("ve99", "std::vector<Event>", &vecPtr, 32000, 99);
+   tree.Fill();
+
+   file.Write();
+
+   std::cout << "Wrote " << vec.size() << " events.\n";
+
+   return 0;
+}

--- a/roottest/root/io/datamodelevolution/stl/nestedsource/execWriteNestedSource.ref
+++ b/roottest/root/io/datamodelevolution/stl/nestedsource/execWriteNestedSource.ref
@@ -1,0 +1,3 @@
+Processing execWriteNestedSource.cxx+...
+Wrote 3 events.
+(int) 0

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -51,7 +51,8 @@ protected:
       kOwnOnfileObj  = BIT(19), ///<  We are the owner of fOnfileObject.
       kAddressSet    = BIT(20), ///<  The addressing set have been called for this branch
       kMakeClass     = BIT(21), ///<  This branch has been switched to using the MakeClass Mode
-      kDecomposedObj = BIT(21)  ///<  More explicit alias for kMakeClass.
+      kDecomposedObj = BIT(21), ///<  More explicit alias for kMakeClass.
+      kReadFromStagingArray = BIT(23) ///< This split sub-branch must read its data into the parent's on-file staging area (e.g. for a schema-evolution rule with a nested split source).
    };
 
 

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -52,7 +52,8 @@ protected:
       kAddressSet    = BIT(20), ///<  The addressing set have been called for this branch
       kMakeClass     = BIT(21), ///<  This branch has been switched to using the MakeClass Mode
       kDecomposedObj = BIT(21), ///<  More explicit alias for kMakeClass.
-      kReadFromStagingArray = BIT(23) ///< This split sub-branch must read its data into the parent's on-file staging area (e.g. for a schema-evolution rule with a nested split source).
+      kReadFromStagingArray = BIT(23) ///< This split sub-branch must read its data into the parent's on-file staging
+                                      ///< area (e.g. for a schema-evolution rule with a nested split source).
    };
 
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3695,6 +3695,18 @@ void TBranchElement::InitializeOffsets()
                dataName.Replace(dotpos,endpos-dotpos,subBranchElement->GetFullName());
             }
             TRealData* rd = pClass->GetRealData(dataName);
+            TRealData* stagingRd = nullptr;
+            if (!rd && fOnfileObject && fOnfileObject->fClass) {
+               // The data member does not exist in the user (target) class.
+               // If the parent owns an on-file staging area (e.g. for an I/O
+               // rule whose source is a struct member that has itself been
+               // split on disk), try the staging class.  When found, the
+               // sub-branch will be redirected to read its bytes into the
+               // staging area rather than be skipped.
+               stagingRd = fOnfileObject->fClass->GetRealData(dataName);
+               if (stagingRd && stagingRd->TestBit(TRealData::kTransient))
+                  stagingRd = nullptr;
+            }
             if (rd && (!rd->TestBit(TRealData::kTransient) || alternateElement)) {
                // -- Data member exists in the dictionary meta info, get the offset.
                // If we are using an alternateElement, it is the target of a rule
@@ -3704,6 +3716,17 @@ void TBranchElement::InitializeOffsets()
                // We are a rule with no specific target, it applies to the whole
                // object, let's set the offset to zero
                offset = 0;
+            } else if (stagingRd) {
+               // -- Staging redirect: read into the parent's on-file object.
+               offset = stagingRd->GetThisOffset();
+               subBranch->fOnfileObject = fOnfileObject;
+               subBranch->SetBit(kReadFromStagingArray);
+               // The sub-branch's read-action sequence may have been built
+               // earlier (before we had a chance to set the bit and the
+               // on-file object), so re-build it now to pick up the staging
+               // redirect.  We defer this until after the per-sub-branch
+               // SetOffset call below to make sure the action offsets are
+               // computed against the staging element layout.
             } else {
                // -- No dictionary meta info for this data member, it must no
                // longer exist
@@ -3766,6 +3789,15 @@ void TBranchElement::InitializeOffsets()
                   // The value of 'offset' for a regular data member does include its
                   // 'localOffset', we need to remove it explicitly.
                   subBranch->SetOffset(offset - localOffset);
+               }
+               if (subBranch->TestBit(kReadFromStagingArray)
+                   && subBranch->fReadActionSequence)
+               {
+                  // The sub-branch's read action sequence may have been
+                  // built before the staging-redirect bit was set above,
+                  // so re-build it now to install the UseCacheVectorLoop
+                  // wrappers (see TBranchElement::SetReadActionSequence).
+                  subBranch->SetReadActionSequence();
                }
             }
          } else {
@@ -5763,6 +5795,21 @@ void TBranchElement::SetReadActionSequence()
 
    if (create) {
       SetActionSequence(originalClass, localInfo, create, fReadActionSequence);
+   }
+
+   if (TestBit(kReadFromStagingArray) && fReadActionSequence && fOnfileObject) {
+      // The on-disk data for this split sub-branch needs to land in the
+      // parent's on-file staging area (e.g. it is the source of an I/O rule
+      // whose source member is a nested struct that has been split on disk).
+      // Replace each action with a UseCacheVectorLoop wrapping the original,
+      // so the action iterates over the staging area rather than the user
+      // collection.  The element offsets configured on the inner actions are
+      // already expressed relative to the staging element layout.
+      TVirtualStreamerInfo *stagingInfo = fOnfileObject->fClass
+         ? fOnfileObject->fClass->GetStreamerInfo()
+         : nullptr;
+      if (stagingInfo)
+         fReadActionSequence->WrapAllActionsWithUseCacheVectorLoop(stagingInfo);
    }
 }
 

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -3695,7 +3695,7 @@ void TBranchElement::InitializeOffsets()
                dataName.Replace(dotpos,endpos-dotpos,subBranchElement->GetFullName());
             }
             TRealData* rd = pClass->GetRealData(dataName);
-            TRealData* stagingRd = nullptr;
+            TRealData *stagingRd = nullptr;
             if (!rd && fOnfileObject && fOnfileObject->fClass) {
                // The data member does not exist in the user (target) class.
                // If the parent owns an on-file staging area (e.g. for an I/O
@@ -3790,9 +3790,7 @@ void TBranchElement::InitializeOffsets()
                   // 'localOffset', we need to remove it explicitly.
                   subBranch->SetOffset(offset - localOffset);
                }
-               if (subBranch->TestBit(kReadFromStagingArray)
-                   && subBranch->fReadActionSequence)
-               {
+               if (subBranch->TestBit(kReadFromStagingArray) && subBranch->fReadActionSequence) {
                   // The sub-branch's read action sequence may have been
                   // built before the staging-redirect bit was set above,
                   // so re-build it now to install the UseCacheVectorLoop
@@ -5805,9 +5803,7 @@ void TBranchElement::SetReadActionSequence()
       // so the action iterates over the staging area rather than the user
       // collection.  The element offsets configured on the inner actions are
       // already expressed relative to the staging element layout.
-      TVirtualStreamerInfo *stagingInfo = fOnfileObject->fClass
-         ? fOnfileObject->fClass->GetStreamerInfo()
-         : nullptr;
+      TVirtualStreamerInfo *stagingInfo = fOnfileObject->fClass ? fOnfileObject->fClass->GetStreamerInfo() : nullptr;
       if (stagingInfo)
          fReadActionSequence->WrapAllActionsWithUseCacheVectorLoop(stagingInfo);
    }


### PR DESCRIPTION
## Summary
- Fixes #19773: when reading a split `TTree` branch holding `vector<T>` whose schema-evolution rule sources a member nested inside a struct (e.g. `source = "Deep fDeep"`), the rule fired but the new top-level target stayed at its default because the on-file staging area was never populated.
- Detect this case in `TBranchElement::InitializeOffsets` by also looking up the data member in the parent's on-file staging class. When found, propagate `fOnfileObject` to the sub-branch, flag it with a new `kReadFromStagingArray` bit, and re-build its read action sequence.
- Wrap the sub-branch's actions with `UseCacheVectorLoop` (new helper `TActionSequence::WrapAllActionsWithUseCacheVectorLoop`) so the inner action iterates the staging area with the staging element stride and writes at the offset within the staging element — leaving the rule with a properly filled staging area to read from.

## Background
This is the spin-off failure noted in #19773: the fix from #19688 / 121dc61e5d4 handles a split sub-object with a rule on the value type when the rule's source is a flat member (e.g. `fOldMember → fNewMember`). When the rule's source is itself a struct member that has been further split on disk (`ve99.fDeep.fDeepMember`), the existing logic marked the leaf sub-branch missing (because `fDeep` no longer exists in the user class) and the staging `fDeep` was never filled before the rule ran.

## Test plan
Verified locally with the reproducer from the issue (`mini.tar.gz`):

| Case | Before | After |
|---|---|---|
| Plain object | 1 | 1 |
| Plain `vector<T>` | 1 | 1 |
| Tree, split-level 0 | 1 | 1 |
| Tree, split-level 99 (bug) | **0** | **1** |

Also verified manually:
- [x] Multi-element vector (3 elements, distinct values) — all elements read correctly.
- [x] Multi-member source struct (`fA`/`fB`/`fC` of mixed types, three rule targets) — all values populated.
- [x] PR #19688 `RenameSplitCollection` regression case (`EvolutionStruct_V2::fOldMember → EvolutionStruct_V3::fNewMember` over `vector<T>` with split level 99) still passes.
- [x] Same-version split read (no rule) still works.

### Test

Added `roottest/root/io/datamodelevolution/stl/nestedsource/` (per review comment), modelled on the issue reproducer:

- `execWriteNestedSource.cxx` writes with the old model (`Event{int fId; Deep fDeep;}`, `Deep{float fDeepMember; int fDeepInt;}`) as a free-standing object, a free-standing `vector<Event>` with 3 elements, and TTree branches `ve0` (split level 0) and `ve99` (split level 99).
- `execReadNestedSource.cxx` reads it back with the new model (`Event{fId, fMember, fIntMember}`, class version 2) and the rule `source = "Deep fDeep"` → `target = "fMember,fIntMember"`, printing all four cases against `execReadNestedSource.ref`.

Beyond the issue reproducer it also covers a multi-element vector, a surviving top-level member (`fId`) and two rule targets of different types (`float` + `int`), which exercises the offsets within the staging element.

Checked both directions locally: with this branch all four cases give the written values (matching the `.ref`), while against an unpatched ROOT (6.40.02) the plain object, plain vector and split-level-0 cases are correct and split level 99 yields `fMember=0 fIntMember=0`.

Some additional context:  This affects reading CMS ALCARECO files produced with older (Run 2) CMSSW releases in newer Run 3-era releases which is relevant for some analysis workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
