### PR TITLE
[ci] [pyroot] [rf] adding jsonschema dependency for hs3 validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ mplhep
 nbconvert>=7.4.0
 pytest
 setuptools
+jsonschema # for RooFit HS3 validation (using HS3TestSuite)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Adding `jsonschema` to `requirements.txt`, such that it is available to the HS3TestSuite (introduced in #22567) in ci runs.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

