### PR TITLE
[df bulk] Prepare for bulk filters

### DIFF
--- a/roottest/root/dataframe/testIMT.cxx
+++ b/roottest/root/dataframe/testIMT.cxx
@@ -55,18 +55,18 @@ void getTracks(unsigned int mu, FourVectors& tracks) {
 // This makes the example stand-alone
 void FillTree(const char* filename, const char* treeName) {
    if (!gSystem->AccessPathName(filename)) return;
-   TFile f(filename,"RECREATE");
-   TTree t(treeName,treeName);
+   auto f = std::make_unique<TFile>(filename, "RECREATE");
+   auto t = std::make_unique<TTree>(treeName, treeName);
    double b1;
    int b2;
    std::vector<FourVector> tracks;
    std::vector<double> dv {-1,2,3,4};
    std::list<int> sl {1,2,3,4};
-   t.Branch("b1", &b1);
-   t.Branch("b2", &b2);
-   t.Branch("tracks", &tracks);
-   t.Branch("dv", &dv);
-   t.Branch("sl", &sl);
+   t->Branch("b1", &b1);
+   t->Branch("b2", &b2);
+   t->Branch("tracks", &tracks);
+   t->Branch("dv", &dv);
+   t->Branch("sl", &sl);
 
    int nevts = 16000;
    for(int i = 0; i < nevts; ++i) {
@@ -77,11 +77,9 @@ void FillTree(const char* filename, const char* treeName) {
 
       dv.emplace_back(i);
       sl.emplace_back(i);
-      t.Fill();
+      t->Fill();
    }
-   t.Write();
-   f.Close();
-   return;
+   f->Write();
 }
 
 auto fileName = "testIMT.root";

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -82,6 +82,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RJittedVariation.hxx
     ROOT/RDF/RLazyDSImpl.hxx
     ROOT/RDF/RLoopManager.hxx
+    ROOT/RDF/RMaskedEntryRange.hxx
     ROOT/RDF/RMergeableValue.hxx
     ROOT/RDF/RMetaData.hxx
     ROOT/RDF/RNodeBase.hxx

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -28,7 +28,7 @@ namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RCsvDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    void *fValuePtr;
    void *GetImpl(std::size_t) final { return fValuePtr; }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RCsvDSColumnReader(void *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -27,7 +27,8 @@
 namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RCsvDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    void *fValuePtr;
-   void *GetImpl(Long64_t) final { return fValuePtr; }
+   void *GetImpl(std::size_t) final { return fValuePtr; }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RCsvDSColumnReader(void *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -122,9 +122,10 @@ public:
    void Run(unsigned int slot, Long64_t entry) final
    {
       const auto mask = fPrevNode.CheckFilters(slot, entry);
-      std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
+      std::for_each(fValues[slot].begin(), fValues[slot].end(), [&mask](auto *v) { v->Load(mask); });
 
-      if (mask)
+      // Assume 1-size bulk for now
+      if (mask[0])
          CallExec(slot, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -99,31 +99,33 @@ public:
    }
 
    template <typename ColType>
-   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, Long64_t entry) -> ColType &
+   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, std::size_t idx) -> ColType &
    {
-      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(entry))
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(idx))
          return *val;
 
       throw std::out_of_range{"RDataFrame: Action (" + fHelper.GetActionName() +
                               ") could not retrieve value for column '" + fColumnNames[readerIdx] + "' for entry " +
-                              std::to_string(entry) +
+                              std::to_string(idx) +
                               ". You can use the DefaultValueFor operation to provide a default value, or "
                               "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void CallExec(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
+   void CallExec(unsigned int slot, std::size_t idx, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
       ROOT::Internal::RDF::CallGuaranteedOrder{[&](auto &&...args) { return fHelper.Exec(slot, args...); },
-                                               GetValueChecked<ColTypes>(slot, S, entry)...};
-      (void)entry; // avoid unused parameter warning (gcc 12.1)
+                                               GetValueChecked<ColTypes>(slot, S, idx)...};
+      (void)idx; // avoid unused parameter warning (gcc 12.1)
    }
 
    void Run(unsigned int slot, Long64_t entry) final
    {
-      // check if entry passes all filters
-      if (fPrevNode.CheckFilters(slot, entry))
-         CallExec(slot, entry, ColumnTypes_t{}, TypeInd_t{});
+      const auto mask = fPrevNode.CheckFilters(slot, entry);
+      std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
+
+      if (mask)
+         CallExec(slot, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
    }
 
    void TriggerChildrenCount() final { fPrevNode.IncrChildrenCount(); }

--- a/tree/dataframe/inc/ROOT/RDF/RActionSnapshot.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionSnapshot.hxx
@@ -166,27 +166,27 @@ public:
       fHelper.InitTask(r, slot);
    }
 
-   void *GetValue(unsigned int slot, std::size_t readerIdx, Long64_t entry)
+   void *GetValue(unsigned int slot, std::size_t readerIdx, std::size_t idx)
    {
       assert(slot < fValues.size());
       assert(readerIdx < fValues[slot].size());
-      if (auto *val = fValues[slot][readerIdx]->template TryGet<void>(entry))
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<void>(idx))
          return val;
 
       throw std::out_of_range{"RDataFrame: Action (" + fHelper.GetActionName() +
                               ") could not retrieve value for column '" + fColumnNames[readerIdx] + "' for entry " +
-                              std::to_string(entry) +
+                              std::to_string(idx) +
                               ". You can use the DefaultValueFor operation to provide a default value, or "
                               "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
-   void CallExec(unsigned int slot, Long64_t entry)
+   void CallExec(unsigned int slot, std::size_t idx)
    {
       std::vector<void *> untypedValues;
       auto nReaders = fValues[slot].size();
       untypedValues.reserve(nReaders);
       for (decltype(nReaders) readerIdx{}; readerIdx < nReaders; readerIdx++)
-         untypedValues.push_back(GetValue(slot, readerIdx, entry));
+         untypedValues.push_back(GetValue(slot, readerIdx, idx));
 
       fHelper.Exec(slot, untypedValues);
    }
@@ -207,14 +207,17 @@ public:
             std::vector<void *> untypedValues;
             auto nReaders = fValues[slot].size();
             untypedValues.reserve(nReaders);
+            std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry](auto *v) { v->Load(entry, true); });
             for (decltype(nReaders) readerIdx{}; readerIdx < nReaders; readerIdx++)
-               untypedValues.push_back(GetValue(slot, readerIdx, entry));
+               untypedValues.push_back(GetValue(slot, readerIdx, /*idx=*/0u));
 
             fHelper.Exec(slot, untypedValues, filterPassed);
          }
       } else {
-         if (fPrevNodes.front()->CheckFilters(slot, entry))
-            CallExec(slot, entry);
+         const auto mask = fPrevNodes.front()->CheckFilters(slot, entry);
+         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
+         if (mask)
+            CallExec(slot, /*idx=*/0u);
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RActionSnapshot.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionSnapshot.hxx
@@ -195,19 +195,23 @@ public:
    {
       if constexpr (std::is_same_v<Helper, SnapshotHelperWithVariations>) {
          // check if entry passes all filters
-         std::vector<bool> filterPassed(fPrevNodes.size(), false);
+         std::vector<ROOT::Internal::RDF::RMaskedEntryRange> filterPassed(fPrevNodes.size(), 1ul);
          for (unsigned int variation = 0; variation < fPrevNodes.size(); ++variation) {
             filterPassed[variation] = fPrevNodes[variation]->CheckFilters(slot, entry);
          }
 
          // Currently, every event where any of nominal or variations pass gets written to the output.
          // This logic could be extended for different use cases if the need arises.
-         if (std::any_of(filterPassed.begin(), filterPassed.end(), [](bool val) { return val; })) {
+         // Assume 1-size bulk for now
+         if (std::any_of(filterPassed.begin(), filterPassed.end(),
+                         [](const ROOT::Internal::RDF::RMaskedEntryRange &val) { return val[0]; })) {
             // TODO: Don't allocate
             std::vector<void *> untypedValues;
             auto nReaders = fValues[slot].size();
             untypedValues.reserve(nReaders);
-            std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry](auto *v) { v->Load(entry, true); });
+            std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry](auto *v) {
+               v->Load(ROOT::Internal::RDF::RMaskedEntryRange{1ul, true, static_cast<std::uint64_t>(entry)});
+            });
             for (decltype(nReaders) readerIdx{}; readerIdx < nReaders; readerIdx++)
                untypedValues.push_back(GetValue(slot, readerIdx, /*idx=*/0u));
 
@@ -215,8 +219,9 @@ public:
          }
       } else {
          const auto mask = fPrevNodes.front()->CheckFilters(slot, entry);
-         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
-         if (mask)
+         std::for_each(fValues[slot].begin(), fValues[slot].end(), [&mask](auto *v) { v->Load(mask); });
+         // Assume 1-size bulk for now
+         if (mask[0])
             CallExec(slot, /*idx=*/0u);
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -12,6 +12,7 @@
 #define ROOT_INTERNAL_RDF_RCOLUMNREADERBASE
 
 #include <Rtypes.h>
+#include <ROOT/RDF/RMaskedEntryRange.hxx>
 
 namespace ROOT {
 namespace Detail {
@@ -26,7 +27,6 @@ This pure virtual class provides a common base class for the different column re
 RDSColumnReader.
 **/
 class R__CLING_PTRCHECK(off) RColumnReaderBase {
-   Long64_t fLoadedEntry = -1;
 
 public:
    virtual ~RColumnReaderBase() = default;
@@ -34,14 +34,7 @@ public:
    /// Load the column value for the given entry.
    /// \param entry The entry number to load.
    /// \param mask The entry mask. Values will be loaded only for entries for which the mask equals true.
-   void Load(Long64_t entry, bool mask)
-   {
-      // For now, as `mask` is just a single boolean, as an optimization we can return early here if `mask == false`.
-      if (mask) {
-         fLoadedEntry = entry;
-         this->LoadImpl(entry, mask);
-      }
-   }
+   void Load(const ROOT::Internal::RDF::RMaskedEntryRange &mask) { LoadImpl(mask); }
 
    /// Return the column value for the given entry.
    /// \tparam T The column type
@@ -57,7 +50,7 @@ public:
 
 private:
    virtual void *GetImpl(std::size_t idx) = 0;
-   virtual void LoadImpl(Long64_t /*entry*/, bool /*mask*/) = 0;
+   virtual void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) = 0;
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -26,8 +26,22 @@ This pure virtual class provides a common base class for the different column re
 RDSColumnReader.
 **/
 class R__CLING_PTRCHECK(off) RColumnReaderBase {
+   Long64_t fLoadedEntry = -1;
+
 public:
    virtual ~RColumnReaderBase() = default;
+
+   /// Load the column value for the given entry.
+   /// \param entry The entry number to load.
+   /// \param mask The entry mask. Values will be loaded only for entries for which the mask equals true.
+   void Load(Long64_t entry, bool mask)
+   {
+      // For now, as `mask` is just a single boolean, as an optimization we can return early here if `mask == false`.
+      if (mask) {
+         fLoadedEntry = entry;
+         this->LoadImpl(entry, mask);
+      }
+   }
 
    /// Return the column value for the given entry.
    /// \tparam T The column type
@@ -36,13 +50,14 @@ public:
    /// The caller is responsible for checking that the returned value actually
    /// exists.
    template <typename T>
-   T *TryGet(Long64_t entry)
+   T *TryGet(std::size_t idx)
    {
-      return static_cast<T *>(GetImpl(entry));
+      return static_cast<T *>(GetImpl(idx));
    }
 
 private:
-   virtual void *GetImpl(Long64_t entry) = 0;
+   virtual void *GetImpl(std::size_t idx) = 0;
+   virtual void LoadImpl(Long64_t /*entry*/, bool /*mask*/) = 0;
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
@@ -24,7 +24,7 @@ class R__CLING_PTRCHECK(off) RDSColumnReader final : public ROOT::Detail::RDF::R
    T **fDSValuePtr = nullptr;
 
    void *GetImpl(std::size_t) final { return *fDSValuePtr; }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RDSColumnReader(void *DSValuePtr) : fDSValuePtr(static_cast<T **>(DSValuePtr)) {}

--- a/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDSColumnReader.hxx
@@ -23,7 +23,8 @@ template <typename T>
 class R__CLING_PTRCHECK(off) RDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    T **fDSValuePtr = nullptr;
 
-   void *GetImpl(Long64_t) final { return *fDSValuePtr; }
+   void *GetImpl(std::size_t) final { return *fDSValuePtr; }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RDSColumnReader(void *DSValuePtr) : fDSValuePtr(static_cast<T **>(DSValuePtr)) {}

--- a/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
@@ -57,9 +57,9 @@ class R__CLING_PTRCHECK(off) RDefaultValueFor final : public RDefineBase {
    /// The map key is the full variation name, e.g. "pt:up".
    std::unordered_map<std::string, std::unique_ptr<RDefineBase>> fVariedDefines;
 
-   T &GetValueOrDefault(unsigned int slot, Long64_t entry)
+   T &GetValueOrDefault(unsigned int slot, std::size_t idx)
    {
-      if (auto *value = fValues[slot]->template TryGet<T>(entry))
+      if (auto *value = fValues[slot]->template TryGet<T>(idx))
          return *value;
       else
          return fDefaultValue;
@@ -104,12 +104,15 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry) final
+   void Update(unsigned int slot, Long64_t entry, bool mask) final
    {
       if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
          // evaluate this define expression, cache the result
-         fLastResults[slot * RDFInternal::CacheLineStep<T>()] = GetValueOrDefault(slot, entry);
-         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+         fValues[slot]->Load(entry, mask);
+         if (mask) {
+            fLastResults[slot * RDFInternal::CacheLineStep<T>()] = GetValueOrDefault(slot, /*idx=*/0u);
+            fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+         }
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefaultValueFor.hxx
@@ -104,16 +104,20 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry, bool mask) final
+   void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) final
    {
-      if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
-         // evaluate this define expression, cache the result
-         fValues[slot]->Load(entry, mask);
-         if (mask) {
-            fLastResults[slot * RDFInternal::CacheLineStep<T>()] = GetValueOrDefault(slot, /*idx=*/0u);
-            fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
-         }
+      if (static_cast<Long64_t>(mask.GetFirstEntry()) ==
+          fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()])
+         return;
+
+      // Assume 1-size bulk for now
+      fValues[slot]->Load(mask);
+      const std::size_t bulkSize = 1;
+      for (std::size_t i = 0; i < bulkSize; ++i) {
+         if (mask[i])
+            fLastResults[slot * RDFInternal::CacheLineStep<T>()] = GetValueOrDefault(slot, i);
       }
+      fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = mask.GetFirstEntry();
    }
 
    void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo & /*id*/) final {}

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -71,39 +71,43 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    std::unordered_map<std::string, std::unique_ptr<RDefineBase>> fVariedDefines;
 
    template <typename ColType>
-   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, Long64_t entry) -> ColType &
+   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, std::size_t idx) -> ColType &
    {
-      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(entry))
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(idx))
          return *val;
 
       throw std::out_of_range{"RDataFrame: Define could not retrieve value for column '" + fColumnNames[readerIdx] +
-                              "' for entry " + std::to_string(entry) +
+                              "' for entry " + std::to_string(idx) +
                               ". You can use the DefaultValueFor operation to provide a default value, or "
                               "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>, NoneTag)
+   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
+                     std::index_sequence<S...>, NoneTag)
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(GetValueChecked<ColTypes>(slot, S, entry)...);
-      (void)entry; // avoid unused parameter warning (gcc 12.1)
+         fExpression(GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)idx; // avoid unused parameter warning (gcc 12.1)
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>, SlotTag)
+   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
+                     std::index_sequence<S...>, SlotTag)
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(slot, GetValueChecked<ColTypes>(slot, S, entry)...);
-      (void)entry; // avoid unused parameter warning (gcc 12.1)
+         fExpression(slot, GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)idx; // avoid unused parameter warning (gcc 12.1)
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void
-   UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>, SlotAndEntryTag)
+   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t batchFirstEntry, TypeList<ColTypes...>,
+                     std::index_sequence<S...>, SlotAndEntryTag)
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(slot, entry, GetValueChecked<ColTypes>(slot, S, entry)...);
+         fExpression(slot, batchFirstEntry + idx, GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)idx;             // avoid unused parameter warning (gcc 12.1)
+      (void)batchFirstEntry; // avoid unused parameter warning (gcc 12.1)
    }
 
 public:
