### PR TITLE
[gpad] transparent canvas color on Mac

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3715,7 +3715,9 @@ void TPad::PaintBorder(Color_t color, Bool_t /* tops */)
             pp->SetAttFill({color, 1001}); // use fill color producing opacity
             pp->SetOpacity(style - 4000);
          }
-      } else if ((color == 10) && (style > 3000) && (style < 3100))
+      } else if ((style >= 4000) && (style <= 4100) && pp->IsCocoa() && (this == fMother))
+         style = 1001;
+      else if ((color == 10) && (style > 3000) && (style < 3100))
          color = 1;
 
       if (do_paint_box) {


### PR DESCRIPTION
When transparent style is specified,
canvas must be filled with 1001 fill style
to properly clear all previous drawings.

Logic was previously implemented in `TPad::PaintBox` 
and was not properly moved to TPad::PaintBorder

Fixes #22471 