### PR TITLE
[ci] Remove mac-beta builds

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -111,10 +111,6 @@ jobs:
             overrides: ["CMAKE_CXX_STANDARD=23"]
           - platform: mac26
             arch: ARM64
-          - platform: mac-beta
-            is_special: true
-            arch: ARM64
-            overrides: ["CMAKE_CXX_STANDARD=23"]
 
     runs-on: # Using '[self-hosted, ..., ...]' does not work for some reason :)
       - self-hosted


### PR DESCRIPTION
because the clang version of this ROOT version, i.e. llvm18, will be incompatible with the libc++ provided by the sdk shipped with macos27
