### PR TITLE
[ntuple] Add `RNTupleProcessor::RequestField` by typename string

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -377,7 +377,7 @@ public:
    /// \param[in] valuePtr Pointer to bind to the field's value in the entry. If this is a `nullptr`, a pointer will be
    /// created.
    ///
-   /// \return An RNTupleProcessorOptionalPtr, which provides access to the field's value.
+   /// \return An RNTupleProcessorOptionalPtr of type `T`, which provides access to the field's value.
    ///
    /// \warning Provide a `valuePtr` with care! Values may not always be valid for every entry during processing, for
    /// example when a field is not present in one of the chained processors or when during a join operation, no matching
@@ -394,6 +394,29 @@ public:
       }
       auto fieldIdx = AddFieldToEntry(fieldName, typeName, valuePtr, Internal::RNTupleProcessorProvenance());
       return RNTupleProcessorOptionalPtr<T>(fEntry.get(), fieldIdx);
+   }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Request access to a field for reading during processing.
+   ///
+   /// \param[in] fieldName Name of the requested field.
+   /// \param[in] typeName Type of the requested field.
+   /// \param[in] valuePtr Pointer to bind to the field's value in the entry. If this is a `nullptr`, a pointer will be
+   /// created.
+   ///
+   /// \return An void-type RNTupleProcessorOptionalPtr, which provides access to the field's value.
+   ///
+   /// \warning Provide a `valuePtr` with care! Values may not always be valid for every entry during processing, for
+   /// example when a field is not present in one of the chained processors or when during a join operation, no matching
+   /// entry in the auxiliary processor can be found. Reading `valuePtr` as-is therefore comes with the risk of reading
+   /// invalid data. After passing a pointer to `RequestField`, we *strongly* recommend only accessing its data through
+   /// the interface of the returned `RNTupleProcessorOptionalPtr`, to ensure that only valid data can be read.
+   RNTupleProcessorOptionalPtr<void>
+   RequestField(const std::string &fieldName, const std::string &typeName, void *valuePtr = nullptr)
+   {
+      Initialize(fEntry);
+      auto fieldIdx = AddFieldToEntry(fieldName, typeName, valuePtr, Internal::RNTupleProcessorProvenance());
+      return RNTupleProcessorOptionalPtr<void>(fEntry.get(), fieldIdx);
    }
 
    /////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -231,6 +231,38 @@ TEST_F(RNTupleProcessorTest, RequestFieldWithVoidPtr)
    }
 }
 
+TEST_F(RNTupleProcessorTest, RequestFieldWithTypeString)
+{
+   {
+      auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
+      EXPECT_NO_THROW(proc->RequestField("y", "std::vector<float    >"));
+   }
+   {
+      auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
+      EXPECT_NO_THROW(proc->RequestField("y", "std::vector<Float_t>"));
+   }
+   {
+      auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
+      EXPECT_THROW(proc->RequestField("y", "std::vetor<float>"), ROOT::RException);
+   }
+
+   auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
+   auto x = proc->RequestField("x", "float");
+   auto yPtr = std::make_shared<std::vector<float>>();
+   auto y = proc->RequestField("y", "std::vector<float>", yPtr.get());
+
+   for (auto idx : *proc) {
+      EXPECT_EQ(idx, proc->GetCurrentEntryNumber());
+      EXPECT_EQ(idx + 1, proc->GetNEntriesProcessed());
+
+      EXPECT_FLOAT_EQ(static_cast<float>(idx), *std::static_pointer_cast<float>(x.GetPtr()));
+
+      std::vector<float> yExp{static_cast<float>(idx), static_cast<float>((idx) * 2)};
+      EXPECT_EQ(yExp, *std::static_pointer_cast<std::vector<float>>(y.GetPtr()));
+   }
+   EXPECT_EQ(5, proc->GetNEntriesProcessed());
+}
+
 TEST_F(RNTupleProcessorTest, AlternativeTypes)
 {
    auto proc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});


### PR DESCRIPTION
Adds a non-templated overload of `RNTupleProcessor::RequestField` that takes a typename string, in case the type is not known at compile time.

