### PR TITLE
[ntuple] Add RPageSinkS3 for the basic S3 write path (Mode B)

### DIFF
--- a/net/curl/inc/ROOT/RCurlConnection.hxx
+++ b/net/curl/inc/ROOT/RCurlConnection.hxx
@@ -76,7 +76,6 @@ private:
    void SetupErrorBuffer();
    void SetOptions();
    void ResetHandle();
-   RResult<void> SetUrl(const std::string &url);
    void Perform(RStatus &status);
 
 public:
@@ -109,6 +108,10 @@ public:
    void ClearCredentials();
    EHTTPCredentialsType GetCredentialsType() const;
 
+   /// Retargets this connection to `url`, reusing the underlying handle so curl can keep the connection
+   /// to the same host alive across requests. Call before a Send*Req to address a different object.
+   /// Returns an error if the URL cannot be set on the handle.
+   RResult<void> SetUrl(const std::string &url);
    /// Checks if the resource exists and if it does, return the value of the content-length header as size
    RStatus SendHeadReq(std::uint64_t &remoteSize);
    /// Reads the given ranges from the remote resource. The ranges can be in any order and also overlapping. They

--- a/net/curl/test/curl_connection.cxx
+++ b/net/curl/test/curl_connection.cxx
@@ -149,6 +149,32 @@ TEST(RCurlConnection, Put)
    EXPECT_EQ(std::string(reinterpret_cast<const char *>(payload), payloadLen), body);
 }
 
+TEST(RCurlConnection, SetUrlThenPut)
+{
+   TServerSocket sock(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string baseUrl =
+      std::string("http://") + sock.GetLocalInetAddress().GetHostAddress() + ":" + std::to_string(sock.GetLocalPort());
+
+   const unsigned char payload[] = "object body";
+   const std::size_t payloadLen = sizeof(payload) - 1; // exclude null terminator
+
+   std::string headers;
+   std::string body;
+   std::thread threadRecv(TaskRecvPut, &sock, &headers, &body);
+
+   // The connection is created with the base URL; SetUrl retargets it to a per-request URL (the
+   // mechanism that lets one connection be reused across many objects on the same host).
+   ROOT::Internal::RCurlConnection conn(baseUrl);
+   auto urlStatus = conn.SetUrl(baseUrl + "/myobject/42");
+   ASSERT_TRUE(static_cast<bool>(urlStatus));
+   auto status = conn.SendPutReq(payload, payloadLen);
+
+   threadRecv.join();
+   EXPECT_TRUE(static_cast<bool>(status));
+   EXPECT_EQ(0u, headers.find("PUT /myobject/42 ")) << headers.substr(0, 40);
+   EXPECT_EQ(std::string(reinterpret_cast<const char *>(payload), payloadLen), body);
+}
+
 /// GET (range read) after PUT on the same handle — verifies that WRITEFUNCTION is set correctly
 /// in SendRangesReq after a PUT cleared it.
 TEST(RCurlConnection, GetAfterPut)
@@ -194,8 +220,8 @@ TEST(RCurlConnection, GetAfterPut)
          }
       }
 
-      std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(expectedBody.size()) +
-                             "\r\n\r\n" + expectedBody;
+      std::string response =
+         "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(expectedBody.size()) + "\r\n\r\n" + expectedBody;
       s->SendRaw(response.data(), response.size());
       s->Close();
    };

--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -9,6 +9,11 @@
 # @author Jakob Blomer CERN
 ############################################################################
 
+# RNTuple optionally writes to S3-compatible object storage via libcurl (RCurlHttp).
+if(curl)
+  set(ROOTNTuple_OPTIONAL_DEPENDENCIES RCurlHttp)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTNTuple
 HEADERS
   ROOT/RCluster.hxx
@@ -100,6 +105,7 @@ DEPENDENCIES
   Imt
   RIO
   ROOTVecOps
+  ${ROOTNTuple_OPTIONAL_DEPENDENCIES}
 )
 
 target_link_libraries(ROOTNTuple PRIVATE xxHash::xxHash)
@@ -125,6 +131,7 @@ endif()
 if(curl)
   set(ROOTNTuple_EXTRA_HEADERS ${ROOTNTuple_EXTRA_HEADERS} ROOT/RPageStorageS3.hxx)
   target_sources(ROOTNTuple PRIVATE src/RPageStorageS3.cxx)
+  target_compile_definitions(ROOTNTuple PRIVATE R__ENABLE_S3)
   target_link_libraries(ROOTNTuple PRIVATE nlohmann_json::nlohmann_json)
 endif()
 

--- a/tree/ntuple/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorage.hxx
@@ -487,7 +487,6 @@ protected:
    /// Updates the descriptor and calls InitImpl() that handles the backend-specific details (file, DAOS, etc.)
    void InitImpl(RNTupleModel &model) final;
 
-   virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const ROOT::Internal::RPage &page) = 0;
    virtual RNTupleLocator
    CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) = 0;
    /// Vector commit of preprocessed pages. The `ranges` array specifies a range of sealed pages to be

--- a/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageDaos.hxx
@@ -118,7 +118,6 @@ private:
 protected:
    using RPagePersistentSink::InitImpl;
    void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
-   RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const ROOT::Internal::RPage &page) final;
    RNTupleLocator
    CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::vector<RNTupleLocator>

--- a/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageFile.hxx
@@ -87,9 +87,8 @@ private:
 protected:
    using RPagePersistentSink::InitImpl;
    void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
-   RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) override;
    RNTupleLocator
-   CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
+   CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) override;
    std::vector<RNTupleLocator>
    CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges, const std::vector<bool> &mask) final;
    std::uint64_t StageClusterImpl() final;

--- a/tree/ntuple/inc/ROOT/RPageStorageS3.hxx
+++ b/tree/ntuple/inc/ROOT/RPageStorageS3.hxx
@@ -13,11 +13,15 @@
 #ifndef ROOT_RPageStorageS3
 #define ROOT_RPageStorageS3
 
