### PR TITLE
[Python] Deprecate conversion from Python set to RooArgSet

### DIFF
--- a/README/ReleaseNotes/v642/index.md
+++ b/README/ReleaseNotes/v642/index.md
@@ -48,6 +48,7 @@ The following people have contributed to this new version:
 * The bindings to the R programming language that are enabled with the `r=ON` or `tmva-rmva=ON` build options (`TRInterface`, RMVA, and friends) are removed, following deprecation in ROOT 6.40. Their maintenance is no longer justified, given the broader adoption of the scientific Python ecosystem. Users who still rely on R from C++ are encouraged to call R directly via https://cran.r-project.org/package=RInside, which is what the ROOT bindings were using internally.
 * Several enums that are redundant with `ROOT::ESTLType` are deprecated and will be removed in ROOT 6.44: `TClassEdit::ESTLType`, `TDictionary::ESTLType`, `TStreamerElement::ESTLType`. Please use `ROOT::ESTLType` instead.
 * The inclusion by external projects of Makefile templates contained within ROOT is deprecated in 6.42, a warning will be raised if you use them. These files will be removed in ROOT 7.
+* The conversion from Python set to **RooArgSet** is deprecated and won't work anymore in ROOT 6.44. The problem is that Python sets are unordered while RooArgSets are ordered, and this mismatch can lead to subtle problems later on. Prefer conversion from Python lists or tuples, which are ordered too.
 
 ## Python Interface
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
@@ -11,13 +11,13 @@
 
 
 import operator
+import warnings
 
 from ._rooabscollection import RooAbsCollection
 
 
 class RooArgSet(RooAbsCollection):
-
-    __cpp_name__ = 'RooArgSet'
+    __cpp_name__ = "RooArgSet"
 
     def __init__(self, *args, **kwargs):
         """Pythonization of RooArgSet constructor to support implicit
@@ -30,6 +30,16 @@ class RooArgSet(RooAbsCollection):
         # argument is added, hence the `len(kwargs) == 0` check breaks the
         # implicit conversion!
         if len(args) == 1 and isinstance(args[0], set):
+            warnings.warn(
+                "Constructing a RooArgSet from a Python set is deprecated and "
+                "will be removed in ROOT 6.44. Python sets are unordered, while "
+                "a RooArgSet is ordered, so this conversion can silently change "
+                "the order of the elements. Construct the RooArgSet from the "
+                "individual RooFit objects, or from a list or tuple of them "
+                "instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
             return self._init(*args[0], **kwargs)
         return self._init(*args, **kwargs)
 

--- a/bindings/pyroot/pythonizations/test/root_module.py
+++ b/bindings/pyroot/pythonizations/test/root_module.py
@@ -120,11 +120,19 @@ class ROOTModule(unittest.TestCase):
 
         version = tuple(int(n) for n in ROOT.__version__.split("."))
 
-        if version >= (6, 44, 0):
+        if version >= (6, 43, 0):
             # Verify that SetHeuristicMemoryPolicy is not available
             with self.assertRaises(AttributeError):
                 ROOT.SetHeuristicMemoryPolicy(True)
                 ROOT.SetHeuristicMemoryPolicy(False)
+
+        if version >= (6, 43, 0) and hasattr(ROOT, "RooArgSet"):
+            # Verify that the implicit conversion from Python set to RooArgSet
+            # is gone
+            x = ROOT.RooRealVar("x", "x", 1.0)
+            y = ROOT.RooRealVar("y", "y", -1.0)
+            with self.assertRaises(TypeError):
+                ROOT.RooDataSet("data", "data", {x, y})
 
     def test_lazy_gdirectory(self):
         """Check that gDirectory is always lazy evaluated to the current

--- a/tutorials/roofit/roofit/rf101_basics.py
+++ b/tutorials/roofit/roofit/rf101_basics.py
@@ -40,7 +40,7 @@ gauss.plotOn(xframe, LineColor="r")
 # Generate events
 # -----------------------------
 # Generate a dataset of 1000 events in x from gauss
-data = gauss.generate({x}, 10000)  # ROOT.RooDataSet
+data = gauss.generate(x, 10000)  # ROOT.RooDataSet
 
 # Make a second plot frame in x and draw both the
 # data and the pdf in the frame

--- a/tutorials/roofit/roofit/rf102_dataimport.py
+++ b/tutorials/roofit/roofit/rf102_dataimport.py
@@ -104,7 +104,7 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 # and RRV y defines a range [-10,10] this means that the ROOT.RooDataSet
 # below will have less entries than the ROOT.TTree 'tree'
 
-ds = ROOT.RooDataSet("ds", "ds", {x, y}, Import=tree)
+ds = ROOT.RooDataSet("ds", "ds", [x, y], Import=tree)
 
 # Use ascii import/export for datasets
 # ------------------------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf103_interprfuncs.py
