### PR TITLE
[ntuple] Some cleanups in the page source

### DIFF
--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -693,14 +693,13 @@ protected:
       }
    };
 
-   /// Summarizes cluster-level information that are necessary to load a certain page.
-   /// Used by LoadPageImpl().
-   struct RClusterInfo {
+   /// Summarizes meta-data is necessary to load a certain page. Used by LoadPageImpl().
+   struct RPageSummary {
       ROOT::DescriptorId_t fClusterId = 0;
-      /// Location of the page on disk
-      ROOT::RClusterDescriptor::RPageInfoExtended fPageInfo;
       /// The first element number of the page's column in the given cluster
       std::uint64_t fColumnOffset = 0;
+      /// Location of the page on disk
+      ROOT::RClusterDescriptor::RPageInfoExtended fPageInfo;
    };
 
    std::unique_ptr<RCounters> fCounters;
@@ -728,7 +727,7 @@ protected:
    virtual void UnzipClusterImpl(ROOT::Internal::RCluster *cluster);
    // Returns a page from storage if not found in the page pool. Should be able to handle zero page locators.
    virtual ROOT::Internal::RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, ROOT::NTupleSize_t idxInCluster) = 0;
+   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) = 0;
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -726,8 +726,7 @@ protected:
    // Only called if a task scheduler is set. No-op be default.
    virtual void UnzipClusterImpl(ROOT::Internal::RCluster *cluster);
    // Returns a page from storage if not found in the page pool. Should be able to handle zero page locators.
-   virtual ROOT::Internal::RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) = 0;
+   virtual ROOT::Internal::RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) = 0;
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -731,6 +731,9 @@ protected:
    virtual void UnzipClusterImpl(ROOT::Internal::RCluster *cluster);
    // Returns a page from storage if not found in the page pool. Will never receive requests for zero pages.
    virtual ROOT::Internal::RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) = 0;
+   // Returns a sealed page from storage without adding it to the page pool. The sealed pages buffer and buffer size
+   // is already initialized.
+   virtual void LoadSealedPageImpl(const RNTupleLocator &locator, RSealedPage &sealedPage) = 0;
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the
    /// `kTypePageZero` locator are filled in `pageZeroMap`; otherwise, `perPageFunc` is called for each page. This is
@@ -818,8 +821,7 @@ public:
    /// The `fSize` and `fNElements` member of the sealedPage parameters are always set. If `sealedPage.fBuffer` is
    /// `nullptr`, no data will be copied but the returned size information can be used by the caller to allocate a large
    /// enough buffer and call `LoadSealedPage` again.
-   virtual void
-   LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) = 0;
+   void LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage);
 
    /// Populates all the pages of the given cluster ids and columns; it is possible that some columns do not
    /// contain any pages.  The page source may load more columns than the minimal necessary set from `columns`.

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -567,6 +567,16 @@ The page source also gives access to the ntuple's metadata.
 */
 // clang-format on
 class RPageSource : public RPageStorage {
+protected:
+   /// Summarizes meta-data necessary to load a certain page. Used by LoadPageImpl().
+   struct RPageSummary {
+      ROOT::DescriptorId_t fClusterId = 0;
+      /// The first element number of the page's column in the given cluster
+      std::uint64_t fColumnOffset = 0;
+      /// Location of the page on disk
+      ROOT::RClusterDescriptor::RPageInfoExtended fPageInfo;
+   };
+
 public:
    /// Used in SetEntryRange / GetEntryRange
    struct REntryRange {
@@ -640,6 +650,9 @@ private:
    /// Must not be called when the descriptor guard is taken.
    void UpdateLastUsedCluster(ROOT::DescriptorId_t clusterId);
 
+   // Common treatment of zero pages that would otherwise need to be handled in LoadPageImpl()
+   ROOT::Internal::RPageRef LoadZeroPage(ColumnHandle_t columnHandle, const RPageSummary &pageSummary);
+
 protected:
    /// Default I/O performance counters that get registered in `fMetrics`
    struct RCounters {
@@ -693,15 +706,6 @@ protected:
       }
    };
 
-   /// Summarizes meta-data is necessary to load a certain page. Used by LoadPageImpl().
-   struct RPageSummary {
-      ROOT::DescriptorId_t fClusterId = 0;
-      /// The first element number of the page's column in the given cluster
-      std::uint64_t fColumnOffset = 0;
-      /// Location of the page on disk
-      ROOT::RClusterDescriptor::RPageInfoExtended fPageInfo;
-   };
-
    std::unique_ptr<RCounters> fCounters;
 
    ROOT::RNTupleReadOptions fOptions;
@@ -725,7 +729,7 @@ protected:
    virtual std::unique_ptr<RPageSource> CloneImpl() const = 0;
    // Only called if a task scheduler is set. No-op be default.
    virtual void UnzipClusterImpl(ROOT::Internal::RCluster *cluster);
-   // Returns a page from storage if not found in the page pool. Should be able to handle zero page locators.
+   // Returns a page from storage if not found in the page pool. Will never receive requests for zero pages.
    virtual ROOT::Internal::RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) = 0;
 
    /// Prepare a page range read for the column set in `clusterKey`.  Specifically, pages referencing the

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -160,6 +160,7 @@ private:
    ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
    ROOT::Internal::RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) final;
