### PR TITLE
[ci] Add minimal asan build

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -92,9 +92,10 @@ def main():
         build_utils.print_options_diff(options_dict, last_options)
 
     if args.overrides is not None:
+        overrides = ' '.join(args.overrides).split('@')
         print("Build option overrides from command line:")
         last_options = dict(options_dict)
-        options_dict.update((arg.split("=", maxsplit=1) for arg in args.overrides))
+        options_dict.update((arg.split("=", maxsplit=1) for arg in overrides))
         build_utils.print_options_diff(options_dict, last_options)
 
     ctest_custom_flags = ""

--- a/.github/workflows/root-ci-config/buildconfig/alma10-minimal-asan.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-minimal-asan.txt
@@ -1,0 +1,11 @@
+CMAKE_BUILD_TYPE=Debug
+CMAKE_CXX_FLAGS_DEBUG="-Og -g"
+asan=ON
+ccache=ON
+builtin_vdt=ON
+fail-on-missing=ON
+minimal=ON
+roottest=ON
+testing=ON
+LSAN_OPTIONS=verbosity=1:log_threads=1
+ROOT_CTEST_CUSTOM_FLAGS="-E \(cppinterop-CppInterOpTest\|roottest-cling-specialobj-runf02$\|roottest-root-collection-DeleteWarning$\|roottest-root-io-evolution-fixarr2$\|roottest-root-meta-rlibmap$\|roottest-root-treeproxy-vectorint-vectorint$\)"

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -415,6 +415,12 @@ jobs:
             is_special: true
             property: "clang Ninja builtins auto-registration off"
             overrides: ["CMAKE_CXX_STANDARD=20"]
+          # Asan build
+          - image: alma10
+            platform_config: alma10-minimal
+            is_special: true
+            property: "asan"
+            overrides: ["asan=ON", "minimal=ON", "CMAKE_BUILD_TYPE=Debug"]
           # Fedora Rawhide with Python freethreading+debug build
           - image: rawhide
             python_venv: "/py-venv-3.15td/ROOT-CI"

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -156,7 +156,7 @@ jobs:
           HOME: /Users/sftnight
           INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') && !matrix.platform == 'mac15' && !matrix.platform == 'mac26'}}
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
-          OVERRIDES: ${{ join( matrix.overrides, ' ') }}
+          OVERRIDES: ${{ join( matrix.overrides, '@') }}
         run: |
           [ -d "${VIRTUAL_ENV_DIR}" ] && source ${VIRTUAL_ENV_DIR}/bin/activate
           echo "Python is now $(which python3) $(python3 --version)"
@@ -170,7 +170,7 @@ jobs:
                     --head_sha        ${{ github.event.pull_request.head.sha }}             \
                     --repository      ${{ github.server_url }}/${{ github.repository }}     \
                     --platform        ${{ matrix.platform }}                                \
-                    --overrides       ${GLOBAL_OVERRIDES} ${OVERRIDES}
+                    --overrides       "${GLOBAL_OVERRIDES}" "${OVERRIDES}"
 
       - name: Workflow dispatch
         if: ${{ github.event_name == 'workflow_dispatch' && !matrix.is_special }}
@@ -420,7 +420,7 @@ jobs:
             platform_config: alma10-minimal
             is_special: true
             property: "asan"
-            overrides: ["asan=ON", "minimal=ON", "CMAKE_BUILD_TYPE=Debug"]
+            overrides: ["ROOT_CTEST_CUSTOM_FLAGS='-E \\(^tutorial-\\|cppinterop-CppInterOpTest\\|roottest-cling-specialobj-runf02$\\|roottest-root-collection-DeleteWarning$\\|roottest-root-io-evolution-fixarr2$\\|roottest-root-meta-rlibmap$\\|roottest-root-treeproxy-vectorint-vectorint$\\)'"]
           # Fedora Rawhide with Python freethreading+debug build
           - image: rawhide
             python_venv: "/py-venv-3.15td/ROOT-CI"

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -190,7 +190,7 @@ option(minimal "Enable only required options by default" OFF)
 option(rootbench "Build rootbench if rootbench exists in root or if it is a sibling directory (implies testing=ON)" OFF)
 option(roottest "Build roottest (implies testing=ON)" OFF)
 option(testing "Enable testing with CTest" OFF)
-option(asan "Build ROOT with address sanitizer instrumentation" OFF)
+option(asan "Build ROOT with address sanitizer instrumentation (only GCC is currently supported)" OFF)
 
 set(gcctoolchain "" CACHE PATH "Set path to GCC toolchain used to build llvm/clang")
 

--- a/core/sanitizer/SanitizerSetup.cxx
+++ b/core/sanitizer/SanitizerSetup.cxx
@@ -31,7 +31,8 @@ const char* __asan_default_options() {
          ":detect_container_overflow=1"
          ":alloc_dealloc_mismatch=0"
          DETECT_LEAKS
-         ":verify_asan_link_order=0";
+         ":verify_asan_link_order=0"
+         ":halt_on_error=0";
 }
 
 /// Default options when leak sanitizer starts up in ROOT executables.


### PR DESCRIPTION
Using the alma10 image.

**IMPORTANT**: asan currently only works with gcc (or at least, that was the case on my machine).

## Additional notes 
- We are enabling asan both for PRs and for nightly builds; the latter also includes the tutorials, which we don't run for PRs.
- For the reason above, both the buildconfig and the override contain similar ROOT_CTEST_CUSTOM_FLAGS, but the override one also excludes tutorials.
- The other tests that are excluded are those that currently don't work; they will be fixed over time and removed from the blacklist.
- The build is set to `minimal=on`; this will also be expanded over time to cover more of the codebase. Eventually, hopefully we are able to cover the full build.

**POSTHUMOUS NOTE**: this PR actually failed to enabled Asan in the CI due to a mistake being corrected in a [later PR](https://github.com/root-project/root/pull/22726)