### PR TITLE
[cmake] Detect incomplete gtest installation

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1297,9 +1297,9 @@ if (testing OR testsupport)
   # Verify that all GTest subcomponents are installed
   foreach(LIBNAME gtest_main gmock_main gtest gmock)
     if(NOT TARGET GTest::${LIBNAME} AND NOT TARGET ${LIBNAME})
-      message(SEND_ERROR "Missing GTest subcomponent ${LIBNAME}")
+      message(SEND_ERROR "Missing installation of GTest subcomponent ${LIBNAME}")
     endif()
-  endif()
+  endforeach()
   # Starting from cmake 3.23, the GTest targets will have stable names.
   # ROOT was updated to use those, but for older CMake versions, we have to declare the aliases:
   foreach(LIBNAME gtest_main gmock_main gtest gmock)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1294,6 +1294,12 @@ if (testing OR testsupport)
 endif()
 
 if (testing OR testsupport)
+  # Verify that all GTest subcomponents are installed
+  foreach(LIBNAME gtest_main gmock_main gtest gmock)
+    if(NOT TARGET GTest::${LIBNAME} AND NOT TARGET ${LIBNAME})
+      message(SEND_ERROR "Missing GTest subcomponent ${LIBNAME}")
+    endif()
+  endif()
   # Starting from cmake 3.23, the GTest targets will have stable names.
   # ROOT was updated to use those, but for older CMake versions, we have to declare the aliases:
   foreach(LIBNAME gtest_main gmock_main gtest gmock)


### PR DESCRIPTION
If the user only does sudo apt libgtest-dev on Ubuntu, then find_package works, but it fails later within cppinterop because libname gmock does not exist.

Issue a more clear message earlier on to hint the user to do sudo apt install libgmock-dev