+#include <ROOT/RCurlConnection.hxx>
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTuple.hxx>
+#include <ROOT/RPageStorage.hxx>
 
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <string_view>
 
 namespace ROOT {
 namespace Experimental {
@@ -43,9 +47,10 @@ struct RNTupleAnchorS3 {
    std::uint16_t fVersionMajor = RNTuple::kVersionMajor;
    std::uint16_t fVersionMinor = RNTuple::kVersionMinor;
    std::uint16_t fVersionPatch = RNTuple::kVersionPatch;
-   /// Pattern for resolving object IDs to full S3 URLs.
-   /// ${baseurl} is replaced with the anchor URL, ${objid} with the numeric object ID.
-   std::string fUrlTemplate;
+   /// Pattern for resolving object IDs to full S3 URLs. ${baseurl} is replaced with the anchor URL,
+   /// ${objid} with the numeric object ID. Defaults to the scheme this writer uses; the reader
+   /// overrides it from the stored anchor.
+   std::string fUrlTemplate = "${baseurl}/${objid}";
    /// Object ID and byte offset of the compressed header within the S3 object
    std::uint64_t fHeaderObjId = 0;
    std::uint64_t fHeaderOffset = 0;
@@ -66,6 +71,69 @@ struct RNTupleAnchorS3 {
    /// Deserialize the anchor from a JSON string. Returns an error on malformed or incompatible input.
    static RResult<RNTupleAnchorS3> CreateFromJSON(const std::string &json);
 };
+
+/// \brief Translate an ntpl+s3 URI into its plain HTTP(S) equivalent.
+///
+/// Accepts `ntpl+s3+http://host/bucket/path` and `ntpl+s3+https://host/bucket/path`, returning the
+/// URL with the scheme replaced by http or https respectively. Returns an error result for any other
+/// scheme or a malformed URI (rather than throwing), so callers on untrusted input can handle it.
+RResult<std::string> ParseS3Url(std::string_view uri);
+
+// clang-format off
+/**
+\class ROOT::Experimental::Internal::RPageSinkS3
+\ingroup NTuple
+\brief Storage provider that writes ntuple pages into S3-compatible object storage.
+
+Currently implements Mode B (one sealed page per S3 object, kTypeObject64 locators).
+Mode A (multiple packed pages per object, kTypeMulti locators) will be added separately.
+
+\warning The S3 backend is experimental and under active development.
+*/
+// clang-format on
+class RPageSinkS3 : public ROOT::Internal::RPagePersistentSink {
+private:
+   /// HTTP base URL for this ntuple (derived from the s3 scheme URI); never has a trailing slash
+   std::string fBaseUrl;
+   /// One HTTP connection reused for every upload, so curl keeps it alive across objects on the same
+   /// host instead of re-handshaking per object.
+   ROOT::Internal::RCurlConnection fConnection;
+   /// Object ID counter; incremented for each object written.
+   std::uint64_t fObjectId{0};
+   /// Tracks the number of bytes committed to the current cluster (reset in StageClusterImpl)
+   std::uint64_t fNBytesCurrentCluster{0};
+   /// Anchor metadata populated during the write path and uploaded last in CommitDatasetImpl
+   RNTupleAnchorS3 fAnchor;
+
+   /// Resolve a numeric object ID to its full HTTP URL
+   std::string MakeObjectUrl(std::uint64_t objId) const;
+   /// Upload raw bytes to the given S3 URL via an HTTP PUT request
+   void PutObject(const std::string &url, const unsigned char *data, std::size_t size);
+
+   /// Tag to select the internal constructor that takes an already-resolved base URL.
+   struct RFromBaseUrl {};
+   /// Internal constructor used by CloneAsHidden: the public constructor derives the base URL by parsing
+   /// an s3 scheme URI, whereas a clone already has a resolved base URL to write under.
+   RPageSinkS3(std::string_view ntupleName, std::string_view baseUrl, const ROOT::RNTupleWriteOptions &options,
+               RFromBaseUrl);
+
+protected:
+   using RPagePersistentSink::InitImpl;
+   void InitImpl(unsigned char *serializedHeader, std::uint32_t length) final;
+   RNTupleLocator
+   CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId, const RPageStorage::RSealedPage &sealedPage) final;
+   std::uint64_t StageClusterImpl() final;
+   RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
+   using RPagePersistentSink::CommitDatasetImpl;
+   ROOT::Internal::RNTupleLink CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
+
+public:
+   RPageSinkS3(std::string_view ntupleName, std::string_view uri, const ROOT::RNTupleWriteOptions &options);
+   ~RPageSinkS3() override;
+
+   std::unique_ptr<ROOT::Internal::RPageSink>
+   CloneAsHidden(std::string_view name, const ROOT::RNTupleWriteOptions &opts) const final;
+}; // class RPageSinkS3
 
 } // namespace Internal
 } // namespace Experimental

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -1169,9 +1169,17 @@ void ROOT::Internal::RPagePersistentSink::CommitPage(ColumnHandle_t columnHandle
 {
    fOpenColumnRanges.at(columnHandle.fPhysicalId).IncrementNElements(page.GetNElements());
 
+   auto element = columnHandle.fColumn->GetElement();
+   RPageStorage::RSealedPage sealedPage;
+   {
+      RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
+      sealedPage = SealPage(page, *element);
+   }
+   fCounters->fSzZip.Add(page.GetNBytes());
+
    ROOT::RClusterDescriptor::RPageInfo pageInfo;
    pageInfo.SetNElements(page.GetNElements());
-   pageInfo.SetLocator(CommitPageImpl(columnHandle, page));
+   pageInfo.SetLocator(CommitSealedPageImpl(columnHandle.fPhysicalId, sealedPage));
    pageInfo.SetHasChecksum(GetWriteOptions().GetEnablePageChecksums());
    fOpenPageRanges.at(columnHandle.fPhysicalId).GetPageInfos().emplace_back(pageInfo);
 }

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -23,8 +23,12 @@
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RPageAllocator.hxx>
 #include <ROOT/RPageSinkBuf.hxx>
+#include <ROOT/StringUtils.hxx>
 #ifdef R__ENABLE_DAOS
 #include <ROOT/RPageStorageDaos.hxx>
+#endif
+#ifdef R__ENABLE_S3
+#include <ROOT/RPageStorageS3.hxx>
 #endif
 
 #include <Compression.h>
@@ -187,6 +191,9 @@ ROOT::Internal::RPageSource::Create(std::string_view ntupleName, std::string_vie
 #else
       throw RException(R__FAIL("This RNTuple build does not support DAOS."));
 #endif
+
+   if (ROOT::StartsWith(location, "ntpl+s3+http://") || ROOT::StartsWith(location, "ntpl+s3+https://"))
+      throw RException(R__FAIL("S3 read support is not yet implemented."));
 
    return std::make_unique<ROOT::Internal::RPageSourceFile>(ntupleName, location, options);
 }
@@ -917,6 +924,15 @@ ROOT::Internal::RPagePersistentSink::Create(std::string_view ntupleName, std::st
       return std::make_unique<ROOT::Experimental::Internal::RPageSinkDaos>(ntupleName, location, options);
 #else
       throw RException(R__FAIL("This RNTuple build does not support DAOS."));
+#endif
+   }
+
+   if (ROOT::StartsWith(location, "ntpl+s3+http://") || ROOT::StartsWith(location, "ntpl+s3+https://")) {
+#ifdef R__ENABLE_S3
+      return std::make_unique<ROOT::Experimental::Internal::RPageSinkS3>(ntupleName, location, options);
+#else
+      throw RException(R__FAIL("This RNTuple build does not support S3. Rebuild ROOT with the 'curl' "
+                               "cmake option enabled (-Dcurl=ON) to enable the S3 backend."));
 #endif
    }
 

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -257,20 +257,6 @@ void ROOT::Experimental::Internal::RPageSinkDaos::InitImpl(unsigned char *serial
    WriteNTupleHeader(zipBuffer.get(), szZipHeader, length);
 }
 
-ROOT::RNTupleLocator ROOT::Experimental::Internal::RPageSinkDaos::CommitPageImpl(ColumnHandle_t columnHandle,
-                                                                                 const ROOT::Internal::RPage &page)
-{
-   auto element = columnHandle.fColumn->GetElement();
-   RPageStorage::RSealedPage sealedPage;
-   {
-      Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element);
-   }
-
-   fCounters->fSzZip.Add(page.GetNBytes());
-   return CommitSealedPageImpl(columnHandle.fPhysicalId, sealedPage);
-}
-
 ROOT::RNTupleLocator
 ROOT::Experimental::Internal::RPageSinkDaos::CommitSealedPageImpl(ROOT::DescriptorId_t,
                                                                   const RPageStorage::RSealedPage &sealedPage)

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -149,20 +149,6 @@ ROOT::Internal::RPageSinkFile::WriteSealedPage(const RPageStorage::RSealedPage &
    return result;
 }
 
