### PR TITLE
[df] Create a pool of MT tasks for RNTuple and run constrained by number of slots

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -336,6 +336,9 @@ public:
    /// The task run by every thread on an entry range (known by the input TTreeReader), for the TTree data source.
    void
    TTreeThreadTask(TTreeReader &treeReader, ROOT::Internal::RSlotStack &slotStack, std::atomic<ULong64_t> &entryCount);
+   /// The task run by every thread on the input entry range, for the RNTuple data source.
+   void RNTupleThreadTask(const std::pair<ULong64_t, ULong64_t> &entryRange, unsigned int slot,
+                          std::uint64_t columnReaderOffset);
 };
 
 /// \brief Create an RLoopManager that reads a TChain.

--- a/tree/dataframe/inc/ROOT/RNTupleDS.hxx
+++ b/tree/dataframe/inc/ROOT/RNTupleDS.hxx
@@ -35,6 +35,15 @@
 namespace ROOT {
 class RDataFrame;
 }
+
+namespace ROOT::Detail::RDF {
+class RLoopManager;
+}
+
+namespace ROOT::Internal {
+class RSlotStack;
+}
+
 namespace ROOT::Internal::RDF {
 /**
  * \brief Internal overload of the function that allows passing a range of entries
@@ -90,6 +99,7 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
       ULong64_t fFirstEntry = 0; ///< First entry index in fSource
       /// End entry index in fSource, e.g. the number of entries in the range is fLastEntry - fFirstEntry
       ULong64_t fLastEntry = 0;
+      ULong64_t fEntryOffset = 0; /// Offset of both first and last entries w.r.t. the page source
       std::string_view fFileName; ///< Storage location of the current RNTuple
    };
 
@@ -143,14 +153,15 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
 
    std::vector<REntryRangeDS> fCurrentRanges; ///< Basis for the ranges returned by the last GetEntryRanges() call
    std::vector<REntryRangeDS> fNextRanges;    ///< Basis for the ranges populated by the PrepareNextRanges() call
+
+   // During MT runs, the current window of entries seen by an active slot
+   std::vector<REntryRangeDS> fActiveRangesPerSlot;
    /// Maps the first entries from the ranges of the last GetEntryRanges() call to their corresponding index in
    /// the fCurrentRanges vectors.  This is necessary because the returned ranges get distributed arbitrarily
    /// onto slots.  In the InitSlot method, the column readers use this map to find the correct range to connect to.
    std::unordered_map<ULong64_t, std::size_t> fFirstEntry2RangeIdx;
    // Keep track of the scheduled entries - necessary for processing of GlobalEntries
    std::vector<std::pair<ULong64_t, ULong64_t>> fOriginalRanges;
-   /// One element per slot, corresponding to the current range index for that slot, as filled by InitSlot
-   std::vector<std::size_t> fSlotsToRangeIdxs;
 
    /// The background thread that runs StageNextSources()
    std::thread fThreadStaging;
@@ -221,7 +232,11 @@ class RNTupleDS final : public ROOT::RDF::RDataSource {
 
    explicit RNTupleDS(std::string_view ntupleName, const std::vector<std::string> &fileNames,
                       const std::pair<ULong64_t, ULong64_t> &range);
-
+#ifdef R__USE_IMT
+   void ProcessMTRange(std::size_t fileIdx, const ROOT::Internal::RNTupleClusterBoundaries &cluster,
+                       ROOT::Detail::RDF::RLoopManager &lm, ROOT::Internal::RSlotStack &slotStack,
+                       std::atomic<ULong64_t> &entryCount, std::atomic<ULong64_t> &globalEntryCount);
+#endif
 public:
    RNTupleDS(std::string_view ntupleName, std::string_view fileName);
    RNTupleDS(std::string_view ntupleName, const std::vector<std::string> &fileNames);
@@ -255,7 +270,9 @@ public:
 
    // Old API, unused
    bool SetEntry(unsigned int, ULong64_t) final { return true; }
-
+#ifdef R__USE_IMT
+   void ProcessMT(ROOT::Detail::RDF::RLoopManager &lm) final;
+#endif
 protected:
    Record_t GetColumnReadersImpl(std::string_view name, const std::type_info &) final;
 };

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -1374,6 +1374,40 @@ void ROOT::Detail::RDF::RLoopManager::DataSourceThreadTask(const std::pair<ULong
 #endif
 }
 
+void ROOT::Detail::RDF::RLoopManager::RNTupleThreadTask(const std::pair<ULong64_t, ULong64_t> &entryRange,
+                                                        unsigned int slot, std::uint64_t columnReaderOffset)
+{
+#ifdef R__USE_IMT
+   // These are begin and end entries of the current cluster in the file currently opened by the slot, offset by a
+   // global atomic counter with the value passed via columnReaderOffset. The only reason we use it for the moment is to
+   // provide a seed for a unique rdfentry_ sequence in the current slot task.
+   const auto &[start, end] = entryRange;
+
+   RDSRangeRAII _{*this, slot, columnReaderOffset};
+   RCallCleanUpTask cleanup(*this, slot);
+
+   fSampleInfos[slot] = ROOT::Internal::RDF::CreateSampleInfo(*fDataSource, slot, fSampleMap);
+
+   R__LOG_DEBUG(0, RDFLogChannel()) << LogRangeProcessing(
+      {fDataSource->GetLabel(), start - columnReaderOffset, end - columnReaderOffset, slot});
+
+   try {
+      for (auto entry = start; entry < end; ++entry) {
+         if (fDataSource->SetEntry(slot, entry)) {
+            RunAndCheckFilters(slot, entry);
+         }
+      }
+   } catch (...) {
+      std::cerr << "RDataFrame::Run: event loop was interrupted\n";
+      throw;
+   }
+#else
+   (void)entryRange;
+   (void)slot;
+   (void)columnReaderOffset;
+#endif
+}
+
 void ROOT::Detail::RDF::RLoopManager::TTreeThreadTask(TTreeReader &treeReader, ROOT::Internal::RSlotStack &slotStack,
                                                       std::atomic<ULong64_t> &entryCount)
 {

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -36,6 +36,11 @@
 #include <type_traits>
 #include <utility>
 
+#ifdef R__USE_IMT
+#include <ROOT/RSlotStack.hxx>
+#include <ROOT/TThreadExecutor.hxx>
+#endif
+
 // clang-format off
 /**
 * \class ROOT::RDF::RNTupleDS
@@ -678,69 +683,11 @@ void ROOT::RDF::RNTupleDS::PrepareNextRanges()
       }
       return;
    }
-
-   // Work scheduling of the tail: multiple slots work on the same file.
-   // Every slot still has its own page source but these page sources may open the same file.
-   // Again, we need to skip empty files.
-   unsigned int nSlotsPerFile = fNSlots / nRemainingFiles;
-   for (std::size_t i = 0; (fNextRanges.size() < fNSlots) && (fNextFileIndex < nFiles); ++i) {
-      std::unique_ptr<ROOT::Internal::RPageSource> source;
-      // Need to look for the file name to populate the sample info later
-      const auto &sourceFileName = fFileNames[fNextFileIndex];
-      std::swap(fStagingArea[fNextFileIndex], source);
-      if (!source) {
-         // Empty files trigger this condition
-         source = CreatePageSource(fNTupleName, fFileNames[fNextFileIndex]);
-      }
-      source->Attach();
-      fNextFileIndex++;
-
-      auto nEntries = source->GetNEntries();
-      if (nEntries == 0)
-         continue;
-
-      // If last file: use all remaining slots
-      if (i == (nRemainingFiles - 1))
-         nSlotsPerFile = fNSlots - fNextRanges.size();
-
-      const auto rangesByCluster = [&source]() {
-         // Take the shared lock of the descriptor just for the time necessary
-         const auto descGuard = source->GetSharedDescriptorGuard();
-         return ROOT::Internal::GetClusterBoundaries(descGuard.GetRef());
-      }();
-
-      const unsigned int nRangesByCluster = rangesByCluster.size();
-
-      // Distribute slots equidistantly over the entry range, aligned on cluster boundaries
-      const auto nClustersPerSlot = nRangesByCluster / nSlotsPerFile;
-      const auto remainder = nRangesByCluster % nSlotsPerFile;
-      std::size_t iRange = 0;
-      unsigned int iSlot = 0;
-      const unsigned int N = std::min(nSlotsPerFile, nRangesByCluster);
-      for (; iSlot < N; ++iSlot) {
-         auto start = rangesByCluster[iRange].fFirstEntry;
-         iRange += nClustersPerSlot + static_cast<int>(iSlot < remainder);
-         assert(iRange > 0);
-         auto end = rangesByCluster[iRange - 1].fLastEntryPlusOne;
-
-         REntryRangeDS range;
-         range.fFileName = sourceFileName;
-         // The last range for this file just takes the already opened page source. All previous ranges clone.
-         if (iSlot == N - 1) {
-            range.fSource = std::move(source);
-         } else {
-            range.fSource = source->Clone();
-         }
-         range.fSource->SetEntryRange({start, end - start});
-         range.fFirstEntry = start;
-         range.fLastEntry = end;
-         fNextRanges.emplace_back(std::move(range));
-      }
-   } // loop over tail of remaining files
 }
 
 std::vector<std::pair<ULong64_t, ULong64_t>> ROOT::RDF::RNTupleDS::GetEntryRanges()
 {
+   assert(fNSlots == 1); // MT scheduling doesn't use this function
    std::vector<std::pair<ULong64_t, ULong64_t>> ranges;
 
    // We need to distinguish between single threaded and multi-threaded runs.
@@ -748,11 +695,8 @@ std::vector<std::pair<ULong64_t, ULong64_t>> ROOT::RDF::RNTupleDS::GetEntryRange
    // to new page sources of the chain in GetEntryRanges. In multi-threaded mode, on the other hand,
    // InitSlot is called for every returned range, thus rewiring the column readers takes place in
    // InitSlot and FinalizeSlot.
-
-   if (fNSlots == 1) {
-      for (auto r : fActiveColumnReaders[0]) {
-         r->Disconnect(true /* keepValue */);
-      }
+   for (auto r : fActiveColumnReaders[0]) {
+      r->Disconnect(true /* keepValue */);
    }
 
    // If we have fewer files than slots and we run multiple event loops, we can reuse fCurrentRanges and don't need
