### PR TITLE
[ci] Use Python 3.15 on Fedora Rawhide

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -417,7 +417,7 @@ jobs:
             overrides: ["CMAKE_CXX_STANDARD=20"]
           # Fedora Rawhide with Python freethreading+debug build
           - image: rawhide
-            python_venv: "/py-venv-3.14td/ROOT-CI"
+            python_venv: "/py-venv-3.15td/ROOT-CI"
             is_special: true
             property: "Fedora pydebug no GIL"
             overrides: ["CMAKE_CXX_STANDARD=23"]


### PR DESCRIPTION
This is to cover the upcoming Python 3.15 in our CI.

Just like before with Python 3.14, we will use a Python debug build with freethreading (no GIL).