-ROOT::RNTupleLocator
-ROOT::Internal::RPageSinkFile::CommitPageImpl(ColumnHandle_t columnHandle, const ROOT::Internal::RPage &page)
-{
-   auto element = columnHandle.fColumn->GetElement();
-   RPageStorage::RSealedPage sealedPage;
-   {
-      RNTupleAtomicTimer timer(fCounters->fTimeWallZip, fCounters->fTimeCpuZip);
-      sealedPage = SealPage(page, *element);
-   }
-
-   fCounters->fSzZip.Add(page.GetNBytes());
-   return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
-}
-
 ROOT::RNTupleLocator ROOT::Internal::RPageSinkFile::CommitSealedPageImpl(ROOT::DescriptorId_t physicalColumnId,
                                                                          const RPageStorage::RSealedPage &sealedPage)
 {

--- a/tree/ntuple/src/RPageStorageS3.cxx
+++ b/tree/ntuple/src/RPageStorageS3.cxx
@@ -12,9 +12,24 @@
 
 #include <ROOT/RPageStorageS3.hxx>
 
+#include <ROOT/RCurlConnection.hxx>
+#include <ROOT/RLogger.hxx>
+#include <ROOT/RNTupleTypes.hxx>
+#include <ROOT/RNTupleUtils.hxx>
+#include <ROOT/RNTupleZip.hxx>
+#include <ROOT/RPage.hxx>
+#include <ROOT/StringUtils.hxx>
+
 #include <nlohmann/json.hpp>
 
+#include <cctype>
+#include <cstring>
+#include <mutex>
 #include <string>
+#include <utility>
+
+using ROOT::Internal::MakeUninitArray;
+using ROOT::Internal::RNTupleCompressor;
 
 /// Field-by-field equality check across all 14 anchor members.
 /// Used to verify round-trip correctness in tests.
@@ -96,4 +111,197 @@ ROOT::Experimental::Internal::RNTupleAnchorS3::CreateFromJSON(const std::string 
    }
 
    return anchor;
+}
+
+// S3 URI parsing
+
+ROOT::RResult<std::string> ROOT::Experimental::Internal::ParseS3Url(std::string_view uri)
+{
+   const std::string uriStr(uri);
+
+   // The base URL is a plain bucket/path prefix (MakeObjectUrl() appends "/<id>") and S3 authentication
+   // comes from the environment via SigV4, not from the URL. Reject embedded userinfo, query strings,
+   // and fragments rather than silently mishandling them.
+   if (uriStr.find_first_of("@?#") != std::string::npos)
+      return R__FAIL("S3 URI must not contain userinfo ('@'), a query ('?') or a fragment ('#'): " + uriStr);
+
+   // The dedicated ntpl+s3 scheme marks an RNTuple stored natively as S3 objects, distinguishing it
+   // from a ROOT file stored on S3 (which is opened through the S3 handler for s3:// URLs). Use
+   // ntpl+s3+https:// in production; ntpl+s3+http:// targets local/testing endpoints such as MinIO and
+   // transmits data unencrypted. The scheme is matched case-insensitively (RFC 3986), but the host,
+   // bucket and key are kept verbatim because they are case-sensitive.
+   std::string schemeLower;
+   for (std::size_t i = 0; i < uriStr.size() && i < std::strlen("ntpl+s3+https://"); ++i)
+      schemeLower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(uriStr[i]))));
+
+   std::string httpScheme;
+   std::size_t schemeLen = 0;
+   if (ROOT::StartsWith(schemeLower, "ntpl+s3+https://")) {
+      httpScheme = "https";
+      schemeLen = std::strlen("ntpl+s3+https://");
+   } else if (ROOT::StartsWith(schemeLower, "ntpl+s3+http://")) {
+      httpScheme = "http";
+      schemeLen = std::strlen("ntpl+s3+http://");
+   } else {
+      return R__FAIL("invalid S3 URI (expected ntpl+s3+http:// or ntpl+s3+https://): " + uriStr);
+   }
+
+   std::string hostAndPath = uriStr.substr(schemeLen);
+   // Drop trailing slashes so MakeObjectUrl() never produces "//" in an object key and the anchor key
+   // (the base URL itself) is not left ending in '/'.
+   while (!hostAndPath.empty() && hostAndPath.back() == '/')
+      hostAndPath.pop_back();
+
+   // There must be a host after the scheme; check for emptiness once the trailing slashes are removed,
+   // so a URI that is only slashes after the scheme (e.g. "ntpl+s3+http:///") is rejected as well.
+   if (hostAndPath.empty())
+      return R__FAIL("S3 URI has no host: " + uriStr);
+
+   return httpScheme + "://" + hostAndPath;
+}
+
+// RPageSinkS3
+
+ROOT::Experimental::Internal::RPageSinkS3::RPageSinkS3(std::string_view ntupleName, std::string_view uri,
+                                                       const ROOT::RNTupleWriteOptions &options)
+   : RPageSinkS3(ntupleName, ParseS3Url(uri).Unwrap(), options, RFromBaseUrl{})
+{
+}
+
+ROOT::Experimental::Internal::RPageSinkS3::RPageSinkS3(std::string_view ntupleName, std::string_view baseUrl,
+                                                       const ROOT::RNTupleWriteOptions &options, RFromBaseUrl)
+   : RPagePersistentSink(ntupleName, options), fBaseUrl(baseUrl), fConnection(fBaseUrl)
+{
+   static std::once_flag once;
+   std::call_once(once, []() {
+      R__LOG_WARNING(ROOT::Internal::NTupleLog()) << "The S3 backend is experimental and still under development. "
+                                                  << "Do not store real data with this version of RNTuple!";
+   });
+   fConnection.SetCredentialsFromEnvironment();
+   EnableDefaultMetrics("RPageSinkS3");
+}
+
+ROOT::Experimental::Internal::RPageSinkS3::~RPageSinkS3() = default;
+
+std::string ROOT::Experimental::Internal::RPageSinkS3::MakeObjectUrl(std::uint64_t objId) const
+{
+   return fBaseUrl + "/" + std::to_string(objId);
+}
+
+void ROOT::Experimental::Internal::RPageSinkS3::PutObject(const std::string &url, const unsigned char *data,
+                                                          std::size_t size)
+{
+   // All objects share fConnection; retarget it to this object's URL (via SetUrl) so curl can keep
+   // the connection alive across uploads to the same host.
+   fConnection.SetUrl(url).ThrowOnError();
+   auto status = fConnection.SendPutReq(data, size);
+   if (!status)
+      throw ROOT::RException(R__FAIL("S3 PUT failed for " + url + ": " + status.fStatusMsg));
+}
+
+void ROOT::Experimental::Internal::RPageSinkS3::InitImpl(unsigned char *serializedHeader, std::uint32_t length)
+{
+   // fAnchor.fUrlTemplate keeps its default ("${baseurl}/${objid}").
+
+   auto zipBuffer = MakeUninitArray<unsigned char>(length);
+   auto szZipHeader =
+      RNTupleCompressor::Zip(serializedHeader, length, GetWriteOptions().GetCompression(), zipBuffer.get());
+
+   const auto headerObjId = fObjectId++;
+   {
+      Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+      PutObject(MakeObjectUrl(headerObjId), zipBuffer.get(), szZipHeader);
+   }
+
+   fAnchor.fHeaderObjId = headerObjId;
+   fAnchor.fHeaderOffset = 0;
+   fAnchor.fNBytesHeader = szZipHeader;
+   fAnchor.fLenHeader = length;
+}
+
+ROOT::RNTupleLocator
+ROOT::Experimental::Internal::RPageSinkS3::CommitSealedPageImpl(ROOT::DescriptorId_t,
+                                                                const RPageStorage::RSealedPage &sealedPage)
+{
+   // Mode B: one S3 object per sealed page, located by a kTypeObject64 locator
+   const auto pageObjId = fObjectId++;
+   {
+      Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+      PutObject(MakeObjectUrl(pageObjId), reinterpret_cast<const unsigned char *>(sealedPage.GetBuffer()),
+                sealedPage.GetBufferSize());
+   }
+
+   RNTupleLocator result;
+   result.SetType(RNTupleLocator::kTypeObject64);
+   result.SetNBytesOnStorage(sealedPage.GetDataSize());
+   result.SetPosition(ROOT::RNTupleLocatorObject64{pageObjId});
+   fCounters->fNPageCommitted.Inc();
+   fCounters->fSzWritePayload.Add(sealedPage.GetBufferSize());
+   fNBytesCurrentCluster += sealedPage.GetBufferSize();
+   return result;
+}
+
+std::uint64_t ROOT::Experimental::Internal::RPageSinkS3::StageClusterImpl()
+{
+   return std::exchange(fNBytesCurrentCluster, 0);
+}
+
+ROOT::RNTupleLocator
+ROOT::Experimental::Internal::RPageSinkS3::CommitClusterGroupImpl(unsigned char *serializedPageList,
+                                                                  std::uint32_t length)
+{
+   auto bufPageListZip = MakeUninitArray<unsigned char>(length);
+   auto szPageListZip =
+      RNTupleCompressor::Zip(serializedPageList, length, GetWriteOptions().GetCompression(), bufPageListZip.get());
+
+   const auto objId = fObjectId++;
+   {
+      Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+      PutObject(MakeObjectUrl(objId), bufPageListZip.get(), szPageListZip);
+   }
+
+   RNTupleLocator result;
+   result.SetType(RNTupleLocator::kTypeObject64);
+   result.SetNBytesOnStorage(szPageListZip);
+   result.SetPosition(ROOT::RNTupleLocatorObject64{objId});
+   fCounters->fSzWritePayload.Add(static_cast<std::int64_t>(szPageListZip));
+   return result;
+}
+
+ROOT::Internal::RNTupleLink
+ROOT::Experimental::Internal::RPageSinkS3::CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length)
+{
+   auto bufFooterZip = MakeUninitArray<unsigned char>(length);
+   auto szFooterZip =
+      RNTupleCompressor::Zip(serializedFooter, length, GetWriteOptions().GetCompression(), bufFooterZip.get());
+
+   const auto footerObjId = fObjectId++;
+   {
+      Detail::RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+      PutObject(MakeObjectUrl(footerObjId), bufFooterZip.get(), szFooterZip);
+   }
+
+   fAnchor.fFooterObjId = footerObjId;
+   fAnchor.fFooterOffset = 0;
+   fAnchor.fNBytesFooter = szFooterZip;
+   fAnchor.fLenFooter = length;
+
+   // Upload the anchor LAST: once it exists at the base URL, a reader can assume the whole ntuple
+   // is complete. Never upload it before all other objects are in place.
+   const auto anchorJson = fAnchor.ToJSON();
+   PutObject(fBaseUrl, reinterpret_cast<const unsigned char *>(anchorJson.data()), anchorJson.size());
+
+   // An S3 ntuple is self-locating: its anchor always lives at the base URL, so there is no anchor
+   // link to hand back here.
+   return {};
+}
+
+std::unique_ptr<ROOT::Internal::RPageSink>
+ROOT::Experimental::Internal::RPageSinkS3::CloneAsHidden(std::string_view name,
+                                                         const ROOT::RNTupleWriteOptions &opts) const
+{
+   // The hidden (attribute-set) ntuple is stored under a reserved "_clone" sub-prefix so its objects and
+   // anchor can never collide with the main ntuple's numeric object keys ($baseurl/0, $baseurl/1, ...).
+   std::string cloneBaseUrl = fBaseUrl + "/_clone/" + std::string(name);
+   return std::unique_ptr<ROOT::Internal::RPageSink>(new RPageSinkS3(name, cloneBaseUrl, opts, RFromBaseUrl{}));
 }

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -177,7 +177,7 @@ if(daos OR daos_mock)
 endif()
 
 if(curl)
