### PR TITLE
[ntuple] Add flamegraph visualizator backend supporting Speedscope

### DIFF
--- a/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
@@ -50,6 +50,10 @@ enum class ENTupleInspectorHist {
    kUncompressedSize
 };
 
+enum class EFlamegraphSpecificationFormat {
+   kSpeedscopeJSON
+};
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleInspector
@@ -493,6 +497,9 @@ public:
    {
       PrintFieldTreeAsDot(GetDescriptor().GetFieldZero(), output);
    }
+
+   void PrintFieldTreeAsFlamegraphSpecification(EFlamegraphSpecificationFormat format,
+                                                std::ostream &output = std::cout) const;
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/src/RNTupleInspector.cxx
@@ -565,3 +565,113 @@ void ROOT::Experimental::RNTupleInspector::PrintFieldTreeAsDot(const ROOT::RFiel
    if (isZeroField)
       output << "}";
 }
+
+void ROOT::Experimental::RNTupleInspector::PrintFieldTreeAsFlamegraphSpecification(
+   EFlamegraphSpecificationFormat format, std::ostream &output) const
+{
+   (void)format; // There is only one format at the moment
+
+   const auto &tupleDescriptor = GetDescriptor();
+   ROOT::DescriptorId_t rootId = tupleDescriptor.GetFieldZeroId();
+   const auto &rootFieldDescriptor = tupleDescriptor.GetFieldDescriptor(rootId);
+
+   struct FrameDescription {
+      std::string name;
+      std::string type;
+      size_t byteSize = 0;
+      char kind; // 'F' or 'C' for field or column
+   };
+
+   struct TimelineOcurrence {
+      size_t frameDescriptionIndex;
+      unsigned int timestamp;
+      char type; // 'O' or 'C' for open or close
+   };
+
+   std::vector<FrameDescription> frameDescriptions;
+   std::vector<TimelineOcurrence> timelineOcurrences;
+   unsigned int currentTime = 0;
+
+   auto visitFieldsDFS = [&](auto &self, const ROOT::RFieldDescriptor &fieldDescriptor) -> size_t {
+      FrameDescription fieldFrame;
+      fieldFrame.name = tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId());
+      fieldFrame.type = fieldDescriptor.GetTypeName();
+      fieldFrame.kind = 'F';
+      frameDescriptions.push_back(fieldFrame);
+
+      size_t frameDescriptionIndex = frameDescriptions.size() - 1;
+
+      timelineOcurrences.push_back({frameDescriptionIndex, currentTime, 'O'});
+
+      size_t subTreeSize = 0;
+      const auto &childIds = fieldDescriptor.GetLinkIds();
+
+      for (const auto &childFieldId : childIds) {
+         const auto &childFieldDescriptor = tupleDescriptor.GetFieldDescriptor(childFieldId);
+         subTreeSize += self(self, childFieldDescriptor);
+      }
+
+      for (const auto &columnDescriptor : tupleDescriptor.GetColumnIterable(fieldDescriptor.GetId())) {
+         const auto &columnInfo = GetColumnInspector(columnDescriptor.GetPhysicalId());
+         size_t columnSize = columnInfo.GetCompressedSize();
+
+         FrameDescription columnFrame;
+
+         columnFrame.name = tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId()) + " [col#" +
+                            std::to_string(columnDescriptor.GetPhysicalId()) + "]";
+         columnFrame.type = ROOT::Internal::RColumnElementBase::GetColumnTypeName(columnDescriptor.GetType());
+         columnFrame.byteSize = columnSize;
+         columnFrame.kind = 'C';
+         frameDescriptions.push_back(columnFrame);
+
+         size_t columnFrameIdx = frameDescriptions.size() - 1;
+
+         timelineOcurrences.push_back({columnFrameIdx, currentTime, 'O'});
+         currentTime += columnSize;
+         timelineOcurrences.push_back({columnFrameIdx, currentTime, 'C'});
+
+         subTreeSize += columnSize;
+      }
+
+      frameDescriptions[frameDescriptionIndex].byteSize = subTreeSize;
+
+      timelineOcurrences.push_back({frameDescriptionIndex, currentTime, 'C'});
+
+      return subTreeSize;
+   };
+
+   visitFieldsDFS(visitFieldsDFS, rootFieldDescriptor);
+
+   output << "{\n";
+   output << "   \"$schema\":\"https://www.speedscope.app/file-format-schema.json\",\n";
+   output << "   \"shared\":{\n";
+   output << "      \"frames\":[\n";
+
+   for (size_t i = 0; i < frameDescriptions.size(); ++i) {
+      output << "         { \"name\":\"" << frameDescriptions[i].name
+             << "\", \"file\":\"Type: " << frameDescriptions[i].type << ", Size: " << frameDescriptions[i].byteSize
+             << "B\" }" << (i + 1 < frameDescriptions.size() ? ",\n" : "\n");
+   }
+
+   output << "      ]\n";
+   output << "   },\n";
+   output << "   \"profiles\":[\n";
+   output << "      {\n";
+   output << "         \"type\":\"evented\",\n";
+   output << "         \"name\":\"Flattened Timeline\",\n";
+   output << "         \"unit\":\"bytes\",\n";
+   output << "         \"startValue\":0,\n";
+   output << "         \"endValue\":" << currentTime << ",\n";
+   output << "         \"events\":[\n";
+
+   for (size_t i = 0; i < timelineOcurrences.size(); ++i) {
+      const auto &e = timelineOcurrences[i];
+      output << "            {\"type\":\"" << e.type << "\",\"frame\":" << e.frameDescriptionIndex
+             << ",\"at\":" << e.timestamp << "}" << (i + 1 < timelineOcurrences.size() ? ",\n" : "\n");
+   }
+
+   output << "         ]\n";
+   output << "      }\n";
+   output << "   ]\n";
+   output << "}\n";
+}