+   void LoadSealedPageImpl(const RNTupleLocator &locator, RSealedPage &sealedPage) final;
 
 protected:
    void LoadStructureImpl() final {}
@@ -170,9 +171,6 @@ protected:
 public:
    RPageSourceDaos(std::string_view ntupleName, std::string_view uri, const ROOT::RNTupleReadOptions &options);
    ~RPageSourceDaos() override;
-
-   void
-   LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<ROOT::Internal::RCluster>>
    LoadClusters(std::span<ROOT::Internal::RCluster::RKey> clusterKeys) final;

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -160,7 +160,7 @@ private:
    ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
    ROOT::Internal::RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, ROOT::NTupleSize_t idxInCluster) final;
+   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) final;
 
 protected:
    void LoadStructureImpl() final {}

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -159,8 +159,7 @@ private:
 
    ROOT::Internal::RNTupleDescriptorBuilder fDescriptorBuilder;
 
-   ROOT::Internal::RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) final;
+   ROOT::Internal::RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) final;
 
 protected:
    void LoadStructureImpl() final {}

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -181,7 +181,7 @@ protected:
    std::unique_ptr<RPageSource> CloneImpl() const final;
 
    RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo, ROOT::NTupleSize_t idxInCluster) final;
+   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const ROOT::RNTupleReadOptions &options);

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -181,6 +181,7 @@ protected:
    std::unique_ptr<RPageSource> CloneImpl() const final;
 
    RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) final;
+   void LoadSealedPageImpl(const RNTupleLocator &locator, RSealedPage &sealedPage) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const ROOT::RNTupleReadOptions &options);
@@ -199,9 +200,6 @@ public:
 
    std::unique_ptr<RPageSource> OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &anchorLink,
                                                         const ROOT::RNTupleReadOptions &options = {}) final;
-
-   void
-   LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<ROOT::Internal::RCluster>>
    LoadClusters(std::span<ROOT::Internal::RCluster::RKey> clusterKeys) final;

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -180,8 +180,7 @@ protected:
    /// The cloned page source creates a new raw file and reader and opens its own file descriptor to the data.
    std::unique_ptr<RPageSource> CloneImpl() const final;
 
-   RPageRef
-   LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary, ROOT::NTupleSize_t idxInCluster) final;
+   RPageRef LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary) final;
 
 public:
    RPageSourceFile(std::string_view ntupleName, std::string_view path, const ROOT::RNTupleReadOptions &options);

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -393,6 +393,24 @@ void ROOT::Internal::RPageSource::UpdateLastUsedCluster(ROOT::DescriptorId_t clu
 }
 
 ROOT::Internal::RPageRef
+ROOT::Internal::RPageSource::LoadZeroPage(ColumnHandle_t columnHandle, const RPageSummary &pageSummary)
+{
+   const auto &pageInfo = pageSummary.fPageInfo;
+   assert(pageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero);
+
+   const auto element = columnHandle.fColumn->GetElement();
+   const auto elementSize = element->GetSize();
+   const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
+
+   auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
+   pageZero.GrowUnchecked(pageInfo.GetNElements());
+   std::memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
+   pageZero.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
+                      RPage::RClusterInfo(pageSummary.fClusterId, pageSummary.fColumnOffset));
+   return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnHandle.fPhysicalId, elementInMemoryType});
+}
+
+ROOT::Internal::RPageRef
 ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, ROOT::NTupleSize_t globalIndex)
 {
    const auto columnId = columnHandle.fPhysicalId;
@@ -422,8 +440,11 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, ROOT::NTupleS
       pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(globalIndex - pageSummary.fColumnOffset);
    }
 
-   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
+   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown) {
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
+   } else if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
+      return LoadZeroPage(columnHandle, pageSummary);
+   }
 
    UpdateLastUsedCluster(pageSummary.fClusterId);
    return LoadPageImpl(columnHandle, pageSummary);
@@ -458,8 +479,11 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, RNTupleLocalI
       pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(localIndex.GetIndexInCluster());
    }
 
-   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
+   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown) {
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
+   } else if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
+      return LoadZeroPage(columnHandle, pageSummary);
+   }
 
    UpdateLastUsedCluster(clusterId);
    return LoadPageImpl(columnHandle, pageSummary);

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -392,6 +392,36 @@ void ROOT::Internal::RPageSource::UpdateLastUsedCluster(ROOT::DescriptorId_t clu
    fLastUsedCluster = clusterId;
 }
 
