### PR TITLE
[HS3][RF] I/O for RooWrapperPdf and RooExtendPdf

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -63,7 +63,6 @@ public:
    static RooFit::Detail::JSONNode const *findNamedChild(RooFit::Detail::JSONNode const &node, std::string const &name);
 
    static void fillSeq(RooFit::Detail::JSONNode &node, RooAbsCollection const &coll, size_t nMax = -1);
-   static void fillSeqSanitizedName(RooFit::Detail::JSONNode &node, RooAbsCollection const &coll, size_t nMax = -1);
 
    template <class T>
    T *request(const std::string &objname, const std::string &requestAuthor)

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -765,12 +765,6 @@ std::vector<std::string> splitTopLevelProduct(const std::string &expr)
    return parts;
 }
 
-#include <regex>
-#include <string>
-#include <cctype>
-#include <cstdlib>
-#include <iostream>
-
 NormSys parseOverallModifierFormula(const std::string &s, RooFormulaVar *formula)
 {
    static const std::regex pattern(

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -499,37 +499,6 @@ public:
    }
 };
 
-class RooLegacyExpPolyFactory : public RooFit::JSONIO::Importer {
-public:
-   bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
-   {
-      std::string name(RooJSONFactoryWSTool::name(p));
-      if (!p.has_child("coefficients")) {
-         RooJSONFactoryWSTool::error("no coefficients given in '" + name + "'");
-      }
-      RooAbsReal *x = tool->requestArg<RooAbsReal>(p, "x");
-      RooArgList coefs;
-      int order = 0;
-      int lowestOrder = 0;
-      for (const auto &coef : p["coefficients"].children()) {
-         // As long as the coefficients match the default coefficients in
-         // RooFit, we don't have to instantiate RooFit objects but can
-         // increase the lowestOrder flag.
-         if (order == 0 && coef.val() == "1.0") {
-            ++lowestOrder;
-         } else if (coefs.empty() && coef.val() == "0.0") {
-            ++lowestOrder;
-         } else {
-            coefs.add(*tool->request<RooAbsReal>(coef.val(), name));
-         }
-         ++order;
-      }
-
-      tool->wsEmplace<RooLegacyExpPoly>(name, *x, coefs, lowestOrder);
-      return true;
-   }
-};
-
 class RooMultiVarGaussianFactory : public RooFit::JSONIO::Importer {
 public:
    bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
@@ -744,12 +713,13 @@ public:
    }
 };
 
