### PR TITLE
[hist] Initialize `std::atomic` in test

### DIFF
--- a/hist/histv7/test/hist_test.hxx
+++ b/hist/histv7/test/hist_test.hxx
@@ -48,7 +48,7 @@ using ROOT::Experimental::Internal::RSliceBinIndexMapper;
 template <typename Work>
 void StressInParallel(std::size_t nThreads, Work &&w)
 {
-   std::atomic<bool> flag;
+   std::atomic<bool> flag = false;
 
    std::vector<std::thread> threads;
    for (std::size_t i = 0; i < nThreads; i++) {


### PR DESCRIPTION
Before LWG 2334, in implementations only fixed in C++20 and later, the value would be uninitialized.