-  ROOT_ADD_GTEST(ntuple_storage_s3 ntuple_storage_s3.cxx LIBRARIES ROOTNTuple)
+  ROOT_ADD_GTEST(ntuple_storage_s3 ntuple_storage_s3.cxx LIBRARIES ROOTNTuple Net)
 endif()
 
 

--- a/tree/ntuple/test/ntuple_compat.cxx
+++ b/tree/ntuple/test/ntuple_compat.cxx
@@ -537,19 +537,15 @@ TEST(RNTupleCompat, FutureFieldStructuralRole_Nested)
 }
 
 class RPageSinkTestLocator : public RPageSinkFile {
-   ROOT::RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage & /* sealedPage */, std::size_t)
+   // CommitPage() seals the page in the base class and routes it here; we return a page locator with an
+   // unknown type (without writing any data, since the test never reads the page back).
+   ROOT::RNTupleLocator CommitSealedPageImpl(ROOT::DescriptorId_t /* physicalColumnId */,
+                                             const RPageStorage::RSealedPage & /* sealedPage */) override
    {
       RNTupleLocator result;
       result.SetType(ROOT::Internal::kTestLocatorType);
       // Don't set position and nbytes, we won't read it back anyway
       return result;
-   }
-
-   RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) override
-   {
-      auto element = columnHandle.fColumn->GetElement();
-      RPageStorage::RSealedPage sealedPage = SealPage(page, *element);
-      return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
    }
 
 public:

