### PR TITLE
[hist] Allow TF1 lambdas to receive ndim and npar as arguments - Issue #22071

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -716,7 +716,7 @@ namespace ROOT {
                   return func(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
                };
                f->fType = TF1::EFType::kTemplScalar;
-               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
+               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
             } else {
                f->fType = TF1::EFType::kTemplScalar;
                f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -28,6 +28,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+#if __has_include(<span>)
+#include <span>
+#endif
 #include "TFormula.h"
 #include "TMethodCall.h"
 #include "TAttLine.h"
@@ -710,6 +713,14 @@ namespace ROOT {
 #endif
          {
             f->fType = TF1::EFType::kTemplScalar;
+#ifdef __cpp_lib_span
+            if constexpr (std::is_invocable_r_v<double, Func, std::span<const double>, std::span<const double>>) {
+               auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
+                  return func(std::span<const double>(x, ndim), std::span<const double>(p, npar));
+               };
+               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper));
+            } else
+#endif
             if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
                auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
                   return func(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
@@ -735,6 +746,14 @@ namespace ROOT {
 #endif
          {
             f->fType = TF1::EFType::kTemplScalar;
+#ifdef __cpp_lib_span
+            if constexpr (std::is_invocable_r_v<double, Func, std::span<const double>, std::span<const double>>) {
+               auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
+                  return (*func)(std::span<const double>(x, ndim), std::span<const double>(p, npar));
+               };
+               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper));
+            } else
+#endif
             if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
                auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
                   return (*func)(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -710,9 +710,7 @@ namespace ROOT {
 #endif
          {
             if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
-               Int_t npar = f->fNpar;
-               Int_t ndim = f->fNdim;
-               auto wrapper = [func, npar, ndim](const double *x, const double *p) -> double {
+               auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
                   return func(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
                };
                f->fType = TF1::EFType::kTemplScalar;

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -709,14 +709,13 @@ namespace ROOT {
          } else
 #endif
          {
+            f->fType = TF1::EFType::kTemplScalar;
             if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
                auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
                   return func(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
                };
-               f->fType = TF1::EFType::kTemplScalar;
-               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
+               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper));
             } else {
-               f->fType = TF1::EFType::kTemplScalar;
                f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
             }
          }
@@ -735,16 +734,13 @@ namespace ROOT {
          } else
 #endif
          {
+            f->fType = TF1::EFType::kTemplScalar;
             if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
-               Int_t npar = f->fNpar;
-               Int_t ndim = f->fNdim;
-               auto wrapper = [func, npar, ndim](const double *x, const double *p) -> double {
+               auto wrapper = [func, npar = f->fNpar, ndim = f->fNdim](const double *x, const double *p) -> double {
                   return (*func)(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
                };
-               f->fType = TF1::EFType::kTemplScalar;
-               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
+               f->fFunctor = std::make_unique<TF1::TF1FunctorPointerImpl<double>>(ROOT::Math::ParamFunctorTempl<double>(wrapper));
             } else {
-               f->fType = TF1::EFType::kTemplScalar;
                f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
             }
          }

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -22,8 +22,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "RConfigure.h"
-#include <functional>
 #include <cassert>
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -708,8 +709,18 @@ namespace ROOT {
          } else
 #endif
          {
-            f->fType = TF1::EFType::kTemplScalar;
-            f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
+            if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
+               Int_t npar = f->fNpar;
+               Int_t ndim = f->fNdim;
+               auto wrapper = [func, npar, ndim](const double *x, const double *p) -> double {
+                  return func(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
+               };
+               f->fType = TF1::EFType::kTemplScalar;
+               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
+            } else {
+               f->fType = TF1::EFType::kTemplScalar;
+               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
+            }
          }
 
          f->fParams = std::make_unique<TF1Parameters>(f->fNpar);
@@ -726,8 +737,18 @@ namespace ROOT {
          } else
 #endif
          {
-            f->fType = TF1::EFType::kTemplScalar;
-            f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
+            if constexpr (std::is_invocable_r_v<double, Func, const double *, std::size_t, const double *, std::size_t>) {
+               Int_t npar = f->fNpar;
+               Int_t ndim = f->fNdim;
+               auto wrapper = [func, npar, ndim](const double *x, const double *p) -> double {
+                  return (*func)(x, static_cast<std::size_t>(ndim), p, static_cast<std::size_t>(npar));
+               };
+               f->fType = TF1::EFType::kTemplScalar;
+               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl<double>(ROOT::Math::ParamFunctorTempl<double>(wrapper)));
+            } else {
+               f->fType = TF1::EFType::kTemplScalar;
+               f->fFunctor.reset(new TF1::TF1FunctorPointerImpl(ROOT::Math::ParamFunctorTempl<double>(func)));
+            }
          }
 
          f->fParams = std::make_unique<TF1Parameters>(f->fNpar);

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -11,6 +11,7 @@
 #include "ROOT/TestSupport.hxx"
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 
 class MyClass {
@@ -238,6 +239,29 @@ TEST(TF1, Constructors)
 
    for (auto tf1 : vtf1)
       EXPECT_EQ(tf1(&x, &p), 2);
+}
+
+TEST(TF1, LambdaWithSizes)
+{
+   // lambda with explicit ndim and npar -- allows safe bound checking inside
+   auto f4arg = [](const double *x, std::size_t ndim, const double *p, std::size_t npar) -> double {
+      EXPECT_EQ(ndim, std::size_t{1});
+      EXPECT_EQ(npar, std::size_t{2});
+      return p[0] * x[0] + p[1];
+   };
+
+   TF1 f("f4arg", f4arg, 0, 10, 2);
+   f.SetParameters(3.0, 1.0);
+
+   EXPECT_NEAR(f.Eval(2.0), 7.0, 1e-10);
+   EXPECT_NEAR(f.Eval(5.0), 16.0, 1e-10);
+
+   // same but passing via pointer
+   TF1 fptr("f4arg_ptr", &f4arg, 0, 10, 2);
+   fptr.SetParameters(3.0, 1.0);
+
+   EXPECT_NEAR(fptr.Eval(2.0), 7.0, 1e-10);
+   EXPECT_NEAR(fptr.Eval(5.0), 16.0, 1e-10);
 }
 
 TEST(TF1, Save)

--- a/hist/hist/test/test_tf1.cxx
+++ b/hist/hist/test/test_tf1.cxx
@@ -264,6 +264,30 @@ TEST(TF1, LambdaWithSizes)
    EXPECT_NEAR(fptr.Eval(5.0), 16.0, 1e-10);
 }
 
