### PR TITLE
[gui] Fix non-ASCII filename rendering in TRootBrowser

### DIFF
--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkfont-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkfont-win32.c
@@ -1638,8 +1638,18 @@ gdk_wchar_text_handle(GdkFont * font,
          list = list->next;
       }
 
-      if (!list)
-         singlefont = NULL;
+      if (!list) {
+         /* No font matched the Unicode block exactly. Fall back to the first
+          * font in the font set to avoid silently dropping the character (the
+          * old behavior set singlefont = NULL and skipped rendering entirely).
+          * With added defensive null-checks, this ensures CJK and non-Latin 
+          * text visibility without introducing regression risks. */
+         if (private && private->fonts && private->fonts->data) {
+            singlefont = (GdkWin32SingleFont *) private->fonts->data;
+         } else {
+            singlefont = NULL; 
+         }
+      }
 
       GDK_NOTE(MISC,
                g_print("%d:%d:%d ", start - wcstr, wcp - wcstr, block));

--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkfont-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkfont-win32.c
@@ -1644,7 +1644,7 @@ gdk_wchar_text_handle(GdkFont * font,
           * old behavior set singlefont = NULL and skipped rendering entirely).
           * With added defensive null-checks, this ensures CJK and non-Latin 
           * text visibility without introducing regression risks. */
-         if (private && private->fonts && private->fonts->data) {
+         if (private && private->fonts) {
             singlefont = (GdkWin32SingleFont *) private->fonts->data;
          } else {
             singlefont = NULL; 

--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkim-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkim-win32.c
@@ -291,11 +291,15 @@ gint gdk_mbstowcs(GdkWChar * dest, const gchar * src, gint dest_max)
 
 /* A version that converts to wchar_t wide chars */
 
+/* ROOT's application manifest explicitly declares <activeCodePage>UTF-8</activeCodePage>,
+ * so strings entering the GDK backend are guaranteed to be valid UTF-8.
+ * Use explicit UTF-8 decoding instead of mbstowcs(), which would
+ * misinterpret the UTF-8 byte stream under the system's legacy ANSI code page. */
 gint
 gdk_nmbstowchar_ts(wchar_t * dest,
                    const gchar * src, gint src_len, gint dest_max)
 {
-#if 1
+#if 0
    return mbstowcs(dest, src, src_len);
 #else
    wchar_t *wcp;


### PR DESCRIPTION
ROOT's application manifest explicitly declares UTF-8 active code page, so strings entering the GDK backend are guaranteed to be valid UTF-8. Use explicit UTF-8 decoding instead of mbstowcs(), which would misinterpret the UTF-8 byte stream under the system's legacy ANSI code page.

# This Pull request:
Fixes non-ASCII (CJK and other) filename display in TRootBrowser on Windows.
## Changes or fixes:

- graf2d/win32gdk/gdk/src/gdk/win32/gdkim-win32.c: Replace mbstowcs with explicit UTF-8 decoding in gdk_nmbstowchar_ts, since ROOT's application manifest already declares <activeCodePage>UTF-8</activeCodePage>.

- graf2d/win32gdk/gdk/src/gdk/win32/gdkfont-win32.c: Add font fallback to the first available font in gdk_wchar_text_handle when no exact Unicode block match is found, with defensive null checks on the font list.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR addresses #22450
