### PR TITLE
[rfile] ListKeys: don't include the root directory itself in the listing

### DIFF
--- a/io/io/inc/ROOT/RFile.hxx
+++ b/io/io/inc/ROOT/RFile.hxx
@@ -376,6 +376,7 @@ public:
    /// `basePath` (defaulting to include the content of all subdirectories).
    /// By default, keys referring to directories are not returned: only those referring to leaf objects are.
    /// If `basePath` is the path of a leaf object, only `basePath` itself will be returned.
+   /// If `basePath` is the path of a directory, it won't appear in the listing.
    /// `flags` is a bitmask specifying the listing mode.
    /// If `(flags & kListObjects) != 0`, the listing will include keys of non-directory objects (default);
    /// If `(flags & kListDirs) != 0`, the listing will include keys of directory objects;

--- a/io/io/src/RFile.cxx
+++ b/io/io/src/RFile.cxx
@@ -475,6 +475,10 @@ void ROOT::Experimental::RFileKeyIterable::RIterator::Advance()
       assert(!fIterStack.empty());
       const std::size_t nesting = fIterStack.size() - 1;
 
+      // Skip key if it's the root dir itself
+      if (isDir && fullPath == fPattern)
+         continue;
+
       // Skip key if it's not a child of root dir
       if (!ROOT::StartsWith(fullPath, fPattern))
          continue;

--- a/io/io/test/rfile.cxx
+++ b/io/io/test/rfile.cxx
@@ -482,10 +482,10 @@ TEST(RFile, IterateKeysOnlyDirs)
    {
       auto file = RFile::Open(fileGuard.GetPath());
       EXPECT_EQ(JoinKeyNames(file->ListKeys("", RFile::kListDirs | RFile::kListRecursive)), "a, a/b, e, e/c");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("a", RFile::kListDirs | RFile::kListRecursive)), "a, a/b");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b", RFile::kListDirs | RFile::kListRecursive)), "a/b");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("a", RFile::kListDirs | RFile::kListRecursive)), "a/b");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b", RFile::kListDirs | RFile::kListRecursive)), "");
       EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b/c", RFile::kListDirs | RFile::kListRecursive)), "");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("e", RFile::kListDirs | RFile::kListRecursive)), "e, e/c");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("e", RFile::kListDirs | RFile::kListRecursive)), "e/c");
    }
 }
 
@@ -506,10 +506,10 @@ TEST(RFile, IterateKeysOnlyDirsNonRecursive)
    {
       auto file = RFile::Open(fileGuard.GetPath());
       EXPECT_EQ(JoinKeyNames(file->ListKeys("", RFile::kListDirs)), "a, e");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("a", RFile::kListDirs)), "a, a/b");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b", RFile::kListDirs)), "a/b");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("a", RFile::kListDirs)), "a/b");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b", RFile::kListDirs)), "");
       EXPECT_EQ(JoinKeyNames(file->ListKeys("a/b/c", RFile::kListDirs)), "");
-      EXPECT_EQ(JoinKeyNames(file->ListKeys("e", RFile::kListDirs)), "e, e/c");
+      EXPECT_EQ(JoinKeyNames(file->ListKeys("e", RFile::kListDirs)), "e/c");
    }
 }
 

--- a/io/io/test/rfile.py
+++ b/io/io/test/rfile.py
@@ -116,6 +116,10 @@ class RFileTests(unittest.TestCase):
                     ["foo"],
                 )
                 self.assertEqual(
+                    [key.GetPath() for key in rfile.ListKeys("foo", listDirs=True, listObjects=False, listRecursive=False)],
+                    ["foo/bar"],
+                )
+                self.assertEqual(
                     [key.GetPath() for key in rfile.ListKeys("", listDirs=True, listRecursive=False)], ["hist", "foo"]
                 )
         finally:


### PR DESCRIPTION
# This Pull request:
changes the behavior of `RFile::ListKeys` to exclude the root directory itself from the list of returned keyInfos.

Previously `ListKeys("a", kListDirs)` would return (e.g.) `{ "a", "a/b", "a/c", "a/d" }`; now it only returns `{ "a/b", "a/c", "a/d" }`.

Rationale: you generally don't care about the root dir in the listing, since you already know it's there.