@@ -134,12 +138,14 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry) final
+   void Update(unsigned int slot, Long64_t entry, bool mask) final
    {
       if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
-         // evaluate this define expression, cache the result
-         UpdateHelper(slot, entry, ColumnTypes_t{}, TypeInd_t{}, ExtraArgsTag{});
-         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
+         if (mask) {
+            UpdateHelper(slot, /*idx=*/0u, entry, ColumnTypes_t{}, TypeInd_t{}, ExtraArgsTag{});
+            fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+         }
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -83,31 +83,31 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
+   auto UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
                      std::index_sequence<S...>, NoneTag)
    {
-      fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(GetValueChecked<ColTypes>(slot, S, idx)...);
-      (void)idx; // avoid unused parameter warning (gcc 12.1)
+      return fExpression(GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)slot; // avoid unused parameter warning
+      (void)idx;  // avoid unused parameter warning
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
+   auto UpdateHelper(unsigned int slot, std::size_t idx, Long64_t /*entry*/, TypeList<ColTypes...>,
                      std::index_sequence<S...>, SlotTag)
    {
-      fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(slot, GetValueChecked<ColTypes>(slot, S, idx)...);
-      (void)idx; // avoid unused parameter warning (gcc 12.1)
+      return fExpression(slot, GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)slot; // avoid unused parameter warning
+      (void)idx;  // avoid unused parameter warning
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, std::size_t idx, Long64_t batchFirstEntry, TypeList<ColTypes...>,
+   auto UpdateHelper(unsigned int slot, std::size_t idx, Long64_t entryInBatch, TypeList<ColTypes...>,
                      std::index_sequence<S...>, SlotAndEntryTag)
    {
-      fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
-         fExpression(slot, batchFirstEntry + idx, GetValueChecked<ColTypes>(slot, S, idx)...);
-      (void)idx;             // avoid unused parameter warning (gcc 12.1)
-      (void)batchFirstEntry; // avoid unused parameter warning (gcc 12.1)
+      return fExpression(slot, entryInBatch, GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)slot;         // avoid unused parameter warning
+      (void)idx;          // avoid unused parameter warning
+      (void)entryInBatch; // avoid unused parameter warning
    }
 
 public:
@@ -138,13 +138,20 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry, bool mask) final
+   void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) final
    {
-      if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
-         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
-         if (mask) {
-            UpdateHelper(slot, /*idx=*/0u, entry, ColumnTypes_t{}, TypeInd_t{}, ExtraArgsTag{});
-            fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+      if (static_cast<Long64_t>(mask.GetFirstEntry()) ==
+          fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()])
+         return;
+
+      std::for_each(fValues[slot].begin(), fValues[slot].end(), [&mask](auto *v) { v->Load(mask); });
+      // Assume 1-size bulk for now
+      const std::size_t bulkSize = 1;
+      auto &result = fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()];
+      for (std::size_t i = 0; i < bulkSize; ++i) {
+         if (mask[i]) {
+            result = UpdateHelper(slot, i, mask.GetFirstEntry() + i, ColumnTypes_t{}, TypeInd_t{}, ExtraArgsTag{});
+            fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = mask.GetFirstEntry();
          }
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -63,7 +63,7 @@ public:
    std::string GetName() const;
    std::string GetTypeName() const;
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   virtual void Update(unsigned int slot, Long64_t entry) = 0;
+   virtual void Update(unsigned int slot, Long64_t entry, bool mask) = 0;
    /// Update function to be called once per sample, used if the derived type is a RDefinePerSample
    virtual void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo &/*id*/) {}
    /// Clean-up operations to be performed at the end of a task.

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -16,6 +16,7 @@
 #include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RVec.hxx"
+#include <ROOT/RDF/RMaskedEntryRange.hxx>
 
 #include <deque>
 #include <map>
