### PR TITLE
[geom] Fix tessellated closure checks after initialization

### DIFF
--- a/geom/geom/src/TGeoTessellated.cxx
+++ b/geom/geom/src/TGeoTessellated.cxx
@@ -328,38 +328,36 @@ bool TGeoTessellated::FacetCheck(int ifacet) const
 
 void TGeoTessellated::CloseShape(bool check, bool fixFlipped, bool verbose)
 {
-   if (fIsClosed && fBVH) {
+   const bool initialized = fIsClosed && fBVH;
+   if (initialized && !check) {
       return;
    }
-   // Compute bounding box
-   fDefined = true;
-   fNvert = fVertices.size();
-   fNfacets = fFacets.size();
-   ComputeBBox();
 
-   BuildBVH();
-   if (fOutwardNormals.size() == 0) {
-      CalculateNormals();
-   } else {
-      // short check if the normal container is of correct size
-      if (fOutwardNormals.size() != fFacets.size()) {
-         std::cerr << "Inconsistency in normal container";
-      }
+   if (!initialized) {
+      // Compute bounding box
+      fDefined = true;
+      fNvert = fVertices.size();
+      fNfacets = fFacets.size();
+      ComputeBBox();
+
+      BuildBVH();
+      fIsClosed = true;
+
+      // Cleanup the vertex map
+      std::multimap<long, int>().swap(fVerticesMap);
    }
-   fIsClosed = true;
-
-   // Cleanup the vertex map
-   std::multimap<long, int>().swap(fVerticesMap);
 
    if (fVertices.size() > 0) {
-      if (!check)
-         return;
+      if (check) {
+         // Check facets
+         for (auto i = 0; i < fNfacets; ++i)
+            FacetCheck(i);
 
-      // Check facets
-      for (auto i = 0; i < fNfacets; ++i)
-         FacetCheck(i);
+         fClosedBody = CheckClosure(fixFlipped, verbose);
+      }
 
-      fClosedBody = CheckClosure(fixFlipped, verbose);
+      if (fOutwardNormals.size() != fFacets.size())
+         CalculateNormals();
    }
 }
 
@@ -422,6 +420,8 @@ bool TGeoTessellated::CheckClosure(bool fixFlipped, bool verbose)
       }
       if (nfixed && verbose)
          Info("Check", "Automatically flipped %d facets to match first defined facet", nfixed);
+      if (nfixed && !fOutwardNormals.empty())
+         CalculateNormals();
    }
    delete[] nn;
    delete[] flipped;
@@ -1277,8 +1277,7 @@ inline Double_t TGeoTessellated::SafetyKernel(const Double_t *point, bool in, in
             const auto object_id = mybvh->prim_ids[p_id];
 
             const auto &facet = fFacets[object_id];
-            auto thissafetySQ =
-               pointFacetDistSq(Vec3f<float>(point[0], point[1], point[2]), facet, fVertices);
+            auto thissafetySQ = pointFacetDistSq(Vec3f<float>(point[0], point[1], point[2]), facet, fVertices);
 
             if (thissafetySQ < smallest_safety_sq) {
                smallest_safety_sq = thissafetySQ;

--- a/geom/test/test_tessellated.cxx
+++ b/geom/test/test_tessellated.cxx
@@ -96,7 +96,38 @@ CreateTrdLikeTessellated_Triangles(const char *name, double x1, double x2, doubl
    return tsl;
 }
 
+void AddClosedTetrahedronFacets(TGeoTessellated &tsl)
+{
+   // Closed tetrahedron using the same facet winding as the GDML reproducer
+   // for ROOT issue #22395.
+   const Vtx v0(0, 0, 0);
+   const Vtx v1(10, 0, 0);
+   const Vtx v2(5, 10, 0);
+   const Vtx v3(5, 5, 10);
+
+   EXPECT_TRUE(tsl.AddFacet(v0, v2, v1));
+   EXPECT_TRUE(tsl.AddFacet(v0, v1, v3));
+   EXPECT_TRUE(tsl.AddFacet(v1, v2, v3));
+   EXPECT_TRUE(tsl.AddFacet(v0, v3, v2));
+}
+
 } // namespace
+
+TEST(TGeoTessellated, CloseShapeCanCheckAfterUncheckedClose)
+{
+   // TGDMLParse finalizes tessellated solids with CloseShape(false). This must
+   // initialize the shape without preventing a later explicit CloseShape(true)
+   // from running closure validation and setting the closed-body state.
+   TGeoTessellated tsl("Closed Tetrahedron");
+   AddClosedTetrahedronFacets(tsl);
+
+   tsl.CloseShape(/*check=*/false);
+   EXPECT_TRUE(tsl.IsDefined());
+   EXPECT_FALSE(tsl.IsClosedBody());
+
+   tsl.CloseShape(/*check=*/true, /*fixFlipped=*/true, /*verbose=*/false);
+   EXPECT_TRUE(tsl.IsClosedBody());
+}
 
 TEST(TGeoTessellated, TrdLike_CoreNavigation)
 {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Fixes a regression in `TGeoTessellated::CloseShape()` where a tessellated shape finalized with `CloseShape(false)` could not later be checked with `CloseShape(true)`.

This affects GDML-imported tessellated solids because `TGDMLParse::Tessellated()` finalizes them with `CloseShape(false)`. Since the BVH navigation change added an early return for already-initialized shapes, a later explicit `CloseShape(true)` returned before running `CheckClosure()`, leaving `fClosedBody == false`.

The fix keeps the BVH/initialization fast path for repeated unchecked closes, but lets checked closes run facet and closure validation while reusing the existing BVH. This avoids rebuilding the BVH in the GDML reproducer path.

This follows the minimal direction suggested in the issue #22395 comments while avoiding the addition of more state flags or data members. Wouter's broader suggestion of lazy BVH construction on first navigation use was not taken in this PR because it would require a larger redesign of the cache ownership/state model, including const navigation methods, thread-safety of lazy cache construction, and streaming/readback behavior. This PR is intentionally scoped to the regression.

The patch also refreshes cached normals if `CheckClosure(..., fixFlipped=true)` flips facets, so navigation data remains consistent with the facet winding.

A regression test was added for the failing sequence:
1. create a closed tetrahedron matching the GDML reproducer,
2. call `CloseShape(false)`,
3. call `CloseShape(true)`,
4. verify that `IsClosedBody()` becomes true.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #22395 

