### PR TITLE
[reve] Fix misleading client error message in streaming of an empty projected track

### DIFF
--- a/graf3d/eve7/src/REveTrackProjected.cxx
+++ b/graf3d/eve7/src/REveTrackProjected.cxx
@@ -317,7 +317,8 @@ Int_t REveTrackProjected::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 {
    Int_t ret = REveTrack::WriteCoreJson(j, rnr_offset);
 
-   j["render_data"]["break_point_size"] = fBreakPoints.size();
+   if (j.contains("render_data"))
+      j["render_data"]["break_point_size"] = fBreakPoints.size();
 
    return ret;
 }


### PR DESCRIPTION
The client logs reported an error in streaming binary data from the server to the client.
The erroneous message was generated because REveTrackProjected::WriteCoreJson created a render_data JSON object even when the track had no points. This can be reproduced by creating a track with a vertex outside the track propagator radius and then projecting it.

The missing check for an empty track in REveTrackProjected::WriteCoreJson had no consequence on streaming and rendering of other elements in the scene.

