### PR TITLE
[http] fix ssl_certificate handling

### DIFF
--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -603,7 +603,7 @@ Int_t TCivetweb::ChangeNumActiveThrerads(int cnt)
 ///
 ///     thrds=N               - there N is number of threads used by the civetweb (default is 10)
 ///     top=name              - configure top name, visible in the web browser
-///     ssl_certificate=filename - SSL certificate, see docs/OpenSSL.md from civetweb
+///     ssl_cert=filename     - SSL certificate, see docs/OpenSSL.md from civetweb
 ///     auth_file=filename    - authentication file name, created with htdigets utility
 ///     auth_domain=domain    - authentication domain
 ///     websocket_timeout=tm  - set web sockets timeout in seconds (default 300)
@@ -685,7 +685,9 @@ Bool_t TCivetweb::Create(const char *args)
             if (adomain)
                auth_domain = adomain;
 
-            const char *sslc = url.GetValueFromOptions("ssl_cert");
+            const char *sslc = url.GetValueFromOptions("ssl_certificate");
+            if (!sslc)
+               sslc = url.GetValueFromOptions("ssl_cert");
             if (sslc)
                ssl_cert = sslc;
 


### PR DESCRIPTION
In the documentation "ssl_certificate" URL parameter was mentioned, but in fact "ssl_cert" was checked.
Now handle both URL parameters to be compatible with previously published docu.