@@ -40,7 +41,9 @@ class RDefineBase {
 protected:
    const std::string fName; ///< The name of the custom column
    const std::string fType; ///< The type of the custom column as a text string
-   std::vector<Long64_t> fLastCheckedEntry;
+   std::vector<Long64_t> fLastCheckedEntry; /// Starting entry of the last bulk processed, per slot
+   /// Which entries in the current bulk are valid, per slot
+   std::vector<ROOT::Internal::RDF::RMaskedEntryRange> fMaskPerSlot;
    RDFInternal::RColumnRegister fColRegister;
    RLoopManager *fLoopManager; // non-owning pointer to the RLoopManager
    const ROOT::RDF::ColumnNames_t fColumnNames;
@@ -63,7 +66,7 @@ public:
    std::string GetName() const;
    std::string GetTypeName() const;
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   virtual void Update(unsigned int slot, Long64_t entry, bool mask) = 0;
+   virtual void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) = 0;
    /// Update function to be called once per sample, used if the derived type is a RDefinePerSample
    virtual void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo &/*id*/) {}
    /// Clean-up operations to be performed at the end of a task.

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -59,7 +59,7 @@ public:
       return static_cast<void *>(&fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()]);
    }
 
-   void Update(unsigned int, Long64_t) final
+   void Update(unsigned int, Long64_t, bool) final
    {
       // no-op
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -59,7 +59,7 @@ public:
       return static_cast<void *>(&fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()]);
    }
 
-   void Update(unsigned int, Long64_t, bool) final
+   void Update(unsigned int, const ROOT::Internal::RDF::RMaskedEntryRange &) final
    {
       // no-op
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -42,11 +42,9 @@ class R__CLING_PTRCHECK(off) RDefineReader final : public ROOT::Detail::RDF::RCo
    /// The slot this value belongs to.
    unsigned int fSlot = std::numeric_limits<unsigned int>::max();
 
-   void *GetImpl(Long64_t entry) final
-   {
-      fDefine.Update(fSlot, entry);
-      return fValuePtr;
-   }
+   void *GetImpl(std::size_t /*idx*/) final { return fValuePtr; }
+
+   void LoadImpl(Long64_t entry, bool mask) final { fDefine.Update(fSlot, entry, mask); }
 
 public:
    RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define)

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -44,7 +44,7 @@ class R__CLING_PTRCHECK(off) RDefineReader final : public ROOT::Detail::RDF::RCo
 
    void *GetImpl(std::size_t /*idx*/) final { return fValuePtr; }
 
-   void LoadImpl(Long64_t entry, bool mask) final { fDefine.Update(fSlot, entry, mask); }
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask) final { fDefine.Update(fSlot, mask); }
 
 public:
    RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define)

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -93,35 +93,42 @@ public:
       fLoopManager->Deregister(this);
    }
 
-   bool CheckFilters(unsigned int slot, Long64_t entry) final
+   ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int slot, Long64_t entry) final
    {
-      auto &newMask = fLastResult[slot * RDFInternal::CacheLineStep<int>()];
-      auto &lastEntry = fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()];
+      auto &cachedResults = fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()];
+      if (entry == fLastCheckedEntry[slot * ROOT::Internal::RDF::CacheLineStep<Long64_t>()])
+         return {cachedResults, static_cast<std::uint64_t>(entry)};
 
-      if (entry != lastEntry) {
-         newMask = fPrevNode.CheckFilters(slot, entry);
-
-         // evaluate this filter, cache the result
-         std::for_each(fValues[slot].begin(), fValues[slot].end(),
-                       [entry, newMask](auto *v) { v->Load(entry, newMask); });
-         CheckFilterHelper(slot, /*idx=*/0u, newMask, ColumnTypes_t{}, TypeInd_t{});
-
-         lastEntry = entry;
+      auto mask = fPrevNode.CheckFilters(slot, entry);
+      std::for_each(fValues[slot].begin(), fValues[slot].end(), [&mask](auto *v) { v->Load(mask); });
+      // Assume 1-size bulk for now
+      const std::size_t bulkSize{1};
+      std::size_t accepted{0};
+      std::size_t rejected{0};
+      cachedResults.clear();
+      cachedResults.resize(bulkSize);
+      for (std::size_t i = 0; i < bulkSize; ++i) {
+         if (mask[i]) {
+            cachedResults[i] = CheckFilterHelper(slot, i, ColumnTypes_t{}, TypeInd_t{});
+            if (cachedResults[i])
+               ++accepted;
+            else
+               ++rejected;
+         }
       }
+      fLastCheckedEntry[slot * ROOT::Internal::RDF::CacheLineStep<Long64_t>()] = entry;
+      fAccepted[slot * RDFInternal::CacheLineStep<ULong64_t>()] += accepted;
+      fRejected[slot * RDFInternal::CacheLineStep<ULong64_t>()] += rejected;
 
-      return newMask;
+      return {cachedResults, static_cast<std::uint64_t>(entry)};
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void CheckFilterHelper(unsigned int slot, std::size_t idx, int &entryMask, TypeList<ColTypes...>,
-                          std::index_sequence<S...>)
+   bool CheckFilterHelper(unsigned int slot, std::size_t idx, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
-      if (entryMask) {
-         entryMask = fFilter(GetValueChecked<ColTypes>(slot, S, idx)...);
-         entryMask ? ++fAccepted[slot * RDFInternal::CacheLineStep<ULong64_t>()]
-                   : ++fRejected[slot * RDFInternal::CacheLineStep<ULong64_t>()];
-      }
-      (void)idx; // avoid unused parameter warning (gcc 12.1)
+      return fFilter(GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)slot; // avoid unused parameter warning
+      (void)idx;  // avoid unused parameter warning
    }
 
    template <typename ColType>

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -95,41 +95,45 @@ public:
 
    bool CheckFilters(unsigned int slot, Long64_t entry) final
    {
-      if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
-         if (!fPrevNode.CheckFilters(slot, entry)) {
-            // a filter upstream returned false, cache the result
-            fLastResult[slot * RDFInternal::CacheLineStep<int>()] = false;
-         } else {
-            // evaluate this filter, cache the result
-            auto passed = CheckFilterHelper(slot, entry, ColumnTypes_t{}, TypeInd_t{});
-            passed ? ++fAccepted[slot * RDFInternal::CacheLineStep<ULong64_t>()]
-                   : ++fRejected[slot * RDFInternal::CacheLineStep<ULong64_t>()];
-            fLastResult[slot * RDFInternal::CacheLineStep<int>()] = passed;
-         }
-         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = entry;
+      auto &newMask = fLastResult[slot * RDFInternal::CacheLineStep<int>()];
+      auto &lastEntry = fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()];
+
+      if (entry != lastEntry) {
+         newMask = fPrevNode.CheckFilters(slot, entry);
+
+         // evaluate this filter, cache the result
+         std::for_each(fValues[slot].begin(), fValues[slot].end(),
+                       [entry, newMask](auto *v) { v->Load(entry, newMask); });
+         CheckFilterHelper(slot, /*idx=*/0u, newMask, ColumnTypes_t{}, TypeInd_t{});
+
+         lastEntry = entry;
       }
-      return fLastResult[slot * RDFInternal::CacheLineStep<int>()];
-   }
 
-   template <typename ColType>
-   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, Long64_t entry) -> ColType &
-   {
-      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(entry))
-         return *val;
-
-      throw std::out_of_range{"RDataFrame: Filter could not retrieve value for column '" + fColumnNames[readerIdx] +
-                              "' for entry " + std::to_string(entry) +
-                              ". You can use the DefaultValueFor operation to provide a default value, or "
-                              "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
+      return newMask;
    }
 
    template <typename... ColTypes, std::size_t... S>
