### PR TITLE
[DF] Enable RDataFrame exception tests also on macOS

### DIFF
--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -128,9 +128,8 @@ TEST(RDFVary, RequireVariationsHaveConsistentType)
       std::runtime_error);
 }
 
-// throwing exceptions from jitted code cause problems on windows and MacOS+M1
+// throwing exceptions from jitted code cause problems on windows
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
-#if !(defined(R__MACOSX) && defined(__arm64__))
 TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
 {
    // non-jitted Define, jitted Vary with incompatible type
@@ -229,7 +228,6 @@ TEST(RDFVaryDeathTest, JitFailureThrowsInsteadOfCrashing)
       },
       ::testing::ExitedWithCode(0), "");
 }
-#endif
 #endif
 
 TEST(RDFVary, RequireReturnTypeIsRVec)


### PR DESCRIPTION
Now that catching exceptions through interpreted code on Apple silicon is possible, the RDataFrame tests that require this functionality can be unconditionally enabled on macOS again. See also commit 9d097fbb5b17 and ROOT GitHub issue https://github.com/root-project/root/issues/7541.