### PR TITLE
core: use ::operator delete for RVec heavy storage on Windows

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -418,13 +418,13 @@ void R__CLING_PTRCHECK(off) SmallVectorTemplateBase<T, TriviallyCopyable>::grow(
       destroy_range(this->begin(), this->end());
 
       // If this wasn't grown from the inline copy, deallocate the old space.
-      #if _WIN32
-         if (!this->isSmall())
-            ::operator delete(this->begin());
-      #else
-         if (!this->isSmall())
-            free(this->begin());
-      #endif
+#ifdef _WIN32
+      if (!this->isSmall())
+         ::operator delete(this->begin());
+#else
+      if (!this->isSmall())
+         free(this->begin());
+#endif
    }
 
    this->fBeginX = NewElts;

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -403,7 +403,11 @@ void R__CLING_PTRCHECK(off) SmallVectorTemplateBase<T, TriviallyCopyable>::grow(
    // Always grow, even from zero.
    size_t NewCapacity = size_t(NextPowerOf2(this->capacity() + 2));
    NewCapacity = std::min(std::max(NewCapacity, MinSize), this->SizeTypeMax());
-   T *NewElts = static_cast<T *>(malloc(NewCapacity * sizeof(T)));
+   #if _WIN32
+      T *NewElts = static_cast<T *>(::operator new(NewCapacity * sizeof(T), std::nothrow));
+   #else
+      T *NewElts = static_cast<T *>(malloc(NewCapacity * sizeof(T)));
+   #endif
    R__ASSERT(NewElts != nullptr);
 
    // Move the elements over.
@@ -414,8 +418,13 @@ void R__CLING_PTRCHECK(off) SmallVectorTemplateBase<T, TriviallyCopyable>::grow(
       destroy_range(this->begin(), this->end());
 
       // If this wasn't grown from the inline copy, deallocate the old space.
-      if (!this->isSmall())
-         free(this->begin());
+      #if _WIN32
+         if (!this->isSmall())
+            ::operator delete(this->begin());
+      #else
+         if (!this->isSmall())
+            free(this->begin());
+      #endif
    }
 
    this->fBeginX = NewElts;
@@ -575,8 +584,13 @@ public:
    {
       // Subclass has already destructed this vector's elements.
       // If this wasn't grown from the inline copy, deallocate the old space.
-      if (!this->isSmall() && this->Owns())
-         free(this->begin());
+      #if _WIN32
+         if (!this->isSmall() && this->Owns())
+            ::operator delete(this->begin());
+      #else
+         if (!this->isSmall() && this->Owns())
+            free(this->begin());
+      #endif
    }
 
    // also give up adopted memory if applicable
@@ -1052,8 +1066,13 @@ RVecImpl<T> &RVecImpl<T>::operator=(RVecImpl<T> &&RHS)
    if (!RHS.isSmall()) {
       if (this->Owns()) {
          this->destroy_range(this->begin(), this->end());
-         if (!this->isSmall())
-            free(this->begin());
+         #if _WIN32
+            if (!this->isSmall())
+               ::operator delete(this->begin());
+         #else
+            if (!this->isSmall())
+               free(this->begin());
+         #endif
       }
       this->fBeginX = RHS.fBeginX;
       this->fSize = RHS.fSize;

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -584,13 +584,13 @@ public:
    {
       // Subclass has already destructed this vector's elements.
       // If this wasn't grown from the inline copy, deallocate the old space.
-      #if _WIN32
-         if (!this->isSmall() && this->Owns())
-            ::operator delete(this->begin());
-      #else
-         if (!this->isSmall() && this->Owns())
-            free(this->begin());
-      #endif
+#ifdef _WIN32
+      if (!this->isSmall() && this->Owns())
+         ::operator delete(this->begin());
+#else
+      if (!this->isSmall() && this->Owns())
+         free(this->begin());
+#endif
    }
 
    // also give up adopted memory if applicable

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -403,11 +403,11 @@ void R__CLING_PTRCHECK(off) SmallVectorTemplateBase<T, TriviallyCopyable>::grow(
    // Always grow, even from zero.
    size_t NewCapacity = size_t(NextPowerOf2(this->capacity() + 2));
    NewCapacity = std::min(std::max(NewCapacity, MinSize), this->SizeTypeMax());
-   #if _WIN32
-      T *NewElts = static_cast<T *>(::operator new(NewCapacity * sizeof(T), std::nothrow));
-   #else
-      T *NewElts = static_cast<T *>(malloc(NewCapacity * sizeof(T)));
-   #endif
+#ifdef _WIN32
+   T *NewElts = static_cast<T *>(::operator new(NewCapacity * sizeof(T), std::nothrow));
+#else
+   T *NewElts = static_cast<T *>(malloc(NewCapacity * sizeof(T)));
+#endif
    R__ASSERT(NewElts != nullptr);
 
    // Move the elements over.

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1066,13 +1066,13 @@ RVecImpl<T> &RVecImpl<T>::operator=(RVecImpl<T> &&RHS)
    if (!RHS.isSmall()) {
       if (this->Owns()) {
          this->destroy_range(this->begin(), this->end());
-         #if _WIN32
-            if (!this->isSmall())
-               ::operator delete(this->begin());
-         #else
-            if (!this->isSmall())
-               free(this->begin());
-         #endif
+#ifdef _WIN32
+         if (!this->isSmall())
+            ::operator delete(this->begin());
+#else
+         if (!this->isSmall())
+            free(this->begin());
+#endif
       }
       this->fBeginX = RHS.fBeginX;
       this->fSize = RHS.fSize;

--- a/math/vecops/src/RVec.cxx
+++ b/math/vecops/src/RVec.cxx
@@ -68,17 +68,33 @@ void ROOT::Internal::VecOps::SmallVectorBase::grow_pod(void *FirstEl, size_t Min
    NewCapacity = std::min(std::max(NewCapacity, MinSize), SizeTypeMax());
 
    void *NewElts;
-   if (fBeginX == FirstEl || !this->Owns()) {
-      NewElts = malloc(NewCapacity * TSize);
-      R__ASSERT(NewElts != nullptr);
+   #if _WIN32
+      if (fBeginX == FirstEl || !this->Owns()) {
+         NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
+         R__ASSERT(NewElts != nullptr);
 
-      // Copy the elements over.  No need to run dtors on PODs.
-      memcpy(NewElts, this->fBeginX, size() * TSize);
-   } else {
-      // If this wasn't grown from the inline copy, grow the allocated space.
-      NewElts = realloc(this->fBeginX, NewCapacity * TSize);
-      R__ASSERT(NewElts != nullptr);
-   }
+         // Copy the elements over.  No need to run dtors on PODs.
+         memcpy(NewElts, this->fBeginX, size() * TSize);
+      } else {
+         // If this wasn't grown from the inline copy, grow the allocated space.
+         NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
+         R__ASSERT(NewElts != nullptr);
+         memcpy(NewElts, this->fBeginX, size() * TSize);
+         ::operator delete(this->fBeginX);
+      }
+   #else
+      if (fBeginX == FirstEl || !this->Owns()) {
+         NewElts = malloc(NewCapacity * TSize);
+         R__ASSERT(NewElts != nullptr);
+
+         // Copy the elements over.  No need to run dtors on PODs.
+         memcpy(NewElts, this->fBeginX, size() * TSize);
+      } else {
+         // If this wasn't grown from the inline copy, grow the allocated space.
+         NewElts = realloc(this->fBeginX, NewCapacity * TSize);
+         R__ASSERT(NewElts != nullptr);
+      }
+   #endif
 
    this->fBeginX = NewElts;
    this->fCapacity = NewCapacity;

--- a/math/vecops/src/RVec.cxx
+++ b/math/vecops/src/RVec.cxx
@@ -68,33 +68,33 @@ void ROOT::Internal::VecOps::SmallVectorBase::grow_pod(void *FirstEl, size_t Min
    NewCapacity = std::min(std::max(NewCapacity, MinSize), SizeTypeMax());
 
    void *NewElts;
-   #if _WIN32
-      if (fBeginX == FirstEl || !this->Owns()) {
-         NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
-         R__ASSERT(NewElts != nullptr);
+#ifdef _WIN32
+   if (fBeginX == FirstEl || !this->Owns()) {
+      NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
+      R__ASSERT(NewElts != nullptr);
 
-         // Copy the elements over.  No need to run dtors on PODs.
-         memcpy(NewElts, this->fBeginX, size() * TSize);
-      } else {
-         // If this wasn't grown from the inline copy, grow the allocated space.
-         NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
-         R__ASSERT(NewElts != nullptr);
-         memcpy(NewElts, this->fBeginX, size() * TSize);
-         ::operator delete(this->fBeginX);
-      }
-   #else
-      if (fBeginX == FirstEl || !this->Owns()) {
-         NewElts = malloc(NewCapacity * TSize);
-         R__ASSERT(NewElts != nullptr);
+      // Copy the elements over.  No need to run dtors on PODs.
+      memcpy(NewElts, this->fBeginX, size() * TSize);
+   } else {
+      // If this wasn't grown from the inline copy, grow the allocated space.
+      NewElts = ::operator new(NewCapacity * TSize, std::nothrow);
+      R__ASSERT(NewElts != nullptr);
+      memcpy(NewElts, this->fBeginX, size() * TSize);
+      ::operator delete(this->fBeginX);
+   }
+#else
+   if (fBeginX == FirstEl || !this->Owns()) {
+      NewElts = malloc(NewCapacity * TSize);
+      R__ASSERT(NewElts != nullptr);
 
-         // Copy the elements over.  No need to run dtors on PODs.
-         memcpy(NewElts, this->fBeginX, size() * TSize);
-      } else {
-         // If this wasn't grown from the inline copy, grow the allocated space.
-         NewElts = realloc(this->fBeginX, NewCapacity * TSize);
-         R__ASSERT(NewElts != nullptr);
-      }
-   #endif
+      // Copy the elements over.  No need to run dtors on PODs.
+      memcpy(NewElts, this->fBeginX, size() * TSize);
+   } else {
+      // If this wasn't grown from the inline copy, grow the allocated space.
+      NewElts = realloc(this->fBeginX, NewCapacity * TSize);
+      R__ASSERT(NewElts != nullptr);
+   }
+#endif
 
    this->fBeginX = NewElts;
    this->fCapacity = NewCapacity;


### PR DESCRIPTION
# This Pull request:
Fixes a cross-module/cross-CRT heap allocation mismatch in `RVec` on Windows platforms. This issue can lead to undefined behaviors, memory corruption, or silent exits when memory allocated inside `RVec` is freed across module boundaries (e.g., between a pre-compiled DLL and JIT-generated code).

## Changes or fixes:

- **`math/vecops/src/RVec.cxx`**: In `SmallVectorBase::grow_pod`, replaced `malloc`/`realloc`/`free` with `::operator new(std::nothrow)` and `::operator delete`, guarded by `#ifdef _WIN32`.

- **`math/vecops/inc/ROOT/RVec.hxx`**: In `SmallVectorTemplateBase::grow` and destructor-related deallocations, applied the same guarded replacement to ensure all heap operations are unified across the class layout.

These changes are strictly restricted to Windows via platform macros; Linux and macOS targets remain completely untouched to preserve their high-performance native `realloc` paths.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #22449

