### PR TITLE
Avoid triggering uninitialized warning in RVec

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -219,7 +219,12 @@ class R__CLING_PTRCHECK(off) SmallVectorTemplateCommon : public SmallVectorBase 
    // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
 
 protected:
-   SmallVectorTemplateCommon(size_t Size) : Base(getFirstEl(), Size) {}
+   SmallVectorTemplateCommon(size_t Size) : Base(nullptr, Size)
+   {
+      // We delay the initialization of fBeginX until the constructor of the derived class, to avoid doing pointer math
+      // on an object that is not yet fully constructed.
+      fBeginX = getFirstEl();
+   }
 
    void grow_pod(size_t MinSize, size_t TSize) { Base::grow_pod(getFirstEl(), MinSize, TSize); }
 

--- a/roottest/root/aclic/rvec_uninitialized/CMakeLists.txt
+++ b/roottest/root/aclic/rvec_uninitialized/CMakeLists.txt
@@ -1,0 +1,3 @@
+ROOTTEST_ADD_TEST(rvec_uninitialized
+                  MACRO rvec_uninitialized.C+
+                  OUTREF rvec_uninitialized.ref)

--- a/roottest/root/aclic/rvec_uninitialized/rvec_uninitialized.C
+++ b/roottest/root/aclic/rvec_uninitialized/rvec_uninitialized.C
@@ -1,0 +1,7 @@
+#include <ROOT/RVec.hxx>
+
+struct RVecUninitialized {
+   ROOT::RVec<bool> v;
+};
+
+void rvec_uninitialized() {}


### PR DESCRIPTION
Fixes #22467 

For now the PR only contains the commit adding the test, to make sure we can see the failure in the CI as well.