--- a/tree/ntuple/test/ntuple_storage_s3.cxx
+++ b/tree/ntuple/test/ntuple_storage_s3.cxx
@@ -5,6 +5,18 @@
 
 #include "ntuple_test.hxx"
 #include <ROOT/RPageStorageS3.hxx>
+#include <ROOT/TestSupport.hxx>
+
+#include "TServerSocket.h"
+#include "TSocket.h"
+#include "TSystem.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+#include <vector>
 
 using RNTupleAnchorS3 = ROOT::Experimental::Internal::RNTupleAnchorS3;
 
@@ -168,6 +180,12 @@ TEST(RNTupleAnchorS3, DefaultValues)
    EXPECT_EQ(0u, parsed.fFooterObjId);
    EXPECT_EQ(0u, parsed.fNBytesFooter);
    EXPECT_EQ(0u, parsed.fLenFooter);
+}
+
+TEST(RNTupleAnchorS3, UrlTemplateDefault)
+{
+   // A freshly constructed anchor carries the writer's default object-naming scheme.
+   EXPECT_EQ("${baseurl}/${objid}", RNTupleAnchorS3().fUrlTemplate);
 }
 
 TEST(RNTupleAnchorS3, BackslashInUrl)
@@ -348,4 +366,318 @@ TEST(RNTupleAnchorS3, MaxUint64Values)
    EXPECT_EQ(UINT64_MAX, parsed.fFooterOffset);
    EXPECT_EQ(UINT64_MAX, parsed.fNBytesFooter);
    EXPECT_EQ(UINT64_MAX, parsed.fLenFooter);