+void ROOT::Internal::RPageSource::LoadSealedPage(ROOT::DescriptorId_t physicalColumnId, RNTupleLocalIndex localIndex,
+                                                 RSealedPage &sealedPage)
+{
+   const auto clusterId = localIndex.GetClusterId();
+
+   ROOT::RClusterDescriptor::RPageInfo pageInfo;
+   {
+      auto descriptorGuard = GetSharedDescriptorGuard();
+      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
+      pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(localIndex.GetIndexInCluster());
+   }
+
+   sealedPage.SetBufferSize(pageInfo.GetLocator().GetNBytesOnStorage() + pageInfo.HasChecksum() * kNBytesPageChecksum);
+   sealedPage.SetNElements(pageInfo.GetNElements());
+   sealedPage.SetHasChecksum(pageInfo.HasChecksum());
+
+   if (!sealedPage.GetBuffer())
+      return;
+
+   if (pageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
+      assert(!pageInfo.HasChecksum());
+      memcpy(const_cast<void *>(sealedPage.GetBuffer()), ROOT::Internal::RPage::GetPageZeroBuffer(),
+             sealedPage.GetBufferSize());
+      return;
+   }
+
+   LoadSealedPageImpl(pageInfo.GetLocator(), sealedPage);
+   sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
+}
+
 ROOT::Internal::RPageRef
 ROOT::Internal::RPageSource::LoadZeroPage(ColumnHandle_t columnHandle, const RPageSummary &pageSummary)
 {

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -405,30 +405,30 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, ROOT::NTupleS
    }
 
    std::uint64_t idxInCluster;
-   RClusterInfo clusterInfo;
+   RPageSummary pageSummary;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
-      clusterInfo.fClusterId = descriptorGuard->FindClusterId(columnId, globalIndex);
+      pageSummary.fClusterId = descriptorGuard->FindClusterId(columnId, globalIndex);
 
-      if (clusterInfo.fClusterId == ROOT::kInvalidDescriptorId)
+      if (pageSummary.fClusterId == ROOT::kInvalidDescriptorId)
          throw RException(R__FAIL("entry with index " + std::to_string(globalIndex) + " out of bounds"));
 
-      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterInfo.fClusterId);
+      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(pageSummary.fClusterId);
       const auto &columnRange = clusterDescriptor.GetColumnRange(columnId);
       if (columnRange.IsSuppressed())
          return ROOT::Internal::RPageRef();
 
-      clusterInfo.fColumnOffset = columnRange.GetFirstElementIndex();
-      R__ASSERT(clusterInfo.fColumnOffset <= globalIndex);
-      idxInCluster = globalIndex - clusterInfo.fColumnOffset;
-      clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
+      pageSummary.fColumnOffset = columnRange.GetFirstElementIndex();
+      R__ASSERT(pageSummary.fColumnOffset <= globalIndex);
+      idxInCluster = globalIndex - pageSummary.fColumnOffset;
+      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 
-   if (clusterInfo.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
+   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
-   UpdateLastUsedCluster(clusterInfo.fClusterId);
-   return LoadPageImpl(columnHandle, clusterInfo, idxInCluster);
+   UpdateLastUsedCluster(pageSummary.fClusterId);
+   return LoadPageImpl(columnHandle, pageSummary, idxInCluster);
 }
 
 ROOT::Internal::RPageRef
@@ -448,7 +448,7 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, RNTupleLocalI
    if (clusterId == kInvalidDescriptorId)
       throw RException(R__FAIL("entry out of bounds"));
 
-   RClusterInfo clusterInfo;
+   RPageSummary pageSummary;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
       const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
@@ -456,16 +456,16 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, RNTupleLocalI
       if (columnRange.IsSuppressed())
          return ROOT::Internal::RPageRef();
 
-      clusterInfo.fClusterId = clusterId;
-      clusterInfo.fColumnOffset = columnRange.GetFirstElementIndex();
-      clusterInfo.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
+      pageSummary.fClusterId = clusterId;
+      pageSummary.fColumnOffset = columnRange.GetFirstElementIndex();
+      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
    }
 
-   if (clusterInfo.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
+   if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
-   UpdateLastUsedCluster(clusterInfo.fClusterId);
-   return LoadPageImpl(columnHandle, clusterInfo, idxInCluster);
+   UpdateLastUsedCluster(clusterId);
+   return LoadPageImpl(columnHandle, pageSummary, idxInCluster);
 }
 
 void ROOT::Internal::RPageSource::EnableDefaultMetrics(const std::string &prefix)

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -404,7 +404,6 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, ROOT::NTupleS
       return cachedPageRef;
    }
 
-   std::uint64_t idxInCluster;
    RPageSummary pageSummary;
    {
       auto descriptorGuard = GetSharedDescriptorGuard();
@@ -420,22 +419,20 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, ROOT::NTupleS
 
       pageSummary.fColumnOffset = columnRange.GetFirstElementIndex();
       R__ASSERT(pageSummary.fColumnOffset <= globalIndex);
-      idxInCluster = globalIndex - pageSummary.fColumnOffset;
-      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
+      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(globalIndex - pageSummary.fColumnOffset);
    }
 
    if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
    UpdateLastUsedCluster(pageSummary.fClusterId);