-class RooHistFuncStreamer : public RooFit::JSONIO::Exporter {
+template <class RooArg_t>
+class RooHistStreamer : public RooFit::JSONIO::Exporter {
 public:
    std::string const &key() const override;
    bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
    {
-      const RooHistFunc *hf = static_cast<const RooHistFunc *>(func);
+      const RooArg_t *hf = static_cast<const RooArg_t *>(func);
       elem["type"] << key();
       RooDataHist const &dh = hf->dataHist();
       tool->exportHisto(*dh.get(), dh.numEntries(), dh.weightArray(), elem["data"].set_map());
@@ -757,7 +727,8 @@ public:
    }
 };
 
-class RooHistFuncFactory : public RooFit::JSONIO::Importer {
+template <class RooArg_t>
+class RooHistFactory : public RooFit::JSONIO::Importer {
 public:
    bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
    {
@@ -767,35 +738,7 @@ public:
       }
       std::unique_ptr<RooDataHist> dataHist =
          RooJSONFactoryWSTool::readBinnedData(p["data"], name, RooJSONFactoryWSTool::readAxes(p["data"]));
-      tool->wsEmplace<RooHistFunc>(name, *dataHist->get(), *dataHist);
-      return true;
-   }
-};
-
-class RooHistPdfStreamer : public RooFit::JSONIO::Exporter {
-public:
-   std::string const &key() const override;
-   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
-   {
-      const RooHistPdf *hf = static_cast<const RooHistPdf *>(func);
-      elem["type"] << key();
-      RooDataHist const &dh = hf->dataHist();
-      tool->exportHisto(*dh.get(), dh.numEntries(), dh.weightArray(), elem["data"].set_map());
-      return true;
-   }
-};
-
-class RooHistPdfFactory : public RooFit::JSONIO::Importer {
-public:
-   bool importArg(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
-   {
-      std::string name(RooJSONFactoryWSTool::name(p));
-      if (!p.has_child("data")) {
-         RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
-      }
-      std::unique_ptr<RooDataHist> dataHist =
-         RooJSONFactoryWSTool::readBinnedData(p["data"], name, RooJSONFactoryWSTool::readAxes(p["data"]));
-      tool->wsEmplace<RooHistPdf>(name, *dataHist->get(), *dataHist);
+      tool->wsEmplace<RooArg_t>(name, *dataHist->get(), *dataHist);
       return true;
    }
 };
@@ -890,17 +833,6 @@ public:
    {
       elem["type"] << key();
       writePolynomialBody(static_cast<const RooArg_t *>(func), elem);
-      return true;
-   }
-};
-
-class RooLegacyExpPolyStreamer : public RooFit::JSONIO::Exporter {
-public:
-   std::string const &key() const override;
-   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
-   {
-      elem["type"] << key();
-      writePolynomialBody(static_cast<const RooLegacyExpPoly *>(func), elem);
       return true;
    }
 };
@@ -1249,14 +1181,17 @@ DEFINE_EXPORTER_KEY(RooAddPdfStreamer<RooAddModel>, "mixture_model");
 DEFINE_EXPORTER_KEY(RooBinSamplingPdfStreamer, "binsampling");
 DEFINE_EXPORTER_KEY(RooWrapperPdfStreamer, "density_function_dist");
 DEFINE_EXPORTER_KEY(RooBinWidthFunctionStreamer, "binwidth");
-DEFINE_EXPORTER_KEY(RooLegacyExpPolyStreamer, "legacy_exp_poly_dist");
+template <>
+DEFINE_EXPORTER_KEY(RooPolynomialStreamer<RooLegacyExpPoly>, "legacy_exp_poly_dist");
 DEFINE_EXPORTER_KEY(RooExponentialStreamer, "exponential_dist");
 template <>
 DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooFormulaVar>, "generic_function");
 template <>
 DEFINE_EXPORTER_KEY(RooFormulaArgStreamer<RooGenericPdf>, "generic_dist");
-DEFINE_EXPORTER_KEY(RooHistFuncStreamer, "histogram");
-DEFINE_EXPORTER_KEY(RooHistPdfStreamer, "histogram_dist");
+template <>
+DEFINE_EXPORTER_KEY(RooHistStreamer<RooHistFunc>, "histogram");
+template <>
+DEFINE_EXPORTER_KEY(RooHistStreamer<RooHistPdf>, "histogram_dist");
 DEFINE_EXPORTER_KEY(RooLogNormalStreamer, "lognormal_dist");
 DEFINE_EXPORTER_KEY(RooMultiVarGaussianStreamer, "multivariate_normal_dist");
 DEFINE_EXPORTER_KEY(RooPoissonStreamer, "poisson_dist");
