### PR TITLE
[docs] Put the file list back into the doxygen sidebar.

### DIFF
--- a/documentation/doxygen/DoxygenLayout.xml
+++ b/documentation/doxygen/DoxygenLayout.xml
@@ -16,7 +16,7 @@
       <tab type="hierarchy" visible="yes" title="" intro=""/>
       <tab type="classmembers" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="files" visible="no" title="">
+    <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="" intro=""/>
       <tab type="globals" visible="yes" title="" intro=""/>
     </tab>


### PR DESCRIPTION
After cleaning up the sidebar, doxygen seemed to have skipped the step of generating the webpages for the tutorials. Here, the menu is put back into the sidebar to force doxygen to run the tutorials.
