### PR TITLE
[net] Add SendPutReq to RCurlConnection for S3 uploads

### DIFF
--- a/net/curl/inc/ROOT/RCurlConnection.hxx
+++ b/net/curl/inc/ROOT/RCurlConnection.hxx
@@ -117,6 +117,8 @@ public:
    /// a valid batching of requests into multiple multi-range requests takes place automatically.
    /// The fNBytesRecv member of the ranges is only well-defined on success.
    RStatus SendRangesReq(std::size_t N, RUserRange *ranges);
+   /// Uploads data to the URL using an HTTP PUT request.
+   RStatus SendPutReq(const unsigned char *data, std::size_t length);
 
    const std::string &GetEscapedUrl() const { return fEscapedUrl; }
 

--- a/net/curl/inc/ROOT/RCurlConnection.hxx
+++ b/net/curl/inc/ROOT/RCurlConnection.hxx
@@ -75,6 +75,7 @@ private:
 
    void SetupErrorBuffer();
    void SetOptions();
+   void ResetHandle();
    RResult<void> SetUrl(const std::string &url);
    void Perform(RStatus &status);
 

--- a/net/curl/src/RCurlConnection.cxx
+++ b/net/curl/src/RCurlConnection.cxx
@@ -552,6 +552,52 @@ void ReverseDisplacements(std::vector<std::size_t> &displacements, ROOT::Interna
    }
 }
 
+/// State for the PUT upload read callback: tracks progress through the upload buffer.
+struct RUploadState {
+   const unsigned char *fData = nullptr;
+   std::size_t fLength = 0;
+   std::size_t fOffset = 0;
+};
+
+/// CURLOPT_READFUNCTION callback for PUT uploads.  Copies up to `size * nmemb` bytes from the
+/// upload buffer into `buffer` and advances the offset.  Returns the number of bytes copied,
+/// i.e. min(requested, remaining), or 0 at end-of-data to signal that the upload is complete.
+std::size_t CallbackPutRead(char *buffer, std::size_t size, std::size_t nmemb, void *userdata)
+{
+   auto *state = static_cast<RUploadState *>(userdata);
+   R__ASSERT(state->fOffset <= state->fLength);
+
+   std::size_t remaining = state->fLength - state->fOffset;
+   if (remaining == 0)
+      return 0;
+
+   std::size_t requested = size * nmemb;
+   // CURL_READFUNC_ABORT (0x10000000) collides with a valid byte count at 256 MiB;
+   // assert that curl never asks for that much in a single callback invocation.
+   R__ASSERT(requested < CURL_READFUNC_ABORT);
+   std::size_t nbytes = std::min(requested, remaining);
+   memcpy(buffer, state->fData + state->fOffset, nbytes);
+   state->fOffset += nbytes;
+   return nbytes;
+}
+
+/// CURLOPT_SEEKFUNCTION callback for PUT uploads.  Required because CURLOPT_FOLLOWLOCATION
+/// is enabled: on a redirect curl needs to rewind the upload data before resending.
+/// Returns CURL_SEEKFUNC_OK (0) on success, CURL_SEEKFUNC_FAIL (1) for invalid offsets
+/// which aborts the transfer, or CURL_SEEKFUNC_CANTSEEK (2) for unsupported seek origins
+/// which lets curl try to work around it.
+int CallbackPutSeek(void *userdata, curl_off_t offset, int origin)
+{
+   auto *state = static_cast<RUploadState *>(userdata);
+   // curl documents that it will only use SEEK_SET; guard against anything else defensively.
+   if (origin != SEEK_SET)
+      return CURL_SEEKFUNC_CANTSEEK;
+   if (offset < 0 || static_cast<std::size_t>(offset) > state->fLength)
+      return CURL_SEEKFUNC_FAIL;
+   state->fOffset = static_cast<std::size_t>(offset);
+   return CURL_SEEKFUNC_OK;
+}
+
 /// Wrapper around curl_easy_setopt that asserts on failure.  Most option-setting calls in this
 /// file use valid options and values by construction, so failure indicates a programming error.
 template <typename T>