@@ -873,26 +817,16 @@ std::vector<std::pair<ULong64_t, ULong64_t>> ROOT::RDF::RNTupleDS::GetEntryRange
    return ranges;
 }
 
-void ROOT::RDF::RNTupleDS::InitSlot(unsigned int slot, ULong64_t firstEntry)
+void ROOT::RDF::RNTupleDS::InitSlot(unsigned int slot, ULong64_t columnReaderOffset)
 {
    if (fNSlots == 1) {
-      // Ensure the connection between slot and range is valid also in single-thread mode
-      fSlotsToRangeIdxs[0] = 0;
       return;
    }
 
-   // The same slot ID could be picked multiple times in the same execution, thus
-   // ending up processing different page sources. Here we re-establish the
-   // connection between the slot and the correct page source by finding which
-   // range index corresponds to the first entry passed.
-   auto idxRange = fFirstEntry2RangeIdx.at(firstEntry);
-
-   // We also remember this connection so it can later be retrieved in CreateSampleInfo
-   fSlotsToRangeIdxs[slot * ROOT::Internal::RDF::CacheLineStep<std::size_t>()] = idxRange;
+   const auto &entryRangeDS = fActiveRangesPerSlot.at(slot * ROOT::Internal::RDF::CacheLineStep<REntryRangeDS>());
 
    for (auto r : fActiveColumnReaders[slot]) {
-      r->Connect(*fCurrentRanges[idxRange].fSource,
-                 fOriginalRanges[idxRange].first - fCurrentRanges[idxRange].fFirstEntry);
+      r->Connect(*entryRangeDS.fSource, columnReaderOffset);
    }
 }
 
