### PR TITLE
[rootci] Use system nlohmann/json.hpp on opensuse16

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/opensuse16-march_native.txt
+++ b/.github/workflows/root-ci-config/buildconfig/opensuse16-march_native.txt
@@ -5,7 +5,6 @@ builtin_tbb=ON
 builtin_vdt=ON
 builtin_xrootd=ON
 builtin_unuran=ON
-builtin_nlohmannjson=ON
 test_distrdf_dask=OFF
 test_distrdf_pyspark=OFF
 tmva-pymva=ON


### PR DESCRIPTION
opensuse16 includes `nlohmann_json-devel` package which should be enough for ROOT functionality

