### PR TITLE
[do not merge] Test debug config GCC 16

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora44.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora44.txt
@@ -1,6 +1,4 @@
 CMAKE_CXX_STANDARD=23
-experimental_adaptivecpp=ON
-pythia8=ON
-roofit_multiprocess=ON
-test_distrdf_pyspark=OFF
-vdt=OFF
+CMAKE_BUILD_TYPE=Debug
+minimal=ON
+testing=ON


### PR DESCRIPTION
Related to https://github.com/root-project/root/issues/22467 . Locally I see with a Fedora44 debug build the same warning being triggered pretty much everywhere in ROOT using RVec. Using this PR to confirm.