@@ -975,7 +909,7 @@ void ROOT::RDF::RNTupleDS::SetNSlots(unsigned int nSlots)
    assert(nSlots > 0);
    fNSlots = nSlots;
    fActiveColumnReaders.resize(fNSlots);
-   fSlotsToRangeIdxs.resize(fNSlots * ROOT::Internal::RDF::CacheLineStep<std::size_t>());
+   fActiveRangesPerSlot.resize(fNSlots * ROOT::Internal::RDF::CacheLineStep<REntryRangeDS>());
 }
 
 ROOT::RDataFrame ROOT::RDF::FromRNTuple(std::string_view ntupleName, std::string_view fileName)
@@ -996,27 +930,31 @@ ROOT::RDF::RSampleInfo ROOT::Internal::RDF::RNTupleDS::CreateSampleInfo(
    // connection between the slot and the correct page source by retrieving
    // which range is connected currently to the slot
 
-   const auto &rangeIdx = fSlotsToRangeIdxs.at(slot * ROOT::Internal::RDF::CacheLineStep<std::size_t>());
+   const auto &entryRangeDS = fNSlots == 1
+                                 ? fCurrentRanges[0]
+                                 : fActiveRangesPerSlot.at(slot * ROOT::Internal::RDF::CacheLineStep<REntryRangeDS>());
 
    // Missing source if a file does not exist
-   if (!fCurrentRanges[rangeIdx].fSource)
+   if (!entryRangeDS.fSource)
       return ROOT::RDF::RSampleInfo{};
 
-   const auto &ntupleName = fCurrentRanges[rangeIdx].fSource->GetNTupleName();
-   const auto &ntuplePath = fCurrentRanges[rangeIdx].fFileName;
+   const auto &ntupleName = entryRangeDS.fSource->GetNTupleName();
+   const auto &ntuplePath = entryRangeDS.fFileName;
    const auto ntupleID = std::string(ntuplePath) + '/' + ntupleName;
 
    if (sampleMap.empty())
-      return ROOT::RDF::RSampleInfo(
-         ntupleID, std::make_pair(fCurrentRanges[rangeIdx].fFirstEntry, fCurrentRanges[rangeIdx].fLastEntry), nullptr,
-         fPrincipalDescriptor.GetNEntries());
+      return ROOT::RDF::RSampleInfo(ntupleID,
+                                    std::make_pair(entryRangeDS.fFirstEntry - entryRangeDS.fEntryOffset,
+                                                   entryRangeDS.fLastEntry - entryRangeDS.fEntryOffset),
+                                    nullptr, fPrincipalDescriptor.GetNEntries());
 
    if (sampleMap.find(ntupleID) == sampleMap.end())
       throw std::runtime_error("Full sample identifier '" + ntupleID + "' cannot be found in the available samples.");
 
-   return ROOT::RDF::RSampleInfo(
-      ntupleID, std::make_pair(fCurrentRanges[rangeIdx].fFirstEntry, fCurrentRanges[rangeIdx].fLastEntry),
-      sampleMap.at(ntupleID), fPrincipalDescriptor.GetNEntries());
+   return ROOT::RDF::RSampleInfo(ntupleID,
+                                 std::make_pair(entryRangeDS.fFirstEntry - entryRangeDS.fEntryOffset,
+                                                entryRangeDS.fLastEntry - entryRangeDS.fEntryOffset),
+                                 sampleMap.at(ntupleID), fPrincipalDescriptor.GetNEntries());
 }
 
 ROOT::RDataFrame ROOT::Internal::RDF::FromRNTuple(std::string_view ntupleName,
@@ -1035,3 +973,149 @@ ROOT::Internal::RDF::GetClustersAndEntries(std::string_view ntupleName, std::str
    const auto descGuard = source->GetSharedDescriptorGuard();
    return std::make_pair(ROOT::Internal::GetClusterBoundaries(descGuard.GetRef()), descGuard->GetNEntries());
 }
+
+#ifdef R__USE_IMT
+void ROOT::RDF::RNTupleDS::ProcessMTRange(std::size_t fileIdx, const ROOT::Internal::RNTupleClusterBoundaries &cluster,
+                                          ROOT::Detail::RDF::RLoopManager &lm, ROOT::Internal::RSlotStack &slotStack,
+                                          std::atomic<ULong64_t> &entryCount, std::atomic<ULong64_t> &globalEntryCount)
+{
+   ROOT::Internal::RSlotStackRAII slotRAII(slotStack);
+   const auto &slot = slotRAII.fSlot;
+
+   const std::pair<ULong64_t, ULong64_t> range{cluster.fFirstEntry, cluster.fLastEntryPlusOne};
+   entryCount.fetch_add((range.second - range.first));
+
+   auto source = CreatePageSource(fNTupleName, fFileNames[fileIdx]);
+   source->Attach();
+
+   auto nEntries = source->GetNEntries();
+   if (nEntries == 0)
+      return;
+
+   const auto offset{globalEntryCount.fetch_add(nEntries)};
+
+   REntryRangeDS entryRangeDS;
+   entryRangeDS.fFileName = fFileNames[fileIdx];
+   entryRangeDS.fSource = std::move(source);
+   entryRangeDS.fSource->SetEntryRange({range.first, range.second - range.first});
+   entryRangeDS.fFirstEntry = range.first + offset;
+   entryRangeDS.fLastEntry = range.second + offset;
+   entryRangeDS.fEntryOffset = offset;
+
+   fActiveRangesPerSlot[slot * ROOT::Internal::RDF::CacheLineStep<REntryRangeDS>()] = std::move(entryRangeDS);
+
+   lm.RNTupleThreadTask({range.first + offset, range.second + offset}, slot, offset);
+}
+
+void ROOT::RDF::RNTupleDS::ProcessMT(ROOT::Detail::RDF::RLoopManager &lm)
+{
+   ROOT::Internal::RSlotStack slotStack(fNSlots);
+   std::atomic<ULong64_t> entryCount(0ull);
+   std::atomic<ULong64_t> globalEntryCount(0ull);
+   ROOT::TThreadExecutor pool;
+
+   std::vector<std::uint64_t> globalFileOffsets;
+
+   if (fGlobalEntryRange.has_value()) {
+      // If the user explicitly request a global entry range, we pay the cost of
+      // computing the global entry offsets upfront
+      std::vector<std::uint64_t> fileEntries(fFileNames.size());
+      auto processFile = [](const std::string &ntupleName, const std::string &fileName) {
+         // RNTuple
+         auto source = ROOT::Internal::RPageSource::Create(ntupleName, fileName);
+         source->Attach();
+         const auto descGuard = source->GetSharedDescriptorGuard();
+         return descGuard->GetNEntries();
+      };
+      pool.Foreach([&fileEntries, &processFile,
+                    this](std::size_t idx) { fileEntries[idx] = processFile(fNTupleName, fFileNames[idx]); },
+                   ROOT::TSeq<std::size_t>(fFileNames.size()));
+
+      std::uint64_t offset{};
+      globalFileOffsets.reserve(fFileNames.size());
+      for (auto entries : fileEntries) {
+         globalFileOffsets.push_back(offset);
+         offset += entries;
+      }
+   }
+
+   auto processFileWithGlobalOffset = [&](std::size_t fileIdx) {
+      // This function is called when the user has explicitly requested to process only a global entry range. In this
+      // scenario we have precomputed the entry offsets of each file upfront (aligned with the global dataset entry
+      // index) so we can then adjust the range of entries in each file accordingly.
+
+      // Evaluate clusters (with local entry numbers) and number of entries for this file
+      const auto clustersAndEntries = ROOT::Internal::RDF::GetClustersAndEntries(fNTupleName, fFileNames[fileIdx]);
+      const auto &clustersInFile = clustersAndEntries.first;
+      const auto &globalFileOffset = globalFileOffsets[fileIdx];
+      const auto &[globalBegin, globalEnd] = fGlobalEntryRange.value();
+
+      if ((globalFileOffset + clustersAndEntries.second) < globalBegin || globalFileOffset > globalEnd)
+         return;
+
+      if (((globalBegin >= globalFileOffset) && (globalBegin < (globalFileOffset + clustersAndEntries.second))) ||
+          ((globalEnd >= globalFileOffset) && (globalEnd < (globalFileOffset + clustersAndEntries.second)))) {
+         std::vector<ROOT::Internal::RNTupleClusterBoundaries> adjustedClusters;
+         for (const auto &cluster : clustersInFile) {
+            // If either the global begin or global end fit within the current file, we adjust the cluster ranges
+            // accordingly
+            const std::uint64_t localBegin = globalBegin < globalFileOffset ? 0 : globalBegin - globalFileOffset;
+            const std::uint64_t localEnd = globalEnd > globalFileOffset + clustersAndEntries.second
+                                              ? globalFileOffset + clustersAndEntries.second
+                                              : globalEnd - globalFileOffset;
+            const auto currentStart = std::max(cluster.fFirstEntry, localBegin);
+            const auto currentEnd = std::min(cluster.fLastEntryPlusOne, localEnd);
+            // This is not satified if the desired start is larger than the last entry of some cluster
+            // In this case, this cluster is not going to be processes further
+            if (currentStart < currentEnd)
+               adjustedClusters.push_back(ROOT::Internal::RNTupleClusterBoundaries{currentStart, currentEnd});
+         }
+         pool.Foreach(
+            [this, &lm, &slotStack, &entryCount, &globalEntryCount,
+             &fileIdx](const ROOT::Internal::RNTupleClusterBoundaries &cluster) {
+               this->ProcessMTRange(fileIdx, cluster, lm, slotStack, entryCount, globalEntryCount);
+            },
+            adjustedClusters);
+      } else {
+         // Otherwise, we just use the cluster boundaries of the whole file
+         pool.Foreach(
+            [this, &lm, &slotStack, &entryCount, &globalEntryCount,
+             &fileIdx](const ROOT::Internal::RNTupleClusterBoundaries &cluster) {
+               this->ProcessMTRange(fileIdx, cluster, lm, slotStack, entryCount, globalEntryCount);
+            },
+            clustersInFile);
+      }
+   };
+
+   // Per-file processing that also retrieves cluster info for a file
+   auto processFileRetrievingClusters = [&](std::size_t fileIdx) {
+      // Evaluate clusters (with local entry numbers) and number of entries for this file
+      const auto clustersAndEntries = ROOT::Internal::RDF::GetClustersAndEntries(fNTupleName, fFileNames[fileIdx]);
+      const auto &clusters = clustersAndEntries.first;
+      pool.Foreach(
+         [this, &lm, &slotStack, &entryCount, &globalEntryCount,
+          &fileIdx](const ROOT::Internal::RNTupleClusterBoundaries &cluster) {
+            this->ProcessMTRange(fileIdx, cluster, lm, slotStack, entryCount, globalEntryCount);
+         },
+         clusters);
+   };
+
+   std::vector<std::size_t> fileIdxs(fFileNames.size());
+   std::iota(fileIdxs.begin(), fileIdxs.end(), 0);
+   if (fGlobalEntryRange.has_value())
+      pool.Foreach(processFileWithGlobalOffset, fileIdxs);
+   else
+      pool.Foreach(processFileRetrievingClusters, fileIdxs);
+
+   if (fGlobalEntryRange.has_value()) {
+      auto &&[begin, end] = fGlobalEntryRange.value();
+      auto &&processedEntries = entryCount.load();
+      if ((end - begin) > processedEntries) {
+         Warning("RDataFrame::Run",
+                 "RDataFrame stopped processing after %lld entries, whereas an entry range (begin=%lld,end=%lld) was "
+                 "requested. Consider adjusting the end value of the entry range to a maximum of %lld.",
+                 processedEntries, begin, end, begin + processedEntries);
+      }
+   }
+}
+#endif

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -31,6 +31,13 @@ void EXPECT_VEC_SEQ_EQ(const std::vector<ULong64_t> &vec, const ROOT::TSeq<ULong
       EXPECT_EQ(vec[i], seq[i]);
 }
 
+void expect_vec_eq(const std::vector<ULong64_t> &a, const std::vector<ULong64_t> &b)
+{
+   ASSERT_EQ(a.size(), b.size());
+   for (decltype(a.size()) i{}; i < a.size(); i++)
+      EXPECT_EQ(a[i], b[i]);
+}
+
 struct RTestSample {
    std::string name;
    ULong64_t sampleStart;
@@ -944,50 +951,72 @@ TEST_P(RDatasetSpecTest, RNTupleWithGlobalRanges)
    spec.AddSample(samp);
    spec.AddSample(samp1);
    spec.AddSample(samp2);
-   auto df1 = ROOT::RDataFrame(spec);
+
+   auto is_vector_unique = [](std::vector<ULong64_t> &vec) {
+      std::sort(vec.begin(), vec.end());
+      return std::adjacent_find(vec.begin(), vec.end()) == vec.end();
+   };
+
+   auto df = ROOT::RDataFrame(spec);
+   auto definepersamp =
+      df.DefinePerSample("lum", [](unsigned int, const ROOT::RDF::RSampleInfo &id) { return id.GetD("lum"); });
+   auto df_filtered = definepersamp.Filter("lum == 10.").Count();
+   auto df_final = df.Filter("x > 3").Count();
+   auto df_rdfentry = df.Define("entry", [](ULong64_t entry) { return entry; }, {"rdfentry_"}).Take<ULong64_t>("entry");
+   EXPECT_EQ(df_filtered.GetValue(), 10);
+   EXPECT_EQ(df_final.GetValue(), 11);
+   // rdfentry_ should be a unique number per entry, no guarantee about ordering or alignment with dataset entries
+   EXPECT_TRUE(is_vector_unique(*df_rdfentry));
 
    std::vector<RDatasetSpec::REntryRange> goodRanges = {{1, 4}, {2, 7}, {6, 19}, {16, 20}};
 
-   auto df_final = df1.Filter("x > 3").Count();
-
-   auto definepersamp =
-      df1.DefinePerSample("lum", [](unsigned int, const ROOT::RDF::RSampleInfo &id) { return id.GetD("lum"); });
-   auto df_filtered = definepersamp.Filter("lum == 10.").Count();
-
-   auto df = RDataFrame(spec.WithGlobalRange(goodRanges[0]));
-   auto filt = df.Filter("rdfentry_ == 2");
-   auto result = filt.Take<ULong64_t>("x");
-   auto res = result.GetValue();
-   auto count_entries = df.Count().GetValue();
-   EXPECT_EQ(res[0], 2);
-   EXPECT_EQ(count_entries, 3);
+   auto df1 = RDataFrame(spec.WithGlobalRange(goodRanges[0]));
+   auto rptr_1 = df1.Take<ULong64_t>("x");
+   auto count_entries_1 = df1.Count();
+   auto df1_rdfentry =
+      df1.Define("entry", [](ULong64_t entry) { return entry; }, {"rdfentry_"}).Take<ULong64_t>("entry");
+   // Entries are processed unordered, sort before comparing with expected values
+   std::sort(rptr_1->begin(), rptr_1->end());
+   expect_vec_eq(rptr_1.GetValue(), {1, 2, 3});
+   EXPECT_EQ(count_entries_1.GetValue(), 3);
+   // rdfentry_ should be a unique number per entry, no guarantee about ordering or alignment with dataset entries
+   EXPECT_TRUE(is_vector_unique(*df1_rdfentry));
 
    auto df2 = RDataFrame(spec.WithGlobalRange(goodRanges[1]));
-   auto filt2 = df2.Filter("rdfentry_ == 3");
-   auto result2 = filt2.Take<ULong64_t>("x");
-   auto res2 = result2.GetValue();
-   auto count_entries_2 = df2.Count().GetValue();
-   EXPECT_EQ(res2[0], 3);
-   EXPECT_EQ(count_entries_2, 5);
+   auto rptr_2 = df2.Take<ULong64_t>("x");
+   auto count_entries_2 = df2.Count();
+   auto df2_rdfentry =
+      df2.Define("entry", [](ULong64_t entry) { return entry; }, {"rdfentry_"}).Take<ULong64_t>("entry");
+   // Entries are processed unordered, sort before comparing with expected values
+   std::sort(rptr_2->begin(), rptr_2->end());
+   expect_vec_eq(rptr_2.GetValue(), {0, 2, 3, 4, 4});
+   EXPECT_EQ(count_entries_2.GetValue(), 5);
+   // rdfentry_ should be a unique number per entry, no guarantee about ordering or alignment with dataset entries
+   EXPECT_TRUE(is_vector_unique(*df2_rdfentry));
 
    auto df3 = RDataFrame(spec.WithGlobalRange(goodRanges[2]));
-   auto filt3 = df3.Filter("rdfentry_ == 8");
-   auto result3 = filt3.Take<ULong64_t>("x");
-   auto res3 = result3.GetValue();
-   auto count_entries_3 = df3.Count().GetValue();
-   EXPECT_EQ(res3[0], 12);
-   EXPECT_EQ(count_entries_3, 13);
+   auto rptr_3 = df3.Take<ULong64_t>("x");
+   auto count_entries_3 = df3.Count();
+   auto df3_rdfentry =
+      df3.Define("entry", [](ULong64_t entry) { return entry; }, {"rdfentry_"}).Take<ULong64_t>("entry");
+   // Entries are processed unordered, sort before comparing with expected values
+   std::sort(rptr_3->begin(), rptr_3->end());
+   expect_vec_eq(rptr_3.GetValue(), {0, 0, 2, 3, 4, 4, 6, 6, 8, 8, 9, 12, 16});
+   EXPECT_EQ(count_entries_3.GetValue(), 13);
+   // rdfentry_ should be a unique number per entry, no guarantee about ordering or alignment with dataset entries
+   EXPECT_TRUE(is_vector_unique(*df3_rdfentry));
 
    auto df4 = RDataFrame(spec.WithGlobalRange(goodRanges[3]));
-   auto filt4 = df4.Filter("rdfentry_ == 19");
-   auto result4 = filt4.Take<ULong64_t>("x");
-   auto res4 = result4.GetValue();
-   auto count_entries_4 = df4.Count().GetValue();
-   EXPECT_EQ(res4[0], 12);
-   EXPECT_EQ(count_entries_4, 4);
-
-   EXPECT_EQ(df_final.GetValue(), 11);
-   EXPECT_EQ(df_filtered.GetValue(), 10);
+   auto rptr_4 = df4.Take<ULong64_t>("x");
+   auto count_entries_4 = df4.Count();
+   auto df4_rdfentry =
+      df4.Define("entry", [](ULong64_t entry) { return entry; }, {"rdfentry_"}).Take<ULong64_t>("entry");
+   // Entries are processed unordered, sort before comparing with expected values
+   std::sort(rptr_4->begin(), rptr_4->end());
+   expect_vec_eq(rptr_4.GetValue(), {3, 6, 9, 12});
+   EXPECT_EQ(count_entries_4.GetValue(), 4);
+   // rdfentry_ should be a unique number per entry, no guarantee about ordering or alignment with dataset entries
+   EXPECT_TRUE(is_vector_unique(*df4_rdfentry));
 }
 
 TEST_P(RDatasetSpecTest, FromSpecRNTuple)


### PR DESCRIPTION
This commit changes the scheduling behaviour for MT RNTuple runs in RDataFrame.

It mimicks part of the mechanism used by TTreeProcessorMT. For the more general case of having a dataset comprised of N files and wanting to process all entries, the strategy is summarised as:

* With the input list of files, launch one TBB task per file
* Within each of those, open the file, compute cluster boundaries, launch another TBB task per each cluster

The actual processing is done in the RLoopManager::RNTupleThreadTask function which needs to receive an available slot from the slot stack, which is thus limiting the number of open files.

The strategy could be further improved such that there is a pool of open files with no boundaries imposed on the RNTuple cluster cache. TBB tasks should then need to operate sequentially on the same file(s) until all entries are done to make best use of the cache. This is left for another commit.

For now marked as a draft since I would like to see all tests passing (they are passing on my machine). Known things to work on:

* Introduce cluster coalescing to accumulate multiple consecutive cluster boundaries in the same TBB task
* Re-introduce the staging area for open page sources as discussed above.