@@ -655,7 +701,6 @@ void ROOT::Internal::RCurlConnection::SetOptions()
    static const std::string kUserAgent = GetUserAgentString();
    SetCurlOption(fHandle, CURLOPT_USERAGENT, kUserAgent.c_str());
    SetCurlOption(fHandle, CURLOPT_FOLLOWLOCATION, 1);
-   SetCurlOption(fHandle, CURLOPT_WRITEFUNCTION, CallbackData);
 }
 
 /// Reset method-specific sticky curl options so that the easy handle is in a clean state
@@ -666,6 +711,8 @@ void ROOT::Internal::RCurlConnection::ResetHandle()
    SetCurlOption(fHandle, CURLOPT_HTTPGET, 0L);
    SetCurlOption(fHandle, CURLOPT_UPLOAD, 0L);
    SetCurlOption(fHandle, CURLOPT_RANGE, static_cast<const char *>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_WRITEFUNCTION, static_cast<curl_write_callback>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_WRITEDATA, static_cast<void *>(nullptr));
    SetCurlOption(fHandle, CURLOPT_READFUNCTION, static_cast<curl_read_callback>(nullptr));
    SetCurlOption(fHandle, CURLOPT_READDATA, static_cast<void *>(nullptr));
    SetCurlOption(fHandle, CURLOPT_SEEKFUNCTION, static_cast<curl_seek_callback>(nullptr));
@@ -791,6 +838,7 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
    SetCurlOption(fHandle, CURLOPT_HTTPGET, 1);
 
    RTransferState transfer(ranges, order, fHandle);
+   SetCurlOption(fHandle, CURLOPT_WRITEFUNCTION, CallbackData);
    SetCurlOption(fHandle, CURLOPT_WRITEDATA, &transfer);
 
 #ifndef HAS_CURL_EASY_HEADER
@@ -850,6 +898,26 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
    }
 
    ReverseDisplacements(displacements, ranges, order, static_cast<bool>(status));
+
+   return status;
+}
+
+ROOT::Internal::RCurlConnection::RStatus
+ROOT::Internal::RCurlConnection::SendPutReq(const unsigned char *data, std::size_t length)
+{
+   ResetHandle();
+
+   SetCurlOption(fHandle, CURLOPT_UPLOAD, 1L);
+   SetCurlOption(fHandle, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(length));
+
+   RUploadState uploadState{data, length, 0};
+   SetCurlOption(fHandle, CURLOPT_READFUNCTION, CallbackPutRead);
+   SetCurlOption(fHandle, CURLOPT_READDATA, &uploadState);
+   SetCurlOption(fHandle, CURLOPT_SEEKFUNCTION, CallbackPutSeek);
+   SetCurlOption(fHandle, CURLOPT_SEEKDATA, &uploadState);
+
+   RStatus status;
+   Perform(status);
 
    return status;
 }

--- a/net/curl/src/RCurlConnection.cxx
+++ b/net/curl/src/RCurlConnection.cxx
@@ -660,6 +660,37 @@ void ROOT::Internal::RCurlConnection::SetOptions()
    R__ASSERT(rc == CURLE_OK);
 }
 
+/// Reset method-specific sticky curl options so that the easy handle is in a clean state
+/// before configuring it for the next request (HEAD, GET, or PUT).
+void ROOT::Internal::RCurlConnection::ResetHandle()
+{
+   auto rc = curl_easy_setopt(fHandle, CURLOPT_NOBODY, 0L);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_HTTPGET, 0L);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_UPLOAD, 0L);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_RANGE, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_READFUNCTION, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_READDATA, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_SEEKFUNCTION, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_SEEKDATA, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(-1));
+   R__ASSERT(rc == CURLE_OK);
+
+#ifndef HAS_CURL_EASY_HEADER
+   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERFUNCTION, NULL);
+   R__ASSERT(rc == CURLE_OK);
+   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERDATA, NULL);
+   R__ASSERT(rc == CURLE_OK);
+#endif
+}
+
 ROOT::RResult<void> ROOT::Internal::RCurlConnection::SetUrl(const std::string &url)
 {
    CURLU *cu = curl_url();
@@ -731,17 +762,9 @@ ROOT::Internal::RCurlConnection::RStatus ROOT::Internal::RCurlConnection::SendHe
 {
    remoteSize = kUnknownSize;
 
+   ResetHandle();
    auto rc = curl_easy_setopt(fHandle, CURLOPT_NOBODY, 1);
    R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_RANGE, NULL); // may have been set by a previous SendRangesReq() on the object
-   R__ASSERT(rc == CURLE_OK);
-
-#ifndef HAS_CURL_EASY_HEADER
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERFUNCTION, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERDATA, NULL);
-   R__ASSERT(rc == CURLE_OK);
-#endif
 
    RStatus status;
    Perform(status);
