### PR TITLE
[webgui] improve TMethodCall usage

### DIFF
--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -35,11 +35,21 @@ using namespace ROOT::Experimental;
 void TObjectDrawable::CheckOwnership(TObject *obj)
 {
    if (obj && obj->InheritsFrom("TH1")) {
-      TMethodCall call(obj->IsA(), "SetDirectory", "nullptr");
-      call.Execute((void *)(obj));
+      TMethodCall call;
+      call.InitWithPrototype(obj->IsA(), "SetDirectory", "TDirectory*");
+      if (call.IsValid()) {
+         void *arg0 = nullptr;
+         const void *method_args[1] = { &arg0 };
+         call.Execute((void *) obj, method_args, 1);
+      }
    } else if (obj && obj->InheritsFrom("TF1")) {
-      TMethodCall call(obj->IsA(), "AddToGlobalList", "kFALSE");
-      call.Execute((void *)(obj));
+      TMethodCall call;
+      call.InitWithPrototype(obj->IsA(), "AddToGlobalList", "Bool_t");
+      if (call.IsValid()) {
+         Bool_t arg0 = kFALSE;
+         const void *method_args[1] = { &arg0 };
+         call.Execute((void *) obj, method_args, 1);
+      }
    }
 }
 

--- a/gui/webgui6/src/TWebMenuItem.cxx
+++ b/gui/webgui6/src/TWebMenuItem.cxx
@@ -83,20 +83,12 @@ void TWebMenuItems::PopulateObjectMenu(void *obj, TClass *cl)
 
          if ((getter.Length() > 0) && cl->GetMethodAllAny(getter)) {
             // execute getter method to get current state of toggle item
-
-            TMethodCall *call = new TMethodCall(cl, getter, "");
-
-            if (call->ReturnType() == TMethodCall::kLong) {
-               Longptr_t l(0);
-               call->Execute(obj, l);
-
+            TMethodCall call(cl, getter, "");
+            if (call.ReturnType() == TMethodCall::kLong) {
+               Longptr_t l = 0;
+               call.Execute(obj, l);
                AddChkMenuItem(m->GetName(), m->GetTitle(), l != 0, TString::Format("%s(%s)", m->GetName(), (l != 0) ? "0" : "1").Data(), m->GetClass());
-
-            } else {
-               // Error("CheckModifiedFlag", "Cannot get toggle value with getter %s", getter.Data());
             }
-
-            delete call;
          }
       } else {
          TList *args = m->GetListOfMethodArgs();


### PR DESCRIPTION
Use different signature when invoke method with arguments. 
If arguments provided as string - cling is invoked and leaves memory leak.
Use different `TMethodCall::Execute()` signature to avoid such leaks.
