### PR TITLE
[CMake] Make dictionary module dependencies independent of config order

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -623,22 +623,17 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   #---Get the library and module dependencies-----------------
   if(ARG_DEPENDENCIES)
     foreach(dep ${ARG_DEPENDENCIES})
-      if(NOT TARGET G__${dep})
-        # This is a library that doesn't come with dictionary/pcm
-        continue()
-      endif()
-
+      # Whether <dep> provides a dictionary/pcm is decided at generation time
+      # via $<TARGET_EXISTS:G__<dep>>, so the '-m' flag and the module-file
+      # dependency below are independent of configuration order and expand to
+      # nothing for a dictionary-less library.
+      set(dep_has_dict "$<TARGET_EXISTS:G__${dep}>")
       set(dependent_pcm ${libprefix}${dep}_rdict.pcm)
       if (runtime_cxxmodules AND NOT dep IN_LIST local_no_cxxmodules)
         set(dependent_pcm ${dep}.pcm)
-        if(TARGET ${dep})
-          get_target_property(_dep_pcm_filename ${dep} ROOT_PCM_FILENAME)
-          if(_dep_pcm_filename)
-            list(APPEND pcm_dependencies ${_dep_pcm_filename})
-          endif()
-        endif()
+        list(APPEND pcm_dependencies "$<${dep_has_dict}:$<TARGET_PROPERTY:${dep},ROOT_PCM_FILENAME>>")
       endif()
-      set(newargs ${newargs} -m  ${dependent_pcm})
+      set(newargs ${newargs} "$<${dep_has_dict}:-m>" "$<${dep_has_dict}:${dependent_pcm}>")
     endforeach()
   endif()
 


### PR DESCRIPTION
For each entry in DEPENDENCIES, ROOT_GENERATE_DICTIONARY passes rootcling a `-m <dep>.pcm` flag and a dependency on the dependency's module file, so that the prebuilt module is loaded instead of being built implicitly. This was wired up by inspecting the target graph while the macro runs (`if(NOT TARGET G__${dep})` / `get_target_property(... ROOT_PCM_FILENAME)`), which only works if <dep> is configured before the dictionaries using it.

That breaks for core/multiproc: libMultiProc depends on Net (via TSocket), but it lives under core/, configured long before net/. So when G__MultiProc is generated, G__Net does not exist yet, the dependency is silently dropped, and rootcling can build Net implicitly, failing with "Building module 'Net' implicitly ... 'G__MultiProc.cxx' depends on 'Net'". The same shape affects every dictionary depending on a module configured later (Tree -> Net, ...).

Decide this at generation time instead, when all targets exist: guard the flag and the module-file dependency with $<TARGET_EXISTS:G__<dep>>. They are emitted whenever <dep> provides a dictionary and expand to nothing otherwise (e.g. a plain library such as TBB::tbb), regardless of configuration order.

Closes #21673.

🤖 Problem identified by AI, then the human guided the AI to write the solution that the human wanted to apply.