@@ -778,6 +801,7 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
       return RStatus(RStatus::kSuccess);
    }
 
+   ResetHandle();
    auto rc = curl_easy_setopt(fHandle, CURLOPT_HTTPGET, 1);
    R__ASSERT(rc == CURLE_OK);
 

--- a/net/curl/src/RCurlConnection.cxx
+++ b/net/curl/src/RCurlConnection.cxx
@@ -552,6 +552,15 @@ void ReverseDisplacements(std::vector<std::size_t> &displacements, ROOT::Interna
    }
 }
 
+/// Wrapper around curl_easy_setopt that asserts on failure.  Most option-setting calls in this
+/// file use valid options and values by construction, so failure indicates a programming error.
+template <typename T>
+void SetCurlOption(void *handle, CURLoption option, T value)
+{
+   auto rc = curl_easy_setopt(handle, option, value);
+   R__ASSERT(rc == CURLE_OK);
+}
+
 std::string GetCurlErrorString(CURLcode code)
 {
    return std::string(curl_easy_strerror(code)) + " (" + std::to_string(code) + ")";
@@ -631,63 +640,41 @@ void ROOT::Internal::RCurlConnection::SetupErrorBuffer()
 {
    if (!fErrorBuffer)
       fErrorBuffer = std::make_unique<char[]>(CURL_ERROR_SIZE);
-   auto rc = curl_easy_setopt(fHandle, CURLOPT_ERRORBUFFER, fErrorBuffer.get());
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_ERRORBUFFER, fErrorBuffer.get());
 }
 
 void ROOT::Internal::RCurlConnection::SetOptions()
 {
-   int rc;
-
    if (gDebug) {
-      rc = curl_easy_setopt(fHandle, CURLOPT_VERBOSE, 1);
-      R__ASSERT(rc == CURLE_OK);
-      rc = curl_easy_setopt(fHandle, CURLOPT_DEBUGFUNCTION, CallbackDebug);
-      R__ASSERT(rc == CURLE_OK);
+      SetCurlOption(fHandle, CURLOPT_VERBOSE, 1);
+      SetCurlOption(fHandle, CURLOPT_DEBUGFUNCTION, CallbackDebug);
    } else {
-      rc = curl_easy_setopt(fHandle, CURLOPT_VERBOSE, 0);
-      R__ASSERT(rc == CURLE_OK);
+      SetCurlOption(fHandle, CURLOPT_VERBOSE, 0);
    }
 
    static const std::string kUserAgent = GetUserAgentString();
-   rc = curl_easy_setopt(fHandle, CURLOPT_USERAGENT, kUserAgent.c_str());
-   R__ASSERT(rc == CURLE_OK);
-
-   rc = curl_easy_setopt(fHandle, CURLOPT_FOLLOWLOCATION, 1);
-   R__ASSERT(rc == CURLE_OK);
-
-   rc = curl_easy_setopt(fHandle, CURLOPT_WRITEFUNCTION, CallbackData);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_USERAGENT, kUserAgent.c_str());
+   SetCurlOption(fHandle, CURLOPT_FOLLOWLOCATION, 1);
+   SetCurlOption(fHandle, CURLOPT_WRITEFUNCTION, CallbackData);
 }
 
 /// Reset method-specific sticky curl options so that the easy handle is in a clean state
 /// before configuring it for the next request (HEAD, GET, or PUT).
 void ROOT::Internal::RCurlConnection::ResetHandle()
 {
-   auto rc = curl_easy_setopt(fHandle, CURLOPT_NOBODY, 0L);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_HTTPGET, 0L);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_UPLOAD, 0L);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_RANGE, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_READFUNCTION, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_READDATA, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_SEEKFUNCTION, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_SEEKDATA, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(-1));
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_NOBODY, 0L);
+   SetCurlOption(fHandle, CURLOPT_HTTPGET, 0L);
+   SetCurlOption(fHandle, CURLOPT_UPLOAD, 0L);
+   SetCurlOption(fHandle, CURLOPT_RANGE, static_cast<const char *>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_READFUNCTION, static_cast<curl_read_callback>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_READDATA, static_cast<void *>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_SEEKFUNCTION, static_cast<curl_seek_callback>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_SEEKDATA, static_cast<void *>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(-1));
 
 #ifndef HAS_CURL_EASY_HEADER
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERFUNCTION, NULL);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERDATA, NULL);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_HEADERFUNCTION, static_cast<curl_write_callback>(nullptr));
+   SetCurlOption(fHandle, CURLOPT_HEADERDATA, static_cast<void *>(nullptr));
 #endif
 }
 