-   return LoadPageImpl(columnHandle, pageSummary, idxInCluster);
+   return LoadPageImpl(columnHandle, pageSummary);
 }
 
 ROOT::Internal::RPageRef
 ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, RNTupleLocalIndex localIndex)
 {
    const auto clusterId = localIndex.GetClusterId();
-   const auto idxInCluster = localIndex.GetIndexInCluster();
    const auto columnId = columnHandle.fPhysicalId;
    const auto columnElementId = columnHandle.fColumn->GetElement()->GetIdentifier();
    auto cachedPageRef =
@@ -458,14 +455,14 @@ ROOT::Internal::RPageSource::LoadPage(ColumnHandle_t columnHandle, RNTupleLocalI
 
       pageSummary.fClusterId = clusterId;
       pageSummary.fColumnOffset = columnRange.GetFirstElementIndex();
-      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(idxInCluster);
+      pageSummary.fPageInfo = clusterDescriptor.GetPageRange(columnId).Find(localIndex.GetIndexInCluster());
    }
 
    if (pageSummary.fPageInfo.GetLocator().GetType() == RNTupleLocator::kTypeUnknown)
       throw RException(R__FAIL("tried to read a page with an unknown locator"));
 
    UpdateLastUsedCluster(clusterId);
-   return LoadPageImpl(columnHandle, pageSummary, idxInCluster);
+   return LoadPageImpl(columnHandle, pageSummary);
 }
 
 void ROOT::Internal::RPageSource::EnableDefaultMetrics(const std::string &prefix)

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -515,39 +515,9 @@ std::string ROOT::Experimental::Internal::RPageSourceDaos::GetObjectClass() cons
    return fDaosContainer->GetDefaultObjectClass().ToString();
 }
 
-void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(ROOT::DescriptorId_t physicalColumnId,
-                                                                   RNTupleLocalIndex localIndex,
-                                                                   RSealedPage &sealedPage)
+void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPageImpl(const RNTupleLocator &, RSealedPage &)
 {
-   const auto clusterId = localIndex.GetClusterId();
-
-   ROOT::RClusterDescriptor::RPageInfo pageInfo;
-   {
-      auto descriptorGuard = GetSharedDescriptorGuard();
-      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
-      pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(localIndex.GetIndexInCluster());
-   }
-
-   sealedPage.SetBufferSize(pageInfo.GetLocator().GetNBytesOnStorage() + pageInfo.HasChecksum() * kNBytesPageChecksum);
-   sealedPage.SetNElements(pageInfo.GetNElements());
-   sealedPage.SetHasChecksum(pageInfo.HasChecksum());
-   if (!sealedPage.GetBuffer())
-      return;
-
-   if (pageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
-      assert(!pageInfo.HasChecksum());
-      memcpy(const_cast<void *>(sealedPage.GetBuffer()), ROOT::Internal::RPage::GetPageZeroBuffer(),
-             sealedPage.GetBufferSize());
-      return;
-   }
-
-   RDaosKey daosKey =
-      GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, physicalColumnId,
-                                          pageInfo.GetLocator().GetPosition<RNTupleLocatorObject64>().GetLocation());
-   fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(), daosKey.fOid,
-                                  daosKey.fDkey, daosKey.fAkey);
-
-   sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
+   throw ROOT::RException(R__FAIL("temporarily not implemented"));
 }
 
 ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t columnHandle,

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -49,12 +49,6 @@ using ROOT::Internal::RNTupleCompressor;
 using ROOT::Internal::RNTupleDecompressor;
 using ROOT::Internal::RNTupleSerializer;
 
-/// \brief RNTuple page-DAOS mappings
-enum EDaosMapping {
-   kOidPerCluster,
-   kOidPerPage
-};
-
 struct RDaosKey {
    daos_obj_id_t fOid;
    DistributionKey_t fDkey;
@@ -77,21 +71,11 @@ static constexpr decltype(daos_obj_id_t::lo) kOidLowPageList = -2;
 
 static constexpr daos_oclass_id_t kCidMetadata = OC_SX;
 
-static constexpr EDaosMapping kDefaultDaosMapping = kOidPerCluster;
-
-template <EDaosMapping mapping>
-RDaosKey GetPageDaosKey(ROOT::Experimental::Internal::ntuple_index_t ntplId, long unsigned clusterId,
-                        long unsigned columnId, long unsigned pageCount)
+RDaosKey GetPageDaosKey(ROOT::Experimental::Internal::ntuple_index_t ntplId, long unsigned pageCount)
 {
-   if constexpr (mapping == kOidPerCluster) {
-      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(clusterId),
-                                    static_cast<decltype(daos_obj_id_t::hi)>(ntplId)},
-                      static_cast<DistributionKey_t>(columnId), static_cast<AttributeKey_t>(pageCount)};
-   } else if constexpr (mapping == kOidPerPage) {
-      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(pageCount),
-                                    static_cast<decltype(daos_obj_id_t::hi)>(ntplId)},
-                      kDistributionKeyDefault, kAttributeKeyDefault};
-   }
+   return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(pageCount),
+                                 static_cast<decltype(daos_obj_id_t::hi)>(ntplId)},
+                   kDistributionKeyDefault, kAttributeKeyDefault};
 }
 
 struct RDaosURI {
@@ -308,15 +292,14 @@ ROOT::RNTupleLocator ROOT::Experimental::Internal::RPageSinkDaos::CommitPageImpl
 }
 
 ROOT::RNTupleLocator
-ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId,
+ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageImpl(ROOT::DescriptorId_t,
                                                                   const RPageStorage::RSealedPage &sealedPage)
 {
    auto pageId = fPageId.fetch_add(1);
-   ROOT::DescriptorId_t clusterId = fDescriptorBuilder.GetDescriptor().GetNActiveClusters();
 
    {
       Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, physicalColumnId, pageId);
+      RDaosKey daosKey = GetPageDaosKey(fNTupleIndex, pageId);
       fDaosContainer->WriteSingleAkey(sealedPage.GetBuffer(), sealedPage.GetBufferSize(), daosKey.fOid, daosKey.fDkey,
                                       daosKey.fAkey);
    }
@@ -340,7 +323,6 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
    auto nPages = mask.size();
    locators.reserve(nPages);
 
-   ROOT::DescriptorId_t clusterId = fDescriptorBuilder.GetDescriptor().GetNActiveClusters();
    int64_t payloadSz = 0;
 
    /// Aggregate batch of requests by object ID and distribution key, determined by the ntuple-DAOS mapping
@@ -353,8 +335,7 @@ ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPa
          d_iov_t pageIov;
          d_iov_set(&pageIov, const_cast<void *>(s.GetBuffer()), s.GetBufferSize());
 
-         RDaosKey daosKey =
-            GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fPhysicalColumnId, pageId);
+         RDaosKey daosKey = GetPageDaosKey(fNTupleIndex, pageId);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [it, ret] = writeRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
          it->second.Insert(daosKey.fAkey, pageIov);
@@ -515,9 +496,12 @@ std::string ROOT::Experimental::Internal::RPageSourceDaos::GetObjectClass() cons
    return fDaosContainer->GetDefaultObjectClass().ToString();
 }
 
-void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPageImpl(const RNTupleLocator &, RSealedPage &)
+void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPageImpl(const RNTupleLocator &locator,
+                                                                       RSealedPage &sealedPage)
 {
-   throw ROOT::RException(R__FAIL("temporarily not implemented"));
+   RDaosKey daosKey = GetPageDaosKey(fNTupleIndex, locator.GetPosition<RNTupleLocatorObject64>().GetLocation());
+   fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(), daosKey.fOid,
+                                  daosKey.fDkey, daosKey.fAkey);
 }
 
 ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t columnHandle,
@@ -539,8 +523,8 @@ ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPage
 
    if (fOptions.GetClusterCache() == ROOT::RNTupleReadOptions::EClusterCache::kOff) {
       directReadBuffer = MakeUninitArray<unsigned char>(sealedPage.GetBufferSize());
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(
-         fNTupleIndex, clusterId, columnId, pageInfo.GetLocator().GetPosition<RNTupleLocatorObject64>().GetLocation());
+      RDaosKey daosKey =
+         GetPageDaosKey(fNTupleIndex, pageInfo.GetLocator().GetPosition<RNTupleLocatorObject64>().GetLocation());
       fDaosContainer->ReadSingleAkey(directReadBuffer.get(), sealedPage.GetBufferSize(), daosKey.fOid, daosKey.fDkey,
                                      daosKey.fAkey);
       fCounters->fNPageRead.Inc();
@@ -633,8 +617,7 @@ ROOT::Experimental::Internal::RPageSourceDaos::LoadClusters(std::span<RCluster::
          d_iov_t iov;
          d_iov_set(&iov, clusterBuffer, sealedLoc.fBufferSize);
 
-         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, sealedLoc.fClusterId, sealedLoc.fColumnId,
-                                                                sealedLoc.fPageId);
+         RDaosKey daosKey = GetPageDaosKey(fNTupleIndex, sealedLoc.fPageId);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [itReq, ret] = readRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
          itReq->second.Insert(daosKey.fAkey, iov);

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -551,8 +551,7 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(ROOT::Descrip
 }
 
 ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                                                     const RPageSummary &pageSummary,
-                                                                                     ROOT::NTupleSize_t idxInCluster)
+                                                                                     const RPageSummary &pageSummary)
 {
    const auto &columnId = columnHandle.fPhysicalId;
    const auto &clusterId = pageSummary.fClusterId;
@@ -593,8 +592,9 @@ ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPage
          fCurrentCluster = fClusterPool.GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
+      // The cluster pool may have unzipped the required page into the page pool
       auto cachedPageRef = fPagePool.GetPage(ROOT::Internal::RPagePool::RKey{columnId, elementInMemoryType},
-                                             RNTupleLocalIndex(clusterId, idxInCluster));
+                                             RNTupleLocalIndex(clusterId, pageInfo.GetFirstElementIndex()));
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -551,12 +551,12 @@ void ROOT::Experimental::Internal::RPageSourceDaos::LoadSealedPage(ROOT::Descrip
 }
 
 ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                                                     const RClusterInfo &clusterInfo,