-   bool CheckFilterHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
+   void CheckFilterHelper(unsigned int slot, std::size_t idx, int &entryMask, TypeList<ColTypes...>,
+                          std::index_sequence<S...>)
    {
-      return fFilter(GetValueChecked<ColTypes>(slot, S, entry)...);
-      // avoid unused parameter warnings (gcc 12.1)
-      (void)slot;
-      (void)entry;
+      if (entryMask) {
+         entryMask = fFilter(GetValueChecked<ColTypes>(slot, S, idx)...);
+         entryMask ? ++fAccepted[slot * RDFInternal::CacheLineStep<ULong64_t>()]
+                   : ++fRejected[slot * RDFInternal::CacheLineStep<ULong64_t>()];
+      }
+      (void)idx; // avoid unused parameter warning (gcc 12.1)
+   }
+
+   template <typename ColType>
+   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, std::size_t idx) -> ColType &
+   {
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(idx))
+         return *val;
+
+      throw std::out_of_range{"RDataFrame: Filter could not retrieve value for column '" + fColumnNames[readerIdx] +
+                              "' for entry " + std::to_string(idx) +
+                              ". You can use the DefaultValueFor operation to provide a default value, or "
+                              "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -37,8 +37,6 @@ class RLoopManager;
 
 class RFilterBase : public RNodeBase {
 protected:
-   std::vector<Long64_t> fLastCheckedEntry;
-   std::vector<int> fLastResult = {true}; // std::vector<bool> cannot be used in a MT context safely
    std::vector<ULong64_t> fAccepted = {0};
    std::vector<ULong64_t> fRejected = {0};
    const std::string fName;
@@ -48,6 +46,8 @@ protected:
    ROOT::RVecB fIsDefine;
    std::string fVariation; ///< This indicates for what variation this filter evaluates values.
    std::unordered_map<std::string, std::shared_ptr<RFilterBase>> fVariedFilters;
+
+   std::vector<ROOT::RVec<bool>> fCachedResults{}; // Vector of cached results, per slot
 
 public:
    RFilterBase(RLoopManager *df, std::string_view name, const unsigned int nSlots,

--- a/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
@@ -102,24 +102,30 @@ public:
       constexpr static auto cacheLineStepint = RDFInternal::CacheLineStep<int>();
       constexpr static auto cacheLineStepULong64_t = RDFInternal::CacheLineStep<ULong64_t>();
 
-      if (entry != fLastCheckedEntry[slot * cacheLineStepLong64_t]) {
-         if (!fPrevNodePtr->CheckFilters(slot, entry)) {
-            // a filter upstream returned false, cache the result
-            fLastResult[slot * cacheLineStepint] = false;
-         } else {
-            // evaluate this filter, cache the result
-            const bool valueIsMissing = fValues[slot]->template TryGet<void>(entry) == nullptr;
-            if (fDiscardEntryWithMissingValue) {
-               valueIsMissing ? ++fRejected[slot * cacheLineStepULong64_t] : ++fAccepted[slot * cacheLineStepULong64_t];
-               fLastResult[slot * cacheLineStepint] = !valueIsMissing;
-            } else {
-               valueIsMissing ? ++fAccepted[slot * cacheLineStepULong64_t] : ++fRejected[slot * cacheLineStepULong64_t];
-               fLastResult[slot * cacheLineStepint] = valueIsMissing;
-            }
-         }
-         fLastCheckedEntry[slot * cacheLineStepLong64_t] = entry;
+      auto &newMask = fLastResult[slot * cacheLineStepint];
+      auto &lastEntry = fLastCheckedEntry[slot * cacheLineStepLong64_t];
+
+      if (entry == lastEntry)
+         return newMask;
+
+      newMask = fPrevNodePtr->CheckFilters(slot, entry);
+      if (!newMask)
+         return false;
+
+      fValues[slot]->Load(entry, newMask);
+
+      const bool valueIsMissing = fValues[slot]->template TryGet<void>(/*idx=*/0u) == nullptr;
+      if (fDiscardEntryWithMissingValue) {
+         valueIsMissing ? ++fRejected[slot * cacheLineStepULong64_t] : ++fAccepted[slot * cacheLineStepULong64_t];
+         newMask = !valueIsMissing;
+      } else {
+         valueIsMissing ? ++fAccepted[slot * cacheLineStepULong64_t] : ++fRejected[slot * cacheLineStepULong64_t];
+         newMask = valueIsMissing;
       }
-      return fLastResult[slot * cacheLineStepint];
+
+      lastEntry = entry;
+
+      return newMask;
    }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final

--- a/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterWithMissingValues.hxx
@@ -96,36 +96,40 @@ public:
       fLoopManager->EraseSuppressErrorsForMissingBranch(fColumnNames[0]);
    }
 
-   bool CheckFilters(unsigned int slot, Long64_t entry) final
+   ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int slot, Long64_t entry) final
    {
       constexpr static auto cacheLineStepLong64_t = RDFInternal::CacheLineStep<Long64_t>();
-      constexpr static auto cacheLineStepint = RDFInternal::CacheLineStep<int>();
       constexpr static auto cacheLineStepULong64_t = RDFInternal::CacheLineStep<ULong64_t>();
 
-      auto &newMask = fLastResult[slot * cacheLineStepint];
-      auto &lastEntry = fLastCheckedEntry[slot * cacheLineStepLong64_t];
+      if (entry == fLastCheckedEntry[slot * cacheLineStepLong64_t])
+         return {fCachedResults[slot], static_cast<std::uint64_t>(entry)};
 
-      if (entry == lastEntry)
-         return newMask;
+      // Assume 1-size bulk for now
+      const std::size_t bulkSize{1};
+      auto mask = fPrevNodePtr->CheckFilters(slot, entry);
 
-      newMask = fPrevNodePtr->CheckFilters(slot, entry);
-      if (!newMask)
-         return false;
+      fValues[slot]->Load(mask);
 
-      fValues[slot]->Load(entry, newMask);
+      std::size_t accepted{0};
+      std::size_t rejected{0};
+      fCachedResults[slot].clear();
+      fCachedResults[slot].resize(bulkSize);
+      for (std::size_t i = 0; i < bulkSize; i++) {
 
-      const bool valueIsMissing = fValues[slot]->template TryGet<void>(/*idx=*/0u) == nullptr;
-      if (fDiscardEntryWithMissingValue) {
-         valueIsMissing ? ++fRejected[slot * cacheLineStepULong64_t] : ++fAccepted[slot * cacheLineStepULong64_t];
-         newMask = !valueIsMissing;
-      } else {
-         valueIsMissing ? ++fAccepted[slot * cacheLineStepULong64_t] : ++fRejected[slot * cacheLineStepULong64_t];
-         newMask = valueIsMissing;
+         const bool valueIsMissing = fValues[slot]->template TryGet<void>(i) == nullptr;
+         if (fDiscardEntryWithMissingValue) {
+            valueIsMissing ? ++rejected : ++accepted;
+            fCachedResults[slot][i] = mask[i] && !valueIsMissing;
+         } else {
+            valueIsMissing ? ++accepted : ++rejected;
+            fCachedResults[slot][i] = mask[i] && valueIsMissing;
+         }
       }
+      fAccepted[slot * cacheLineStepULong64_t] += accepted;
+      fRejected[slot * cacheLineStepULong64_t] += rejected;
+      fLastCheckedEntry[slot * cacheLineStepLong64_t] = entry;
 
-      lastEntry = entry;
-
-      return newMask;
+      return {fCachedResults[slot], static_cast<std::uint64_t>(entry)};
    }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -58,7 +58,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void *GetValuePtr(unsigned int slot) final;
    const std::type_info &GetTypeId() const final;
-   void Update(unsigned int slot, Long64_t entry) final;
+   void Update(unsigned int slot, Long64_t entry, bool mask) final;
    void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id) final;
    void FinalizeSlot(unsigned int slot) final;
    void MakeVariations(const std::vector<std::string> &variations) final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -58,7 +58,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void *GetValuePtr(unsigned int slot) final;
    const std::type_info &GetTypeId() const final;
-   void Update(unsigned int slot, Long64_t entry, bool mask) final;
+   void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) final;
    void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id) final;
    void FinalizeSlot(unsigned int slot) final;
    void MakeVariations(const std::vector<std::string> &variations) final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -55,7 +55,7 @@ public:
    void SetFilter(std::unique_ptr<RFilterBase> f);
 
    void InitSlot(TTreeReader *r, unsigned int slot) final;
-   bool CheckFilters(unsigned int slot, Long64_t entry) final;
+   ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int, Long64_t) final;
    void Report(ROOT::RDF::RCutFlowReport &) const final;
    void PartialReport(ROOT::RDF::RCutFlowReport &) const final;
    void FillReport(ROOT::RDF::RCutFlowReport &) const final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
@@ -43,7 +43,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void *GetValuePtr(unsigned int slot, const std::string &column, const std::string &variation) final;
    const std::type_info &GetTypeId() const final;
-   void Update(unsigned int slot, Long64_t entry) final;
+   void Update(unsigned int slot, Long64_t entry, bool mask) final;
    void FinalizeSlot(unsigned int slot) final;
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
@@ -43,7 +43,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final;
    void *GetValuePtr(unsigned int slot, const std::string &column, const std::string &variation) final;
    const std::type_info &GetTypeId() const final;
-   void Update(unsigned int slot, Long64_t entry, bool mask) final;
+   void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) final;
    void FinalizeSlot(unsigned int slot) final;
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -27,7 +27,8 @@
 namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RLazyDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    ROOT::Internal::RDF::TPointerHolder *fPtr;
-   void *GetImpl(Long64_t) final { return fPtr->GetPointer(); }
+   void *GetImpl(std::size_t) final { return fPtr->GetPointer(); }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RLazyDSColumnReader(ROOT::Internal::RDF::TPointerHolder *ptr) : fPtr(ptr) {}

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -28,7 +28,7 @@ namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RLazyDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    ROOT::Internal::RDF::TPointerHolder *fPtr;
    void *GetImpl(std::size_t) final { return fPtr->GetPointer(); }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RLazyDSColumnReader(ROOT::Internal::RDF::TPointerHolder *ptr) : fPtr(ptr) {}

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -256,7 +256,7 @@ public:
    void Deregister(RDefineBase *definePtr);
    void Register(RDFInternal::RVariationBase *varPtr);
    void Deregister(RDFInternal::RVariationBase *varPtr);
-   bool CheckFilters(unsigned int, Long64_t) final;
+   ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int, Long64_t) final;
    unsigned int GetNSlots() const { return fNSlots; }
    void Report(ROOT::RDF::RCutFlowReport &rep) const final;
    /// End of recursive chain of calls, does nothing

