### PR TITLE
[gl] use TTFhandle for text extension method

### DIFF
--- a/graf2d/gpad/inc/TPadPainterBase.h
+++ b/graf2d/gpad/inc/TPadPainterBase.h
@@ -24,9 +24,10 @@ protected:
    TAttLine   fAttLine;   ///< current line attributes
    TAttMarker fAttMarker; ///< current marker attributes
    TAttText   fAttText;   ///< current text attributes
-   Bool_t      fFullyTransparent = kFALSE; ///< if transformed fill attributes fully transparent
+   Bool_t     fFullyTransparent = kFALSE; ///< if transformed fill attributes fully transparent
 
    TAttFill   GetAttFillInternal(Bool_t with_transparency);
+   virtual Double_t GetTTFScale() const { return 1.; }
 
 public:
 

--- a/graf2d/gpad/src/TPadPainterBase.cxx
+++ b/graf2d/gpad/src/TPadPainterBase.cxx
@@ -58,7 +58,7 @@ void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_
    if (!res) {
       TTFhandle ttf;
       ttf.SetTextFont(font);
-      ttf.SetTextSize(size);
+      ttf.SetTextSize(size * GetTTFScale());
       ttf.GetTextExtent(w, h, mess);
    }
 }
@@ -76,7 +76,7 @@ void TPadPainterBase::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_
    if (!res) {
       TTFhandle ttf;
       ttf.SetTextFont(font);
-      ttf.SetTextSize(size);
+      ttf.SetTextSize(size * GetTTFScale());
       ttf.GetTextExtent(w, h, mess);
    }
 }
@@ -99,7 +99,7 @@ void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a
    if (!res) {
       TTFhandle ttf;
       ttf.SetTextFont(font);
-      ttf.SetTextSize(size);
+      ttf.SetTextSize(size * GetTTFScale());
       UInt_t w, h;
       ttf.GetTextExtent(w, h, mess);
       a = ttf.GetBox().yMax;
@@ -126,7 +126,7 @@ void TPadPainterBase::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a
    if (!res) {
       TTFhandle ttf;
       ttf.SetTextFont(font);
-      ttf.SetTextSize(size);
+      ttf.SetTextSize(size * GetTTFScale());
       UInt_t w, h;
       ttf.GetTextExtent(w, h, mess);
       a = ttf.GetBox().yMax;
@@ -147,7 +147,7 @@ UInt_t TPadPainterBase::GetTextAdvance(Font_t font, Double_t size, const char *m
 
    TTFhandle ttf;
    ttf.SetTextFont(font);
-   ttf.SetTextSize(size);
+   ttf.SetTextSize(size * GetTTFScale());
    ttf.SetKerning(kern);
 
    UInt_t a = 0;

--- a/graf3d/gl/inc/TGLPadPainter.h
+++ b/graf3d/gl/inc/TGLPadPainter.h
@@ -60,11 +60,9 @@ private:
    template<class Char_t>
    void DrawTextHelper(Double_t x, Double_t y, const Char_t *text, ETextMode mode);
 
-   template<class Char_t>
-   void TextExtentHelper(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const Char_t *text);
+protected:
 
-   template<class Char_t>
-   void TextAscentDescentHelper(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const Char_t *text);
+   Double_t GetTTFScale() const override { return 1./0.93376068; }
 
 public:
    TGLPadPainter();
@@ -116,12 +114,6 @@ public:
    void     DrawText(Double_t, Double_t, const wchar_t *, ETextMode) override;
    void     DrawTextNDC(Double_t x, Double_t y, const char *text, ETextMode mode) override;
    void     DrawTextNDC(Double_t, Double_t, const wchar_t *, ETextMode) override;
-
-   void     GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *mess) override;
-   void     GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *mess) override;
-   void     GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *mess) override;
-   void     GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *mess) override;
-   UInt_t   GetTextAdvance(Font_t font, Double_t size, const char *text, Bool_t kern) override;
 
    //jpg, png, gif and bmp output.
    void     SaveImage(TVirtualPad *pad, const char *fileName, Int_t type) const override;

--- a/graf3d/gl/src/TGLPadPainter.cxx
+++ b/graf3d/gl/src/TGLPadPainter.cxx
@@ -847,42 +847,6 @@ void TGLPadPainter::DrawTextHelper(Double_t x, Double_t y, const Char *text, ETe
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Helper function to get text extent
-
-template<class Char_t>
-void TGLPadPainter::TextExtentHelper(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const Char_t *text)
-{
-   SelectGLFont(font, size);
-
-   Float_t llx, lly, llz, urx, ury, urz;
-   fF.BBox(text, llx, lly, llz, urx, ury, urz);
-   urx -= llx;
-   ury -= lly;
-   w = (UInt_t) (urx > 0. ? urx : 0.);
-   h = (UInt_t) (ury > 0. ? ury : 0.);
-   (void) llz;
-   (void) urz;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Helper function to get text ascent / descent
-
-template<class Char_t>
-void TGLPadPainter::TextAscentDescentHelper(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const Char_t *text)
-{
-   SelectGLFont(font, size);
-
-   Float_t llx, lly, llz, urx, ury, urz;
-   fF.BBox(text, llx, lly, llz, urx, ury, urz);
-   a = (UInt_t) (ury > 0. ? ury : 0.);
-   d = (UInt_t) (lly < 0. ? -lly : 0.);
-   (void) llx;
-   (void) llz;
-   (void) urx;
-   (void) urz;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 ///Draw text. This operation is especially
 ///dangerous if in locked state -
 ///ftgl will assert on zero texture size
@@ -923,50 +887,6 @@ void TGLPadPainter::DrawTextNDC(Double_t u, Double_t v, const char *text, ETextM
    const Double_t xRange = gPad->GetX2() - gPad->GetX1();
    const Double_t yRange = gPad->GetY2() - gPad->GetY1();
    DrawText(gPad->GetX1() + u * xRange, gPad->GetY1() + v * yRange, text, mode);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get text extent
-
-void TGLPadPainter::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const char *text)
-{
-   TextExtentHelper(font, size, w, h, text);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get text extent
-
-void TGLPadPainter::GetTextExtent(Font_t font, Double_t size, UInt_t &w, UInt_t &h, const wchar_t *text)
-{
-   TextExtentHelper(font, size, w, h, text);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get text extent
-
-void TGLPadPainter::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const char *text)
-{
-   TextAscentDescentHelper(font, size, a, d, text);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get text extent
-
-void TGLPadPainter::GetTextAscentDescent(Font_t font, Double_t size, UInt_t &a, UInt_t &d, const wchar_t *text)
-{
-   TextAscentDescentHelper(font, size, a, d, text);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get text advance
-
-UInt_t TGLPadPainter::GetTextAdvance(Font_t font, Double_t size, const char *text, Bool_t)
-{
-   SelectGLFont(font, size);
-
-   auto advance = fF.Advance(text);
-
-   return (UInt_t) (advance > 0. ? advance : 0.);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Always use TTFhandle methods for text extension methods. Unfortunately, libFTGL has several problems and not always correctly return text extension for special symbols like integral from symbol.tff

When getting text extension GL - use scaling factor 1/0.93376 to be consistent with FTGL painting.
