### PR TITLE
[build] Add demo script for exposing pip-installed ROOT to CMake

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_export_cmake.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_export_cmake.py
@@ -1,0 +1,20 @@
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def main():
+    # This trick is only necessary for the wheel distribution
+    try:
+        if "a" in version("ROOT"):
+            root_site_package = Path(__file__).resolve().parent
+        
+            # Print a warning to stdout that eval will ignore but would be visible to user who accidentally runs raw command
+            print('# ERROR: You should eval the output of this command, not run it directly in your shell.\n# Use eval "$(export_cmake)"')
+            # Print the export commands to be eval'd by user's shell
+            print(f'export CMAKE_PREFIX_PATH="{root_site_package}"')
+
+    except PackageNotFoundError:
+        print("Setting CMAKE_PREFIX_PATH is only necessary when linking against ROOT's PyPI wheels. Please use thisroot.sh.")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 # `root`, other tools can be added later using the same approach.
 [project.scripts]
 root = "ROOT._rootcli:main"
+export_cmake = "ROOT._export_cmake:main"
 
 [tool.cibuildwheel]
 # Increase pip debugging output


### PR DESCRIPTION
# This Pull request:
Provides an example approach for enabling users to build their custom ROOT applications by linking against a pip-installed distribution of ROOT.
If a user writes a custom application (built with CMake) which they would like to link against ROOT, they must currently manually export `CMAKE_PREFIX_PATH` to point at ROOT in their venv's site-packages. To avoid this tedium, this change exposes a script to $PATH which users can `eval` to automatically set the `CMAKE_PREFIX_PATH` variable: `eval "$(export_cmake)"`.
This is not a particularly clean approach, but it works and seems preferable to having users manually identify and export the correct path on their own.
## Changes or fixes:
- Adds `_export_cmake.py` which determines ROOT's site-packages path and print it such that it can be `eval`'d.
- Exposes `_export_cmake.py` to $PATH via `[project.scripts]`.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

