### PR TITLE
[ntuple] Remove `RAuxiliaryProcessorField`

### DIFF
--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -398,24 +398,6 @@ void ROOT::Experimental::RNTupleChainProcessor::PrintStructureImpl(std::ostream 
 
 //------------------------------------------------------------------------------
 
-namespace ROOT::Experimental::Internal {
-class RAuxiliaryProcessorField final : public ROOT::RRecordField {
-private:
-   using RFieldBase::GenerateColumns;
-   void GenerateColumns() final
-   {
-      throw RException(R__FAIL("RAuxiliaryProcessorField fields must only be used for reading"));
-   }
-
-public:
-   RAuxiliaryProcessorField(std::string_view fieldName, std::vector<std::unique_ptr<RFieldBase>> itemFields)
-      : ROOT::RRecordField(fieldName, "RAuxiliaryProcessorField")
-   {
-      AttachItemFields(std::move(itemFields));
-   }
-};
-} // namespace ROOT::Experimental::Internal
-
 ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                                                                std::unique_ptr<RNTupleProcessor> auxProcessor,
                                                                const std::vector<std::string> &joinFields,


### PR DESCRIPTION
This class was used when `RNTupleProcessor` still relied on `RNTupleModel` internally, but this is not the case anymore.