--- a/tree/ntupleutil/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/test/ntuple_inspector.cxx
@@ -308,13 +308,13 @@ TEST(RNTupleInspector, ColumnInfoUncompressed)
    {
       auto model = RNTupleModel::Create();
 
-      auto int32fld = std::make_unique<RField<std::int32_t>>("int32");
-      int32fld->SetColumnRepresentatives({{ENTupleColumnType::kInt32}});
-      model->AddField(std::move(int32fld));
+      auto int32field = std::make_unique<RField<std::int32_t>>("int32");
+      int32field->SetColumnRepresentatives({{ENTupleColumnType::kInt32}});
+      model->AddField(std::move(int32field));
 
-      auto splitReal64fld = std::make_unique<RField<double>>("splitReal64");
-      splitReal64fld->SetColumnRepresentatives({{ENTupleColumnType::kSplitReal64}});
-      model->AddField(std::move(splitReal64fld));
+      auto splitReal64field = std::make_unique<RField<double>>("splitReal64");
+      splitReal64field->SetColumnRepresentatives({{ENTupleColumnType::kSplitReal64}});
+      model->AddField(std::move(splitReal64field));
 
       auto writeOptions = RNTupleWriteOptions();
       writeOptions.SetCompression(0);
@@ -823,9 +823,9 @@ TEST(RNTupleInspector, MultiColumnRepresentations)
    FileRaii fileGuard("test_ntuple_inspector_multi_column_representations.root");
    {
       auto model = RNTupleModel::Create();
-      auto fldPx = RFieldBase::Create("px", "float").Unwrap();
-      fldPx->SetColumnRepresentatives({{ENTupleColumnType::kReal32}, {ENTupleColumnType::kReal16}});
-      model->AddField(std::move(fldPx));
+      auto fieldPx = RFieldBase::Create("px", "float").Unwrap();
+      fieldPx->SetColumnRepresentatives({{ENTupleColumnType::kReal32}, {ENTupleColumnType::kReal16}});
+      model->AddField(std::move(fieldPx));
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntpl", fileGuard.GetPath());
       writer->Fill();
       writer->CommitCluster();
@@ -848,8 +848,8 @@ TEST(RNTupleInspector, FieldTreeAsDot)
    FileRaii fileGuard("test_ntuple_inspector_fields_tree_as_dot.root");
    {
       auto model = RNTupleModel::Create();
-      auto fldFloat1 = model->MakeField<float>("float1");
-      auto fldInt = model->MakeField<std::int32_t>("int");
+      auto fieldFloat1 = model->MakeField<float>("float1");
+      auto fieldInt = model->MakeField<std::int32_t>("int");
       auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
    }
    auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
@@ -861,4 +861,61 @@ TEST(RNTupleInspector, FieldTreeAsDot)
       "</b>float1<br></br><b>Type: </b>float<br></br><b>ID: </b>0<br></br>>]\n0->2\n2[label=<<b>Name: "
       "</b>int<br></br><b>Type: </b>std::int32_t<br></br><b>ID: </b>1<br></br>>]\n}";
    EXPECT_EQ(dot, expected);
+}
+
+TEST(RNTupleInspector, FieldTreeAsFlamegraphSpecification)
+{
+   FileRaii fileGuard("test_ntuple_inspector_field_tree_as_flamegraph_specification");
+   {
+      auto model = RNTupleModel::Create();
+      auto fieldFloat1 = model->MakeField<float>("float1");
+      auto fieldInt = model->MakeField<std::int32_t>("int");
+      auto writer = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath());
+
+      for (int i = 0; i < 10; ++i) {
+         *fieldFloat1 = 3.14f * i;
+         *fieldInt = 42 * i;
+         writer->Fill();
+      }
+   }
+   auto inspector = RNTupleInspector::Create("ntuple", fileGuard.GetPath());
+   std::ostringstream flamegraphSpecificationStream;
+   inspector->PrintFieldTreeAsFlamegraphSpecification(
+      ROOT::Experimental::EFlamegraphSpecificationFormat::kSpeedscopeJSON, flamegraphSpecificationStream);
+   const std::string flamegraphSpecification = flamegraphSpecificationStream.str();
+   const std::string &expected = R"({
+   "$schema":"https://www.speedscope.app/file-format-schema.json",
+   "shared":{
+      "frames":[
+         { "name":"", "file":"Type: , Size: 80B" },
+         { "name":"float1", "file":"Type: float, Size: 40B" },
+         { "name":"float1 [col#0]", "file":"Type: SplitReal32, Size: 40B" },
+         { "name":"int", "file":"Type: std::int32_t, Size: 40B" },
+         { "name":"int [col#1]", "file":"Type: SplitInt32, Size: 40B" }
+      ]
+   },
+   "profiles":[
+      {
+         "type":"evented",
+         "name":"Flattened Timeline",
+         "unit":"bytes",
+         "startValue":0,
+         "endValue":80,
+         "events":[
+            {"type":"O","frame":0,"at":0},
+            {"type":"O","frame":1,"at":0},
+            {"type":"O","frame":2,"at":0},
+            {"type":"C","frame":2,"at":40},
+            {"type":"C","frame":1,"at":40},
+            {"type":"O","frame":3,"at":40},
+            {"type":"O","frame":4,"at":40},
+            {"type":"C","frame":4,"at":80},
+            {"type":"C","frame":3,"at":80},
+            {"type":"C","frame":0,"at":80}
+         ]
+      }
+   ]
+}
+)";
+   EXPECT_EQ(flamegraphSpecification, expected);
 }


### PR DESCRIPTION
# This Pull request:

## Changes:

This PR adds `void PrintFieldTreeAsFlamegraphSpecification(EFlamegraphSpecificationFormat format, std::ostream &output = std::cout) const;` method to the `RNTupleInspector` class.

It also adds a trivial unit test to the `ntuple_inspector.cxx` file which locally works. 

## Checklist:

- [x] tested changes locally on tests whose name match ntuple and on the `ntuple_inspector` file tests. 
- [x] updated the docs (if necessary) <- no need to update the docs I believe.