### PR TITLE
[RF] Fix Windows compiler warnings about mixing int and bool

### DIFF
--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -518,8 +518,6 @@ int FitUsingRooFit(TH1 *hist, TF1 *func)
 // unbinned roo fit
 int FitUsingRooFit(TTree *tree, TF1 *func)
 {
-
-   int iret = 0;
    std::cout << "\n************************************************************\n";
    std::cout << "\tFit using RooFit (Likelihood Fit)\n";
    std::cout << "\twith function " << func->GetName() << "\n";
@@ -567,26 +565,21 @@ int FitUsingRooFit(TTree *tree, TF1 *func)
       std::cout << " Roofit status " << result->status() << std::endl;
       result->Print();
 #endif
-      if (save)
-         iret |= int(result == nullptr);
-
-      if (iret != 0) {
+      if (save && result == nullptr) {
          std::cout << "Fit failed " << std::endl;
-         return iret;
+         return 1;
       }
    }
 
    w.Stop();
    std::cout << "\nTime: \t" << w.RealTime() << " , " << w.CpuTime() << std::endl;
    std::cout << "\n************************************************************\n";
-   return iret;
+   return 0;
 }
 
 // unbinned roo fit (large tree)
 int FitUsingRooFit2(TTree *tree)
 {
-
-   int iret = 0;
    std::cout << "\n************************************************************\n";
    std::cout << "\tFit using RooFit (Likelihood Fit)\n";
 
@@ -647,23 +640,16 @@ int FitUsingRooFit2(TTree *tree)
       std::unique_ptr<RooFitResult> result{
          pdf[N - 1]->fitTo(data, RooFit::Minos(0), RooFit::Hesse(1), RooFit::PrintLevel(level), RooFit::Save(save))};
 
-#ifdef DEBUG
-      assert(result == nullptr);
-//std::cout << " Roofit status " << result->status() << std::endl;
-//result->Print();
-#endif
-
-      iret |= int(result != nullptr);
-
-      if (iret != 0)
-         return iret;
-      // assert(iret == 0);
+      if (save && result == nullptr) {
+         std::cout << "Fit failed " << std::endl;
+         return 1;
+      }
    }
 
    w.Stop();
    std::cout << "\nTime: \t" << w.RealTime() << " , " << w.CpuTime() << std::endl;
    std::cout << "\n************************************************************\n";
-   return iret;
+   return 0;
 }
 
 double poly2(const double *x, const double *p)

--- a/roofit/roofit/test/testRooFit.cxx
+++ b/roofit/roofit/test/testRooFit.cxx
@@ -209,7 +209,8 @@ int FitUsingRooFit(TTree &tree, RooAbsPdf &pdf, RooArgSet &xvars)
       std::cout << " Roofit status " << result->status() << std::endl;
       result->Print();
 #endif
-      iret |= int(result == nullptr);
+      if (save && result == nullptr)
+         iret = 1;
    }
 
    w.Stop();
@@ -265,15 +266,15 @@ int FitUsingNewFitter(FitObj *fitobj, Func &func, bool useGrad = false)
    std::cout << "\tFit using new Fit::Fitter\n";
    std::cout << "\tMinimizer is " << MinType::name() << "  " << MinType::name2() << std::endl;
 
-   int iret = 0;
    TStopwatch w;
    w.Start();
 
 #ifdef DEBUG
    func.SetParameters(iniPar);
-   iret |= DoFit<MinType>(fitobj, func, true, useGrad);
+   int iret = DoFit<MinType>(fitobj, func, true, useGrad);
 
 #else
+   int iret = 0;
    for (int i = 0; i < nfit; ++i) {
       func.SetParameters(iniPar);
       iret = DoFit<MinType>(fitobj, func, false, useGrad);


### PR DESCRIPTION
Update the code to avoid the following compiler warnings:

```
C:\ROOT-CI\src\roofit\roofit\test\testFitPerf.cxx(571,26): warning C4805: '|=': unsafe mix of type 'int' and type 'bool' in operation [C:\ROOT-CI\build\roofit\roofit\test\testFitPerf.vcxproj]
C:\ROOT-CI\src\roofit\roofit\test\testFitPerf.cxx(656,23): warning C4805: '|=': unsafe mix of type 'int' and type 'bool' in operation [C:\ROOT-CI\build\roofit\roofit\test\testFitPerf.vcxproj]
C:\ROOT-CI\src\roofit\roofit\test\testRooFit.cxx(212,23): warning C4805: '|=': unsafe mix of type 'int' and type 'bool' in operation [C:\ROOT-CI\build\roofit\roofit\test\testRooFitExe.vcxproj]
```