### PR TITLE
[UHI] Remove non-existent `TH2K` and `TH3K`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi/__init__.py
@@ -49,8 +49,6 @@ values_func_dict: dict[str, Callable] = {
     "TH1C": _values_by_copy,
     "TH2C": _values_by_copy,
     "TH3C": _values_by_copy,
-    "TH2K": _values_by_copy,
-    "TH3K": _values_by_copy,
     "TProfile": _values_by_copy,
     "TProfile2D": _values_by_copy,
     "TProfile2Poly": _values_by_copy,


### PR DESCRIPTION
They were already removed by commit c791b9b162, but brought back commit b747ba5a88.