### PR TITLE
[CPyCppyy] Avoid compiler warnings with Python 3.15

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPDataMember.cxx
@@ -307,12 +307,7 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPExcInstance.cxx
@@ -285,12 +285,7 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                            // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                            // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
@@ -1125,12 +1125,7 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx
@@ -1092,12 +1092,7 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                                // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                                // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPScope.cxx
@@ -705,12 +705,7 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyy.h
@@ -385,4 +385,34 @@ static inline PyObject* PyObject_CallMethodOneArg(PyObject* obj, PyObject* name,
 // export macros for our own API
 #include "CPyCppyy/CommonDefs.h"
 
+// --- reusable PyTypeObject initializer tail -------------------------------
+// Members appended to PyTypeObject in newer CPython releases. Every CPyCppyy
+// type leaves all of these zero/null-initialized, so they share one tail.
+// To support a future Python version, add one block below and one line to
+// CPYCPPYY_PYTYPE_TAIL.
+
+#if PY_VERSION_HEX >= 0x030c0000
+#define CPYCPPYY_TP_WATCHED        , 0          /* tp_watched      (>= 3.12) */
+#else
+#define CPYCPPYY_TP_WATCHED
+#endif
+
+#if PY_VERSION_HEX >= 0x030d0000
+#define CPYCPPYY_TP_VERSIONS_USED  , 0          /* tp_versions_used(>= 3.13) */
+#else
+#define CPYCPPYY_TP_VERSIONS_USED
+#endif
+
+#if PY_VERSION_HEX >= 0x030f0000
+#define CPYCPPYY_TP_ITERITEM       , nullptr    /* _tp_iteritem    (>= 3.15) */
+#else
+#define CPYCPPYY_TP_ITERITEM
+#endif
+
+#define CPYCPPYY_PYTYPE_TAIL \
+    CPYCPPYY_TP_WATCHED \
+    CPYCPPYY_TP_VERSIONS_USED \
+    CPYCPPYY_TP_ITERITEM
+// --------------------------------------------------------------------------
+
 #endif // !CPYCPPYY_CPYCPPYY_H

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -171,12 +171,7 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                  // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                  // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                  // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -218,12 +213,7 @@ static PyTypeObject PyDefault_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                 // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                 // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                 // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 namespace {

--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
@@ -167,12 +167,7 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -341,12 +336,7 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -401,12 +391,7 @@ PyTypeObject IndexIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -472,12 +457,7 @@ PyTypeObject VectorIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/LowLevelViews.cxx
@@ -980,12 +980,7 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                            // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                            // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TemplateProxy.cxx
@@ -978,12 +978,7 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                                // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                                // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy

--- a/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/TupleOfInstances.cxx
@@ -117,12 +117,7 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 
@@ -254,12 +249,7 @@ PyTypeObject TupleOfInstances_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
-#if PY_VERSION_HEX >= 0x030c0000
-    , 0                           // tp_watched
-#endif
-#if PY_VERSION_HEX >= 0x030d0000
-    , 0                           // tp_versions_used
-#endif
+    CPYCPPYY_PYTYPE_TAIL
 };
 
 } // namespace CPyCppyy


### PR DESCRIPTION
This avoids compiler warnings about missing field initializers because of a new data member in Python 3.15.

Also, refactor the code a bit, so that next time a new member is added, we just have to change the code in one place.