--- a/tree/dataframe/inc/ROOT/RDF/RMaskedEntryRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMaskedEntryRange.hxx
@@ -1,0 +1,38 @@
+// Author: Enrico Guiraud, Vincenzo Eduardo Padulano
+
+/*************************************************************************
+ * Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RMASKEDENTRYRANGE
+#define ROOT_RDF_RMASKEDENTRYRANGE
+
+#include <ROOT/RVec.hxx>
+
+#include <cstdint>
+#include <cstddef>
+
+namespace ROOT::Internal::RDF {
+
+/// RDataFrame's internal representation of an entry range with a boolean mask.
+/// The mask has static size but depending on the dynamic bulk size fewer elements could be in use:
+/// do not take the size of the mask as the size of the bulk.
+class RMaskedEntryRange {
+   ROOT::RVec<bool> fMask{}; ///< Boolean mask. Its size is set at construction time.
+   std::uint64_t fBegin{};   ///< Entry number of the first entry in the range this mask corresponds to.
+
+public:
+   RMaskedEntryRange(std::size_t size, bool set = true, std::uint64_t entry = 0) : fMask(size, set), fBegin(entry) {}
+   RMaskedEntryRange(const ROOT::RVec<bool> &mask, std::uint64_t begin) : fMask(mask), fBegin(begin) {}
+   const bool &operator[](std::size_t idx) const { return fMask.at(idx); }
+   bool &operator[](std::size_t idx) { return fMask.at(idx); }
+   std::uint64_t GetFirstEntry() const { return fBegin; }
+   void SetFirstEntry(std::uint64_t e) { fBegin = e; }
+};
+
+} // namespace ROOT::Internal::RDF
+#endif

--- a/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
@@ -13,6 +13,8 @@
 
 #include "RtypesCore.h"
 #include "TError.h" // R__ASSERT
+#include <ROOT/RDF/RMaskedEntryRange.hxx>
+#include <ROOT/RDF/Utils.hxx>
 
 #include <memory>
 #include <string>
@@ -46,10 +48,13 @@ protected:
    unsigned int fNChildren{0};      ///< Number of nodes of the functional graph hanging from this object
    unsigned int fNStopsReceived{0}; ///< Number of times that a children node signaled to stop processing entries.
    std::vector<std::string> fVariations; ///< List of systematic variations that affect this node.
+   std::vector<Long64_t> fLastCheckedEntry;
 
 public:
-   RNodeBase(const std::vector<std::string> &variations = {}, RLoopManager *lm = nullptr)
-      : fLoopManager(lm), fVariations(variations)
+   RNodeBase(const std::vector<std::string> &variations = {}, RLoopManager *lm = nullptr, unsigned int nSlots = 1)
+      : fLoopManager(lm),
+        fVariations(variations),
+        fLastCheckedEntry(nSlots * ROOT::Internal::RDF::CacheLineStep<Long64_t>(), -1)
    {
    }
 
@@ -60,7 +65,7 @@ public:
    RNodeBase &operator=(RNodeBase &&) = delete;
    virtual ~RNodeBase() = default;
 
-   virtual bool CheckFilters(unsigned int, Long64_t) = 0;
+   virtual ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int, Long64_t) = 0;
    virtual void Report(ROOT::RDF::RCutFlowReport &) const = 0;
    virtual void PartialReport(ROOT::RDF::RCutFlowReport &) const = 0;
    virtual void IncrChildrenCount() = 0;

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -68,30 +68,36 @@ public:
    ~RRange() final { fLoopManager->Deregister(this); }
 
    /// Ranges act as filters when it comes to selecting entries that downstream nodes should process
-   bool CheckFilters(unsigned int slot, Long64_t entry) final
+   ROOT::Internal::RDF::RMaskedEntryRange CheckFilters(unsigned int slot, Long64_t entry) final
    {
-      if (entry != fLastCheckedEntry) {
-         if (fHasStopped)
-            return false;
-         if (!fPrevNode.CheckFilters(slot, entry)) {
-            // a filter upstream returned false, cache the result
-            fLastResult = false;
-         } else {
-            // apply range filter logic, cache the result
-            if (fNProcessedEntries < fStart || (fStop > 0 && fNProcessedEntries >= fStop) ||
-                (fStride != 1 && (fNProcessedEntries - fStart) % fStride != 0))
-               fLastResult = false;
-            else
-               fLastResult = true;
+      if (entry == fLastCheckedEntry[slot * ROOT::Internal::RDF::CacheLineStep<Long64_t>()])
+         return {fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()],
+                 static_cast<std::uint64_t>(entry)};
+
+      if (fHasStopped)
+         return {1ul, false, static_cast<std::uint64_t>(entry)};
+
+      // Assume 1-size bulk for now
+      fLastCheckedEntry[slot * ROOT::Internal::RDF::CacheLineStep<Long64_t>()] = entry;
+      auto mask = fPrevNode.CheckFilters(slot, entry);
+      const std::size_t bulkSize = 1;
+      fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()].clear();
+      fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()].resize(bulkSize);
+      for (std::size_t i = 0; i < bulkSize; ++i) {
+         if (mask[i]) {
+            fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()][i] =
+               fNProcessedEntries >= fStart && (fStop == 0 || fNProcessedEntries < fStop) &&
+               (fStride == 1 || (fNProcessedEntries - fStart) % fStride == 0);
             ++fNProcessedEntries;
-            if (fNProcessedEntries == fStop) {
-               fHasStopped = true;
-               fPrevNode.StopProcessing();
-            }
          }
-         fLastCheckedEntry = entry;
       }
-      return fLastResult;
+
+      if (fStop > 0 && fNProcessedEntries >= fStop) {
+         fHasStopped = true;
+         fPrevNode.StopProcessing();
+      }
+
+      return {fCachedResults[slot * RDFInternal::CacheLineStep<ROOT::RVec<bool>>()], static_cast<std::uint64_t>(entry)};
    }
 
    // recursive chain of `Report`s

--- a/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
@@ -35,12 +35,12 @@ protected:
    unsigned int fStart;
    unsigned int fStop;
    unsigned int fStride;
-   Long64_t fLastCheckedEntry{-1};
-   bool fLastResult{true};
    ULong64_t fNProcessedEntries{0};
    bool fHasStopped{false};    ///< True if the end of the range has been reached
    const unsigned int fNSlots; ///< Number of thread slots used by this node, inherited from parent node.
    std::unordered_map<std::string, std::shared_ptr<RRangeBase>> fVariedRanges;
+
+   std::vector<ROOT::RVec<bool>> fCachedResults;
 
 public:
    RRangeBase(RLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,

--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -38,7 +38,8 @@ namespace RDF {
 class R__CLING_PTRCHECK(off) RTreeOpaqueColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<ROOT::Internal::TTreeReaderOpaqueValue> fTreeValue;
 
-   void *GetImpl(Long64_t) override;
+   void *GetImpl(std::size_t) override;
+   void LoadImpl(Long64_t, bool) override;
 
 public:
    /// Construct the RTreeColumnReader. Actual initialization is performed lazily by the Init method.
@@ -57,7 +58,8 @@ public:
 class R__CLING_PTRCHECK(off) RTreeUntypedValueColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<ROOT::Internal::TTreeReaderUntypedValue> fTreeValue;
 
-   void *GetImpl(Long64_t) override;
+   void *GetImpl(std::size_t) override;
+   void LoadImpl(Long64_t, bool) override;
 
 public:
    RTreeUntypedValueColumnReader(TTreeReader &r, std::string_view colName, std::string_view typeName);
@@ -111,11 +113,14 @@ private:
    /// Whether we already printed a warning about performing a copy of the TTreeReaderArray contents
    bool fCopyWarningPrinted = false;
 
-   void *GetImpl(Long64_t entry) override;
+   void *fValuePtr{nullptr};
 
-   void *ReadStdArray(Long64_t entry);
-   void *ReadStdVector(Long64_t entry);
-   void *ReadRVec(Long64_t entry);
+   void *GetImpl(std::size_t) override;
+   void LoadImpl(Long64_t, bool) override;
+
+   void *LoadStdArray(Long64_t entry);
+   void *LoadStdVector(Long64_t entry);
+   void *LoadRVec(Long64_t entry);
 };
 
 class R__CLING_PTRCHECK(off) RMaskedColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
@@ -123,7 +128,9 @@ class R__CLING_PTRCHECK(off) RMaskedColumnReader : public ROOT::Detail::RDF::RCo
    std::unique_ptr<TTreeReaderValue<uint64_t>> fTreeValueMask;
    unsigned int fMaskIndex = 0;
 
-   void *GetImpl(Long64_t) override;
+   void *fValuePtr{nullptr};
+   void *GetImpl(std::size_t) override;
+   void LoadImpl(Long64_t, bool) override;
 
 public:
    RMaskedColumnReader(TTreeReader &r, std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase> valueReader,

--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -37,9 +37,10 @@ namespace RDF {
 
 class R__CLING_PTRCHECK(off) RTreeOpaqueColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<ROOT::Internal::TTreeReaderOpaqueValue> fTreeValue;
+   void *fValuePtr{nullptr};
 
    void *GetImpl(std::size_t) override;
-   void LoadImpl(Long64_t, bool) override;
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) override;
 
 public:
    /// Construct the RTreeColumnReader. Actual initialization is performed lazily by the Init method.
@@ -57,9 +58,10 @@ public:
 /// RTreeColumnReader specialization for TTree values read via TTreeReaderUntypedValue
 class R__CLING_PTRCHECK(off) RTreeUntypedValueColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<ROOT::Internal::TTreeReaderUntypedValue> fTreeValue;
+   void *fValuePtr{nullptr};
 
    void *GetImpl(std::size_t) override;
-   void LoadImpl(Long64_t, bool) override;
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) override;
 
 public:
    RTreeUntypedValueColumnReader(TTreeReader &r, std::string_view colName, std::string_view typeName);
@@ -116,7 +118,7 @@ private:
    void *fValuePtr{nullptr};
 
    void *GetImpl(std::size_t) override;
-   void LoadImpl(Long64_t, bool) override;
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) override;
 
    void *LoadStdArray(Long64_t entry);
    void *LoadStdVector(Long64_t entry);
@@ -130,7 +132,7 @@ class R__CLING_PTRCHECK(off) RMaskedColumnReader : public ROOT::Detail::RDF::RCo
 
    void *fValuePtr{nullptr};
    void *GetImpl(std::size_t) override;
-   void LoadImpl(Long64_t, bool) override;
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) override;
 
 public:
    RMaskedColumnReader(TTreeReader &r, std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase> valueReader,

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -230,14 +230,18 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry, bool mask) final
+   void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) final
    {
-      if (entry != fLastCheckedEntry[slot * CacheLineStep<Long64_t>()]) {
-         // evaluate this filter, cache the result
-         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
-         if (mask) {
-            UpdateHelper(slot, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
-            fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = entry;
+      if (static_cast<Long64_t>(mask.GetFirstEntry()) == fLastCheckedEntry[slot * CacheLineStep<Long64_t>()])
+         return;
+
+      std::for_each(fValues[slot].begin(), fValues[slot].end(), [&mask](auto *v) { v->Load(mask); });
+      // Assume 1-size bulk for now
+      const std::size_t bulkSize = 1;
+      for (std::size_t i = 0; i < bulkSize; ++i) {
+         if (mask[i]) {
+            UpdateHelper(slot, i, ColumnTypes_t{}, TypeInd_t{});
+            fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = mask.GetFirstEntry();
          }
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -160,23 +160,23 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>> fValues;
 
    template <typename ColType>
-   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, Long64_t entry) -> ColType &
+   auto GetValueChecked(unsigned int slot, std::size_t readerIdx, std::size_t idx) -> ColType &
    {
-      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(entry))
+      if (auto *val = fValues[slot][readerIdx]->template TryGet<ColType>(idx))
          return *val;
 
       throw std::out_of_range{"RDataFrame: Could not retrieve value for variation '" + fColNames[readerIdx] +
-                              "' for entry " + std::to_string(entry) +
+                              "' for entry " + std::to_string(idx) +
                               ". You can use the DefaultValueFor operation to provide a default value, or "
                               "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
    template <typename... ColTypes, std::size_t... S>
-   void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
+   void UpdateHelper(unsigned int slot, std::size_t idx, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
       // fExpression must return an RVec<T>
-      auto &&results = fExpression(GetValueChecked<ColTypes>(slot, S, entry)...);
-      (void)entry; // avoid unused parameter warnings (gcc 12.1)
+      auto &&results = fExpression(GetValueChecked<ColTypes>(slot, S, idx)...);
+      (void)idx; // avoid unused parameter warnings (gcc 12.1)
 
       if (!ResultsSizeEq(results, fVariationNames.size(), fColNames.size(),
                          std::integral_constant<bool, IsSingleColumn>{})) {
@@ -230,12 +230,15 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, Long64_t entry) final
+   void Update(unsigned int slot, Long64_t entry, bool mask) final
    {
       if (entry != fLastCheckedEntry[slot * CacheLineStep<Long64_t>()]) {
          // evaluate this filter, cache the result
-         UpdateHelper(slot, entry, ColumnTypes_t{}, TypeInd_t{});
-         fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = entry;
+         std::for_each(fValues[slot].begin(), fValues[slot].end(), [entry, mask](auto *v) { v->Load(entry, mask); });
+         if (mask) {
+            UpdateHelper(slot, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
+            fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = entry;
+         }
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariationBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationBase.hxx
@@ -70,7 +70,7 @@ public:
    const std::string &GetVariationName() const;
    std::string GetTypeName() const;
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   virtual void Update(unsigned int slot, Long64_t entry) = 0;
+   virtual void Update(unsigned int slot, Long64_t entry, bool mask) = 0;
    /// Clean-up operations to be performed at the end of a task.
    virtual void FinalizeSlot(unsigned int slot) = 0;
 };

--- a/tree/dataframe/inc/ROOT/RDF/RVariationBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationBase.hxx
@@ -14,6 +14,7 @@
 #include <ROOT/RDF/RColumnRegister.hxx>
 #include <ROOT/RDF/Utils.hxx> // ColumnNames_t
 #include <ROOT/RVec.hxx>
+#include <ROOT/RDF/RMaskedEntryRange.hxx>
 
 #include <array>
 #include <deque>
@@ -70,7 +71,7 @@ public:
    const std::string &GetVariationName() const;
    std::string GetTypeName() const;
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   virtual void Update(unsigned int slot, Long64_t entry, bool mask) = 0;
+   virtual void Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask) = 0;
    /// Clean-up operations to be performed at the end of a task.
    virtual void FinalizeSlot(unsigned int slot) = 0;
 };

--- a/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
@@ -32,11 +32,9 @@ class R__CLING_PTRCHECK(off) RVariationReader final : public ROOT::Detail::RDF::
    /// The slot this value belongs to.
    unsigned int fSlot = std::numeric_limits<unsigned int>::max();
 
-   void *GetImpl(Long64_t entry) final
-   {
-      fVariation->Update(fSlot, entry);
-      return fValuePtr;
-   }
+   void *GetImpl(std::size_t /*idx*/) final { return fValuePtr; }
+
+   void LoadImpl(Long64_t entry, bool mask) final { fVariation->Update(fSlot, entry, mask); }
 
 public:
    RVariationReader(unsigned int slot, const std::string &colName, const std::string &variationName,

--- a/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
@@ -34,7 +34,7 @@ class R__CLING_PTRCHECK(off) RVariationReader final : public ROOT::Detail::RDF::
 
    void *GetImpl(std::size_t /*idx*/) final { return fValuePtr; }
 
-   void LoadImpl(Long64_t entry, bool mask) final { fVariation->Update(fSlot, entry, mask); }
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask) final { fVariation->Update(fSlot, mask); }
 
 public:
    RVariationReader(unsigned int slot, const std::string &colName, const std::string &variationName,

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -166,9 +166,10 @@ public:
       for (auto varIdx = 0u; varIdx < GetVariations().size(); ++varIdx) {
          const auto mask = fPrevNodes[varIdx]->CheckFilters(slot, entry);
          std::for_each(fInputValues[slot][varIdx].begin(), fInputValues[slot][varIdx].end(),
-                       [entry, mask](auto *v) { v->Load(entry, mask); });
+                       [&mask](auto *v) { v->Load(mask); });
 
-         if (mask)
+         // Assume 1-size bulk for now
+         if (mask[0])
             CallExec(slot, varIdx, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -141,31 +141,35 @@ public:
    }
 
    template <typename ColType>
-   auto GetValueChecked(unsigned int slot, unsigned int varIdx, std::size_t readerIdx, Long64_t entry) -> ColType &
+   auto GetValueChecked(unsigned int slot, unsigned int varIdx, std::size_t readerIdx, std::size_t idx) -> ColType &
    {
-      if (auto *val = fInputValues[slot][varIdx][readerIdx]->template TryGet<ColType>(entry))
+      if (auto *val = fInputValues[slot][varIdx][readerIdx]->template TryGet<ColType>(idx))
          return *val;
 
       throw std::out_of_range{"RDataFrame: Varied action (" + fHelpers[0].GetActionName() +
                               ") could not retrieve value for column '" + fColumnNames[readerIdx] + "' for entry " +
-                              std::to_string(entry) +
+                              std::to_string(idx) +
                               ". You can use the DefaultValueFor operation to provide a default value, or "
                               "FilterAvailable/FilterMissing to discard/keep entries with missing values instead."};
    }
 
    template <typename... ColTypes, std::size_t... ReaderIdxs>
-   void CallExec(unsigned int slot, unsigned int varIdx, Long64_t entry, TypeList<ColTypes...>,
+   void CallExec(unsigned int slot, unsigned int varIdx, std::size_t idx, TypeList<ColTypes...>,
                  std::index_sequence<ReaderIdxs...>)
    {
-      fHelpers[varIdx].Exec(slot, GetValueChecked<ColTypes>(slot, varIdx, ReaderIdxs, entry)...);
-      (void)entry;
+      fHelpers[varIdx].Exec(slot, GetValueChecked<ColTypes>(slot, varIdx, ReaderIdxs, idx)...);
+      (void)idx;
    }
 
    void Run(unsigned int slot, Long64_t entry) final
    {
       for (auto varIdx = 0u; varIdx < GetVariations().size(); ++varIdx) {
-         if (fPrevNodes[varIdx]->CheckFilters(slot, entry))
-            CallExec(slot, varIdx, entry, ColumnTypes_t{}, TypeInd_t{});
+         const auto mask = fPrevNodes[varIdx]->CheckFilters(slot, entry);
+         std::for_each(fInputValues[slot][varIdx].begin(), fInputValues[slot][varIdx].end(),
+                       [entry, mask](auto *v) { v->Load(entry, mask); });
+
+         if (mask)
+            CallExec(slot, varIdx, /*idx=*/0u, ColumnTypes_t{}, TypeInd_t{});
       }
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/SnapshotHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/SnapshotHelpers.hxx
@@ -299,7 +299,8 @@ public:
 
    void InitTask(TTreeReader *, unsigned int slot);
 
-   void Exec(unsigned int /*slot*/, const std::vector<void *> &values, std::vector<bool> const &filterPassed);
+   void Exec(unsigned int /*slot*/, const std::vector<void *> &values,
+             std::vector<ROOT::Internal::RDF::RMaskedEntryRange> const &filterPassed);
 
    /// Nothing to do. All initialisations run in the constructor or InitTask().
    void Initialize() {}

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -22,7 +22,8 @@
 namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RSqliteDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    void *fValuePtr;
-   void *GetImpl(Long64_t) final { return fValuePtr; }
+   void *GetImpl(std::size_t) final { return fValuePtr; }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RSqliteDSColumnReader(void *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RSqliteDS.hxx
+++ b/tree/dataframe/inc/ROOT/RSqliteDS.hxx
@@ -23,7 +23,7 @@ namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RSqliteDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    void *fValuePtr;
    void *GetImpl(std::size_t) final { return fValuePtr; }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RSqliteDSColumnReader(void *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -17,7 +17,8 @@
 namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RTrivialDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    ULong64_t *fValuePtr;
-   void *GetImpl(Long64_t) final { return fValuePtr; }
+   void *GetImpl(std::size_t) final { return fValuePtr; }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RTrivialDSColumnReader(ULong64_t *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -18,7 +18,7 @@ namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RTrivialDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    ULong64_t *fValuePtr;
    void *GetImpl(std::size_t) final { return fValuePtr; }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RTrivialDSColumnReader(ULong64_t *valuePtr) : fValuePtr(valuePtr) {}

--- a/tree/dataframe/inc/ROOT/RVecDS.hxx
+++ b/tree/dataframe/inc/ROOT/RVecDS.hxx
@@ -30,7 +30,8 @@ namespace ROOT::Internal::RDF {
 
 class R__CLING_PTRCHECK(off) RVecDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    TPointerHolder *fPtrHolder;
-   void *GetImpl(Long64_t) final { return fPtrHolder->GetPointer(); }
+   void *GetImpl(std::size_t) final { return fPtrHolder->GetPointer(); }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RVecDSColumnReader(TPointerHolder *ptrHolder) : fPtrHolder(ptrHolder) {}

--- a/tree/dataframe/inc/ROOT/RVecDS.hxx
+++ b/tree/dataframe/inc/ROOT/RVecDS.hxx
@@ -31,7 +31,7 @@ namespace ROOT::Internal::RDF {
 class R__CLING_PTRCHECK(off) RVecDSColumnReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    TPointerHolder *fPtrHolder;
    void *GetImpl(std::size_t) final { return fPtrHolder->GetPointer(); }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RVecDSColumnReader(TPointerHolder *ptrHolder) : fPtrHolder(ptrHolder) {}

--- a/tree/dataframe/src/RDFSnapshotHelpers.cxx
+++ b/tree/dataframe/src/RDFSnapshotHelpers.cxx
@@ -1222,9 +1222,11 @@ void ROOT::Internal::RDF::SnapshotHelperWithVariations::InitTask(TTreeReader *, 
 
 /// Connect all output fields to the values pointed to by `values`, fill the output dataset,
 /// call the Fill of the output tree, and clear the mask bits that show whether a variation was reached.
-void ROOT::Internal::RDF::SnapshotHelperWithVariations::Exec(unsigned int /*slot*/, const std::vector<void *> &values,
-                                                             std::vector<bool> const &filterPassed)
+void ROOT::Internal::RDF::SnapshotHelperWithVariations::Exec(
+   unsigned int /*slot*/, const std::vector<void *> &values,
+   std::vector<ROOT::Internal::RDF::RMaskedEntryRange> const &filterPassed)
 {
+   // Assume 1-size bulk for now
    // Rebind branch pointers to RDF values
    assert(fBranchData.size() == values.size());
    for (std::size_t i = 0; i < values.size(); i++) {
@@ -1234,14 +1236,14 @@ void ROOT::Internal::RDF::SnapshotHelperWithVariations::Exec(unsigned int /*slot
          SetBranchesHelper(fInputTree, *fOutputHandle->fTree, fBranchData, i, fOptions.fBasketSize, values[i]);
       } else {
          // Nominal will always be written, systematics only if needed
-         if (variationIndex == 0 || filterPassed[variationIndex]) {
+         if (variationIndex == 0 || filterPassed[variationIndex][0]) {
             const bool fundamentalType = fBranchData[i].WriteValueIfFundamental(values[i]);
             if (!fundamentalType) {
                SetBranchesHelper(fInputTree, *fOutputHandle->fTree, fBranchData, i, fOptions.fBasketSize, values[i]);
             }
          }
 
-         if (filterPassed[variationIndex]) {
+         if (filterPassed[variationIndex][0]) {
             fOutputHandle->SetMaskBit(variationIndex);
          }
       }

--- a/tree/dataframe/src/RFilterBase.cxx
+++ b/tree/dataframe/src/RFilterBase.cxx
@@ -19,12 +19,15 @@ using namespace ROOT::Detail::RDF;
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots,
                          const RDFInternal::RColumnRegister &colRegister, const ColumnNames_t &columns,
                          const std::vector<std::string> &prevVariations, const std::string &variation)
-   : RNodeBase(ROOT::Internal::RDF::Union(colRegister.GetVariationDeps(columns), prevVariations), implPtr),
-     fLastCheckedEntry(nSlots * RDFInternal::CacheLineStep<Long64_t>(), -1),
-     fLastResult(nSlots * RDFInternal::CacheLineStep<int>()),
+   : RNodeBase(ROOT::Internal::RDF::Union(colRegister.GetVariationDeps(columns), prevVariations), implPtr, nSlots),
      fAccepted(nSlots * RDFInternal::CacheLineStep<ULong64_t>()),
-     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()), fName(name), fColumnNames(columns),
-     fColRegister(colRegister), fIsDefine(columns.size()), fVariation(variation)
+     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()),
+     fName(name),
+     fColumnNames(columns),
+     fColRegister(colRegister),
+     fIsDefine(columns.size()),
+     fVariation(variation),
+     fCachedResults(nSlots * RDFInternal::CacheLineStep<ROOT::RVec<bool>>())
 {
    const auto nColumns = fColumnNames.size();
    for (auto i = 0u; i < nColumns; ++i) {

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -39,10 +39,10 @@ const std::type_info &RJittedDefine::GetTypeId() const
                                "retrieved. This should never happen, please report this as a bug.");
 }
 
-void RJittedDefine::Update(unsigned int slot, Long64_t entry)
+void RJittedDefine::Update(unsigned int slot, Long64_t entry, bool mask)
 {
    assert(fConcreteDefine != nullptr);
-   fConcreteDefine->Update(slot, entry);
+   fConcreteDefine->Update(slot, entry, mask);
 }
 
 void RJittedDefine::Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -39,10 +39,10 @@ const std::type_info &RJittedDefine::GetTypeId() const
                                "retrieved. This should never happen, please report this as a bug.");
 }
 
-void RJittedDefine::Update(unsigned int slot, Long64_t entry, bool mask)
+void RJittedDefine::Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask)
 {
    assert(fConcreteDefine != nullptr);
-   fConcreteDefine->Update(slot, entry, mask);
+   fConcreteDefine->Update(slot, mask);
 }
 
 void RJittedDefine::Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -55,7 +55,7 @@ void RJittedFilter::InitSlot(TTreeReader *r, unsigned int slot)
    fConcreteFilter->InitSlot(r, slot);
 }
 
-bool RJittedFilter::CheckFilters(unsigned int slot, Long64_t entry)
+ROOT::Internal::RDF::RMaskedEntryRange RJittedFilter::CheckFilters(unsigned int slot, Long64_t entry)
 {
    assert(fConcreteFilter != nullptr);
    return fConcreteFilter->CheckFilters(slot, entry);

--- a/tree/dataframe/src/RJittedVariation.cxx
+++ b/tree/dataframe/src/RJittedVariation.cxx
@@ -34,10 +34,10 @@ const std::type_info &RJittedVariation::GetTypeId() const
    return fConcreteVariation->GetTypeId();
 }
 
-void RJittedVariation::Update(unsigned int slot, Long64_t entry)
+void RJittedVariation::Update(unsigned int slot, Long64_t entry, bool mask)
 {
    assert(fConcreteVariation != nullptr);
-   fConcreteVariation->Update(slot, entry);
+   fConcreteVariation->Update(slot, entry, mask);
 }
 
 void RJittedVariation::FinalizeSlot(unsigned int slot)

--- a/tree/dataframe/src/RJittedVariation.cxx
+++ b/tree/dataframe/src/RJittedVariation.cxx
@@ -34,10 +34,10 @@ const std::type_info &RJittedVariation::GetTypeId() const
    return fConcreteVariation->GetTypeId();
 }
 
-void RJittedVariation::Update(unsigned int slot, Long64_t entry, bool mask)
+void RJittedVariation::Update(unsigned int slot, const ROOT::Internal::RDF::RMaskedEntryRange &mask)
 {
    assert(fConcreteVariation != nullptr);
-   fConcreteVariation->Update(slot, entry, mask);
+   fConcreteVariation->Update(slot, mask);
 }
 
 void RJittedVariation::FinalizeSlot(unsigned int slot)

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1058,9 +1058,10 @@ void RLoopManager::Deregister(RDFInternal::RVariationBase *v)
 }
 
 // dummy call, end of recursive chain of calls
-bool RLoopManager::CheckFilters(unsigned int, Long64_t)
+ROOT::Internal::RDF::RMaskedEntryRange RLoopManager::CheckFilters(unsigned int, Long64_t entry)
 {
-   return true;
+   // Assume 1-size bulk for now
+   return ROOT::Internal::RDF::RMaskedEntryRange{1ul, true, static_cast<std::uint64_t>(entry)};
 }
 
 /// Call `FillReport` on all booked filters

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -270,13 +270,14 @@ public:
       fLastEntry = -1;
    }
 
-   void *GetImpl(Long64_t entry) final
+   void *GetImpl(std::size_t /*idx*/) final { return fValue->GetPtr<void>().get(); }
+
+   void LoadImpl(Long64_t entry, bool mask) final
    {
-      if (entry != fLastEntry) {
+      if (entry != fLastEntry && mask) {
          fValue->Read(entry - fEntryOffset);
          fLastEntry = entry;
       }
-      return fValue->GetPtr<void>().get();
    }
 };
 } // namespace ROOT::Internal::RDF

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -204,7 +204,6 @@ class RNTupleColumnReader : public ROOT::Detail::RDF::RColumnReaderBase {
    std::unique_ptr<RFieldBase> fField;         ///< The field backing the RDF column
    std::unique_ptr<RFieldBase::RValue> fValue; ///< The memory location used to read from fField
    std::shared_ptr<void> fValuePtr;            ///< Used to reuse the object created by fValue when reconnecting sources
-   Long64_t fLastEntry = -1;                   ///< Last entry number that was read
    /// For chains, the logical entry and the physical entry in any particular file can be different.
    /// The entry offset stores the logical entry number (sum of all previous physical entries) when a file of the
    /// corresponding data source was opened.
@@ -217,7 +216,6 @@ public:
    /// Connect the field and its subfields to the page source
    void Connect(RPageSource &source, Long64_t entryOffset)
    {
-      assert(fLastEntry == -1);
 
       fEntryOffset = entryOffset;
 
@@ -267,16 +265,15 @@ public:
       }
       fValue = nullptr;
       fField = nullptr;
-      fLastEntry = -1;
    }
 
    void *GetImpl(std::size_t /*idx*/) final { return fValue->GetPtr<void>().get(); }
 
-   void LoadImpl(Long64_t entry, bool mask) final
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask) final
    {
-      if (entry != fLastEntry && mask) {
-         fValue->Read(entry - fEntryOffset);
-         fLastEntry = entry;
+      // Assume 1-size bulk for now
+      if (mask[0]) {
+         fValue->Read(mask.GetFirstEntry() - fEntryOffset);
       }
    }
 };

--- a/tree/dataframe/src/RRangeBase.cxx
+++ b/tree/dataframe/src/RRangeBase.cxx
@@ -14,13 +14,17 @@ using ROOT::Detail::RDF::RRangeBase;
 
 RRangeBase::RRangeBase(RLoopManager *implPtr, unsigned int start, unsigned int stop, unsigned int stride,
                        const unsigned int nSlots, const std::vector<std::string> &prevVariations)
-   : RNodeBase(prevVariations, implPtr), fStart(start), fStop(stop), fStride(stride), fNSlots(nSlots)
+   : RNodeBase(prevVariations, implPtr, nSlots),
+     fStart(start),
+     fStop(stop),
+     fStride(stride),
+     fNSlots(nSlots),
+     fCachedResults(nSlots * ROOT::Internal::RDF::CacheLineStep<ROOT::RVec<bool>>())
 {
 }
 
 void RRangeBase::InitNode()
 {
-   fLastCheckedEntry = -1;
    fNProcessedEntries = 0;
    fHasStopped = false;
 }

--- a/tree/dataframe/src/RTreeColumnReader.cxx
+++ b/tree/dataframe/src/RTreeColumnReader.cxx
@@ -7,10 +7,15 @@
 
 void *ROOT::Internal::RDF::RTreeOpaqueColumnReader::GetImpl(std::size_t)
 {
-   return fTreeValue->GetAddress();
+   return fValuePtr;
 }
 
-void ROOT::Internal::RDF::RTreeOpaqueColumnReader::LoadImpl(Long64_t, bool) {}
+void ROOT::Internal::RDF::RTreeOpaqueColumnReader::LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask)
+{
+   // Assume size-1 bulk for now
+   if (mask[0])
+      fValuePtr = fTreeValue->GetAddress();
+}
 
 ROOT::Internal::RDF::RTreeOpaqueColumnReader::RTreeOpaqueColumnReader(TTreeReader &r, std::string_view colName)
    : fTreeValue(std::make_unique<ROOT::Internal::TTreeReaderOpaqueValue>(r, colName.data()))
@@ -21,10 +26,15 @@ ROOT::Internal::RDF::RTreeOpaqueColumnReader::~RTreeOpaqueColumnReader() = defau
 
 void *ROOT::Internal::RDF::RTreeUntypedValueColumnReader::GetImpl(std::size_t)
 {
-   return fTreeValue->Get();
+   return fValuePtr;
 }
 
-void ROOT::Internal::RDF::RTreeUntypedValueColumnReader::LoadImpl(Long64_t, bool) {}
+void ROOT::Internal::RDF::RTreeUntypedValueColumnReader::LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask)
+{
+   // Assume size-1 bulk for now
+   if (mask[0])
+      fValuePtr = fTreeValue->Get();
+}
 
 ROOT::Internal::RDF::RTreeUntypedValueColumnReader::RTreeUntypedValueColumnReader(TTreeReader &r,
                                                                                   std::string_view colName,
@@ -164,19 +174,20 @@ void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadRVec(Long64_t entr
    return &fRVec;
 }
 
-void ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadImpl(Long64_t entry, bool mask)
+void ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask)
 {
-   if (entry != fLastEntry && mask) {
+   // Assume size-1 bulk for now
+   if (mask[0]) {
       if (fCollectionType == ECollectionType::kStdArray)
-         fValuePtr = LoadStdArray(entry);
+         fValuePtr = LoadStdArray(mask.GetFirstEntry());
       else if (fCollectionType == ECollectionType::kStdVector)
-         fValuePtr = LoadStdVector(entry);
+         fValuePtr = LoadStdVector(mask.GetFirstEntry());
       else
-         fValuePtr = LoadRVec(entry);
+         fValuePtr = LoadRVec(mask.GetFirstEntry());
    }
 }
 
-void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::GetImpl(std::size_t /*idx*/)
+void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::GetImpl(std::size_t)
 {
    return fValuePtr;
 }
@@ -208,9 +219,9 @@ void *ROOT::Internal::RDF::RMaskedColumnReader::GetImpl(std::size_t)
    return fValuePtr;
 }
 
-void ROOT::Internal::RDF::RMaskedColumnReader::LoadImpl(Long64_t entry, bool mask)
+void ROOT::Internal::RDF::RMaskedColumnReader::LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &mask)
 {
-   if (!mask) {
+   if (!mask[0]) {
       fValuePtr = nullptr;
       return;
    }
@@ -221,6 +232,6 @@ void ROOT::Internal::RDF::RMaskedColumnReader::LoadImpl(Long64_t entry, bool mas
       return;
    }
 
-   fValueReader->Load(entry, mask);
+   fValueReader->Load(mask);
    fValuePtr = fValueReader->TryGet<void>(/*idx=*/0u);
 }

--- a/tree/dataframe/src/RTreeColumnReader.cxx
+++ b/tree/dataframe/src/RTreeColumnReader.cxx
@@ -5,10 +5,12 @@
 
 #include <bitset>
 
-void *ROOT::Internal::RDF::RTreeOpaqueColumnReader::GetImpl(Long64_t)
+void *ROOT::Internal::RDF::RTreeOpaqueColumnReader::GetImpl(std::size_t)
 {
    return fTreeValue->GetAddress();
 }
+
+void ROOT::Internal::RDF::RTreeOpaqueColumnReader::LoadImpl(Long64_t, bool) {}
 
 ROOT::Internal::RDF::RTreeOpaqueColumnReader::RTreeOpaqueColumnReader(TTreeReader &r, std::string_view colName)
    : fTreeValue(std::make_unique<ROOT::Internal::TTreeReaderOpaqueValue>(r, colName.data()))
@@ -17,10 +19,12 @@ ROOT::Internal::RDF::RTreeOpaqueColumnReader::RTreeOpaqueColumnReader(TTreeReade
 
 ROOT::Internal::RDF::RTreeOpaqueColumnReader::~RTreeOpaqueColumnReader() = default;
 
-void *ROOT::Internal::RDF::RTreeUntypedValueColumnReader::GetImpl(Long64_t)
+void *ROOT::Internal::RDF::RTreeUntypedValueColumnReader::GetImpl(std::size_t)
 {
    return fTreeValue->Get();
 }
+
+void ROOT::Internal::RDF::RTreeUntypedValueColumnReader::LoadImpl(Long64_t, bool) {}
 
 ROOT::Internal::RDF::RTreeUntypedValueColumnReader::RTreeUntypedValueColumnReader(TTreeReader &r,
                                                                                   std::string_view colName,
@@ -31,7 +35,7 @@ ROOT::Internal::RDF::RTreeUntypedValueColumnReader::RTreeUntypedValueColumnReade
 
 ROOT::Internal::RDF::RTreeUntypedValueColumnReader::~RTreeUntypedValueColumnReader() = default;
 
-void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadStdArray(Long64_t entry)
+void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadStdArray(Long64_t entry)
 {
    if (entry == fLastEntry)
       return fRVec.data(); // We return the RVec we already created
@@ -61,7 +65,7 @@ void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadStdArray(Long64_t 
    return fRVec.data();
 }
 
-void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadStdVector(Long64_t entry)
+void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadStdVector(Long64_t entry)
 {
    if (entry == fLastEntry)
       return &fStdVector; // We return the std::vector we already created
@@ -95,7 +99,7 @@ void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadStdVector(Long64_t
    return &fStdVector;
 }
 
-void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadRVec(Long64_t entry)
+void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadRVec(Long64_t entry)
 {
    if (entry == fLastEntry)
       return &fRVec; // We return the RVec we already created
@@ -160,15 +164,21 @@ void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::ReadRVec(Long64_t entr
    return &fRVec;
 }
 
-void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::GetImpl(Long64_t entry)
+void ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::LoadImpl(Long64_t entry, bool mask)
 {
-   if (fCollectionType == ECollectionType::kStdArray)
-      return ReadStdArray(entry);
+   if (entry != fLastEntry && mask) {
+      if (fCollectionType == ECollectionType::kStdArray)
+         fValuePtr = LoadStdArray(entry);
+      else if (fCollectionType == ECollectionType::kStdVector)
+         fValuePtr = LoadStdVector(entry);
+      else
+         fValuePtr = LoadRVec(entry);
+   }
+}
 
-   if (fCollectionType == ECollectionType::kStdVector)
-      return ReadStdVector(entry);
-
-   return ReadRVec(entry);
+void *ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::GetImpl(std::size_t /*idx*/)
+{
+   return fValuePtr;
 }
 
 ROOT::Internal::RDF::RTreeUntypedArrayColumnReader::RTreeUntypedArrayColumnReader(TTreeReader &r,
@@ -193,11 +203,24 @@ ROOT::Internal::RDF::RMaskedColumnReader::RMaskedColumnReader(
 
 ROOT::Internal::RDF::RMaskedColumnReader::~RMaskedColumnReader() = default;
 
-void *ROOT::Internal::RDF::RMaskedColumnReader::GetImpl(Long64_t event)
+void *ROOT::Internal::RDF::RMaskedColumnReader::GetImpl(std::size_t)
 {
-   const std::bitset<64> mask{*fTreeValueMask->Get()};
-   if (mask.test(fMaskIndex) == false)
-      return nullptr;
+   return fValuePtr;
+}
 
-   return fValueReader->TryGet<void>(event);
+void ROOT::Internal::RDF::RMaskedColumnReader::LoadImpl(Long64_t entry, bool mask)
+{
+   if (!mask) {
+      fValuePtr = nullptr;
+      return;
+   }
+
+   const std::bitset<64> treeMask{*fTreeValueMask->Get()};
+   if (treeMask.test(fMaskIndex) == false) {
+      fValuePtr = nullptr;
+      return;
+   }
+
+   fValueReader->Load(entry, mask);
+   fValuePtr = fValueReader->TryGet<void>(/*idx=*/0u);
 }

--- a/tree/dataframe/test/RArraysDS.hxx
+++ b/tree/dataframe/test/RArraysDS.hxx
@@ -12,7 +12,8 @@
 
 class R__CLING_PTRCHECK(off) RArraysDSVarReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::vector<int> *fPtr = nullptr;
-   void *GetImpl(Long64_t) final { return fPtr; }
+   void *GetImpl(std::size_t) final { return fPtr; }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RArraysDSVarReader(std::vector<int> &v) : fPtr(&v) {}
@@ -21,11 +22,12 @@ public:
 class R__CLING_PTRCHECK(off) RArraysDSVarSizeReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::vector<int> *fPtr = nullptr;
    std::size_t fSize = 0;
-   void *GetImpl(Long64_t) final
+   void *GetImpl(std::size_t) final
    {
       fSize = fPtr->size();
       return &fSize;
    }
+   void LoadImpl(Long64_t, bool) final {}
 
 public:
    RArraysDSVarSizeReader(std::vector<int> &v) : fPtr(&v) {}

--- a/tree/dataframe/test/RArraysDS.hxx
+++ b/tree/dataframe/test/RArraysDS.hxx
@@ -13,7 +13,7 @@
 class R__CLING_PTRCHECK(off) RArraysDSVarReader final : public ROOT::Detail::RDF::RColumnReaderBase {
    std::vector<int> *fPtr = nullptr;
    void *GetImpl(std::size_t) final { return fPtr; }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RArraysDSVarReader(std::vector<int> &v) : fPtr(&v) {}
@@ -27,7 +27,7 @@ class R__CLING_PTRCHECK(off) RArraysDSVarSizeReader final : public ROOT::Detail:
       fSize = fPtr->size();
       return &fSize;
    }
-   void LoadImpl(Long64_t, bool) final {}
+   void LoadImpl(const ROOT::Internal::RDF::RMaskedEntryRange &) final {}
 
 public:
    RArraysDSVarSizeReader(std::vector<int> &v) : fPtr(&v) {}


### PR DESCRIPTION
Nodes of the computation graph which may operate a selection on which entries are valid or not are modified to accommodate for multiple entries being evaluated at the same time. For now, the size of the bulk is set to one.

Note that this commit does not touch in any way the reading of data.

Needs https://github.com/root-project/root/pull/22313

Part 2 of N of the dataframe bulk processing effort.