+                                                                                     const RPageSummary &pageSummary,
                                                                                      ROOT::NTupleSize_t idxInCluster)
 {
-   const auto columnId = columnHandle.fPhysicalId;
-   const auto clusterId = clusterInfo.fClusterId;
-   const auto &pageInfo = clusterInfo.fPageInfo;
+   const auto &columnId = columnHandle.fPhysicalId;
+   const auto &clusterId = pageSummary.fClusterId;
+   const auto &pageInfo = pageSummary.fPageInfo;
 
    const auto element = columnHandle.fColumn->GetElement();
    const auto elementSize = element->GetSize();
@@ -566,8 +566,8 @@ ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPage
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                         ROOT::Internal::RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
+      pageZero.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
+                         ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero),
                                     ROOT::Internal::RPagePool::RKey{columnId, elementInMemoryType});
    }
@@ -611,8 +611,8 @@ ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPage
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                     ROOT::Internal::RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
+   newPage.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
+                     ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), ROOT::Internal::RPagePool::RKey{columnId, elementInMemoryType});
 }

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -561,16 +561,6 @@ ROOT::Internal::RPageRef ROOT::Experimental::Internal::RPageSourceDaos::LoadPage
    const auto elementSize = element->GetSize();
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
-   if (pageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
-      auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
-      pageZero.GrowUnchecked(pageInfo.GetNElements());
-      memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                         ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
-      return fPagePool.RegisterPage(std::move(pageZero),
-                                    ROOT::Internal::RPagePool::RKey{columnId, elementInMemoryType});
-   }
-
    RSealedPage sealedPage;
    sealedPage.SetNElements(pageInfo.GetNElements());
    sealedPage.SetHasChecksum(pageInfo.HasChecksum());

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -518,33 +518,10 @@ ROOT::RNTupleDescriptor ROOT::Internal::RPageSourceFile::AttachImpl(RNTupleSeria
    return desc;
 }
 
-void ROOT::Internal::RPageSourceFile::LoadSealedPage(ROOT::DescriptorId_t physicalColumnId,
-                                                     RNTupleLocalIndex localIndex, RSealedPage &sealedPage)
+void ROOT::Internal::RPageSourceFile::LoadSealedPageImpl(const RNTupleLocator &locator, RSealedPage &sealedPage)
 {
-   const auto clusterId = localIndex.GetClusterId();
-
-   ROOT::RClusterDescriptor::RPageInfo pageInfo;
-   {
-      auto descriptorGuard = GetSharedDescriptorGuard();
-      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
-      pageInfo = clusterDescriptor.GetPageRange(physicalColumnId).Find(localIndex.GetIndexInCluster());
-   }
-
-   sealedPage.SetBufferSize(pageInfo.GetLocator().GetNBytesOnStorage() + pageInfo.HasChecksum() * kNBytesPageChecksum);
-   sealedPage.SetNElements(pageInfo.GetNElements());
-   sealedPage.SetHasChecksum(pageInfo.HasChecksum());
-   if (!sealedPage.GetBuffer())
-      return;
-   if (pageInfo.GetLocator().GetType() != RNTupleLocator::kTypePageZero) {
-      fReader.ReadBuffer(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(),
-                         pageInfo.GetLocator().GetPosition<std::uint64_t>());
-   } else {
-      assert(!pageInfo.HasChecksum());
-      memcpy(const_cast<void *>(sealedPage.GetBuffer()), ROOT::Internal::RPage::GetPageZeroBuffer(),
-             sealedPage.GetBufferSize());
-   }
-
-   sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
+   fReader.ReadBuffer(const_cast<void *>(sealedPage.GetBuffer()), sealedPage.GetBufferSize(),
+                      locator.GetPosition<std::uint64_t>());
 }
 
 ROOT::Internal::RPageRef

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -558,15 +558,6 @@ ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t columnHandle, const
    const auto elementSize = element->GetSize();
    const auto elementInMemoryType = element->GetIdentifier().fInMemoryType;
 
-   if (pageInfo.GetLocator().GetType() == RNTupleLocator::kTypePageZero) {
-      auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
-      pageZero.GrowUnchecked(pageInfo.GetNElements());
-      memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                         ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
-      return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
-   }
-
    RSealedPage sealedPage;
    sealedPage.SetNElements(pageInfo.GetNElements());
    sealedPage.SetHasChecksum(pageInfo.HasChecksum());

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -548,12 +548,12 @@ void ROOT::Internal::RPageSourceFile::LoadSealedPage(ROOT::DescriptorId_t physic
 }
 
 ROOT::Internal::RPageRef ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                                       const RClusterInfo &clusterInfo,
