### PR TITLE
[tutorials][UHI] Fix rendering of tutorials using non-ROOT graphics

### DIFF
--- a/tutorials/hist/hist001_TH1_fillrandom_uhi.py
+++ b/tutorials/hist/hist001_TH1_fillrandom_uhi.py
@@ -3,7 +3,6 @@
 ## \notebook
 ## Fill a 1D histogram with random values using predefined functions.
 ##
-## \macro_image
 ## \macro_code
 ##
 ## \date July 2025

--- a/tutorials/hist/hist002_TH1_fillrandom_userfunc_uhi.py
+++ b/tutorials/hist/hist002_TH1_fillrandom_userfunc_uhi.py
@@ -3,7 +3,6 @@
 ## \notebook
 ## Fill a 1D histogram from a user-defined parametric function.
 ##
-## \macro_image
 ## \macro_code
 ##
 ## \date July 2025

--- a/tutorials/hist/hist003_TH1_draw_uhi.py
+++ b/tutorials/hist/hist003_TH1_draw_uhi.py
@@ -5,7 +5,6 @@
 ##
 ## \note When using graphics inside a ROOT macro the objects must be created with `new`.
 ##
-## \macro_image
 ## \macro_code
 ##
 ## \date July 2025

--- a/tutorials/hist/hist007_TH1_liveupdate_uhi.py
+++ b/tutorials/hist/hist007_TH1_liveupdate_uhi.py
@@ -3,7 +3,6 @@
 ## \notebook -js
 ## Simple example illustrating how to use the C++ interpreter.
 ##
-## \macro_image
 ## \macro_code
 ##
 ## \date July 2025

--- a/tutorials/hist/hist010_TH1_two_scales_uhi.py
+++ b/tutorials/hist/hist010_TH1_two_scales_uhi.py
@@ -5,7 +5,6 @@
 ## with different scales in the "same" pad.
 ## Inspired by work of Rene Brun.
 ##
-## \macro_image
 ## \macro_code
 ##
 ## \date July 2025

--- a/tutorials/hist/hist015_TH1_read_and_draw_uhi.py
+++ b/tutorials/hist/hist015_TH1_read_and_draw_uhi.py
@@ -3,8 +3,6 @@
 ## \notebook -js
 ## A Simple histogram drawing example.
 ##
-## \macro_image
-## \macro_output
 ## \macro_code
 ##
 ## \date July 2025


### PR DESCRIPTION
# This Pull request:

Some UHI tutorials that render graphics via `mplhep` cannot produce the canvas png files expected by `\macro_image` and `\macro_output` so we get empty frames in the documentation page.

<img width="473" height="69" alt="image" src="https://github.com/user-attachments/assets/7cb9f5ad-02a0-41dc-9759-f27333ccaefd" />

<img width="473" height="77" alt="image" src="https://github.com/user-attachments/assets/c8b3a3d2-4603-4264-a510-7ee3aa1cb20d" />