@@ -1293,12 +1228,12 @@ STATIC_EXECUTE([]() {
    registerImporter<RooAddModelFactory>("mixture_model", false);
    registerImporter<RooBinSamplingPdfFactory>("binsampling_dist", false);
    registerImporter<RooBinWidthFunctionFactory>("binwidth", false);
-   registerImporter<RooLegacyExpPolyFactory>("legacy_exp_poly_dist", false);
+   registerImporter<RooPolynomialFactory<RooLegacyExpPoly>>("legacy_exp_poly_dist", false);
    registerImporter<RooExponentialFactory>("exponential_dist", false);
    registerImporter<RooFormulaArgFactory<RooFormulaVar>>("generic_function", false);
    registerImporter<RooFormulaArgFactory<RooGenericPdf>>("generic_dist", false);
-   registerImporter<RooHistFuncFactory>("histogram", false);
-   registerImporter<RooHistPdfFactory>("histogram_dist", false);
+   registerImporter<RooHistFactory<RooHistFunc>>("histogram", false);
+   registerImporter<RooHistFactory<RooHistPdf>>("histogram_dist", false);
    registerImporter<RooLogNormalFactory>("lognormal_dist", false);
    registerImporter<RooMultiVarGaussianFactory>("multivariate_normal_dist", false);
    registerImporter<RooPoissonFactory>("poisson_dist", false);
@@ -1321,12 +1256,12 @@ STATIC_EXECUTE([]() {
    registerExporter<RooAddPdfStreamer<RooAddModel>>(RooAddModel::Class(), false);
    registerExporter<RooBinSamplingPdfStreamer>(RooBinSamplingPdf::Class(), false);
    registerExporter<RooBinWidthFunctionStreamer>(RooBinWidthFunction::Class(), false);
-   registerExporter<RooLegacyExpPolyStreamer>(RooLegacyExpPoly::Class(), false);
+   registerExporter<RooPolynomialStreamer<RooLegacyExpPoly>>(RooLegacyExpPoly::Class(), false);
    registerExporter<RooExponentialStreamer>(RooExponential::Class(), false);
    registerExporter<RooFormulaArgStreamer<RooFormulaVar>>(RooFormulaVar::Class(), false);
    registerExporter<RooFormulaArgStreamer<RooGenericPdf>>(RooGenericPdf::Class(), false);
-   registerExporter<RooHistFuncStreamer>(RooHistFunc::Class(), false);
-   registerExporter<RooHistPdfStreamer>(RooHistPdf::Class(), false);
+   registerExporter<RooHistStreamer<RooHistFunc>>(RooHistFunc::Class(), false);
+   registerExporter<RooHistStreamer<RooHistPdf>>(RooHistPdf::Class(), false);
    registerExporter<RooLogNormalStreamer>(RooLognormal::Class(), false);
    registerExporter<RooMultiVarGaussianStreamer>(RooMultiVarGaussian::Class(), false);
    registerExporter<RooPoissonStreamer>(RooPoisson::Class(), false);

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -48,6 +48,7 @@
 #include <RooTFnBinding.h>
 #include <RooTruthModel.h>
 #include <RooGaussModel.h>
+#include <RooWrapperPdf.h>
 #include <RooWorkspace.h>
 #include <RooRealIntegral.h>
 #include <RooSpline.h>
@@ -1188,17 +1189,65 @@ public:
    }
 };
 
+class RooWrapperPdfImporter : public RooFit::JSONIO::Importer {
+public:
+   bool importArg(RooJSONFactoryWSTool *tool, const RooFit::Detail::JSONNode &node) const override
+   {
+      if (node["type"].val() != "density_function_dist")
+         return false;
+
+      auto name = RooJSONFactoryWSTool::name(node);
+      auto *func = tool->requestArg<RooAbsReal>(node, "function");
+
+      bool selfNormalized = false;
+
+      if (auto sn = node.find("selfNormalized"))
+         selfNormalized = sn->val_bool();
+
+      tool->wsEmplace<RooWrapperPdf>(name, *func, selfNormalized);
+      return true;
+   }
+};
+
+class RooWrapperPdfStreamer : public RooFit::JSONIO::Exporter {
+public:
+   std::string const &key() const override;
+
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *arg, RooFit::Detail::JSONNode &node) const override
+   {
+      auto const *pdf = dynamic_cast<RooWrapperPdf const *>(arg);
+      if (!pdf)
+         return false;
+
+      node["type"] << "density_function_dist";
+
+      // Proxy name in RooWrapperPdf is "_func" / "func" depending on accessor/proxy export.
+      // Prefer a public accessor if one exists; otherwise inspect proxies as below.
+      auto const *funcProxy = dynamic_cast<RooRealProxy const *>(pdf->getProxy(0));
+      if (!funcProxy || !funcProxy->absArg())
+         return false;
+
+      node["function"] << funcProxy->absArg()->GetName();
+      if (pdf->selfNormalized())
+         node["selfnormalized"] << true;
+
+      return true;
+   }
+};
+
 #define DEFINE_EXPORTER_KEY(class_name, name)    \
    std::string const &class_name::key() const    \
    {                                             \
       const static std::string keystring = name; \
       return keystring;                          \
    }
+
 template <>
 DEFINE_EXPORTER_KEY(RooAddPdfStreamer<RooAddPdf>, "mixture_dist");
 template <>
 DEFINE_EXPORTER_KEY(RooAddPdfStreamer<RooAddModel>, "mixture_model");
 DEFINE_EXPORTER_KEY(RooBinSamplingPdfStreamer, "binsampling");
+DEFINE_EXPORTER_KEY(RooWrapperPdfStreamer, "density_function_dist");
 DEFINE_EXPORTER_KEY(RooBinWidthFunctionStreamer, "binwidth");
 DEFINE_EXPORTER_KEY(RooLegacyExpPolyStreamer, "legacy_exp_poly_dist");
 DEFINE_EXPORTER_KEY(RooExponentialStreamer, "exponential_dist");
@@ -1224,7 +1273,7 @@ DEFINE_EXPORTER_KEY(RooTFnBindingStreamer, "generic_function");
 DEFINE_EXPORTER_KEY(RooRealIntegralStreamer, "integral");
 DEFINE_EXPORTER_KEY(RooDerivativeStreamer, "derivative");
 DEFINE_EXPORTER_KEY(RooFFTConvPdfStreamer, "fft_conv_pdf");
-DEFINE_EXPORTER_KEY(RooExtendPdfStreamer, "extend_pdf");
+DEFINE_EXPORTER_KEY(RooExtendPdfStreamer, "rate_extended_dist");
 DEFINE_EXPORTER_KEY(ParamHistFuncStreamer, "step");
 DEFINE_EXPORTER_KEY(RooSplineStreamer, "spline");
 
@@ -1235,6 +1284,8 @@ DEFINE_EXPORTER_KEY(RooSplineStreamer, "spline");
 STATIC_EXECUTE([]() {
    using namespace RooFit::JSONIO;
 
+   registerImporter<RooWrapperPdfImporter>("density_function_dist");
+   registerImporter<RooExtendPdfFactory>("rate_extended_dist");
    registerImporter<RooProductFactory>("product", false);
    registerImporter<RooProdPdfFactory>("product_dist", false);
    registerImporter<RooAdditionFactory>("sum", false);
@@ -1265,6 +1316,7 @@ STATIC_EXECUTE([]() {
    registerImporter<ParamHistFuncFactory>("step", false);
    registerImporter<RooSplineFactory>("spline", false);
 
+   registerExporter<RooWrapperPdfStreamer>(RooWrapperPdf::Class());
    registerExporter<RooAddPdfStreamer<RooAddPdf>>(RooAddPdf::Class(), false);
    registerExporter<RooAddPdfStreamer<RooAddModel>>(RooAddModel::Class(), false);
    registerExporter<RooBinSamplingPdfStreamer>(RooBinSamplingPdf::Class(), false);

--- a/roofit/hs3/src/JSONIO.cxx
+++ b/roofit/hs3/src/JSONIO.cxx
@@ -147,10 +147,13 @@ bool registerExporter(const std::string &key, std::unique_ptr<const Exporter> f,
    return true;
 }
 
-int removeImporters(const std::string &needle)
+namespace {
+
+template <class Map>
+int removeByTypeName(Map &map, const std::string &needle)
 {
    int n = 0;
-   for (auto &element : importers()) {
+   for (auto &element : map) {
       for (size_t i = element.second.size(); i > 0; --i) {
          auto *imp = element.second[i - 1].get();
          std::string name(typeid(*imp).name());
@@ -161,43 +164,39 @@ int removeImporters(const std::string &needle)
       }
    }
    return n;
+}
+
+template <class Map, class KeyPrinter>
+void printByTypeName(Map &map, KeyPrinter printKey)
+{
+   for (const auto &x : map) {
+      for (const auto &ePtr : x.second) {
+         // Passing *e directory to typeid results in clang warnings.
+         auto const &e = *ePtr;
+         std::cout << printKey(x.first) << "\t" << typeid(e).name() << std::endl;
+      }
+   }
+}
+
+} // namespace
+
+int removeImporters(const std::string &needle)
+{
+   return removeByTypeName(importers(), needle);
 }
 
 int removeExporters(const std::string &needle)
 {
-   int n = 0;
-   for (auto &element : exporters()) {
-      for (size_t i = element.second.size(); i > 0; --i) {
-         auto *imp = element.second[i - 1].get();
-         std::string name(typeid(*imp).name());
-         if (name.find(needle) != std::string::npos) {
-            element.second.erase(element.second.begin() + i - 1);
-            ++n;
-         }
-      }
-   }
-   return n;
+   return removeByTypeName(exporters(), needle);
 }
 
 void printImporters()
 {
-   for (const auto &x : importers()) {
-      for (const auto &ePtr : x.second) {
-         // Passing *e directory to typeid results in clang warnings.
-         auto const &e = *ePtr;
-         std::cout << x.first << "\t" << typeid(e).name() << std::endl;
-      }
-   }
+   printByTypeName(importers(), [](auto const &key) { return key; });
 }
 void printExporters()
 {
-   for (const auto &x : exporters()) {
-      for (const auto &ePtr : x.second) {
-         // Passing *e directory to typeid results in clang warnings.
-         auto const &e = *ePtr;
-         std::cout << x.first->GetName() << "\t" << typeid(e).name() << std::endl;
-      }
-   }
+   printByTypeName(exporters(), [](auto const &key) { return key->GetName(); });
 }
 
 void loadFactoryExpressions(const std::string &fname)

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -909,26 +909,6 @@ void RooJSONFactoryWSTool::fillSeq(JSONNode &node, RooAbsCollection const &coll,
    }
 }
 
-void RooJSONFactoryWSTool::fillSeqSanitizedName(JSONNode &node, RooAbsCollection const &coll, size_t nMax)
-{
-   const size_t old_children = node.num_children();
-   node.set_seq();
-   size_t n = 0;
-   for (RooAbsArg const *arg : coll) {
-      if (n >= nMax)
-         break;
-      if (isLiteralConstVar(*arg)) {
-         node.append_child() << static_cast<RooConstVar const *>(arg)->getVal();
-      } else {
-         node.append_child() << sanitizeName(arg->GetName());
-      }
-      ++n;
-   }
-   if (node.num_children() != old_children + coll.size()) {
-      error("unable to stream collection " + std::string(coll.GetName()) + " to " + node.key());
-   }
-}
-
 JSONNode &RooJSONFactoryWSTool::appendNamedChild(JSONNode &node, std::string const &name)
 {
    if (!useListsInsteadOfDicts) {
@@ -1489,25 +1469,31 @@ void RooJSONFactoryWSTool::exportArray(std::size_t n, double const *contents, JS
  * @param node The JSONNode to which the category data will be exported.
  * @return void
  */
+namespace {
+
+// Turn an arbitrary string into a valid variable name, but refuse to change the
+// first character (which would silently rename the object).
+std::string makeValidNameOrError(std::string const &in)
+{
+   if (!std::isalpha(in[0])) {
+      RooJSONFactoryWSTool::error("refusing to change first character of string '" + in + "' to make a valid name!");
+   }
+   std::string out = RooFit::Detail::makeValidVarName(in);
+   if (out != in) {
+      oocoutW(nullptr, IO) << "RooFitHS3: changed '" << in << "' to '" << out << "' to become a valid name";
+   }
+   return out;
+}
+
+} // namespace
+
 void RooJSONFactoryWSTool::exportCategory(RooAbsCategory const &cat, JSONNode &node)
 {
    auto &labels = node["labels"].set_seq();
    auto &indices = node["indices"].set_seq();
 
    for (auto const &item : cat) {
-      std::string label;
-      if (std::isalpha(item.first[0])) {
-         label = RooFit::Detail::makeValidVarName(item.first);
-         if (label != item.first) {
-            oocoutW(nullptr, IO) << "RooFitHS3: changed '" << item.first << "' to '" << label
-                                 << "' to become a valid name";
-         }
-      } else {
-         RooJSONFactoryWSTool::error("refusing to change first character of string '" + item.first +
-                                     "' to make a valid name!");
-         label = item.first;
-      }
-      labels.append_child() << label;
+      labels.append_child() << makeValidNameOrError(item.first);
       indices.append_child() << item.second;
    }
 }
@@ -1569,18 +1555,7 @@ RooJSONFactoryWSTool::CombinedData RooJSONFactoryWSTool::exportCombinedData(RooA
 
    for (std::unique_ptr<RooAbsData> const &absData : dataList) {
       std::string catName(absData->GetName());
-      std::string dataName;
-      if (std::isalpha(catName[0])) {
-         dataName = RooFit::Detail::makeValidVarName(catName);
-         if (dataName != catName) {
-            oocoutW(nullptr, IO) << "RooFitHS3: changed '" << catName << "' to '" << dataName
-                                 << "' to become a valid name";
-         }
-      } else {
-         RooJSONFactoryWSTool::error("refusing to change first character of string '" + catName +
-                                     "' to make a valid name!");
-         dataName = catName;
-      }
+      std::string dataName = makeValidNameOrError(catName);
       absData->SetName((std::string(data.GetName()) + "_" + dataName).c_str());
       datamap.components[catName] = absData->GetName();
       this->exportData(*absData);
@@ -2162,12 +2137,8 @@ bool RooJSONFactoryWSTool::exportJSON(std::ostream &os)
 bool RooJSONFactoryWSTool::exportJSON(std::string const &filename)
 {
    std::ofstream out(filename.c_str());
-   if (!out.is_open()) {
-      std::stringstream ss;
-      ss << "RooJSONFactoryWSTool() invalid output file '" << filename << "'." << std::endl;
-      RooJSONFactoryWSTool::error(ss.str());
-      return false;
-   }
+   if (!out.is_open())
+      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid output file '" + filename + "'.");
    return this->exportJSON(out);
 }
 
@@ -2195,12 +2166,8 @@ bool RooJSONFactoryWSTool::exportYML(std::ostream &os)
 bool RooJSONFactoryWSTool::exportYML(std::string const &filename)
 {
    std::ofstream out(filename.c_str());
-   if (!out.is_open()) {
-      std::stringstream ss;
-      ss << "RooJSONFactoryWSTool() invalid output file '" << filename << "'." << std::endl;
-      RooJSONFactoryWSTool::error(ss.str());
-      return false;
-   }
+   if (!out.is_open())
+      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid output file '" + filename + "'.");
    return this->exportYML(out);
 }
 
@@ -2405,12 +2372,8 @@ bool RooJSONFactoryWSTool::importJSON(std::string const &filename)
 {
    // import a JSON file to the workspace
    std::ifstream infile(filename.c_str());
-   if (!infile.is_open()) {
-      std::stringstream ss;
-      ss << "RooJSONFactoryWSTool() invalid input file '" << filename << "'." << std::endl;
-      RooJSONFactoryWSTool::error(ss.str());
-      return false;
-   }
+   if (!infile.is_open())
+      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid input file '" + filename + "'.");
    return this->importJSON(infile);
 }
 
@@ -2440,12 +2403,8 @@ bool RooJSONFactoryWSTool::importYML(std::string const &filename)
 {
    // import a YML file to the workspace
    std::ifstream infile(filename.c_str());
-   if (!infile.is_open()) {
-      std::stringstream ss;
-      ss << "RooJSONFactoryWSTool() invalid input file '" << filename << "'." << std::endl;
-      RooJSONFactoryWSTool::error(ss.str());
-      return false;
-   }
+   if (!infile.is_open())
+      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid input file '" + filename + "'.");
    return this->importYML(infile);
 }
 


### PR DESCRIPTION
added I/O for roowrapperpdf and changed extendpdf I/O to be compliant with hs3

# This Pull request:

adds JSONIO for the two classes mentioned

## Changes or fixes:

- add importer and exporter for RooWrapperPdf
- rename export of RooExtendPdf to be compliant with HS3 specification

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