+#ifdef __cpp_lib_span
+TEST(TF1, LambdaWithSpan)
+{
+   auto fspan = [](std::span<const double> x, std::span<const double> p) -> double {
+      EXPECT_EQ(x.size(), std::size_t{1});
+      EXPECT_EQ(p.size(), std::size_t{2});
+      return p[0] * x[0] + p[1];
+   };
+
+   TF1 f("fspan", fspan, 0, 10, 2);
+   f.SetParameters(3.0, 1.0);
+
+   EXPECT_NEAR(f.Eval(2.0), 7.0, 1e-10);
+   EXPECT_NEAR(f.Eval(5.0), 16.0, 1e-10);
+
+   // same but passing via pointer
+   TF1 fptr("fspan_ptr", &fspan, 0, 10, 2);
+   fptr.SetParameters(3.0, 1.0);
+
+   EXPECT_NEAR(fptr.Eval(2.0), 7.0, 1e-10);
+   EXPECT_NEAR(fptr.Eval(5.0), 16.0, 1e-10);
+}
+#endif
+
 TEST(TF1, Save)
 {
    TF1 linear("linear", "x", -10., 10.);


### PR DESCRIPTION
Users constructing TF1 with a lambda had no safe way to do bound checking on variables and parameters arrays, since the current API only exposes raw pointers with no size information.

This adds support for a 4-argument lambda signature:

  [](const double *x, std::size_t ndim,
     const double *p, std::size_t npar) -> double

TF1Builder now detects this signature at compile time via std::is_invocable_r_v and wraps it in an adapter that passes fNdim and fNpar captured from the TF1 object. The existing 2-argument API is fully preserved.

Closes #22071

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