+}
+
+// ==================== ParseS3Url Tests ====================
+
+using ROOT::Experimental::Internal::ParseS3Url;
+
+TEST(RPageSinkS3, ParseS3UrlHttp)
+{
+   EXPECT_EQ("http://localhost:9000/mybucket/path", ParseS3Url("ntpl+s3+http://localhost:9000/mybucket/path").Unwrap());
+}
+
+TEST(RPageSinkS3, ParseS3UrlHttps)
+{
+   EXPECT_EQ("https://s3.cern.ch/mybucket/path", ParseS3Url("ntpl+s3+https://s3.cern.ch/mybucket/path").Unwrap());
+}
+
+TEST(RPageSinkS3, ParseS3UrlInvalid)
+{
+   // Non-S3 schemes, the bare s3:// (left to ROOT's S3 file handler), the old s3+http(s):// forms,
+   // and ntpl+s3:// without a transport all yield an error result (so Unwrap() throws).
+   EXPECT_THROW(ParseS3Url("http://example.com").Unwrap(), ROOT::RException);
+   EXPECT_THROW(ParseS3Url("daos://pool/container").Unwrap(), ROOT::RException);
+   EXPECT_THROW(ParseS3Url("").Unwrap(), ROOT::RException);
+   EXPECT_THROW(ParseS3Url("s3://bucket/path").Unwrap(), ROOT::RException);
+   EXPECT_THROW(ParseS3Url("s3+https://host/bucket/path").Unwrap(), ROOT::RException);
+   EXPECT_THROW(ParseS3Url("ntpl+s3://host/bucket/path").Unwrap(), ROOT::RException);
+   // A scheme followed only by slashes has no host either (trailing slashes are stripped before the
+   // emptiness check).
+   EXPECT_THROW(ParseS3Url("ntpl+s3+http:///").Unwrap(), ROOT::RException);
+}
+
+TEST(RPageSinkS3, ParseS3UrlTrailingSlash)
+{
+   // A trailing slash must not leak into object keys (MakeObjectUrl appends "/<id>") or the anchor key.
+   EXPECT_EQ("http://localhost:9000/bucket/path", ParseS3Url("ntpl+s3+http://localhost:9000/bucket/path/").Unwrap());
+   EXPECT_EQ("https://s3.cern.ch/bucket", ParseS3Url("ntpl+s3+https://s3.cern.ch/bucket/").Unwrap());
+}
+
+TEST(RPageSinkS3, ParseS3UrlCaseInsensitiveScheme)
+{
+   // The scheme is matched case-insensitively; the host/bucket/key case is preserved verbatim.
+   EXPECT_EQ("http://Host:9000/MyBucket/Path", ParseS3Url("NTPL+S3+HTTP://Host:9000/MyBucket/Path").Unwrap());
+   EXPECT_EQ("https://Host/MyBucket/Path", ParseS3Url("Ntpl+S3+Https://Host/MyBucket/Path").Unwrap());
+}
+
+TEST(RPageSinkS3, ParseS3UrlAwsAndCeph)
+{
+   // AWS (any region, path-style or virtual-hosted) and Ceph/MinIO endpoints all work through the
+   // explicit ntpl+s3+https:// form: the user supplies the full host, which is passed through verbatim.
+   EXPECT_EQ("https://s3.eu-west-1.amazonaws.com/bucket/data", // AWS path-style, regional
+             ParseS3Url("ntpl+s3+https://s3.eu-west-1.amazonaws.com/bucket/data").Unwrap());
+   EXPECT_EQ("https://bucket.s3.eu-west-1.amazonaws.com/data", // AWS virtual-hosted style
+             ParseS3Url("ntpl+s3+https://bucket.s3.eu-west-1.amazonaws.com/data").Unwrap());
+   EXPECT_EQ("https://s3.cern.ch/bucket/data", // Ceph RGW (CERN)
+             ParseS3Url("ntpl+s3+https://s3.cern.ch/bucket/data").Unwrap());
+}
+
+TEST(RPageSinkS3, ParseS3UrlRejectsUnsupportedComponents)
+{
+   EXPECT_THROW(ParseS3Url("ntpl+s3+https://KEY:SECRET@host/bucket/path").Unwrap(), ROOT::RException); // userinfo
+   EXPECT_THROW(ParseS3Url("ntpl+s3+http://host/bucket/path?versionId=1").Unwrap(), ROOT::RException); // query
+   EXPECT_THROW(ParseS3Url("ntpl+s3+http://host/bucket/path#section").Unwrap(), ROOT::RException);     // fragment
+   EXPECT_THROW(ParseS3Url("ntpl+s3+http://").Unwrap(), ROOT::RException);                             // no host
+}
+
+// ==================== RPageSinkS3 Wire-Level Tests (mock HTTP server) ====================
+
+// These tests stand up a loopback TServerSocket and point an RPageSinkS3 at it, so the exact HTTP
+// PUT requests the write path emits can be inspected with no live S3 service (they always run in
+// CI). The mock-server idiom mirrors net/curl/test/curl_connection.cxx.
+namespace {
+
+/// Read one HTTP request (request line + headers + body) from an accepted socket, reply with the
+/// given status (e.g. "200 OK"), and return the request-target (the path from the request line).
+std::string ServeOneRequest(TSocket *sock, const char *status, std::string &headers, std::string &body)
+{
+   headers.clear();
+   body.clear();
+
+   // Read up to and including the end-of-headers marker, byte by byte.
+   const char *eof = "\r\n\r\n";
+   const std::size_t eofLen = std::strlen(eof);
+   std::size_t nextInEof = 0;
+   char c;
+   while (sock->RecvRaw(&c, 1) > 0) {
+      headers.push_back(c);
+      if (c == eof[nextInEof]) {
+         if (++nextInEof == eofLen)
+            break;
+      } else {
+         nextInEof = 0;
+      }
+   }
+
+   std::string lower(headers);
+   std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char ch) { return std::tolower(ch); });
+
+   // libcurl uploads with "Expect: 100-continue"; acknowledge before reading the body.
+   if (lower.find("expect: 100-continue") != std::string::npos) {
+      const char *cont = "HTTP/1.1 100 Continue\r\n\r\n";
+      sock->SendRaw(cont, std::strlen(cont));
+   }
+
+   std::size_t contentLength = 0;
+   if (auto pos = lower.find("content-length: "); pos != std::string::npos) {
+      auto valStart = pos + std::strlen("content-length: ");
+      auto valEnd = lower.find("\r\n", valStart);
+      contentLength = std::stoul(lower.substr(valStart, valEnd - valStart));
+   }
+   if (contentLength > 0) {
+      body.resize(contentLength);
+      sock->RecvRaw(&body[0], contentLength);
+   }
+
+   // This mock closes the socket after each request, so tell curl not to keep the connection alive
+   // (the sink reuses one connection; without this curl could try to reuse a socket we just closed).
+   const std::string response =
+      std::string("HTTP/1.1 ") + status + "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+   sock->SendRaw(response.data(), response.size());
+
+   // The request line is "PUT /target HTTP/1.1"; return the middle token.
+   std::string target;
+   if (auto sp1 = headers.find(' '); sp1 != std::string::npos) {
+      if (auto sp2 = headers.find(' ', sp1 + 1); sp2 != std::string::npos)
+         target = headers.substr(sp1 + 1, sp2 - sp1 - 1);
+   }
+   return target;
+}
+
+} // anonymous namespace
+
+TEST(RPageSinkS3Wire, WriteIssuesExpectedPuts)
+{
+   TServerSocket server(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string host = server.GetLocalInetAddress().GetHostAddress();
+   const std::string basePath = "/wirebucket/wiretest";
+   const std::string uri = "ntpl+s3+http://" + host + ":" + std::to_string(server.GetLocalPort()) + basePath;
+
+   // Dummy credentials so curl signs every PUT (SigV4 Authorization header). The requests only reach
+   // the loopback mock server in this test, never a real S3 service.
+   gSystem->Setenv("S3_ACCESS_KEY", "dummykey");
+   gSystem->Setenv("S3_SECRET_KEY", "dummysecret");
+   gSystem->Setenv("S3_REGION", "us-east-1");
+
+   struct Request {
+      std::string fPath;
+      std::string fHeaders;
+      std::string fBody;
+   };
+   std::vector<Request> requests;
+
+   // The sink reuses one connection, but this mock replies with "Connection: close", so curl opens a
+   // fresh connection per object. Serve them on a background thread until the anchor (the request
+   // whose target is exactly the base path) arrives last.
+   std::thread serverThread([&] {
+      for (;;) {
+         TSocket *sock = server.Accept();
+         if (!sock || sock == reinterpret_cast<TSocket *>(-1))
+            break;
+         Request req;
+         req.fPath = ServeOneRequest(sock, "200 OK", req.fHeaders, req.fBody);
+         sock->Close();
+         requests.push_back(std::move(req));
+         if (requests.back().fPath == basePath)
+            break;
+      }
+   });
+
+   {
+      // The sink ctor emits a one-time (std::call_once) experimental warning; allow it. It is
+      // optional because it only fires on the first sink construction in the whole process.
+      ROOT::TestSupport::CheckDiagsRAII diags;
+      diags.optionalDiag(kWarning, "[ROOT.NTuple]", "experimental", /*matchFullMessage=*/false);
+
+      auto model = ROOT::RNTupleModel::Create();
+      auto fldValue = model->MakeField<int>("value");
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "wire", uri);
+      for (int i = 0; i < 20; ++i) {
+         *fldValue = i;
+         writer->Fill();
+      }
+   } // writer destroyed here -> footer + anchor PUTs
+
+   serverThread.join();
+
+   gSystem->Unsetenv("S3_ACCESS_KEY");
+   gSystem->Unsetenv("S3_SECRET_KEY");
+   gSystem->Unsetenv("S3_REGION");
+
+   // At minimum: header, one page, page list, footer, anchor.
+   ASSERT_GE(requests.size(), 5u);
+
+   for (const auto &req : requests) {
+      // Every object is uploaded with a SigV4-signed HTTP PUT.
+      EXPECT_EQ(0u, req.fHeaders.find("PUT ")) << req.fHeaders.substr(0, 32);
+      std::string lower(req.fHeaders);
+      std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char ch) { return std::tolower(ch); });
+      EXPECT_NE(std::string::npos, lower.find("authorization: aws4-hmac-sha256"))
+         << "no SigV4 Authorization header on " << req.fPath;
+   }
+
+   // Object 0 is the header, written first.
+   EXPECT_EQ(basePath + "/0", requests.front().fPath);
+   // Every request but the last targets a data object at <base>/<id>; the anchor is last, at <base>.
+   for (std::size_t i = 0; i + 1 < requests.size(); ++i)
+      EXPECT_EQ(0u, requests[i].fPath.rfind(basePath + "/", 0)) << "unexpected object key " << requests[i].fPath;
+   EXPECT_EQ(basePath, requests.back().fPath);
+   // The anchor body is the JSON document the reader bootstraps from.
+   EXPECT_NE(std::string::npos, requests.back().fBody.find("\"footerObjId\""));
+   EXPECT_NE(std::string::npos, requests.back().fBody.find("\"urlTemplate\""));
+}
+
+TEST(RPageSinkS3Wire, PutErrorThrows)
+{
+   TServerSocket server(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string host = server.GetLocalInetAddress().GetHostAddress();
+   const std::string uri =
+      "ntpl+s3+http://" + host + ":" + std::to_string(server.GetLocalPort()) + "/wirebucket/wireerr";
+
+   gSystem->Setenv("S3_ACCESS_KEY", "dummykey");
+   gSystem->Setenv("S3_SECRET_KEY", "dummysecret");
+   gSystem->Setenv("S3_REGION", "us-east-1");
+
+   // Reject the first upload (the header, written during writer construction) with 403.
+   std::thread serverThread([&] {
+      TSocket *sock = server.Accept();
+      if (sock && sock != reinterpret_cast<TSocket *>(-1)) {
+         std::string headers, body;
+         ServeOneRequest(sock, "403 Forbidden", headers, body);
+         sock->Close();
+      }
+   });
+
+   // Allow the one-time (std::call_once) experimental warning the sink ctor may emit; it is optional
+   // because it only fires on the first sink construction in the process.
+   ROOT::TestSupport::CheckDiagsRAII diags;
+   diags.optionalDiag(kWarning, "[ROOT.NTuple]", "experimental", /*matchFullMessage=*/false);
+
+   // The header PUT fails, so RPageSinkS3::PutObject throws out of writer construction.
+   EXPECT_THROW(
+      {
+         auto model = ROOT::RNTupleModel::Create();
+         model->MakeField<int>("value");
+         auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "wire", uri);
+      },
+      ROOT::RException);
+
+   serverThread.join();
+
+   gSystem->Unsetenv("S3_ACCESS_KEY");
+   gSystem->Unsetenv("S3_SECRET_KEY");
+   gSystem->Unsetenv("S3_REGION");
+}
+
+TEST(RPageSinkS3Wire, CloneAsHiddenWritesUnderClonePrefix)
+{
+   TServerSocket server(0, false, TServerSocket::kDefaultBacklog, -1, ESocketBindOption::kInaddrLoopback);
+   const std::string host = server.GetLocalInetAddress().GetHostAddress();
+   const std::string basePath = "/wirebucket/wireclone";
+   const std::string uri = "ntpl+s3+http://" + host + ":" + std::to_string(server.GetLocalPort()) + basePath;
+   const std::string clonePrefix = basePath + "/_clone/attr";
+
+   gSystem->Setenv("S3_ACCESS_KEY", "dummykey");
+   gSystem->Setenv("S3_SECRET_KEY", "dummysecret");
+   gSystem->Setenv("S3_REGION", "us-east-1");
+
+   // Capture the target path of every PUT the clone issues. The clone writes its whole ntuple and its
+   // anchor is last, targeting exactly the clone prefix -- use that as the stop condition.
+   std::vector<std::string> paths;
+   std::thread serverThread([&] {
+      for (;;) {
+         TSocket *sock = server.Accept();
+         if (!sock || sock == reinterpret_cast<TSocket *>(-1))
+            break;
+         std::string headers, body;
+         std::string path = ServeOneRequest(sock, "200 OK", headers, body);
+         sock->Close();
+         paths.push_back(path);
+         if (paths.back() == clonePrefix)
+            break;
+      }
+   });
+
+   {
+      // The sink ctor emits the one-time (std::call_once) experimental warning; allow it (optional).
+      ROOT::TestSupport::CheckDiagsRAII diags;
+      diags.optionalDiag(kWarning, "[ROOT.NTuple]", "experimental", /*matchFullMessage=*/false);
+
+      ROOT::RNTupleWriteOptions opts;
+      auto model = ROOT::RNTupleModel::Create();
+
+      // The main sink only acts as the factory for the hidden clone; we drive the clone itself so its
+      // PUT targets reveal where CloneAsHidden routes the hidden ntuple.
+      ROOT::Experimental::Internal::RPageSinkS3 mainSink("main", uri, opts);
+      auto cloneSink = mainSink.CloneAsHidden("attr", opts);
+      cloneSink->Init(*model);
+      cloneSink->CommitDataset();
+   }
+
+   serverThread.join();
+
+   gSystem->Unsetenv("S3_ACCESS_KEY");
+   gSystem->Unsetenv("S3_SECRET_KEY");
+   gSystem->Unsetenv("S3_REGION");
+
+   ASSERT_FALSE(paths.empty());
+   // The clone's own object counter starts at 0, under its reserved sub-prefix.
+   EXPECT_EQ(clonePrefix + "/0", paths.front());
+   // Every object the clone writes stays under "$baseurl/_clone/attr", so it can never collide with the
+   // main ntuple's numeric object keys ($baseurl/0, $baseurl/1, ...).
+   for (const auto &p : paths)
+      EXPECT_EQ(0u, p.rfind(clonePrefix, 0)) << "clone object escaped the _clone prefix: " << p;
+   // The clone's anchor is written last, at exactly the clone's base URL.
+   EXPECT_EQ(clonePrefix, paths.back());
 }


### PR DESCRIPTION
# This Pull request:
(Is a part of the GSoC 2026 project `S3 Backend for RNTuple.`)

Adds `RPageSinkS3`, the write path of the experimental S3 storage backend for RNTuple.

## Changes or fixes:

- `RPageSinkS3` (Mode B full write path): `InitImpl` (header), `CommitPageImpl`/`CommitSealedPageImpl` (one S3 object per sealed page, `kTypeObject64` locator), `StageClusterImpl`, `CommitClusterGroupImpl` (page list), and `CommitDatasetImpl` (footer, then the JSON anchor written last for atomicity).

## Checklist:

- [x] tested changes locally


