### PR TITLE
[CMake] Set ROOT_genreflex_CMD in a more robust way

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -198,7 +198,13 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
     LIST(APPEND definitions "$<FILTER:$<TARGET_PROPERTY:${dictionary},COMPILE_DEFINITIONS>,EXCLUDE,^$>")
   ENDIF()
 
-  set(ROOT_genreflex_CMD $<TARGET_FILE:genreflex>)
+  if(CMAKE_PROJECT_NAME STREQUAL ROOT)
+    set(ROOT_genreflex_CMD $<TARGET_FILE:genreflex>)
+  elseif(TARGET ROOT::genreflex)
+    set(ROOT_genreflex_CMD $<TARGET_FILE:ROOT::genreflex>)
+  else()
+    set(ROOT_genreflex_CMD ${ROOT_BINDIR}/genreflex)
+  endif()
   add_custom_command(
     COMMAND ${ROOT_genreflex_CMD}
     ARGS ${headerfiles} -o ${gensrcdict} ${rootmapopts} --select=${selectionfile}


### PR DESCRIPTION
Make sure it can be set in downstream projects. `genreflex` as a target doesn't exist, but `ROOT::genreflex` does. Follow the same pattern as for `rootcling`, going back to the old way as a fallback.

dev3 builds are broken since https://github.com/root-project/root/pull/21890.

With this patch I can build podio, the package that is currently failing because it calls `REFLEX_GENERATE_DICTIONARY`.

## Checklist:

- [x] tested changes locally