@@ -763,14 +750,13 @@ ROOT::Internal::RCurlConnection::RStatus ROOT::Internal::RCurlConnection::SendHe
    remoteSize = kUnknownSize;
 
    ResetHandle();
-   auto rc = curl_easy_setopt(fHandle, CURLOPT_NOBODY, 1);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_NOBODY, 1);
 
    RStatus status;
    Perform(status);
    if (status) {
       curl_off_t length = -1;
-      rc = curl_easy_getinfo(fHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &length);
+      auto rc = curl_easy_getinfo(fHandle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &length);
       if (rc == CURLE_OK && length >= 0)
          remoteSize = length;
    }
@@ -802,18 +788,14 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
    }
 
    ResetHandle();
-   auto rc = curl_easy_setopt(fHandle, CURLOPT_HTTPGET, 1);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_HTTPGET, 1);
 
    RTransferState transfer(ranges, order, fHandle);
-   rc = curl_easy_setopt(fHandle, CURLOPT_WRITEDATA, &transfer);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_WRITEDATA, &transfer);
 
 #ifndef HAS_CURL_EASY_HEADER
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERFUNCTION, CallbackHeader);
-   R__ASSERT(rc == CURLE_OK);
-   rc = curl_easy_setopt(fHandle, CURLOPT_HEADERDATA, &transfer);
-   R__ASSERT(rc == CURLE_OK);
+   SetCurlOption(fHandle, CURLOPT_HEADERFUNCTION, CallbackHeader);
+   SetCurlOption(fHandle, CURLOPT_HEADERDATA, &transfer);
 #endif
 
    RStatus status;