+++ b/tutorials/roofit/roofit/rf103_interprfuncs.py
@@ -31,7 +31,7 @@ genpdf = ROOT.RooGenericPdf("genpdf", "genpdf", "(1+0.1*abs(x)+sin(sqrt(abs(x*al
 # ---------------------------------------------------------------
 
 # Generate a toy dataset from the interpreted pdf
-data = genpdf.generate({x}, 10000)
+data = genpdf.generate(x, 10000)
 
 # Fit the interpreted pdf to the generated data
 genpdf.fitTo(data, PrintLevel=-1)
@@ -64,7 +64,7 @@ g2 = ROOT.RooGaussian("g2", "h2", x, mean, sigma)
 # Construct a separate gaussian g1(x,10,3) to generate a toy Gaussian
 # dataset with mean 10 and width 3
 g1 = ROOT.RooGaussian("g1", "g1", x, 10, 3)
-data2 = g1.generate({x}, 1000)
+data2 = g1.generate(x, 1000)
 
 # Fit and plot tailored standard pdf
 # -------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf104_classfactory.py
+++ b/tutorials/roofit/roofit/rf104_classfactory.py
@@ -67,7 +67,7 @@ pdf = ROOT.MyPdfV3("pdf", "pdf", y, a, b)
 
 # Generate toy data from pdf and plot data and pdf on frame
 frame1 = y.frame(Title="Compiled class MyPdfV3")
-data = pdf.generate({y}, 1000)
+data = pdf.generate(y, 1000)
 pdf.fitTo(data, PrintLevel=-1)
 data.plotOn(frame1)
 pdf.plotOn(frame1)
@@ -87,7 +87,7 @@ alpha = ROOT.RooRealVar("alpha", "alpha", 5, 0.1, 10)
 genpdf = ROOT.RooClassFactory.makePdfInstance("GenPdf", "(1+0.1*fabs(x)+sin(sqrt(fabs(x*alpha+0.1))))", [x, alpha])
 
 # Generate a toy dataset from the interpreted pdf
-data2 = genpdf.generate({x}, 50000)
+data2 = genpdf.generate(x, 50000)
 
 # Fit the interpreted pdf to the generated data
 genpdf.fitTo(data2, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf105_funcbinding.py
+++ b/tutorials/roofit/roofit/rf105_funcbinding.py
@@ -41,7 +41,7 @@ beta = ROOT.RooFit.bindPdf("beta", ROOT.Math.beta_pdf, x2, a, b)
 beta.Print()
 
 # Generate some events and fit
-data = beta.generate({x2}, 10000)
+data = beta.generate(x2, 10000)
 beta.fitTo(data, PrintLevel=-1)
 
 # Plot data and pdf on frame

--- a/tutorials/roofit/roofit/rf106_plotdecoration.py
+++ b/tutorials/roofit/roofit/rf106_plotdecoration.py
@@ -23,7 +23,7 @@ mean = ROOT.RooRealVar("mean", "mean", -3, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 1000 events with sigma=3
-data = gauss.generate({x}, 1000)
+data = gauss.generate(x, 1000)
 
 # Fit pdf to data
 gauss.fitTo(data, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf107_plotstyles.py
+++ b/tutorials/roofit/roofit/rf107_plotstyles.py
@@ -25,7 +25,7 @@ mean = ROOT.RooRealVar("mean", "mean", -3, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 100 events with sigma=3
-data = gauss.generate({x}, 100)
+data = gauss.generate(x, 100)
 
 # Fit pdf to data
 gauss.fitTo(data, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf108_plotbinning.py
+++ b/tutorials/roofit/roofit/rf108_plotbinning.py
@@ -38,7 +38,7 @@ bmix = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw,
 # --------------------------------------------
 
 # Sample 2000 events in (dt,mixState,tagFlav) from bmix
-data = bmix.generate({dt, mixState, tagFlav}, 2000)
+data = bmix.generate([dt, mixState, tagFlav], 2000)
 
 # Show dt distribution with custom binning
 # -------------------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf109_chi2residpull.py
+++ b/tutorials/roofit/roofit/rf109_chi2residpull.py
@@ -26,7 +26,7 @@ mean = ROOT.RooRealVar("mean", "mean", 0, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 1000 events with sigma=3
-data = gauss.generate({x}, 10000)
+data = gauss.generate(x, 10000)
 
 # Change sigma to 3.15
 sigma.setVal(3.15)

--- a/tutorials/roofit/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/roofit/rf110_normintegration.py
@@ -34,7 +34,7 @@ print("gx_Norm[x] = ", gx.getVal(nset))
 
 # Create object representing integral over gx
 # which is used to calculate  gx_Norm[x] == gx / gx_Int[x]
-igx = gx.createIntegral({x})
+igx = gx.createIntegral(x)
 print("gx_Int[x] = ", igx.getVal())
 
 # Integrate normalized pdf over subrange
@@ -46,7 +46,7 @@ x.setRange("signal", -5, 5)
 # Create an integral of gx_Norm[x] over x in range "signal"
 # ROOT.This is the fraction of of pdf gx_Norm[x] which is in the
 # range named "signal"
-xset = {x}
+xset = [x]
 igx_sig = gx.createIntegral(xset, NormSet=xset, Range="signal")
 print("gx_Int[x|signal]_Norm[x] = ", igx_sig.getVal())
 
@@ -55,7 +55,7 @@ print("gx_Int[x|signal]_Norm[x] = ", igx_sig.getVal())
 
 # Create the cumulative distribution function of gx
 # i.e. calculate Int[-10,x] gx(x') dx'
-gx_cdf = gx.createCdf({x})
+gx_cdf = gx.createCdf(x)
 
 # Plot cdf of gx versus x
 frame = x.frame(Title="cdf of Gaussian pdf")

--- a/tutorials/roofit/roofit/rf201_composite.py
+++ b/tutorials/roofit/roofit/rf201_composite.py
@@ -56,7 +56,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # ---------------------------------------------------
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Fit model to data
 model.fitTo(data, PrintLevel=-1)
@@ -67,10 +67,10 @@ data.plotOn(xframe)
 model.plotOn(xframe)
 
 # Overlay the background component of model with a dashed line
-model.plotOn(xframe, Components={bkg}, LineStyle="--")
+model.plotOn(xframe, Components=[bkg], LineStyle="--")
 
 # Overlay the background+sig2 components of model with a dotted line
-model.plotOn(xframe, Components={bkg, sig2}, LineStyle=":")
+model.plotOn(xframe, Components=[bkg, sig2], LineStyle=":")
 
 # Print structure of composite pdf
 model.Print("t")
@@ -94,7 +94,7 @@ model2 = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig1, sig2], [bkgfrac, sig1fra
 # Plot recursive addition model
 # ---------------------------------------------------------
 model2.plotOn(xframe, LineColor="r", LineStyle="--")
-model2.plotOn(xframe, Components={bkg, sig2}, LineColor="r", LineStyle="--")
+model2.plotOn(xframe, Components=[bkg, sig2], LineColor="r", LineStyle="--")
 model2.Print("t")
 
 # Draw the frame on the canvas

--- a/tutorials/roofit/roofit/rf202_extendedmlfit.py
+++ b/tutorials/roofit/roofit/rf202_extendedmlfit.py
@@ -50,7 +50,7 @@ model = ROOT.RooAddPdf("model", "(g1+g2)+a", [bkg, sig], [nbkg, nsig])
 
 # Generate a data sample of expected number events in x from model
 # = model.expectedEvents() = nsig+nbkg
-data = model.generate({x})
+data = model.generate(x)
 
 # Fit model to data, ML term automatically included
 model.fitTo(data, PrintLevel=-1)
@@ -61,11 +61,10 @@ data.plotOn(xframe)
 model.plotOn(xframe)
 
 # Overlay the background component of model with a dashed line
-model.plotOn(xframe, Components={bkg}, LineStyle=":")
+model.plotOn(xframe, Components=[bkg], LineStyle=":")
 
 # Overlay the background+sig2 components of model with a dotted line
-ras_bkg_sig2 = {bkg, sig2}
-model.plotOn(xframe, Components=ras_bkg_sig2, LineStyle=":")
+model.plotOn(xframe, Components=[bkg, sig2], LineStyle=":")
 
 # Print structure of composite pdf
 model.Print("t")

--- a/tutorials/roofit/roofit/rf203_ranges.py
+++ b/tutorials/roofit/roofit/rf203_ranges.py
@@ -30,7 +30,7 @@ f = ROOT.RooRealVar("f", "f", 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gx, px], [f])
 
 # Generated 10000 events in (x,y) from pdf model
-modelData = model.generate({x}, 10000)
+modelData = model.generate(x, 10000)
 
 # Fit full range
 # ---------------------------

--- a/tutorials/roofit/roofit/rf205_compplot.py
+++ b/tutorials/roofit/roofit/rf205_compplot.py
@@ -51,7 +51,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # ------------------------------------------------------------------------------
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Plot data and complete PDF overlaid
 xframe = x.frame(Title="Component plotting of pdf=(sig1+sig2)+(bkg1+bkg2)")
@@ -65,18 +65,15 @@ xframe2 = xframe.Clone("xframe2")
 # --------------------------------------------------------------------
 
 # Plot single background component specified by object reference
-ras_bkg = {bkg}
-model.plotOn(xframe, Components=ras_bkg, LineColor="r")
+model.plotOn(xframe, Components=[bkg], LineColor="r")
 
 # Plot single background component specified by object reference
-ras_bkg2 = {bkg2}
-model.plotOn(xframe, Components=ras_bkg2, LineStyle="--", LineColor="r")
+model.plotOn(xframe, Components=[bkg2], LineStyle="--", LineColor="r")
 
 # Plot multiple background components specified by object reference
 # Note that specified components may occur at any level in object tree
 # (e.g bkg is component of 'model' and 'sig2' is component 'sig')
-ras_bkg_sig2 = {bkg, sig2}
-model.plotOn(xframe, Components=ras_bkg_sig2, LineStyle=":")
+model.plotOn(xframe, Components=[bkg, sig2], LineStyle=":")
 
 # Make component by name/regexp
 # ------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf207_comptools.py
+++ b/tutorials/roofit/roofit/rf207_comptools.py
@@ -43,7 +43,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Create dummy dataset that has more observables than the above pdf
 y = ROOT.RooRealVar("y", "y", -10, 10)
-data = ROOT.RooDataSet("data", "data", {x, y})
+data = ROOT.RooDataSet("data", "data", [x, y])
 
 # Basic information requests
 # ---------------------------------------------
@@ -66,7 +66,7 @@ model_obs.Print("v")
 # -------------------------------------------
 
 # Get list of parameters, list of observables
-model_params = model.getParameters({x})
+model_params = model.getParameters(x)
 ROOT.SetOwnership(model_params, True)
 model_params.Print("v")
 

--- a/tutorials/roofit/roofit/rf208_convolution.py
+++ b/tutorials/roofit/roofit/rf208_convolution.py
@@ -45,7 +45,7 @@ lxg = ROOT.RooFFTConvPdf("lxg", "landau (X) gauss", t, landau, gauss)
 # ----------------------------------------------------------------------
 
 # Sample 1000 events in x from gxlx
-data = lxg.generate({t}, 10000)
+data = lxg.generate(t, 10000)
 
 # Fit gxlx to data
 lxg.fitTo(data, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf210_angularconv.py
+++ b/tutorials/roofit/roofit/rf210_angularconv.py
@@ -55,7 +55,7 @@ Mpsi.setBufferFraction(0)
 # --------------------------------------------------------------------------------
 
 # Generate some events in observable psi
-data_psi = Mpsi.generate({psi}, 10000)
+data_psi = Mpsi.generate(psi, 10000)
 
 # Fit convoluted model as function of angle psi
 Mpsi.fitTo(data_psi, PrintLevel=-1)
@@ -85,7 +85,7 @@ Mcpsi.setBufferFraction(0)
 # --------------------------------------------------------------------------------
 
 # Generate some events
-data_cpsi = Mcpsi.generate({cpsi}, 10000)
+data_cpsi = Mcpsi.generate(cpsi, 10000)
 
 # set psi constant to exclude to be a parameter of the fit
 psi.setConstant(True)

--- a/tutorials/roofit/roofit/rf211_paramconv.py
+++ b/tutorials/roofit/roofit/rf211_paramconv.py
@@ -37,14 +37,14 @@ model = ROOT.RooFFTConvPdf("model", "model", mean, modelx, model_mean)
 # Configure convolution to construct a 2-D cache in (x,mean)
 # rather than a 1-d cache in mean that needs to be recalculated
 # for each value of x
-model.setCacheObservables({x})
+model.setCacheObservables(x)
 model.setBufferFraction(1.0)
 
 # Integrate model over projModel = Int model dmean
-projModel = model.createProjection({mean})
+projModel = model.createProjection(mean)
 
 # Generate 1000 toy events
-d = projModel.generateBinned({x}, 1000)
+d = projModel.generateBinned(x, 1000)
 
 # Fit p.d.f. to toy data
 projModel.fitTo(d, Verbose=True, PrintLevel=-1)
@@ -60,7 +60,7 @@ hh = model.createHistogram(
     x,
     Binning=50,
     YVar=dict(var=mean, Binning=50),
-    ConditionalObservables={mean},
+    ConditionalObservables=[mean],
 )
 hh.SetTitle("histogram of model(x|mean)")
 hh.SetLineColor("kBlue")

--- a/tutorials/roofit/roofit/rf301_composition.py
+++ b/tutorials/roofit/roofit/rf301_composition.py
@@ -35,7 +35,7 @@ model = ROOT.RooGaussian("model", "Gaussian with shifting mean", x, fy, sigma)
 # ---------------------------------------------------------------------------------
 
 # Generate 10000 events in x and y from model
-data = model.generate({x, y}, 10000)
+data = model.generate([x, y], 10000)
 
 # Plot x distribution of data and projection of model x = Int(dy)
 # model(x,y)

--- a/tutorials/roofit/roofit/rf303_conditional.py
+++ b/tutorials/roofit/roofit/rf303_conditional.py
@@ -22,7 +22,7 @@ def makeFakeDataXY():
 
     x = ROOT.RooRealVar("x", "x", -10, 10)
     y = ROOT.RooRealVar("y", "y", -10, 10)
-    coord = {x, y}
+    coord = [x, y]
 
     d = ROOT.RooDataSet("d", "d", coord)
 
@@ -60,17 +60,17 @@ expDataXY = makeFakeDataXY()
 # ---------------------------------------------------------------------------------------------
 
 # Make subset of experimental data with only y values
-expDataY = expDataXY.reduce({y})
+expDataY = expDataXY.reduce(y)
 
 # Generate 10000 events in x obtained from _conditional_ model(x|y) with y
 # values taken from experimental data
-data = model.generate({x}, ProtoData=expDataY)
+data = model.generate(x, ProtoData=expDataY)
 data.Print()
 
 # Fit conditional p.d.f model(x|y) to data
 # ---------------------------------------------------------------------------------------------
 
-model.fitTo(expDataXY, ConditionalObservables={y}, PrintLevel=-1)
+model.fitTo(expDataXY, ConditionalObservables=[y], PrintLevel=-1)
 
 # Project conditional p.d.f on x and y dimensions
 # ---------------------------------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf304_uncorrprod.py
+++ b/tutorials/roofit/roofit/rf304_uncorrprod.py
@@ -41,7 +41,7 @@ gaussxy = ROOT.RooProdPdf("gaussxy", "gaussx*gaussy", [gaussx, gaussy])
 # ---------------------------------------------------------------------------
 
 # Generate 10000 events in x and y from gaussxy
-data = gaussxy.generate({x, y}, 10000)
+data = gaussxy.generate([x, y], 10000)
 
 # Plot x distribution of data and projection of gaussxy x = Int(dy)
 # gaussxy(x,y)

--- a/tutorials/roofit/roofit/rf305_condcorrprod.py
+++ b/tutorials/roofit/roofit/rf305_condcorrprod.py
@@ -40,13 +40,13 @@ gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, 0.0, 3.0)
 # -------------------------------------------------------
 
 # Create gaussx(x,sx|y) * gaussy(y)
-model = ROOT.RooProdPdf("model", "gaussx(x|y)*gaussy(y)", {gaussy}, Conditional=({gaussx}, {x}))
+model = ROOT.RooProdPdf("model", "gaussx(x|y)*gaussy(y)", gaussy, Conditional=(gaussx, x))
 
 # Sample, fit and plot product pdf
 # ---------------------------------------------------------------
 
 # Generate 1000 events in x and y from model
-data = model.generate({x, y}, 10000)
+data = model.generate([x, y], 10000)
 
 # Plot x distribution of data and projection of model x = Int(dy)
 # model(x,y)

--- a/tutorials/roofit/roofit/rf306_condpereventerrors.py
+++ b/tutorials/roofit/roofit/rf306_condpereventerrors.py
@@ -34,20 +34,20 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 
 # Use landau pdf to get somewhat realistic distribution with long tail
 pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25)
-expDataDterr = pdfDtErr.generate({dterr}, 10000)
+expDataDterr = pdfDtErr.generate(dterr, 10000)
 
 # Sample data from conditional decay_gm(dt|dterr)
 # ---------------------------------------------------------------------------------------------
 
 # Specify external dataset with dterr values to use decay_dm as
 # conditional pdf
-data = decay_gm.generate({dt}, ProtoData=expDataDterr)
+data = decay_gm.generate(dt, ProtoData=expDataDterr)
 
 # Fit conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------
 
 # Specify dterr as conditional observable
-decay_gm.fitTo(data, ConditionalObservables={dterr}, PrintLevel=-1)
+decay_gm.fitTo(data, ConditionalObservables=[dterr], PrintLevel=-1)
 
 # Plot conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf307_fullpereventerrors.py
+++ b/tutorials/roofit/roofit/rf307_fullpereventerrors.py
@@ -32,18 +32,18 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 
 # Use landau pdf to get empirical distribution with long tail
 pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, 1.0, 0.25)
-expDataDterr = pdfDtErr.generate({dterr}, 10000)
+expDataDterr = pdfDtErr.generate(dterr, 10000)
 
 # Construct a histogram pdf to describe the shape of the dtErr distribution
 expHistDterr = expDataDterr.binnedClone()
-pdfErr = ROOT.RooHistPdf("pdfErr", "pdfErr", {dterr}, expHistDterr)
+pdfErr = ROOT.RooHistPdf("pdfErr", "pdfErr", dterr, expHistDterr)
 
 # Construct conditional product decay_dm(dt|dterr)*pdf(dterr)
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Construct production of conditional decay_dm(dt|dterr) with empirical
 # pdfErr(dterr)
-model = ROOT.RooProdPdf("model", "model", {pdfErr}, Conditional=({decay_gm}, {dt}))
+model = ROOT.RooProdPdf("model", "model", pdfErr, Conditional=(decay_gm, dt))
 
 # (Alternatively you could also use the landau shape pdfDtErr)
 # ROOT.RooProdPdf model("model", "model",pdfDtErr,
@@ -54,7 +54,7 @@ model = ROOT.RooProdPdf("model", "model", {pdfErr}, Conditional=({decay_gm}, {dt
 
 # Specify external dataset with dterr values to use model_dm as
 # conditional pdf
-data = model.generate({dt, dterr}, 10000)
+data = model.generate([dt, dterr], 10000)
 
 # Fit conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/roofit/rf308_normintegration2d.py
@@ -39,7 +39,7 @@ print("gx_Norm[x,y] = ", gxy.getVal(nset_xy))
 
 # Create object representing integral over gx
 # which is used to calculate  gx_Norm[x,y] == gx / gx_Int[x,y]
-x_and_y = {x, y}
+x_and_y = [x, y]
 igxy = gxy.createIntegral(x_and_y)
 print("gx_Int[x,y] = ", igxy.getVal())
 
@@ -74,7 +74,7 @@ print("gx_Int[x,y|signal]_Norm[x,y] = ", igxy_sig.getVal())
 
 # Create the cumulative distribution function of gx
 # i.e. calculate Int[-10,x] gx(x') dx'
-gxy_cdf = gxy.createCdf({x, y})
+gxy_cdf = gxy.createCdf([x, y])
 
 # Plot cdf of gx versus x
 hh_cdf = gxy_cdf.createHistogram("hh_cdf", x, Binning=40, YVar=dict(var=y, Binning=40))

--- a/tutorials/roofit/roofit/rf309_ndimplot.py
+++ b/tutorials/roofit/roofit/rf309_ndimplot.py
@@ -31,7 +31,7 @@ fy = ROOT.RooFormulaVar("fy", "a0-a1*sqrt(10*abs(y))", [y, a0, a1])
 model = ROOT.RooGaussian("model", "Gaussian with shifting mean", x, fy, sigma)
 
 # Sample dataset from gauss(x,y)
-data = model.generate({x, y}, 10000)
+data = model.generate([x, y], 10000)
 
 # Make 2D plots of data and model
 # -------------------------------------------------------------
@@ -53,7 +53,7 @@ z = ROOT.RooRealVar("z", "z", -5, 5)
 gz = ROOT.RooGaussian("gz", "gz", z, 0.0, 2.0)
 model3 = ROOT.RooProdPdf("model3", "model3", [model, gz])
 
-data3 = model3.generate({x, y, z}, 10000)
+data3 = model3.generate([x, y, z], 10000)
 
 # Make 3D plots of data and model
 # -------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf310_sliceplot.py
+++ b/tutorials/roofit/roofit/rf310_sliceplot.py
@@ -39,7 +39,7 @@ gm1 = ROOT.RooGaussModel("gm1", "gauss model 1", dt, bias1, sigma1)
 bmix_gm1 = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw, gm1, type="DoubleSided")
 
 # Generate BMixing data with above set of event errors
-data = bmix_gm1.generate({dt, tagFlav, mixState}, 20000)
+data = bmix_gm1.generate([dt, tagFlav, mixState], 20000)
 
 # Plot full decay distribution
 # ----------------------------------------------------------

--- a/tutorials/roofit/roofit/rf311_rangeplot.py
+++ b/tutorials/roofit/roofit/rf311_rangeplot.py
@@ -36,7 +36,7 @@ bkg = ROOT.RooProdPdf("bkg", "bkg", [px, py, pz])
 fsig = ROOT.RooRealVar("fsig", "signal fraction", 0.1, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
-data = model.generate({x, y, z}, 20000)
+data = model.generate([x, y, z], 20000)
 
 # Project pdf and data on x
 # -------------------------------------------------

--- a/tutorials/roofit/roofit/rf312_multirangefit.py
+++ b/tutorials/roofit/roofit/rf312_multirangefit.py
@@ -38,7 +38,7 @@ f = ROOT.RooRealVar("f", "f", 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [f])
 
 # Sample 10000 events in (x,y) from the model
-modelData = model.generate({x, y}, 10000)
+modelData = model.generate([x, y], 10000)
 
 # Define signal and sideband regions
 # -------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf313_paramranges.py
+++ b/tutorials/roofit/roofit/rf313_paramranges.py
@@ -50,7 +50,7 @@ z.setRange("R", zlo, zhi)
 # ----------------------------------------------------------------------------------
 
 # Create integral over normalized pdf model over x,y, in "R" region
-intPdf = pxyz.createIntegral({x, y, z}, {x, y, z}, "R")
+intPdf = pxyz.createIntegral([x, y, z], [x, y, z], "R")
 
 # Plot value of integral as function of pdf parameter z0
 frame = z0.frame(Title="Integral of pxyz over x,y, in region R")

--- a/tutorials/roofit/roofit/rf314_paramfitrange.py
+++ b/tutorials/roofit/roofit/rf314_paramfitrange.py
@@ -36,13 +36,13 @@ model = ROOT.RooExponential("model", "model", t, tau)
 # ------------------------------------
 
 # Generate complete dataset without acceptance cuts (for reference)
-dall = model.generate({t}, 10000)
+dall = model.generate(t, 10000)
 
 # Generate a (fake) prototype dataset for acceptance limit values
-tmp = ROOT.RooGaussian("gmin", "gmin", tmin, 0.0, 0.5).generate({tmin}, 5000)
+tmp = ROOT.RooGaussian("gmin", "gmin", tmin, 0.0, 0.5).generate(tmin, 5000)
 
 # Generate dataset with t values that observe (t>tmin)
-dacc = model.generate({t}, ProtoData=tmp)
+dacc = model.generate(t, ProtoData=tmp)
 
 # Fit pdf to data in acceptance region
 # -----------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf315_projectpdf.py
+++ b/tutorials/roofit/roofit/rf315_projectpdf.py
@@ -41,21 +41,21 @@ gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, 0.0, 2.0)
 model = ROOT.RooProdPdf(
     "model",
     "gaussx(x|y)*gaussy(y)",
-    {gaussy},
-    Conditional=({gaussx}, {x}),
+    gaussy,
+    Conditional=(gaussx, x),
 )
 
 # Marginalize m(x,y) to m(x)
 # ----------------------------------------------------
 
 # modelx(x) = Int model(x,y) dy
-modelx = model.createProjection({y})
+modelx = model.createProjection(y)
 
 # Use marginalized pdf as regular 1D pdf
 # -----------------------------------------------
 
 # Sample 1000 events from modelx
-data = modelx.generateBinned({x}, 1000)
+data = modelx.generateBinned(x, 1000)
 
 # Fit modelx to toy data
 modelx.fitTo(data, Verbose=True, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf316_llratioplot.py
+++ b/tutorials/roofit/roofit/rf316_llratioplot.py
@@ -38,7 +38,7 @@ bkg = ROOT.RooProdPdf("bkg", "bkg", [px, py, pz])
 fsig = ROOT.RooRealVar("fsig", "signal fraction", 0.1, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
-data = model.generate({x, y, z}, 20000)
+data = model.generate([x, y, z], 20000)
 
 # Project pdf and data on x
 # -------------------------------------------------
@@ -53,8 +53,8 @@ model.plotOn(frame)
 
 # Calculate projection of signal and total likelihood on (y,z) observables
 # i.e. integrate signal and composite model over x
-sigyz = sig.createProjection({x})
-totyz = model.createProjection({x})
+sigyz = sig.createProjection(x)
+totyz = model.createProjection(x)
 
 # Construct the log of the signal / signal+background probability
 llratio_func = ROOT.RooFormulaVar("llratio", "log10(@0)-log10(@1)", [sigyz, totyz])
@@ -78,7 +78,7 @@ dataSel.plotOn(frame2)
 # ---------------------------------------------------------------------------------------------
 
 # Generate large number of events for MC integration of pdf projection
-mcprojData = model.generate({x, y, z}, 10000)
+mcprojData = model.generate([x, y, z], 10000)
 
 # Calculate LL ratio for each generated event and select MC events with
 # llratio)0.7

--- a/tutorials/roofit/roofit/rf401_importttreethx.py
+++ b/tutorials/roofit/roofit/rf401_importttreethx.py
@@ -83,12 +83,12 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 z = ROOT.RooRealVar("z", "z", -10, 10)
 
 # Import only observables (y,z)
-ds = ROOT.RooDataSet("ds", "ds", {x, y}, Import=tree)
+ds = ROOT.RooDataSet("ds", "ds", [x, y], Import=tree)
 ds.Print()
 
 # Import observables (x,y,z) but only event for which (y+z<0) is ROOT.True
 # Import observables (x,y,z) but only event for which (y+z<0) is ROOT.True
-ds2 = ROOT.RooDataSet("ds2", "ds2", {x, y, z}, Import=tree, Cut="y+z<0")
+ds2 = ROOT.RooDataSet("ds2", "ds2", [x, y, z], Import=tree, Cut="y+z<0")
 ds2.Print()
 
 # Importing integer ROOT TTree branches
@@ -96,7 +96,7 @@ ds2.Print()
 
 # Import integer tree branch as ROOT.RooRealVar
 i = ROOT.RooRealVar("i", "i", 0, 5)
-ds3 = ROOT.RooDataSet("ds3", "ds3", {i, x}, Import=tree)
+ds3 = ROOT.RooDataSet("ds3", "ds3", [i, x], Import=tree)
 ds3.Print()
 
 # Define category i
@@ -104,19 +104,19 @@ icat = ROOT.RooCategory("i", "i", {"State0": 0, "State1": 1})
 
 # Import integer tree branch as ROOT.RooCategory (only events with i==0 and i==1
 # will be imported as those are the only defined states)
-ds4 = ROOT.RooDataSet("ds4", "ds4", {icat, x}, Import=tree)
+ds4 = ROOT.RooDataSet("ds4", "ds4", [icat, x], Import=tree)
 ds4.Print()
 
 # Import multiple RooDataSets into a RooDataSet
 # ----------------------------------------------------------------------------------------
 
 # Create three ROOT.RooDataSets in (y,z)
-dsA = ds2.reduce({x, y}, "z<-5")
-dsB = ds2.reduce({x, y}, "abs(z)<5")
-dsC = ds2.reduce({x, y}, "z>5")
+dsA = ds2.reduce([x, y], "z<-5")
+dsB = ds2.reduce([x, y], "abs(z)<5")
+dsC = ds2.reduce([x, y], "z>5")
 
 # Create a dataset that imports contents of all the above datasets mapped
 # by index category c
-dsABC = ROOT.RooDataSet("dsABC", "dsABC", {x, y}, Index=c, Import={"SampleA": dsA, "SampleB": dsB, "SampleC": dsC})
+dsABC = ROOT.RooDataSet("dsABC", "dsABC", [x, y], Index=c, Import={"SampleA": dsA, "SampleB": dsB, "SampleC": dsC})
 
 dsABC.Print()

--- a/tutorials/roofit/roofit/rf402_datahandling.py
+++ b/tutorials/roofit/roofit/rf402_datahandling.py
@@ -31,7 +31,7 @@ c.defineType("Minus", -1)
 
 # ROOT.RooDataSet is an unbinned dataset (a collection of points in
 # N-dimensional space)
-d = ROOT.RooDataSet("d", "d", {x, y, c})
+d = ROOT.RooDataSet("d", "d", [x, y, c])
 
 # Unlike ROOT.RooAbsArgs (ROOT.RooAbsPdf, ROOT.RooFormulaVar,....) datasets are not attached to
 # the variables they are constructed from. Instead they are attached to an internal
@@ -51,7 +51,7 @@ for i in range(1000):
     if i < 3:
         print(x, y, c)
         print(type(x))
-    d.add({x, y, c})
+    d.add([x, y, c])
 
 d.Print("v")
 print("")
@@ -74,11 +74,11 @@ print("")
 # The reduce() function returns a dataset which is a subset of the
 # original
 print("\n >> d1 has only columns x,c")
-d1 = d.reduce({x, c})
+d1 = d.reduce([x, c])
 d1.Print("v")
 
 print("\n >> d2 has only column y")
-d2 = d.reduce({y})
+d2 = d.reduce([y])
 d2.Print("v")
 
 print("\n >> d3 has only the points with y>5.17")
@@ -86,7 +86,7 @@ d3 = d.reduce("y>5.17")
 d3.Print("v")
 
 print("\n >> d4 has only columns x, for data points with y>5.17")
-d4 = d.reduce({x, c}, "y>5.17")
+d4 = d.reduce([x, c], "y>5.17")
 d4.Print("v")
 
 # The merge() function adds two data set column-wise
@@ -114,7 +114,7 @@ print(">> the category 'c' will be projected in the filling process")
 # state
 x.setBins(10)
 y.setBins(10)
-dh = ROOT.RooDataHist("dh", "binned version of d", {x, y}, d)
+dh = ROOT.RooDataHist("dh", "binned version of d", [x, y], d)
 dh.Print("v")
 
 yframe = y.frame(Bins=10, Title="Operations on binned datasets")
@@ -131,7 +131,7 @@ x.setVal(0.3)
 y.setVal(20.5)
 print(">> retrieving the properties of the bin enclosing coordinate (x,y) = (0.3,20.5) bin center:")
 # load bin center coordinates in internal buffer
-dh.get({x, y}).Print("v")
+dh.get([x, y]).Print("v")
 print(" weight = ", dh.weight())  # return weight of last loaded coordinates
 
 # Reduce the 2-dimensional binned dataset to a 1-dimensional binned dataset
@@ -140,7 +140,7 @@ print(" weight = ", dh.weight())  # return weight of last loaded coordinates
 # demonstrated on unbinned datasets can be applied to binned datasets as
 # well.
 print(">> Creating 1-dimensional projection on y of dh for bins with x>0")
-dh2 = dh.reduce({y}, "x>0")
+dh2 = dh.reduce(y, "x>0")
 dh2.Print("v")
 
 # Add dh2 to yframe and redraw

--- a/tutorials/roofit/roofit/rf404_categories.py
+++ b/tutorials/roofit/roofit/rf404_categories.py
@@ -35,7 +35,7 @@ b0flav.Print()
 
 # Generate a dummy dataset
 x = ROOT.RooRealVar("x", "x", 0, 10)
-data = ROOT.RooPolynomial("p", "p", x).generate({x, b0flav, tagCat}, 10000)
+data = ROOT.RooPolynomial("p", "p", x).generate([x, b0flav, tagCat], 10000)
 
 # Print tables of category contents of datasets
 # --------------------------------------------------
@@ -51,7 +51,7 @@ ttable.Print()
 ttable.Print("v")
 
 # Create table for all (tagCat x b0flav) state combinations
-bttable = data.table({tagCat, b0flav})
+bttable = data.table([tagCat, b0flav])
 bttable.Print("v")
 
 # Retrieve number of events from table

--- a/tutorials/roofit/roofit/rf405_realtocatfuncs.py
+++ b/tutorials/roofit/roofit/rf405_realtocatfuncs.py
@@ -21,7 +21,7 @@ x = ROOT.RooRealVar("x", "x", 0, 10)
 a = ROOT.RooArgusBG("a", "argus(x)", x, 10.0, -1.0)
 
 # Generate a dummy dataset
-data = a.generate({x}, 10000)
+data = a.generate(x, 10000)
 
 # Create a threshold real -> cat function
 # --------------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf406_cattocatfuncs.py
+++ b/tutorials/roofit/roofit/rf406_cattocatfuncs.py
@@ -30,7 +30,7 @@ b0flav.Print()
 # Construct a dummy dataset with random values of tagCat and b0flav
 x = ROOT.RooRealVar("x", "x", 0, 10)
 p = ROOT.RooPolynomial("p", "p", x)
-data = p.generate({x, b0flav, tagCat}, 10000)
+data = p.generate([x, b0flav, tagCat], 10000)
 
 # Create a cat -> cat mapping category
 # ---------------------------------------------------------------------
@@ -56,7 +56,7 @@ mtable.Print("v")
 
 # A SUPER-category is 'product' of _lvalue_ categories. The state names of a super
 # category is a composite of the state labels of the input categories
-b0Xtcat = ROOT.RooSuperCategory("b0Xtcat", "b0flav X tagCat", {b0flav, tagCat})
+b0Xtcat = ROOT.RooSuperCategory("b0Xtcat", "b0flav X tagCat", [b0flav, tagCat])
 
 # Make a table of the product category state multiplicity in data
 stable = data.table(b0Xtcat)
@@ -67,7 +67,7 @@ b0Xtcat.setLabel("{B0bar;Lepton}")
 
 # A MULTI-category is a 'product' of any category (function). The state names of a super
 # category is a composite of the state labels of the input categories
-b0Xttype = ROOT.RooMultiCategory("b0Xttype", "b0flav X tagType", {b0flav, tcatType})
+b0Xttype = ROOT.RooMultiCategory("b0Xttype", "b0flav X tagType", [b0flav, tcatType])
 
 # Make a table of the product category state multiplicity in data
 xtable = data.table(b0Xttype)

--- a/tutorials/roofit/roofit/rf407_ComputationalGraphVisualization.py
+++ b/tutorials/roofit/roofit/rf407_ComputationalGraphVisualization.py
@@ -66,13 +66,13 @@ model.graphVizTree("rf206_model.dot")
 # ----------------------------------------------------------------------------------------
 
 # Make list of model parameters
-params = model.getParameters({x})
+params = model.getParameters(x)
 
 # Save snapshot of prefit parameters
 initParams = params.snapshot()
 
 # Do fit to data, obtain error estimates on parameters
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 model.fitTo(data, PrintLevel=-1)
 
 # Print LateX table of parameters of pdf

--- a/tutorials/roofit/roofit/rf501_simultaneouspdf.py
+++ b/tutorials/roofit/roofit/rf501_simultaneouspdf.py
@@ -54,8 +54,8 @@ model_ctl = ROOT.RooAddPdf("model_ctl", "model_ctl", [gx_ctl, px_ctl], [f_ctl])
 # ---------------------------------------------------------------
 
 # Generate 1000 events in x and y from model
-data = model.generate({x}, 1000)
-data_ctl = model_ctl.generate({x}, 2000)
+data = model.generate(x, 1000)
+data_ctl = model_ctl.generate(x, 2000)
 
 # Create index category and join samples
 # ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ sample.defineType("control")
 combData = ROOT.RooDataSet(
     "combData",
     "combined data",
-    {x},
+    x,
     Index=sample,
     Import={"physics": data, "control": data_ctl},
 )

--- a/tutorials/roofit/roofit/rf502_wspacewrite.py
+++ b/tutorials/roofit/roofit/rf502_wspacewrite.py
@@ -41,7 +41,7 @@ bkgfrac = ROOT.RooRealVar("bkgfrac", "fraction of background", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Create workspace, import data and model
 # -----------------------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf504_simwstool.py
+++ b/tutorials/roofit/roofit/rf504_simwstool.py
@@ -47,7 +47,7 @@ d.defineType("bar")
 
 # Import ingredients in a workspace
 w = ROOT.RooWorkspace("w", "w")
-w.Import({model, c, d})
+w.Import([model, c, d])
 
 # Make Sim builder tool
 sct = ROOT.RooSimWSTool(w)

--- a/tutorials/roofit/roofit/rf505_asciicfg.py
+++ b/tutorials/roofit/roofit/rf505_asciicfg.py
@@ -32,14 +32,14 @@ model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 # Fit model to toy data
 # -----------------------------------------
 
-d = model.generate({x}, 1000)
+d = model.generate(x, 1000)
 model.fitTo(d, PrintLevel=-1)
 
 # Write parameters to ASCII file
 # -----------------------------------------------------------
 
 # Obtain set of parameters
-params = model.getParameters({x})
+params = model.getParameters(x)
 
 # Write parameters to file
 params.writeToFile("rf505_asciicfg_example.txt")

--- a/tutorials/roofit/roofit/rf506_msgservice.py
+++ b/tutorials/roofit/roofit/rf506_msgservice.py
@@ -28,7 +28,7 @@ poly = ROOT.RooPolynomial("p", "p", x, [p0])
 f = ROOT.RooRealVar("f", "f", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 
-data = model.generate({x}, 10)
+data = model.generate(x, 10)
 
 # Print configuration of message service
 # ------------------------------------------
@@ -46,7 +46,7 @@ ROOT.RooMsgService.instance().Print()
 ROOT.RooMsgService.instance().getStream(1).addTopic(ROOT.RooFit.Integration)
 
 # Construct integral over gauss to demonstrate message stream
-igauss = gauss.createIntegral({x})
+igauss = gauss.createIntegral(x)
 igauss.Print()
 
 # Print streams configuration in verbose, also shows inactive streams

--- a/tutorials/roofit/roofit/rf510_wsnamedsets.py
+++ b/tutorials/roofit/roofit/rf510_wsnamedsets.py
@@ -59,9 +59,9 @@ def fillWorkspace(w):
     # of defineSet must be set to import them on the fly. Named sets contain only references
     # to the original variables, the value of observables in named sets already
     # reflect their 'current' value
-    params = model.getParameters({x})
+    params = model.getParameters(x)
     w.defineSet("parameters", params)
-    w.defineSet("observables", {x})
+    w.defineSet("observables", x)
 
     # Encode reference value for parameters in workspace
     # ---------------------------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ def fillWorkspace(w):
 
     # Do a dummy fit to a (supposedly) reference dataset here and store the results
     # of that fit into a snapshot
-    refData = model.generate({x}, 10000)
+    refData = model.generate(x, 10000)
     model.fitTo(refData, PrintLevel=-1)
 
     # The kTRUE flag imports the values of the objects in (*params) into the workspace

--- a/tutorials/roofit/roofit/rf511_wsfactory_basic.py
+++ b/tutorials/roofit/roofit/rf511_wsfactory_basic.py
@@ -57,7 +57,7 @@ else:
 # class
 
 # Make a dummy dataset pdf 'model' and import it in the workspace
-data = w["model"].generate({w["x"]}, 1000)
+data = w["model"].generate(w["x"], 1000)
 # Cannot call 'import' directly because this is a python keyword:
 w.Import(data, Rename="data")
 

--- a/tutorials/roofit/roofit/rf601_intminuit.py
+++ b/tutorials/roofit/roofit/rf601_intminuit.py
@@ -34,7 +34,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Construct unbinned likelihood of model w.r.t. data
 nll = model.createNLL(data)
@@ -53,7 +53,7 @@ m.migrad()
 
 # Print values of all parameters, reflect values (and error estimates)
 # that are back propagated from MINUIT
-model.getParameters({x}).Print("s")
+model.getParameters(x).Print("s")
 
 # Disable verbose logging
 m.setVerbose(False)
@@ -66,7 +66,7 @@ m.hesse()
 sigma_g2.Print()
 
 # Run MINOS on sigma_g2 parameter only
-m.minos({sigma_g2})
+m.minos(sigma_g2)
 
 # Print value (and error) of sigma_g2 parameter, reflects
 # value and error back propagated from MINUIT

--- a/tutorials/roofit/roofit/rf602_chi2fit.py
+++ b/tutorials/roofit/roofit/rf602_chi2fit.py
@@ -45,7 +45,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # Create biuned dataset
 # -----------------------------------------
 
-d = model.generate({x}, 10000)
+d = model.generate(x, 10000)
 dh = d.binnedClone()
 
 # Construct a chi^2 of the data and the model.

--- a/tutorials/roofit/roofit/rf604_constraints.py
+++ b/tutorials/roofit/roofit/rf604_constraints.py
@@ -30,7 +30,7 @@ f = ROOT.RooRealVar("f", "f", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 
 # Generate small dataset for use in fitting below
-d = model.generate({x}, 50)
+d = model.generate(x, 50)
 
 # Create constraint pdf
 # -----------------------------------------
@@ -52,7 +52,7 @@ modelc = ROOT.RooProdPdf("modelc", "model with constraint", [model, fconstraint]
 r1 = model.fitTo(d, Save=True, PrintLevel=-1)
 
 # Fit modelc with constraint term on parameter f
-r2 = modelc.fitTo(d, Constrain={f}, Save=True, PrintLevel=-1)
+r2 = modelc.fitTo(d, Constrain=[f], Save=True, PrintLevel=-1)
 
 # Method 2 - specify external constraint when fitting
 # ------------------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ r2 = modelc.fitTo(d, Constrain={f}, Save=True, PrintLevel=-1)
 fconstext = ROOT.RooGaussian("fconstext", "fconstext", f, 0.2, 0.1)
 
 # Fit with external constraint
-r3 = model.fitTo(d, ExternalConstraints={fconstext}, Save=True, PrintLevel=-1)
+r3 = model.fitTo(d, ExternalConstraints=[fconstext], Save=True, PrintLevel=-1)
 
 # Print the fit results
 print("fit result without constraint (data generated at f=0.5)")

--- a/tutorials/roofit/roofit/rf605_profilell.py
+++ b/tutorials/roofit/roofit/rf605_profilell.py
@@ -34,7 +34,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Construct plain likelihood
 # ---------------------------------------------------
@@ -59,7 +59,7 @@ nll.plotOn(frame2, ShiftToZero=True)
 # The profile likelihood estimator on nll for frac will minimize nll w.r.t
 # all floating parameters except frac for each evaluation
 
-pll_frac = nll.createProfile({frac})
+pll_frac = nll.createProfile(frac)
 
 # Plot the profile likelihood in frac
 pll_frac.plotOn(frame1, LineColor="r")
@@ -73,7 +73,7 @@ frame1.SetMaximum(3)
 
 # The profile likelihood estimator on nll for sigma_g2 will minimize nll
 # w.r.t all floating parameters except sigma_g2 for each evaluation
-pll_sigmag2 = nll.createProfile({sigma_g2})
+pll_sigmag2 = nll.createProfile(sigma_g2)
 
 # Plot the profile likelihood in sigma_g2
 pll_sigmag2.plotOn(frame2, LineColor="r")

--- a/tutorials/roofit/roofit/rf606_nllerrorhandling.py
+++ b/tutorials/roofit/roofit/rf606_nllerrorhandling.py
@@ -30,7 +30,7 @@ k = ROOT.RooRealVar("k", "k", -30, -50, -10)
 argus = ROOT.RooArgusBG("argus", "argus", m, m0, k)
 
 # Sample 1000 events in m from argus
-data = argus.generate({m}, 1000)
+data = argus.generate(m, 1000)
 
 # Plot model and data
 # --------------------------------------

--- a/tutorials/roofit/roofit/rf607_fitresult.py
+++ b/tutorials/roofit/roofit/rf607_fitresult.py
@@ -42,7 +42,7 @@ bkgfrac = ROOT.RooRealVar("bkgfrac", "fraction of background", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Generate 1000 events
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Fit pdf to data, save fit result
 # -------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf608_fitresultaspdf.py
+++ b/tutorials/roofit/roofit/rf608_fitresultaspdf.py
@@ -32,7 +32,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate({x}, 1000)
+data = model.generate(x, 1000)
 
 # Fit model to data
 # ----------------------------------
@@ -42,13 +42,13 @@ r = model.fitTo(data, Save=True, PrintLevel=-1)
 # Create MV Gaussian pdf of fitted parameters
 # ------------------------------------------------------------------------------------
 
-parabPdf = r.createHessePdf({frac, mean, sigma_g2})
+parabPdf = r.createHessePdf([frac, mean, sigma_g2])
 
 # Some exercises with the parameter pdf
 # -----------------------------------------------------------------------------
 
 # Generate 100K points in the parameter space, from the MVGaussian pdf
-d = parabPdf.generate({mean, sigma_g2, frac}, 100000)
+d = parabPdf.generate([mean, sigma_g2, frac], 100000)
 
 # Sample a 3-D histogram of the pdf to be visualized as an error
 # ellipsoid using the GLISO draw option
@@ -58,9 +58,9 @@ hh_3d.SetFillColor("kBlue")
 # Project 3D parameter pdf down to 3 permutations of two-dimensional pdfs
 # The integrations corresponding to these projections are performed analytically
 # by the MV Gaussian pdf
-pdf_sigmag2_frac = parabPdf.createProjection({mean})
-pdf_mean_frac = parabPdf.createProjection({sigma_g2})
-pdf_mean_sigmag2 = parabPdf.createProjection({frac})
+pdf_sigmag2_frac = parabPdf.createProjection(mean)
+pdf_mean_frac = parabPdf.createProjection(sigma_g2)
+pdf_mean_sigmag2 = parabPdf.createProjection(frac)
 
 # Make 2D plots of the 3 two-dimensional pdf projections
 hh_sigmag2_frac = pdf_sigmag2_frac.createHistogram("sigma_g2,frac", 50, 50)

--- a/tutorials/roofit/roofit/rf610_visualerror.py
+++ b/tutorials/roofit/roofit/rf610_visualerror.py
@@ -32,7 +32,7 @@ model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
 # Create binned dataset
 x.setBins(25)
-d = model.generateBinned({x}, 1000)
+d = model.generateBinned(x, 1000)
 
 # Perform fit and save fit result
 r = model.fitTo(d, Save=True, PrintLevel=-1)
@@ -113,8 +113,8 @@ frame2 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from (m,
 
 # Propagate partial error due to shape parameters (m,m2) using linear and
 # sampling method
-model.plotOn(frame2, VisualizeError=(r, {m, m2}, 2), FillColor="c")
-model.plotOn(frame2, Components="bkg", VisualizeError=(r, {m, m2}, 2), FillColor="c")
+model.plotOn(frame2, VisualizeError=(r, [m, m2], 2), FillColor="c")
+model.plotOn(frame2, Components="bkg", VisualizeError=(r, [m, m2], 2), FillColor="c")
 
 model.plotOn(frame2)
 model.plotOn(frame2, Components="bkg", LineStyle="--")
@@ -125,8 +125,8 @@ frame3 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from (s,
 
 # Propagate partial error due to yield parameter using linear and sampling
 # method
-model.plotOn(frame3, VisualizeError=(r, {s, s2}, 2), FillColor="g")
-model.plotOn(frame3, Components="bkg", VisualizeError=(r, {fsig}, 2), FillColor="g")
+model.plotOn(frame3, VisualizeError=(r, [s, s2], 2), FillColor="g")
+model.plotOn(frame3, Components="bkg", VisualizeError=(r, [fsig], 2), FillColor="g")
 
 model.plotOn(frame3)
 model.plotOn(frame3, Components="bkg", LineStyle="--")
@@ -137,8 +137,8 @@ frame4 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from fsi
 
 # Propagate partial error due to yield parameter using linear and sampling
 # method
-model.plotOn(frame4, VisualizeError=(r, {fsig}, 2), FillColor="m")
-model.plotOn(frame4, Components="bkg", VisualizeError=(r, {fsig}, 2), FillColor="m")
+model.plotOn(frame4, VisualizeError=(r, [fsig], 2), FillColor="m")
+model.plotOn(frame4, Components="bkg", VisualizeError=(r, [fsig], 2), FillColor="m")
 
 model.plotOn(frame4)
 model.plotOn(frame4, Components="bkg", LineStyle="--")

--- a/tutorials/roofit/roofit/rf613_global_observables.py
+++ b/tutorials/roofit/roofit/rf613_global_observables.py
@@ -99,7 +99,7 @@ model = ROOT.RooProdPdf("model", "model", [gauss, constraint])
 # global observable value (the same is done in the RooStats:ToyMCSampler
 # class):
 
-dataGlob = model.generate({mu_obs}, 1)
+dataGlob = model.generate(mu_obs, 1)
 
 # Next, we temporarily set the value of `mu_obs` to the randomized value for
 # generating our toy dataset:
@@ -110,7 +110,7 @@ ROOT.RooArgSet(mu_obs).assign(dataGlob.get(0))
 # Actually generate the toy dataset. We don't generate too many events,
 # otherwise, the constraint will not have much weight in the fit and the result
 # looks like it's unaffected by it.
-data = model.generate({x}, 50)
+data = model.generate(x, 50)
 
 # When fitting the toy dataset, it is important to set the global
 # observables in the fit to the values that were used to generate the toy
@@ -118,7 +118,7 @@ data = model.generate({x}, 50)
 # can attach a snapshot with the current global observable values to the
 # dataset like this (new feature introduced in ROOT 6.26):
 
-data.setGlobalObservables({mu_obs})
+data.setGlobalObservables([mu_obs])
 
 # reset original mu_obs value
 mu_obs.setVal(mu_obs_orig_val)

--- a/tutorials/roofit/roofit/rf614_binned_fit_problems.py
+++ b/tutorials/roofit/roofit/rf614_binned_fit_problems.py
@@ -33,7 +33,7 @@ def generateBinnedAsimov(pdf, x, n_events):
     Unfortunately it has a problem: it also has the bin bias that this tutorial
     demonstrates, to if we would use it, the biases would cancel out.
     """
-    data_h = ROOT.RooDataHist("dataH", "dataH", {x})
+    data_h = ROOT.RooDataHist("dataH", "dataH", x)
     x_binning = x.getBinning()
 
     for i_bin in range(x.numBins()):

--- a/tutorials/roofit/roofit/rf701_efficiencyfit.py
+++ b/tutorials/roofit/roofit/rf701_efficiencyfit.py
@@ -43,16 +43,16 @@ effPdf = ROOT.RooEfficiency("effPdf", "effPdf", effFunc, cut, "accept")
 # Construct global shape pdf shape(x) and product model(x,cut) = eff(cut|x)*shape(x)
 # (These are _only_ needed to generate some toy MC here to be used later)
 shapePdf = ROOT.RooPolynomial("shapePdf", "shapePdf", x, [-0.095])
-model = ROOT.RooProdPdf("model", "model", {shapePdf}, Conditional=({effPdf}, {cut}))
+model = ROOT.RooProdPdf("model", "model", shapePdf, Conditional=(effPdf, cut))
 
 # Generate some toy data from model
-data = model.generate({x, cut}, 10000)
+data = model.generate([x, cut], 10000)
 
 # Fit conditional efficiency pdf to data
 # --------------------------------------------------------------------------
 
 # Fit conditional efficiency pdf to data
-effPdf.fitTo(data, ConditionalObservables={x}, PrintLevel=-1)
+effPdf.fitTo(data, ConditionalObservables=x, PrintLevel=-1)
 
 # Plot fitted, data efficiency
 # --------------------------------------------------------

--- a/tutorials/roofit/roofit/rf702_efficiencyfit_2D.py
+++ b/tutorials/roofit/roofit/rf702_efficiencyfit_2D.py
@@ -54,16 +54,16 @@ effPdf = ROOT.RooEfficiency("effPdf", "effPdf", effFunc, cut, "accept")
 shapePdfX = ROOT.RooPolynomial("shapePdfX", "shapePdfX", x, [0 if flat else -0.095])
 shapePdfY = ROOT.RooPolynomial("shapePdfY", "shapePdfY", y, [0 if flat else +0.095])
 shapePdf = ROOT.RooProdPdf("shapePdf", "shapePdf", [shapePdfX, shapePdfY])
-model = ROOT.RooProdPdf("model", "model", {shapePdf}, Conditional=({effPdf}, {cut}))
+model = ROOT.RooProdPdf("model", "model", shapePdf, Conditional=(effPdf, cut))
 
 # Generate some toy data from model
-data = model.generate({x, y, cut}, 10000)
+data = model.generate([x, y, cut], 10000)
 
 # Fit conditional efficiency pdf to data
 # --------------------------------------------------------------------------
 
 # Fit conditional efficiency pdf to data
-effPdf.fitTo(data, ConditionalObservables={x, y}, PrintLevel=-1)
+effPdf.fitTo(data, ConditionalObservables=[x, y], PrintLevel=-1)
 
 # Plot fitted, data efficiency
 # --------------------------------------------------------

--- a/tutorials/roofit/roofit/rf703_effpdfprod.py
+++ b/tutorials/roofit/roofit/rf703_effpdfprod.py
@@ -51,7 +51,7 @@ modelEff.plotOn(frame2)
 
 # Generate events. If the input pdf has an internal generator, internal generator
 # is used and an accept/reject sampling on the efficiency is applied.
-data = modelEff.generate({t}, 10000)
+data = modelEff.generate(t, 10000)
 
 # Fit pdf. The normalization integral is calculated numerically.
 modelEff.fitTo(data, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf704_amplitudefit.py
+++ b/tutorials/roofit/roofit/rf704_amplitudefit.py
@@ -44,7 +44,7 @@ f2 = ROOT.RooRealVar("f2", "f2", 0.5, 0, 2)
 pdf = ROOT.RooRealSumPdf("pdf", "pdf", [ampl1, ampl2], [f1, f2])
 
 # Generate some toy data from pdf
-data = pdf.generate({t, cosa}, 10000)
+data = pdf.generate([t, cosa], 10000)
 
 # Fit pdf to toy data with only amplitude strength floating
 pdf.fitTo(data, PrintLevel=-1)

--- a/tutorials/roofit/roofit/rf705_linearmorph.py
+++ b/tutorials/roofit/roofit/rf705_linearmorph.py
@@ -81,7 +81,7 @@ hh.SetLineColor("kBlue")
 
 # Generate a toy dataset alpha = 0.8
 alpha.setVal(0.8)
-data = lmorph.generate({x}, 1000)
+data = lmorph.generate(x, 1000)
 
 # Fit pdf to toy data
 lmorph.setCacheAlpha(True)

--- a/tutorials/roofit/roofit/rf706_histpdf.py
+++ b/tutorials/roofit/roofit/rf706_histpdf.py
@@ -24,13 +24,13 @@ p = ROOT.RooPolynomial("p", "p", x, [0.01, -0.01, 0.0004])
 
 # Sample 500 events from p
 x.setBins(20)
-data1 = p.generate({x}, 500)
+data1 = p.generate(x, 500)
 
 # Create a binned dataset with 20 bins and 500 events
 hist1 = data1.binnedClone()
 
 # Represent data in dh as pdf in x
-histpdf1 = ROOT.RooHistPdf("histpdf1", "histpdf1", {x}, hist1, 0)
+histpdf1 = ROOT.RooHistPdf("histpdf1", "histpdf1", x, hist1, 0)
 
 # Plot unbinned data and histogram pdf overlaid
 frame1 = x.frame(Title="Low statistics histogram pdf", Bins=100)
@@ -42,13 +42,13 @@ histpdf1.plotOn(frame1)
 
 # Sample 100000 events from p
 x.setBins(10)
-data2 = p.generate({x}, 100000)
+data2 = p.generate(x, 100000)
 
 # Create a binned dataset with 10 bins and 100K events
 hist2 = data2.binnedClone()
 
 # Represent data in dh as pdf in x, 2nd order interpolation
-histpdf2 = ROOT.RooHistPdf("histpdf2", "histpdf2", {x}, hist2, 2)
+histpdf2 = ROOT.RooHistPdf("histpdf2", "histpdf2", x, hist2, 2)
 
 # Plot unbinned data and histogram pdf overlaid
 frame2 = x.frame(Title="High stats histogram pdf with interpolation", Bins=100)

--- a/tutorials/roofit/roofit/rf707_kernelestimation.py
+++ b/tutorials/roofit/roofit/rf707_kernelestimation.py
@@ -21,7 +21,7 @@ x = ROOT.RooRealVar("x", "x", 0, 20)
 p = ROOT.RooPolynomial("p", "p", x, [0.01, -0.01, 0.0004])
 
 # Sample 500 events from p
-data1 = p.generate({x}, 200)
+data1 = p.generate(x, 200)
 
 # Create 1D kernel estimation pdf
 # ---------------------------------------------------------------
@@ -62,7 +62,7 @@ py = ROOT.RooPolynomial(
     [0.01, 0.01, -0.0004],
 )
 pxy = ROOT.RooProdPdf("pxy", "pxy", [p, py])
-data2 = pxy.generate({x, y}, 1000)
+data2 = pxy.generate([x, y], 1000)
 
 # Create 2D kernel estimation pdf
 # ---------------------------------------------------------------

--- a/tutorials/roofit/roofit/rf708_bphysics.py
+++ b/tutorials/roofit/roofit/rf708_bphysics.py
@@ -43,7 +43,7 @@ bmix = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw,
 # ---------------------------------------------------
 
 # Generate some data
-data = bmix.generate({dt, mixState, tagFlav}, 10000)
+data = bmix.generate([dt, mixState, tagFlav], 10000)
 
 # Plot B0 and B0bar tagged data separately
 # For all plots below B0 and B0 tagged data will look somewhat differently
@@ -95,7 +95,7 @@ bcp = ROOT.RooBCPEffDecay(
 # ---------------------------------------------------------------------------
 
 # Generate some data
-data2 = bcp.generate({dt, tagFlav}, 10000)
+data2 = bcp.generate([dt, tagFlav], 10000)
 
 # Plot B0 and B0bar tagged data separately
 frame4 = dt.frame(Title="B decay distribution with CPV(|l|=1,Im(l)=0.7) (B0/B0bar)")
@@ -112,7 +112,7 @@ bcp.plotOn(frame4, Slice=(tagFlav, "B0bar"), LineColor="c")
 absLambda.setVal(0.7)
 
 # Generate some data
-data3 = bcp.generate({dt, tagFlav}, 10000)
+data3 = bcp.generate([dt, tagFlav], 10000)
 
 # Plot B0 and B0bar tagged data separately (sin2b = 0.7 plus direct CPV
 # |l|=0.5)
@@ -155,7 +155,7 @@ bcpg = ROOT.RooBDecay(
 # -------------------------------------------------------------------------------------
 
 # Generate some data
-data4 = bcpg.generate({dt, tagFlav}, 10000)
+data4 = bcpg.generate([dt, tagFlav], 10000)
 
 # Plot B0 and B0bar tagged data separately
 frame6 = dt.frame(Title="B decay distribution with CPV(Im(l)=0.7,Re(l)=0.7,|l|=1,dG/G=0.5) (B0/B0bar)")

--- a/tutorials/roofit/roofit/rf709_BarlowBeeston.py
+++ b/tutorials/roofit/roofit/rf709_BarlowBeeston.py
@@ -75,7 +75,7 @@ hc_sig = ROOT.RooHistConstraint("hc_sig", "hc_sig", p_ph_sig1)
 hc_bkg = ROOT.RooHistConstraint("hc_bkg", "hc_bkg", p_ph_bkg1)
 
 # Construct the joint model with template PDFs and constraints
-model1 = ROOT.RooProdPdf("model1", "model1", {hc_sig, hc_bkg}, Conditional=(model_tmp, x))
+model1 = ROOT.RooProdPdf("model1", "model1", [hc_sig, hc_bkg], Conditional=(model_tmp, x))
 
 
 #  Case 2 - 'Barlow Beeston' light (one parameter per bin for all samples)
@@ -97,7 +97,7 @@ Abkg2 = ROOT.RooRealVar("Abkg", "Abkg", 1, 0.01, 5000)
 model2_tmp = ROOT.RooRealSumPdf("sp_ph", "sp_ph", [p_ph_sig2, p_ph_bkg2], [Asig2, Abkg2], True)
 
 # Construct the subsidiary poisson measurements constraining the statistical fluctuations
-hc_sigbkg = ROOT.RooHistConstraint("hc_sigbkg", "hc_sigbkg", {p_ph_sig2, p_ph_bkg2})
+hc_sigbkg = ROOT.RooHistConstraint("hc_sigbkg", "hc_sigbkg", [p_ph_sig2, p_ph_bkg2])
 
 # Construct the joint model
 model2 = ROOT.RooProdPdf("model2", "model2", hc_sigbkg, Conditional=(model2_tmp, x))
@@ -127,10 +127,8 @@ model0.plotOn(frame, LineColor="b", VisualizeError=result0)
 sumData.plotOn(frame)
 # Plot model components
 model0.plotOn(frame, LineColor="b")
-p_ph_sig_set = {p_h_sig}
-p_ph_bkg_set = {p_h_bkg}
-model0.plotOn(frame, Components=p_ph_sig_set, LineColor="kAzure")
-model0.plotOn(frame, Components=p_ph_bkg_set, LineColor="r")
+model0.plotOn(frame, Components=[p_h_sig], LineColor="kAzure")
+model0.plotOn(frame, Components=[p_h_bkg], LineColor="r")
 model0.paramOn(frame)
 
 sigData.plotOn(frame, MarkerColor="b")
@@ -157,11 +155,9 @@ model1.plotOn(frame, LineColor="b", VisualizeError=result1)
 # Plot data again to show it on top of error bands:
 sumData.plotOn(frame)
 model1.plotOn(frame, LineColor="b")
-p_ph_sig1_set = {p_ph_sig1}
-p_ph_bkg1_set = {p_ph_bkg1}
-model1.plotOn(frame, Components=p_ph_sig1_set, LineColor="kAzure")
-model1.plotOn(frame, Components=p_ph_bkg1_set, LineColor="r")
-model1.paramOn(frame, Parameters={Asig1, Abkg1})
+model1.plotOn(frame, Components=[p_ph_sig1], LineColor="kAzure")
+model1.plotOn(frame, Components=[p_ph_bkg1], LineColor="r")
+model1.paramOn(frame, Parameters=[Asig1, Abkg1])
 
 sigData.plotOn(frame, MarkerColor="b")
 frame.Draw()
@@ -189,11 +185,9 @@ model2.plotOn(frame, LineColor="b", VisualizeError=result2)
 # Plot data again to show it on top of model0 error bands:
 sumData.plotOn(frame)
 model2.plotOn(frame, LineColor="b")
-p_ph_sig2_set = {p_ph_sig2}
-p_ph_bkg2_set = {p_ph_bkg2}
-model2.plotOn(frame, Components=p_ph_sig2_set, LineColor="kAzure")
-model2.plotOn(frame, Components=p_ph_bkg2_set, LineColor="r")
-model2.paramOn(frame, Parameters={Asig2, Abkg2})
+model2.plotOn(frame, Components=[p_ph_sig2], LineColor="kAzure")
+model2.plotOn(frame, Components=[p_ph_bkg2], LineColor="r")
+model2.paramOn(frame, Parameters=[Asig2, Abkg2])
 
 sigData.plotOn(frame, MarkerColor="b")
 frame.Draw()

--- a/tutorials/roofit/roofit/rf710_roopoly.C
+++ b/tutorials/roofit/roofit/rf710_roopoly.C
@@ -37,8 +37,8 @@ void rf710_roopoly()
    // C r e a t e   t a y l o r  e x p a n s i o n
    // ---------------------------------------------
    double x0 = 2.0;
-   auto taylor_o1 = RooPolyFunc::taylorExpand("taylor_o1", "taylor expansion order 1", f, {x}, 1, {x0});
-   auto taylor_o2 = RooPolyFunc::taylorExpand("taylor_o2", "taylor expansion order 2", f, {x}, 2, {x0});
+   auto taylor_o1 = RooPolyFunc::taylorExpand("taylor_o1", "taylor expansion order 1", f, x, 1, {x0});
+   auto taylor_o2 = RooPolyFunc::taylorExpand("taylor_o2", "taylor expansion order 2", f, x, 2, {x0});
 
    // Plot polynomial with first and second order taylor expansion overlaid
    auto frame = x.frame(Title("x^{4} - 5x^{3} + 5x^{2} + 5x - 6"));

--- a/tutorials/roofit/roofit/rf711_lagrangianmorph.py
+++ b/tutorials/roofit/roofit/rf711_lagrangianmorph.py
@@ -98,7 +98,7 @@ morph_datahist_0p5.plotOn(frame1, Name="morph_dh_cHq3=0.5", LineColor="kGreen+2"
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -
 
 model = ROOT.RooWrapperPdf("wrap_pdf", "wrap_pdf", morphfunc)
-data = model.generate({cHq3, obsvar}, 1000000)
+data = model.generate([cHq3, obsvar], 1000000)
 hh_data = data.createHistogram("x,y", obsvar, Binning=20, YVar=dict(var=cHq3, Binning=50))
 hh_data.SetTitle("Morphing prediction")
 

--- a/tutorials/roofit/roofit/rf801_mcstudy.py
+++ b/tutorials/roofit/roofit/rf801_mcstudy.py
@@ -63,7 +63,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [nbkg, nsig])
 
 mcstudy = ROOT.RooMCStudy(
     model,
-    {x},
+    x,
     Binned=True,
     Silence=True,
     Extended=True,

--- a/tutorials/roofit/roofit/rf802_mcstudy_addons.py
+++ b/tutorials/roofit/roofit/rf802_mcstudy_addons.py
@@ -33,7 +33,7 @@ gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
 
 # Create study manager for binned likelihood fits of a Gaussian pdf in 10
 # bins
-mcs = ROOT.RooMCStudy(gauss, {x}, Silence=True, Binned=True)
+mcs = ROOT.RooMCStudy(gauss, x, Silence=True, Binned=True)
 
 # Add chi^2 calculator module to mcs
 chi2mod = ROOT.RooChi2MCSModule()
@@ -60,7 +60,7 @@ gauss2 = ROOT.RooGaussian("gauss2", "gaussian PDF2", x, mean2, sigma)
 # Create study manager with separate generation and fit model. ROOT.This configuration
 # is set up to generate bad fits as the fit and generator model have different means
 # and the mean parameter is not floating in the fit
-mcs2 = ROOT.RooMCStudy(gauss2, {x}, FitModel=gauss, Silence=True, Binned=True)
+mcs2 = ROOT.RooMCStudy(gauss2, x, FitModel=gauss, Silence=True, Binned=True)
 
 # Add chi^2 calculator module to mcs
 chi2mod2 = ROOT.RooChi2MCSModule()

--- a/tutorials/roofit/roofit/rf803_mcstudy_addons2.py
+++ b/tutorials/roofit/roofit/rf803_mcstudy_addons2.py
@@ -47,7 +47,7 @@ model = ROOT.RooAddPdf("model", "model", [sig, bkg], [nsig, nbkg])
 # Configure manager to perform binned extended likelihood fits (Binned=True, Extended=True) on data generated
 # with a Poisson fluctuation on Nobs (Extended=True)
 mcs = ROOT.RooMCStudy(
-    model, {mjjj}, Binned=True, Silence=True, Extended=True, FitOptions={"Extended": True, "PrintEvalErrors": -1}
+    model, mjjj, Binned=True, Silence=True, Extended=True, FitOptions={"Extended": True, "PrintEvalErrors": -1}
 )
 
 # Customize manager
@@ -62,7 +62,7 @@ mcs = ROOT.RooMCStudy(
 # by a single randomizer module
 
 randModule = ROOT.RooRandomizeParamMCSModule()
-randModule.sampleSumUniform({nsig, nbkg}, 50, 500)
+randModule.sampleSumUniform([nsig, nbkg], 50, 500)
 mcs.addModule(randModule)
 
 # Add profile likelihood calculation of significance. Redo each

--- a/tutorials/roofit/roofit/rf804_mcstudy_constr.py
+++ b/tutorials/roofit/roofit/rf804_mcstudy_constr.py
@@ -44,7 +44,7 @@ sumc = ROOT.RooProdPdf("sumc", "sum with constraint", [sum, fconstraint])
 # ---------------------------------------------------
 
 # Perform toy study with internal constraint on f
-mcs = ROOT.RooMCStudy(sumc, {x}, Constrain={f}, Silence=True, Binned=True, FitOptions={"PrintLevel": -1})
+mcs = ROOT.RooMCStudy(sumc, x, Constrain=[f], Silence=True, Binned=True, FitOptions={"PrintLevel": -1})
 
 # Run 500 toys of 2000 events.
 # Before each toy is generated, value for the f is sampled from the constraint pdf and

--- a/tutorials/roofit/roofit/rf901_numintconfig.py
+++ b/tutorials/roofit/roofit/rf901_numintconfig.py
@@ -47,7 +47,7 @@ landau.forceNumInt(True)
 ROOT.RooMsgService.instance().addStream(ROOT.RooFit.DEBUG, Topic=ROOT.RooFit.Integration)
 
 # Calculate integral over landau with default choice of numeric integrator
-intLandau = landau.createIntegral({x})
+intLandau = landau.createIntegral(x)
 val = intLandau.getVal()
 print(" [1] int_dx landau(x) = ", val)  # setprecision(15)
 
@@ -62,7 +62,7 @@ if integratorGKNotExisting:
     print("WARNING: RooAdaptiveGaussKronrodIntegrator is not existing because ROOT is built without Mathmore support")
 
 # Calculate integral over landau with custom integral specification
-intLandau2 = landau.createIntegral({x}, NumIntConfig=customConfig)
+intLandau2 = landau.createIntegral(x, NumIntConfig=customConfig)
 val2 = intLandau2.getVal()
 print(" [2] int_dx landau(x) = ", val2)
 
@@ -75,7 +75,7 @@ landau.setIntegratorConfig(customConfig)
 
 # Calculate integral over landau custom numeric integrator specified as
 # object default
-intLandau3 = landau.createIntegral({x})
+intLandau3 = landau.createIntegral(x)
 val3 = intLandau3.getVal()
 print(" [3] int_dx landau(x) = ", val3)
 

--- a/tutorials/roofit/roofit/rf902_numgenconfig.py
+++ b/tutorials/roofit/roofit/rf902_numgenconfig.py
@@ -28,7 +28,7 @@ model = ROOT.RooChebychev("model", "model", x, [0.0, 0.5, -0.1])
 ROOT.RooAbsPdf.defaultGeneratorConfig().method1D(False, False).setLabel("RooAcceptReject")
 
 # Generate 10Kevt using ROOT.RooAcceptReject
-data_ar = model.generate({x}, 10000, Verbose=True)
+data_ar = model.generate(x, 10000, Verbose=True)
 data_ar.Print()
 
 # Adjusting default config for a specific pdf
@@ -53,5 +53,5 @@ model.specialGeneratorConfig().getConfigSection("RooFoamGenerator").setRealValue
 
 # Generate 10Kevt using ROOT.RooFoamGenerator (FOAM verbosity increased
 # with above chatLevel adjustment for illustration purposes)
-data_foam = model.generate({x}, 10000, Verbose=True)
+data_foam = model.generate(x, 10000, Verbose=True)
 data_foam.Print()

--- a/tutorials/roofit/roostats/rs101_limitexample.py
+++ b/tutorials/roofit/roostats/rs101_limitexample.py
@@ -41,7 +41,7 @@ b.setConstant()
 
 ratioSigEff = wspace["ratioSigEff"]  # get uncertain parameter to constrain
 ratioBkgEff = wspace["ratioBkgEff"]  # get uncertain parameter to constrain
-constrainedParams = {ratioSigEff, ratioBkgEff}  # need to constrain these in the fit (should change default behavior)
+constrainedParams = [ratioSigEff, ratioBkgEff]  # need to constrain these in the fit (should change default behavior)
 
 gSigEff = wspace["gSigEff"]  # global observables for signal efficiency
 gSigBkg = wspace["gSigBkg"]  # global obs for background efficiency
@@ -50,7 +50,7 @@ gSigBkg.setConstant()
 
 # Create an example dataset with 160 observed events
 obs.setVal(160.0)
-dataOrig = ROOT.RooDataSet("exampleData", "exampleData", {obs})
+dataOrig = ROOT.RooDataSet("exampleData", "exampleData", [obs])
 dataOrig.add(obs)
 
 # not necessary
@@ -59,10 +59,10 @@ modelWithConstraints.fitTo(dataOrig, Constrain=constrainedParams, PrintLevel=-1)
 # Now let's make some confidence intervals for s, our parameter of interest
 modelConfig = ROOT.RooStats.ModelConfig(wspace)
 modelConfig.SetPdf(modelWithConstraints)
-modelConfig.SetParametersOfInterest({s})
+modelConfig.SetParametersOfInterest(s)
 modelConfig.SetNuisanceParameters(constrainedParams)
 modelConfig.SetObservables(obs)
-modelConfig.SetGlobalObservables({gSigEff, gSigBkg})
+modelConfig.SetGlobalObservables([gSigEff, gSigBkg])
 modelConfig.SetName("ModelConfig")
 wspace.Import(modelConfig)
 wspace.Import(dataOrig)

--- a/tutorials/roofit/roostats/rs401c_FeldmanCousins.py
+++ b/tutorials/roofit/roostats/rs401c_FeldmanCousins.py
@@ -28,10 +28,10 @@ mu = ROOT.RooRealVar("mu", "", 2.5, 0, 15)  # with a limit on mu>=0
 b = ROOT.RooConstVar("b", "", 3.0)
 mean = ROOT.RooAddition("mean", "", [mu, b])
 pois = ROOT.RooPoisson("pois", "", x, mean)
-parameters = {mu}
+parameters = [mu]
 
 # create a toy dataset
-data = pois.generate({x}, 1)
+data = pois.generate(x, 1)
 data.Print("v")
 
 dataCanvas = ROOT.TCanvas("dataCanvas")
@@ -44,7 +44,7 @@ w = ROOT.RooWorkspace()
 modelConfig = ROOT.RooStats.ModelConfig("poissonProblem", w)
 modelConfig.SetPdf(pois)
 modelConfig.SetParametersOfInterest(parameters)
-modelConfig.SetObservables({x})
+modelConfig.SetObservables(x)
 w.Print()
 
 # show use of Feldman-Cousins

--- a/tutorials/roofit/roostats/rs701_BayesianCalculator.py
+++ b/tutorials/roofit/roostats/rs701_BayesianCalculator.py
@@ -27,8 +27,8 @@ priorPOI2 = w.factory("GenericPdf::priorPOI2('1/sqrt(@0)',s)")
 
 w.factory("n[3]")  # observed number of events
 # create a data set with n observed events
-data = ROOT.RooDataSet("data", "", {w["x"], w["n"]}, WeightVar="n")
-data.add({w["x"]}, w["n"].getVal())
+data = ROOT.RooDataSet("data", "", [w["x"], w["n"]], WeightVar="n")
+data.add([w["x"]], w["n"].getVal())
 
 # to suppress messages when pdf goes to zero
 ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.FATAL)
@@ -41,7 +41,7 @@ else:
 
 size = 1.0 - confLevel
 print("\nBayesian Result using a Flat prior ")
-bcalc = ROOT.RooStats.BayesianCalculator(data, model, {POI}, priorPOI, nuisPar)
+bcalc = ROOT.RooStats.BayesianCalculator(data, model, [POI], priorPOI, nuisPar)
 bcalc.SetTestSize(size)
 interval = bcalc.GetInterval()
 cl = bcalc.ConfidenceLevel()
@@ -58,7 +58,7 @@ plot.Draw()
 c1.Update()
 
 print("\nBayesian Result using a 1/sqrt(s) prior  ")
-bcalc2 = ROOT.RooStats.BayesianCalculator(data, model, {POI}, priorPOI2, nuisPar)
+bcalc2 = ROOT.RooStats.BayesianCalculator(data, model, [POI], priorPOI2, nuisPar)
 bcalc2.SetTestSize(size)
 interval2 = bcalc2.GetInterval()
 cl = bcalc2.ConfidenceLevel()


### PR DESCRIPTION
This conversion can lead to subtle problems because Python sets are
unordered, different from C++ initializer lists with the same syntax.
This can lead to confusion that we should prevent.

Example:
```python
import ROOT

x = ROOT.RooRealVar("x", "x", 1.0)
y = ROOT.RooRealVar("y", "y", -1.0)

ROOT.RooArgSet(set([x, y])).Print()
ROOT.RooArgSet(set([y, x])).Print()
```
Gives on my system:
```txt
RooArgSet:: = (x,y)
RooArgSet:: = (x,y) <--- reverse order expected!
```

This is not even deterministic, because Python doesn't guarantee that
a `set` is ordered in any way.

I introduced this 5 years ago in commit https://github.com/guitargeek/root/commit/c54c3244dbeae8e75d2a5103548b7c7e0eafaf2a
(PR https://github.com/root-project/root/pull/8751) without thinking
too much about this footgun.