+                                                                       const RPageSummary &pageSummary,
                                                                        ROOT::NTupleSize_t idxInCluster)
 {
-   const auto columnId = columnHandle.fPhysicalId;
-   const auto clusterId = clusterInfo.fClusterId;
-   const auto pageInfo = clusterInfo.fPageInfo;
+   const auto &columnId = columnHandle.fPhysicalId;
+   const auto &clusterId = pageSummary.fClusterId;
+   const auto &pageInfo = pageSummary.fPageInfo;
 
    const auto element = columnHandle.fColumn->GetElement();
    const auto elementSize = element->GetSize();
@@ -563,8 +563,8 @@ ROOT::Internal::RPageRef ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHan
       auto pageZero = fPageAllocator->NewPage(elementSize, pageInfo.GetNElements());
       pageZero.GrowUnchecked(pageInfo.GetNElements());
       memset(pageZero.GetBuffer(), 0, pageZero.GetNBytes());
-      pageZero.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                         ROOT::Internal::RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
+      pageZero.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
+                         ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
       return fPagePool.RegisterPage(std::move(pageZero), RPagePool::RKey{columnId, elementInMemoryType});
    }
 
@@ -616,8 +616,8 @@ ROOT::Internal::RPageRef ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHan
       fCounters->fSzUnzip.Add(elementSize * pageInfo.GetNElements());
    }
 
-   newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.GetFirstElementIndex(),
-                     ROOT::Internal::RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
+   newPage.SetWindow(pageSummary.fColumnOffset + pageInfo.GetFirstElementIndex(),
+                     ROOT::Internal::RPage::RClusterInfo(clusterId, pageSummary.fColumnOffset));
    fCounters->fNPageUnsealed.Inc();
    return fPagePool.RegisterPage(std::move(newPage), RPagePool::RKey{columnId, elementInMemoryType});
 }

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -547,9 +547,8 @@ void ROOT::Internal::RPageSourceFile::LoadSealedPage(ROOT::DescriptorId_t physic
    sealedPage.VerifyChecksumIfEnabled().ThrowOnError();
 }
 
-ROOT::Internal::RPageRef ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t columnHandle,
-                                                                       const RPageSummary &pageSummary,
-                                                                       ROOT::NTupleSize_t idxInCluster)
+ROOT::Internal::RPageRef
+ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHandle_t columnHandle, const RPageSummary &pageSummary)
 {
    const auto &columnId = columnHandle.fPhysicalId;
    const auto &clusterId = pageSummary.fClusterId;
@@ -598,8 +597,9 @@ ROOT::Internal::RPageRef ROOT::Internal::RPageSourceFile::LoadPageImpl(ColumnHan
          fCurrentCluster = fClusterPool.GetCluster(clusterId, fActivePhysicalColumns.ToColumnSet());
       R__ASSERT(fCurrentCluster->ContainsColumn(columnId));
 
-      auto cachedPageRef =
-         fPagePool.GetPage(RPagePool::RKey{columnId, elementInMemoryType}, RNTupleLocalIndex(clusterId, idxInCluster));
+      // The cluster pool may have unzipped the required page into the page pool
+      auto cachedPageRef = fPagePool.GetPage(ROOT::Internal::RPagePool::RKey{columnId, elementInMemoryType},
+                                             RNTupleLocalIndex(clusterId, pageInfo.GetFirstElementIndex()));
       if (!cachedPageRef.Get().IsNull())
          return cachedPageRef;
 

--- a/tree/ntuple/test/ntuple_cluster.cxx
+++ b/tree/ntuple/test/ntuple_cluster.cxx
@@ -42,6 +42,7 @@ protected:
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
+   void LoadSealedPageImpl(const ROOT::RNTupleLocator &, RSealedPage &) final {}
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final
@@ -75,7 +76,6 @@ public:
       auto descriptorGuard = GetExclDescriptorGuard();
       descriptorGuard.MoveIn(descBuilder.MoveDescriptor());
    }
-   void LoadSealedPage(ROOT::DescriptorId_t, ROOT::RNTupleLocalIndex, RSealedPage &) final {}
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final
    {
       std::vector<std::unique_ptr<RCluster>> result;

--- a/tree/ntuple/test/ntuple_cluster.cxx
+++ b/tree/ntuple/test/ntuple_cluster.cxx
@@ -41,7 +41,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final

--- a/tree/ntuple/test/ntuple_cluster.cxx
+++ b/tree/ntuple/test/ntuple_cluster.cxx
@@ -41,7 +41,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final

--- a/tree/ntuple/test/ntuple_endian.cxx
+++ b/tree/ntuple/test/ntuple_endian.cxx
@@ -94,6 +94,7 @@ protected:
    }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
+   void LoadSealedPageImpl(const ROOT::RNTupleLocator &, RSealedPage &) final {}
    void LoadStreamerInfo() final {}
 
    std::unique_ptr<ROOT::Internal::RPageSource>
@@ -115,7 +116,6 @@ public:
       return fPagePool.RegisterPage(std::move(page), key);
    }
    RPageRef LoadPage(ColumnHandle_t, ROOT::RNTupleLocalIndex) final { return RPageRef(); }