@@ -835,8 +817,7 @@ ROOT::Internal::RCurlConnection::SendRangesReq(std::size_t N, RUserRange *ranges
          for (std::size_t i = 1; i < nRanges; ++i) {
             rangeHeader += "," + requestRanges[b + i].ToString();
          }
-         rc = curl_easy_setopt(fHandle, CURLOPT_RANGE, rangeHeader.c_str());
-         R__ASSERT(rc == CURLE_OK);
+         SetCurlOption(fHandle, CURLOPT_RANGE, rangeHeader.c_str());
 
          if (b > 0) {
             const std::uint64_t lastByteRequested = requestRanges[b - 1].fLastByte;
@@ -900,13 +881,10 @@ void ROOT::Internal::RCurlConnection::ClearCredentials()
    if (!fCredentials)
       return;
 
-   CURLcode rc;
    switch (fCredentials->fType) {
    case EHTTPCredentialsType::kS3:
-      rc = curl_easy_setopt(fHandle, CURLOPT_AWS_SIGV4, NULL);
-      R__ASSERT(rc == CURLE_OK);
-      rc = curl_easy_setopt(fHandle, CURLOPT_USERPWD, NULL);
-      R__ASSERT(rc == CURLE_OK);
+      SetCurlOption(fHandle, CURLOPT_AWS_SIGV4, static_cast<const char *>(nullptr));
+      SetCurlOption(fHandle, CURLOPT_USERPWD, static_cast<const char *>(nullptr));
       break;
    default: R__ASSERT(false && "internal error: unknown credentials type");
    }

--- a/net/curl/test/curl_connection.cxx
+++ b/net/curl/test/curl_connection.cxx
@@ -4,10 +4,67 @@
 
 #include "TServerSocket.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <string>
 #include <thread>
+#include <vector>
+
+/// Return a lower-cased copy of the input string.
+static std::string ToLower(std::string s)
+{
+   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+   return s;
+}
+
+/// Accept a PUT request: read headers + body, optionally respond to Expect: 100-continue, send 200 OK.
+static void TaskRecvPut(TServerSocket *serverSocket, std::string *requestHeaders, std::string *requestBody)
+{
+   requestHeaders->clear();
+   requestBody->clear();
+   auto sock = serverSocket->Accept();
+
+   const char *eof = "\r\n\r\n";
+   const std::size_t eofLen = strlen(eof);
+   std::size_t nextInEof = 0;
+   char c;
+   while (sock->RecvRaw(&c, 1)) {
+      requestHeaders->push_back(c);
+      if (c == eof[nextInEof]) {
+         if (++nextInEof == eofLen)
+            break;
+      } else {
+         nextInEof = 0;
+      }
+   }
+
+   // If the client sent Expect: 100-continue, respond with HTTP 100 before reading the body
+   std::string headersLower = ToLower(*requestHeaders);
+   if (headersLower.find("expect: 100-continue") != std::string::npos) {
+      const char *continueResponse = "HTTP/1.1 100 Continue\r\n\r\n";
+      sock->SendRaw(continueResponse, strlen(continueResponse));
+   }
+
+   // Parse content-length (case-insensitive)
+   std::size_t contentLength = 0;
+   auto pos = headersLower.find("content-length: ");
+   if (pos != std::string::npos) {
+      auto valStart = pos + strlen("content-length: ");
+      auto valEnd = headersLower.find("\r\n", valStart);
+      contentLength = std::stoul(headersLower.substr(valStart, valEnd - valStart));
+   }
+
+   if (contentLength > 0) {
+      requestBody->resize(contentLength);
+      sock->RecvRaw(&(*requestBody)[0], contentLength);
+   }
+
+   const char *response = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+   sock->SendRaw(response, strlen(response));
+   sock->Close();
+}
 
 static void TaskRecv(TServerSocket *serverSocket, std::string *request)
 {
@@ -62,4 +119,132 @@ TEST(RCurlConnection, Cred)
    conn.SendHeadReq(remoteSize);
    threadRecv.join();
    EXPECT_EQ(std::string::npos, request.find("\r\nAuthorization: "));
+}
+
+TEST(RCurlConnection, Put)
+{
+   TServerSocket sock(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string url =
+      std::string("http://") + sock.GetLocalInetAddress().GetHostAddress() + ":" + std::to_string(sock.GetLocalPort());
+
+   const unsigned char payload[] = "Hello, S3!";
+   const std::size_t payloadLen = sizeof(payload) - 1; // exclude null terminator
+
+   std::string headers;
+   std::string body;
+   std::thread threadRecv(TaskRecvPut, &sock, &headers, &body);
+
+   ROOT::Internal::RCurlConnection conn(url);
+   auto status = conn.SendPutReq(payload, payloadLen);
+
+   threadRecv.join();
+   EXPECT_TRUE(static_cast<bool>(status));
+   EXPECT_EQ(0u, headers.find("PUT "));
+
+   // Normalize headers to lower-case for case-insensitive matching
+   std::string headersLower = ToLower(headers);
+   auto clPos = headersLower.find("content-length: " + std::to_string(payloadLen));
+   ASSERT_NE(std::string::npos, clPos) << "content-length header not found in request";
+
+   EXPECT_EQ(std::string(reinterpret_cast<const char *>(payload), payloadLen), body);
+}
+
+/// GET (range read) after PUT on the same handle — verifies that WRITEFUNCTION is set correctly
+/// in SendRangesReq after a PUT cleared it.
+TEST(RCurlConnection, GetAfterPut)
+{
+   TServerSocket sock(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string url =
+      std::string("http://") + sock.GetLocalInetAddress().GetHostAddress() + ":" + std::to_string(sock.GetLocalPort());
+
+   // First: do a PUT
+   const unsigned char putPayload[] = "put-data";
+   const std::size_t putPayloadLen = sizeof(putPayload) - 1;
+
+   std::string putHeaders;
+   std::string putBody;
+   std::thread threadRecvPut(TaskRecvPut, &sock, &putHeaders, &putBody);
+
+   ROOT::Internal::RCurlConnection conn(url);
+   auto putStatus = conn.SendPutReq(putPayload, putPayloadLen);
+
+   threadRecvPut.join();
+   EXPECT_TRUE(static_cast<bool>(putStatus));
+   EXPECT_EQ(0u, putHeaders.find("PUT "));
+
+   // Second: do a GET (SendRangesReq) on the same handle.
+   // The server sends a plain 200 response with the body "response-from-get".
+   const std::string expectedBody = "response-from-get";
+   std::string getHeaders;
+   auto taskRecvGet = [&](TServerSocket *serverSocket) {
+      getHeaders.clear();
+      auto s = serverSocket->Accept();
+
+      const char *eof = "\r\n\r\n";
+      const std::size_t eofLen = strlen(eof);
+      std::size_t nextInEof = 0;
+      char c;
+      while (s->RecvRaw(&c, 1)) {
+         getHeaders.push_back(c);
+         if (c == eof[nextInEof]) {
+            if (++nextInEof == eofLen)
+               break;
+         } else {
+            nextInEof = 0;
+         }
+      }
+
+      std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(expectedBody.size()) +
+                             "\r\n\r\n" + expectedBody;
+      s->SendRaw(response.data(), response.size());
+      s->Close();
+   };
+   std::thread threadRecvGet(taskRecvGet, &sock);
+
+   std::vector<unsigned char> readBuf(expectedBody.size(), 0);
+   ROOT::Internal::RCurlConnection::RUserRange range;
+   range.fDestination = readBuf.data();
+   range.fOffset = 0;
+   range.fLength = expectedBody.size();
+   auto getStatus = conn.SendRangesReq(1, &range);
+
+   threadRecvGet.join();
+   EXPECT_TRUE(static_cast<bool>(getStatus));
+   EXPECT_EQ(0u, getHeaders.find("GET "));
+   EXPECT_EQ(expectedBody.size(), range.fNBytesRecv);
+   std::string received(reinterpret_cast<char *>(readBuf.data()), range.fNBytesRecv);
+   EXPECT_EQ(expectedBody, received);
+}
+
+/// PUT with a payload larger than libcurl's internal Expect: 100-continue threshold (1 MB since curl 7.69).
+/// Verifies that the server-side 100 Continue handshake works and all bytes arrive correctly.
+TEST(RCurlConnection, PutLargeExpect100)
+{
+   TServerSocket sock(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string url =
+      std::string("http://") + sock.GetLocalInetAddress().GetHostAddress() + ":" + std::to_string(sock.GetLocalPort());
+
+   // 2 MB payload with a known repeating pattern
+   const std::size_t payloadLen = 2 * 1024 * 1024;
+   std::vector<unsigned char> payload(payloadLen);
+   for (std::size_t i = 0; i < payloadLen; ++i)
+      payload[i] = static_cast<unsigned char>(i & 0xFF);
+
+   std::string headers;
+   std::string body;
+   std::thread threadRecv(TaskRecvPut, &sock, &headers, &body);
+
+   ROOT::Internal::RCurlConnection conn(url);
+   auto status = conn.SendPutReq(payload.data(), payloadLen);
+
+   threadRecv.join();
+   EXPECT_TRUE(static_cast<bool>(status));
+   EXPECT_EQ(0u, headers.find("PUT "));
+
+   std::string headersLower = ToLower(headers);
+   EXPECT_NE(std::string::npos, headersLower.find("expect: 100-continue"))
+      << "large upload should include Expect: 100-continue header";
+   EXPECT_NE(std::string::npos, headersLower.find("content-length: " + std::to_string(payloadLen)));
+   ASSERT_EQ(payloadLen, body.size());
+   EXPECT_EQ(0, memcmp(body.data(), payload.data(), payloadLen));
 }

--- a/net/curl/test/curl_env.cxx
+++ b/net/curl/test/curl_env.cxx
@@ -11,8 +11,10 @@
 #include "TCurlFile.h"
 #include "TSystem.h"
 
+#include <cstring>
 #include <memory>
 #include <utility>
+#include <vector>
 
 TEST(RCurlConnection, CredFromEnv)
 {
@@ -92,4 +94,59 @@ TEST(CurlFile, S3Credentials)
 
    gSystem->Unsetenv("S3_ACCESS_KEY");
    gSystem->Unsetenv("S3_SECRET_KEY");
+}
+
+TEST(CurlFile, S3PutAndRead)
+{
+   const auto testAccessKey = std::getenv("ROOT_TEST_S3_ACCESS_KEY");
+   const auto testSecretKey = std::getenv("ROOT_TEST_S3_SECRET_KEY");
+   if (!testAccessKey || testAccessKey[0] == '\0' || !testSecretKey || testSecretKey[0] == '\0') {
+      GTEST_SKIP() << "Missing S3 test credentials <ROOT_TEST_S3_[ACCESS|SECRET]_KEY>, skipping";
+   }
+   if (ROOT::Internal::RCurlConnection::GetCurlVersion() <= 0x078100) {
+      GTEST_SKIP() << "libcurl <= 7.81 is known to produce an AWSv4 signature incompatible with Ceph S3";
+   }
+
+   const std::string url = "https://root-project-s3test.s3.cern.ch/test-curl-put-roundtrip.bin";
+
+   ROOT::Internal::RS3Credentials creds;
+   creds.fAccessKey = testAccessKey;
+   creds.fSecretKey = testSecretKey;
+
+   // PUT a known payload
+   const unsigned char payload[] = "RCurlConnection::SendPutReq round-trip test";
+   const std::size_t payloadLen = sizeof(payload) - 1;
+
+   {
+      ROOT::Internal::RCurlConnection conn(url);
+      conn.SetCredentials(creds);
+      auto status = conn.SendPutReq(payload, payloadLen);
+      ASSERT_TRUE(static_cast<bool>(status)) << "PUT failed: " << status.fStatusMsg;
+   }
+
+   // HEAD to verify size
+   {
+      ROOT::Internal::RCurlConnection conn(url);
+      conn.SetCredentials(creds);
+      std::uint64_t remoteSize = 0;
+      auto status = conn.SendHeadReq(remoteSize);
+      ASSERT_TRUE(static_cast<bool>(status)) << "HEAD failed: " << status.fStatusMsg;
+      EXPECT_EQ(static_cast<std::uint64_t>(payloadLen), remoteSize);
+   }
+
+   // GET (range read) to verify content
+   {
+      std::vector<unsigned char> readback(payloadLen, 0);
+      ROOT::Internal::RCurlConnection::RUserRange range;
+      range.fDestination = readback.data();
+      range.fOffset = 0;
+      range.fLength = payloadLen;
+
+      ROOT::Internal::RCurlConnection conn(url);
+      conn.SetCredentials(creds);
+      auto status = conn.SendRangesReq(1, &range);
+      ASSERT_TRUE(static_cast<bool>(status)) << "GET failed: " << status.fStatusMsg;
+      EXPECT_EQ(payloadLen, range.fNBytesRecv);
+      EXPECT_EQ(0, memcmp(readback.data(), payload, payloadLen));
+   }
 }


### PR DESCRIPTION
# This Pull Request: 
(Is a part of the GSoC 2026 project `S3 Backend for RNTuple.`)

The S3 backend needs the ability to upload objects via HTTP PUT. This PR adds a single synchronous PUT method to `RCurlConnection`, following the same pattern as the existing `SendHeadReq()` and `SendRangesReq()` methods. SigV4 signing is handled automatically by the credentials already configured on the curl handle.

This PR:

* Adds `SendPutReq(const unsigned char *data, std::size_t length)` to `RCurlConnection`
* Uses `CURLOPT_UPLOAD` with a read callback (`CURLOPT_READFUNCTION` / `CURLOPT_READDATA`) and `CURLOPT_INFILESIZE_LARGE` for Content-Length
* Adds a wire-level test using the `TServerSocket` pattern from the existing test suite, verifying the PUT method, Content-Length header, and request body
* Adds an integration test gated on S3 credentials (`GTEST_SKIP()` when `S3_ACCESS_KEY` / `S3_SECRET_KEY` are not set) that does a PUT, HEAD, and GET round-trip against a real S3 endpoint

No connection pooling or retry logic is included in this PR. Those are planned for Phase 4 (Weeks 10-11) as `SendMultiGetReq` / `SendMultiPutReq` and a retry wrapper respectively.

### Checklist

- [x] Tested changes locally
- [x] Wire-level test passes (TServerSocket captures correct PUT request)
- [x] Integration test passes against local MinIO

<details>
<summary>Local test output</summary>

```bash

=== SendPutReq Wire-Level Test ===
Testing against locally built ROOT + RCurl library

[Test 1] Basic PUT request
  PASS: SendPutReq returns success
  PASS: HTTP method is PUT
  PASS: Content-Length header matches payload size
  PASS: body matches payload

[Test 2] Empty PUT (zero-length body)
  PASS: empty SendPutReq returns success
  PASS: HTTP method is PUT for empty body
  PASS: body is empty

[Test 3] Large PUT (64 KB payload)
  PASS: large SendPutReq returns success
  PASS: Content-Length matches 64KB
  PASS: received body size == 64KB
  PASS: 64KB body content matches sent payload

[Test 4] HEAD after PUT (sticky-option reset)
  PASS: initial PUT succeeds
  PASS: first request is PUT
  PASS: HEAD after PUT succeeds
  PASS: second request is HEAD (not PUT — sticky options were reset)
  PASS: HEAD returns correct Content-Length

[Test 5] PUT after HEAD (reverse sticky-option check)
  PASS: first request is HEAD
  PASS: PUT after HEAD succeeds
  PASS: second request is PUT (NOBODY was reset)
  PASS: body arrives correctly after HEAD

=== Results ===
Passed: 20
Failed: 0

ALL TESTS PASSED
```

</details>

<details>
<summary>Local test output (MinIO integration)</summary>

```bash
=== SendPutReq MinIO Integration Test ===
Endpoint: http://127.0.0.1:9000
Bucket:   test-ntuple

[Test 1] PUT small object, then HEAD to verify
  PASS: PUT small object succeeds
  PASS: HEAD after PUT succeeds
  PASS: HEAD reports correct Content-Length

[Test 2] PUT object, then GET (range read) to verify content
  PASS: PUT content-verify object succeeds
  PASS: GET after PUT succeeds
  PASS: received full payload length
  PASS: GET content matches PUT payload

[Test 3] PUT empty object (zero bytes)
  PASS: PUT empty object succeeds
  PASS: HEAD after empty PUT succeeds
  PASS: empty object has size 0

[Test 4] PUT large object (256 KB) with content verification
  PASS: PUT 256KB object succeeds
  PASS: HEAD after large PUT succeeds
  PASS: HEAD reports 256KB
  PASS: GET 256KB object succeeds
  PASS: received full 256KB
  PASS: 256KB content matches (byte-for-byte)

[Test 5] PUT overwrite (same key, different content)
  PASS: first PUT succeeds
  PASS: overwrite PUT succeeds
  PASS: HEAD reflects overwritten size
  PASS: GET returns overwritten content

[Test 6] Same connection: PUT then HEAD (sticky-option reset)
  PASS: PUT on shared conn succeeds
  PASS: HEAD on same conn after PUT succeeds (sticky reset works)
  PASS: HEAD on same conn reports correct size

=== Results ===
Passed: 23
Failed: 0

ALL TESTS PASSED
(base) jasmehta@Jass-MacBook-Air-874 test_local % mc ls local/test-ntuple/ 
[2026-05-21 14:29:20 IST]     0B STANDARD test-put-empty.bin
[2026-05-21 14:29:20 IST] 256KiB STANDARD test-put-large.bin
[2026-05-21 14:29:20 IST]    24B STANDARD test-put-overwrite.bin
[2026-05-21 14:29:20 IST]    16B STANDARD test-put-same-conn.bin
[2026-05-21 14:29:20 IST]    39B STANDARD test-put-small.bin
[2026-05-21 14:29:20 IST]    26B STANDARD test-put-verify-content.bin
```

</details>