-   void LoadSealedPage(ROOT::DescriptorId_t, ROOT::RNTupleLocalIndex, RSealedPage &) final {}
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey>) final { return {}; }
 };
 } // anonymous namespace

--- a/tree/ntuple/test/ntuple_endian.cxx
+++ b/tree/ntuple/test/ntuple_endian.cxx
@@ -93,7 +93,7 @@ protected:
       return RNTupleDescriptor();
    }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
 
    std::unique_ptr<ROOT::Internal::RPageSource>

--- a/tree/ntuple/test/ntuple_endian.cxx
+++ b/tree/ntuple/test/ntuple_endian.cxx
@@ -93,7 +93,7 @@ protected:
       return RNTupleDescriptor();
    }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
 
    std::unique_ptr<ROOT::Internal::RPageSource>

--- a/tree/ntuple/test/ntuple_pages.cxx
+++ b/tree/ntuple/test/ntuple_pages.cxx
@@ -11,7 +11,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RClusterInfo &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final

--- a/tree/ntuple/test/ntuple_pages.cxx
+++ b/tree/ntuple/test/ntuple_pages.cxx
@@ -11,7 +11,7 @@ protected:
    void LoadStructureImpl() final {}
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
-   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &, ROOT::NTupleSize_t) final { return RPageRef(); }
+   RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final

--- a/tree/ntuple/test/ntuple_pages.cxx
+++ b/tree/ntuple/test/ntuple_pages.cxx
@@ -12,6 +12,7 @@ protected:
    RNTupleDescriptor AttachImpl(RNTupleSerializer::EDescriptorDeserializeMode) final { return RNTupleDescriptor(); }
    std::unique_ptr<RPageSource> CloneImpl() const final { return nullptr; }
    RPageRef LoadPageImpl(ColumnHandle_t, const RPageSummary &) final { return RPageRef(); }
+   void LoadSealedPageImpl(const ROOT::RNTupleLocator &, RSealedPage &) final {}
    void LoadStreamerInfo() final {}
    std::unique_ptr<ROOT::Internal::RPageSource>
    OpenWithDifferentAnchor(const ROOT::Internal::RNTupleLink &, const ROOT::RNTupleReadOptions &) final
@@ -21,7 +22,6 @@ protected:
 
 public:
    RPageSourceMock() : RPageSource("test", RNTupleReadOptions()) {}
-   void LoadSealedPage(ROOT::DescriptorId_t, ROOT::RNTupleLocalIndex, RSealedPage &) final {}
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey>) final
    {
       return std::vector<std::unique_ptr<RCluster>>();

--- a/tree/ntuple/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/test/ntuple_storage_daos.cxx
@@ -158,6 +158,38 @@ TEST_F(RPageStorageDaos, Options)
    EXPECT_EQ(1U, source.GetNEntries());
 }
 
+TEST_F(RPageStorageDaos, LoadSealedPage)
+{
+   std::string daosUri = RegisterLabel("ntuple-test-load-sealed-page");
+   const std::string_view ntupleName("ntuple");
+
+   {
+      auto model = RNTupleModel::Create();
+      auto ptrPt = model->MakeField<float>("pt");
+
+      RNTupleWriteOptions options;
+      options.SetCompression(0);
+      auto writer = RNTupleWriter::Recreate(std::move(model), ntupleName, daosUri, options);
+      *ptrPt = 1.0;
+      writer->Fill();
+   }
+
+   ROOT::Experimental::Internal::RPageSourceDaos source(ntupleName, daosUri, ROOT::RNTupleReadOptions());
+   source.Attach();
+   RPageStorage::RSealedPage sealedPage;
+   source.LoadSealedPage(0, RNTupleLocalIndex{0, 0}, sealedPage);
+   EXPECT_TRUE(sealedPage.GetHasChecksum());
+   ASSERT_EQ(12u, sealedPage.GetBufferSize());
+
+   unsigned char buffer[12];
+   sealedPage.SetBuffer(buffer);
+   source.LoadSealedPage(0, RNTupleLocalIndex{0, 0}, sealedPage);
+
+   float pt = 0;
+   memcpy(&pt, sealedPage.GetBuffer(), sizeof(pt));
+   EXPECT_FLOAT_EQ(1.0, pt);
+}
+
 TEST_F(RPageStorageDaos, MultipleNTuplesPerContainer)
 {
    std::string daosUri = RegisterLabel("ntuple-test-multiple");


### PR DESCRIPTION
In preparation for huge-file support, some cleanup in the `RPageSource` family of classes.

  - Don't deal with zero pages or with the descriptor when loading concrete pages
  - DAOS: remove object-per-cluster mapping

There is more to improve, left for follow-up PRs.



