### PR TITLE
[RF] Modernize RooFit code with `static_range_cast` and `dynamic_range_cast`

### DIFF
--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -1412,8 +1412,7 @@ public:
    {
       std::vector<RooAbsPdf *> constraints;
       RooRealSumPdf *sumpdf = nullptr;
-      for (RooAbsArg *v : prodpdf->pdfList()) {
-         RooAbsPdf *pdf = static_cast<RooAbsPdf *>(v);
+      for (auto *pdf : static_range_cast<RooAbsPdf *>(prodpdf->pdfList())) {
          auto thispdf = dynamic_cast<RooRealSumPdf *>(pdf);
          if (thispdf) {
             if (!sumpdf)

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -627,8 +627,7 @@ private:
 
       // Now build the final list following the order in varList
       RooArgList vars;
-      for (int i = 0; i < varList.getSize(); ++i) {
-         const auto *refVar = dynamic_cast<RooRealVar *>(varList.at(i));
+      for (auto *refVar : dynamic_range_cast<RooRealVar *>(varList)) {
          if (!refVar)
             continue;
 

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -82,11 +82,10 @@ double RooJeffreysPrior::evaluate() const
     auto& pdf = _nominal.arg();
     RooAbsPdf* clonePdf = static_cast<RooAbsPdf*>(pdf.cloneTree());
     std::unique_ptr<RooArgSet> vars{clonePdf->getParameters(_obsSet)};
-    for (auto varTmp : *vars) {
-      auto& var = static_cast<RooRealVar&>(*varTmp);
-      auto range = var.getRange();
+    for (auto* var : static_range_cast<RooRealVar*>(*vars)) {
+      auto range = var->getRange();
       double span = range.second - range.first;
-      var.setRange(range.first - 0.1*span, range.second + 0.1 * span);
+      var->setRange(range.first - 0.1*span, range.second + 0.1 * span);
     }
 
     cacheElm = new CacheElem;

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -461,8 +461,7 @@ void setOwnerRecursive(TFolder *theFolder)
    theFolder->SetOwner();
    // And also need to set up ownership for nested folders
    auto subdirs = theFolder->GetListOfFolders();
-   for (auto *subdir : *subdirs) {
-      auto thisfolder = dynamic_cast<TFolder *>(subdir);
+   for (auto *thisfolder : dynamic_range_cast<TFolder *>(*subdirs)) {
       if (thisfolder) {
          // no explicit deletion here, will be handled by parent
          setOwnerRecursive(thisfolder);
@@ -678,8 +677,7 @@ inline bool setParam(RooRealVar *p, double val, bool force)
 template <class T1, class T2>
 inline bool setParams(const T2 &args, T1 val)
 {
-   for (auto itr : args) {
-      RooRealVar *param = dynamic_cast<RooRealVar *>(itr);
+   for (auto *param : dynamic_range_cast<RooRealVar *>(args)) {
       if (!param)
          continue;
       setParam(param, val, true);
@@ -696,8 +694,7 @@ inline bool
 setParams(const std::map<const std::string, T1> &point, const T2 &args, bool force = false, T1 defaultVal = 0)
 {
    bool ok = true;
-   for (auto itr : args) {
-      RooRealVar *param = dynamic_cast<RooRealVar *>(itr);
+   for (auto *param : dynamic_range_cast<RooRealVar *>(args)) {
       if (!param || param->isConstant())
          continue;
       ok = setParam(param, defaultVal, force) && ok;
@@ -725,8 +722,7 @@ inline bool setParams(TH1 *hist, const T &args, bool force = false)
 {
    bool ok = true;
 
-   for (auto itr : args) {
-      RooRealVar *param = dynamic_cast<RooRealVar *>(itr);
+   for (auto *param : dynamic_range_cast<RooRealVar *>(args)) {
       if (!param)
          continue;
       ok = setParam(param, 0., force) && ok;
@@ -752,8 +748,7 @@ template <class T>
 inline RooLagrangianMorphFunc::ParamSet getParams(const T &parameters)
 {
    RooLagrangianMorphFunc::ParamSet retval;
-   for (auto itr : parameters) {
-      RooRealVar *param = dynamic_cast<RooRealVar *>(itr);
+   for (auto *param : dynamic_range_cast<RooRealVar *>(parameters)) {
       if (!param)
          continue;
       retval[param->GetName()] = param->getVal();
@@ -977,9 +972,7 @@ inline void fillFeynmanDiagram(FeynmanDiagram &diagram, const std::vector<List *
    for (auto const &vertex : vertices) {
       std::vector<bool> vertexCouplings(ncouplings, false);
       int idx = -1;
-      RooAbsReal *coupling;
-      for (auto citr : couplings) {
-         coupling = dynamic_cast<RooAbsReal *>(citr);
+      for (auto *coupling : dynamic_range_cast<RooAbsReal *>(couplings)) {
          idx++;
          if (!coupling) {
             std::cerr << "encountered invalid list of couplings in vertex!" << std::endl;
@@ -1120,11 +1113,9 @@ FormulaList buildFormulas(const char *mfname, const RooLagrangianMorphFunc::Para
          std::cerr << "internal error, number of operators inconsistent!" << std::endl;
       }
 
-      RooAbsReal *obj0;
       int idx = 0;
 
-      for (auto itr1 : couplings) {
-         obj0 = dynamic_cast<RooAbsReal *>(itr1);
+      for (auto *obj0 : dynamic_range_cast<RooAbsReal *>(couplings)) {
          if (obj0->getVal() != 0) {
             couplingsZero[idx] = false;
          }
@@ -1132,8 +1123,7 @@ FormulaList buildFormulas(const char *mfname, const RooLagrangianMorphFunc::Para
       }
    }
 
-   for (auto itr2 : flags) {
-      auto obj1 = dynamic_cast<RooAbsReal *>(itr2);
+   for (auto *obj1 : dynamic_range_cast<RooAbsReal *>(flags)) {
       int nZero = 0;
       int nNonZero = 0;
       for (auto sampleit : inputFlags) {
@@ -1203,8 +1193,7 @@ FormulaList buildFormulas(const char *mfname, const RooLagrangianMorphFunc::Para
       // check and apply flags
       bool removedByFlag = false;
 
-      for (auto itr : flags) {
-         auto obj = dynamic_cast<RooAbsReal *>(itr);
+      for (auto *obj : dynamic_range_cast<RooAbsReal *>(flags)) {
          if (!obj)
             continue;
          TString sval(obj->getStringAttribute("NewPhysics"));
@@ -1411,10 +1400,8 @@ public:
             // set all vars to value stored in input file
             setParams(sampleit.second, operators, true);
             bool first = true;
-            RooAbsReal *obj;
 
-            for (auto itr : _couplings) {
-               obj = dynamic_cast<RooAbsReal *>(itr);
+            for (auto *obj : dynamic_range_cast<RooAbsReal *>(_couplings)) {
                if (!first)
                   std::cerr << ", ";
                oocxcoutW((TObject *)nullptr, Eval) << obj->GetName() << "=" << obj->getVal();
@@ -1953,8 +1940,8 @@ RooLagrangianMorphFunc::RooLagrangianMorphFunc(const RooLagrangianMorphFunc &oth
 {
    for (size_t j = 0; j < other._diagrams.size(); ++j) {
       std::vector<RooListProxy *> diagram;
-      for (size_t i = 0; i < other._diagrams[j].size(); ++i) {
-         RooListProxy *list = new RooListProxy(other._diagrams[j][i]->GetName(), this, *(other._diagrams[j][i]));
+      for (auto *elem : other._diagrams[j]) {
+         RooListProxy *list = new RooListProxy(elem->GetName(), this, *elem);
          diagram.push_back(list);
       }
       _diagrams.push_back(diagram);
@@ -2158,8 +2145,7 @@ RooProduct *RooLagrangianMorphFunc::getSumElement(const char *name) const
    prodname.Append("_");
    prodname.Append(this->GetName());
 
-   for (auto itr : *args) {
-      RooProduct *prod = dynamic_cast<RooProduct *>(itr);
+   for (auto *prod : dynamic_range_cast<RooProduct *>(*args)) {
       if (!prod)
          continue;
       TString sname(prod->GetName());
@@ -2215,11 +2201,9 @@ void RooLagrangianMorphFunc::printSampleWeights() const
 
 void RooLagrangianMorphFunc::randomizeParameters(double z)
 {
-   RooRealVar *obj;
    TRandom3 r;
 
-   for (auto itr : _operators) {
-      obj = dynamic_cast<RooRealVar *>(itr);
+   for (auto *obj : dynamic_range_cast<RooRealVar *>(_operators)) {
       double val = obj->getVal();
       if (obj->isConstant())
          continue;
@@ -2504,8 +2488,7 @@ RooLagrangianMorphFunc::ParamSet RooLagrangianMorphFunc::getMorphParameters(cons
 
 void RooLagrangianMorphFunc::setParameters(const RooArgList *list)
 {
-   for (auto itr : *list) {
-      RooRealVar *param = dynamic_cast<RooRealVar *>(itr);
+   for (auto *param : dynamic_range_cast<RooRealVar *>(*list)) {
       if (!param)
          continue;
       this->setParameter(param->GetName(), param->getVal());
@@ -2562,8 +2545,7 @@ TH1 *RooLagrangianMorphFunc::createTH1(const std::string &name, bool correlateEr
       double val = 0;
       double unc2 = 0;
       double unc = 0;
-      for (auto itr : *args) {
-         RooProduct *prod = dynamic_cast<RooProduct *>(itr);
+      for (auto *prod : dynamic_range_cast<RooProduct *>(*args)) {
          if (!prod)
             continue;
          RooAbsArg *phys = prod->components().find(Form("phys_%s", prod->GetName()));
@@ -2595,8 +2577,7 @@ int RooLagrangianMorphFunc::countContributingFormulas() const
    if (!mf)
       coutE(InputArguments) << "unable to retrieve morphing function" << std::endl;
    std::unique_ptr<RooArgSet> args{mf->getComponents()};
-   for (auto itr : *args) {
-      RooProduct *prod = dynamic_cast<RooProduct *>(itr);
+   for (auto *prod : dynamic_range_cast<RooProduct *>(*args)) {
       if (prod->getVal() != 0) {
          nFormulas++;
       }
@@ -2721,8 +2702,7 @@ const RooArgList *RooLagrangianMorphFunc::getCouplingSet() const
 RooLagrangianMorphFunc::ParamSet RooLagrangianMorphFunc::getCouplings() const
 {
    RooLagrangianMorphFunc::ParamSet couplings;
-   for (auto obj : *(this->getCouplingSet())) {
-      RooAbsReal *var = dynamic_cast<RooAbsReal *>(obj);
+   for (auto *var : dynamic_range_cast<RooAbsReal *>(*(this->getCouplingSet()))) {
       if (!var)
          continue;
       const std::string name(var->GetName());
@@ -2847,8 +2827,7 @@ double RooLagrangianMorphFunc::expectedUncertainty() const
 void RooLagrangianMorphFunc::printParameters() const
 {
    // print the parameters and their current values
-   for (auto obj : _operators) {
-      RooRealVar *param = static_cast<RooRealVar *>(obj);
+   for (auto *param : static_range_cast<RooRealVar *>(_operators)) {
       if (!param)
          continue;
       param->Print();
@@ -2860,8 +2839,7 @@ void RooLagrangianMorphFunc::printParameters() const
 
 void RooLagrangianMorphFunc::printFlags() const
 {
-   for (auto flag : _flags) {
-      RooRealVar *param = static_cast<RooRealVar *>(flag);
+   for (auto *param : static_range_cast<RooRealVar *>(_flags)) {
       if (!param)
          continue;
       param->Print();

--- a/roofit/roofit/src/RooLegacyExpPoly.cxx
+++ b/roofit/roofit/src/RooLegacyExpPoly.cxx
@@ -109,8 +109,8 @@ double RooLegacyExpPoly::evaluateLog() const
    const double x = _x;
    double xpow = std::pow(x, lowestOrder);
    double retval = 0;
-   for (size_t i = 0; i < sz; ++i) {
-      retval += coefs[i] * xpow;
+   for (double coef : coefs) {
+      retval += coef * xpow;
       xpow *= x;
    }
 
@@ -158,9 +158,8 @@ void RooLegacyExpPoly::adjustLimits()
    if (x) {
       const double xmax = x->getMax();
       double xmaxpow = std::pow(xmax, lowestOrder);
-      for (size_t i = 0; i < sz; ++i) {
+      for (auto *coef : dynamic_range_cast<RooRealVar *>(_coefList)) {
          double thismax = max / xmaxpow;
-         RooRealVar *coef = dynamic_cast<RooRealVar *>(this->_coefList.at(i));
          if (coef) {
             coef->setVal(thismax);
             coef->setMax(thismax);

--- a/roofit/roofit/src/RooMultiBinomial.cxx
+++ b/roofit/roofit/src/RooMultiBinomial.cxx
@@ -126,8 +126,8 @@ double RooMultiBinomial::evaluate() const
   // Calculate efficiency for combination of accept/reject categories
   // put equal to zero if combination of only zeros AND chosen to be invisible
 
-  for (int i=0; i<effFuncListSize; ++i) {
-    _effVal=_effVal*effValue[i];
+  for (double ev : effValue) {
+    _effVal=_effVal*ev;
     if (notVisible && _ignoreNonVisible){
       _effVal=0;
     }

--- a/roofit/roofit/src/RooNDKeysPdf.cxx
+++ b/roofit/roofit/src/RooNDKeysPdf.cxx
@@ -1179,10 +1179,10 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
     norm = bi->nEventsBMSW;
     if (norm<0.) norm=0.;
 
-    for (Int_t i=0; i<Int_t(bi->sIdcs.size()); ++i) {
+    for (Int_t sIdx : bi->sIdcs) {
       double prob=1.;
-      const vector<double>& x = _dataPts[bi->sIdcs[i]];
-      const vector<double>& weight = (*_weights)[_idx[bi->sIdcs[i]]];
+      const vector<double>& x = _dataPts[sIdx];
+      const vector<double>& weight = (*_weights)[_idx[sIdx]];
 
       vector<double> chi(_nDim,100.);
 
@@ -1202,7 +1202,7 @@ double RooNDKeysPdf::analyticalIntegral(Int_t code, const char* rangeName) const
    }
       }
 
-      norm += prob * _wMap.at(_idx[bi->sIdcs[i]]);
+      norm += prob * _wMap.at(_idx[sIdx]);
     }
 
     cxcoutD(Eval) << "RooNDKeysPdf::analyticalIntegral() : Final normalization : " << norm << " " << bi->nEventsBW << std::endl;

--- a/roofit/roofitcore/src/FitHelpers.cxx
+++ b/roofit/roofitcore/src/FitHelpers.cxx
@@ -783,8 +783,7 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, const Ro
       // Create range with name 'fit' with above limits on all observables
       RooArgSet obs;
       pdf.getObservables(data.get(), obs);
-      for (auto arg : obs) {
-         RooRealVar *rrv = dynamic_cast<RooRealVar *>(arg);
+      for (auto *rrv : dynamic_range_cast<RooRealVar *>(obs)) {
          if (rrv)
             rrv->setRange("fit", rangeLo, rangeHi);
       }
@@ -1040,8 +1039,8 @@ std::unique_ptr<RooAbsReal> createChi2(RooAbsReal &real, RooDataHist &data, cons
       const double rangeHi = pc.getDouble("rangeHi");
       RooArgSet obs;
       real.getObservables(data.get(), obs);
-      for (auto arg : obs) {
-         if (auto *rrv = dynamic_cast<RooRealVar *>(arg)) {
+      for (auto *rrv : dynamic_range_cast<RooRealVar *>(obs)) {
+         if (rrv) {
             rrv->setRange("fit", rangeLo, rangeHi);
          }
       }

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -209,8 +209,7 @@ bool RooAbsAnaConvPdf::changeModel(const RooResolutionModel& newModel)
 {
   RooArgList newConvSet ;
   bool allOK(true) ;
-  for (auto convArg : _convSet) {
-    auto conv = static_cast<RooResolutionModel*>(convArg);
+  for (auto *conv : static_range_cast<RooResolutionModel*>(_convSet)) {
 
     // Build new resolution model
     std::unique_ptr<RooResolutionModel> newConv{newModel.convolution(const_cast<RooFormulaVar*>(&conv->basis()),this)};
@@ -330,8 +329,7 @@ double RooAbsAnaConvPdf::evaluate() const
   double result(0) ;
 
   Int_t index(0) ;
-  for (auto convArg : _convSet) {
-    auto conv = static_cast<RooAbsPdf*>(convArg);
+  for (auto *conv : static_range_cast<RooAbsPdf*>(_convSet)) {
     double coef = coefficient(index++) ;
     if (coef!=0.) {
       const double c = conv->getVal(nullptr);

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -244,8 +244,7 @@ RooResolutionModel* RooAddModel::convolution(RooFormulaVar* inBasis, RooAbsArg* 
   newTitle.Append(inBasis->GetName()) ;
 
   RooArgList modelList ;
-  for (auto obj : _pdfList) {
-    auto model = static_cast<RooResolutionModel*>(obj);
+  for (auto *model : static_range_cast<RooResolutionModel*>(_pdfList)) {
     // Create component convolution
     RooResolutionModel* conv = model->convolution(inBasis,owner) ;
     modelList.add(*conv) ;
@@ -281,8 +280,7 @@ Int_t RooAddModel::basisCode(const char* name) const
 {
   bool first(true);
   bool code(false);
-  for (auto obj : _pdfList) {
-    auto model = static_cast<RooResolutionModel*>(obj);
+  for (auto *model : static_range_cast<RooResolutionModel*>(_pdfList)) {
     Int_t subCode = model->basisCode(name) ;
     if (first) {
       code = subCode ;
@@ -362,8 +360,7 @@ double RooAddModel::evaluate() const
   double snormVal ;
   double value(0) ;
   Int_t i(0) ;
-  for (auto obj : _pdfList) {
-    auto pdf = static_cast<RooAbsPdf*>(obj);
+  for (auto *pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
 
     if (_coefCache[i]!=0.) {
       snormVal = nset ? cache->suppNormVal(i) : 1.0 ;
@@ -496,8 +493,7 @@ void RooAddModel::getCompIntList(const RooArgSet* nset, const RooArgSet* iset, p
   cache = new IntCacheElem ;
 
   // Fill Cache
-  for (auto obj : _pdfList) {
-    auto model = static_cast<RooResolutionModel*>(obj);
+  for (auto *model : static_range_cast<RooResolutionModel*>(_pdfList)) {
 
     cache->_intList.addOwned(std::unique_ptr<RooAbsReal>{model->createIntegral(*iset,nset,nullptr,isetRangeName)});
   }
@@ -550,8 +546,7 @@ double RooAddModel::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
   double snormVal ;
   double value(0) ;
   Int_t i(0) ;
-  for (const auto obj : *compIntList) {
-    auto pdfInt = static_cast<const RooAbsReal*>(obj);
+  for (auto *pdfInt : static_range_cast<const RooAbsReal*>(*compIntList)) {
     if (_coefCache[i]!=0.) {
       snormVal = nset ? pcache->suppNormVal(i) : 1.0 ;
       double intVal = pdfInt->getVal(nset) ;
@@ -579,16 +574,14 @@ double RooAddModel::expectedEvents(const RooArgSet* nset) const
   if (_allExtendable) {
 
     // Sum of the extended terms
-    for (auto obj : _pdfList) {
-      auto pdf = static_cast<RooAbsPdf*>(obj);
+    for (auto *pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
       expectedTotal += pdf->expectedEvents(nset) ;
     }
 
   } else {
 
     // Sum the coefficients
-    for (const auto obj : _coefList) {
-      auto coef = static_cast<RooAbsReal*>(obj);
+    for (auto *coef : static_range_cast<RooAbsReal*>(_coefList)) {
       expectedTotal += coef->getVal() ;
     }
   }
@@ -651,8 +644,7 @@ RooAbsGenContext* RooAddModel::genContext(const RooArgSet &vars, const RooDataSe
 
 bool RooAddModel::isDirectGenSafe(const RooAbsArg& arg) const
 {
-  for (auto obj : _pdfList) {
-    auto pdf = static_cast<RooAbsPdf*>(obj);
+  for (auto *pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
 
     if (!pdf->isDirectGenSafe(arg)) {
       return false ;
@@ -668,8 +660,7 @@ bool RooAddModel::isDirectGenSafe(const RooAbsArg& arg) const
 
 Int_t RooAddModel::getGenerator(const RooArgSet& directVars, RooArgSet &/*generateVars*/, bool /*staticInitOK*/) const
 {
-  for (auto obj : _pdfList) {
-    auto pdf = static_cast<RooAbsPdf*>(obj);
+  for (auto *pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
 
     RooArgSet tmp ;
     if (pdf->getGenerator(directVars,tmp)==0) {

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -774,12 +774,12 @@ double RooAddPdf::expectedEvents(const RooArgSet* nset) const
   } else {
 
     if (_allExtendable) {
-      for(auto const& arg : _pdfList) {
-        expectedTotal += static_cast<RooAbsPdf*>(arg)->expectedEvents(nset) ;
+      for(auto *arg : static_range_cast<RooAbsPdf*>(_pdfList)) {
+        expectedTotal += arg->expectedEvents(nset) ;
       }
     } else {
-      for(auto const& arg : _coefList) {
-        expectedTotal += static_cast<RooAbsReal*>(arg)->getVal(nset) ;
+      for(auto *arg : static_range_cast<RooAbsReal*>(_coefList)) {
+        expectedTotal += arg->getVal(nset) ;
       }
     }
 

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -382,9 +382,9 @@ std::string listVars(std::vector<std::string> const &alist, std::vector<bool> co
 std::string declareVarSpans(std::vector<std::string> const &alist)
 {
    std::stringstream ss;
-   for (std::size_t i = 0; i < alist.size(); ++i) {
+   for (auto const &elem : alist) {
       ss << "   "
-         << "std::span<const double> " << alist[i] << "Span = ctx.at(" << alist[i] << ");\n";
+         << "std::span<const double> " << elem << "Span = ctx.at(" << elem << ");\n";
    }
    return ss.str();
 }

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -520,8 +520,7 @@ void RooFFTConvPdf::fillCacheObject(RooAbsCachedPdf::PdfCacheElem& cache) const
 
   std::vector<RooAbsLValue*> obsLV(n);
   Int_t i(0) ;
-  for (auto const& arg : otherObs) {
-    RooAbsLValue* lvarg = dynamic_cast<RooAbsLValue*>(arg) ;
+  for (auto* lvarg : dynamic_range_cast<RooAbsLValue*>(otherObs)) {
     obsLV[i] = lvarg ;
     binCur[i] = 0 ;
     // coverity[FORWARD_NULL]

--- a/roofit/roofitcore/src/RooFoamGenerator.cxx
+++ b/roofit/roofitcore/src/RooFoamGenerator.cxx
@@ -149,8 +149,7 @@ const RooArgSet *RooFoamGenerator::generateEvent(UInt_t /*remaining*/, double& /
 
   // Transfer contents to dataset
   Int_t i(0) ;
-  for (auto arg : _realVars) {
-    auto var = static_cast<RooRealVar*>(arg);
+  for (auto* var : static_range_cast<RooRealVar*>(_realVars)) {
     var->setVal(_xmin[i] + _range[i]*_vec[i]) ;
     i++ ;
   }

--- a/roofit/roofitcore/src/RooLinearCombination.cxx
+++ b/roofit/roofitcore/src/RooLinearCombination.cxx
@@ -133,8 +133,8 @@ std::list<double> *RooLinearCombination::binBoundaries(RooAbsRealLValue &obs,
                                                       double xhi) const {
   // Forward the plot sampling hint from the p.d.f. that defines the observable
   // obs
-  for(auto const& func : _actualVars) {
-    auto binb = static_cast<RooAbsReal*>(func)->binBoundaries(obs, xlo, xhi);
+  for(auto *func : static_range_cast<RooAbsReal*>(_actualVars)) {
+    auto binb = func->binBoundaries(obs, xlo, xhi);
     if (binb) {
       return binb;
     }
@@ -147,8 +147,8 @@ std::list<double> *RooLinearCombination::plotSamplingHint(RooAbsRealLValue &obs,
                                                          double xhi) const {
   // Forward the plot sampling hint from the p.d.f. that defines the observable
   // obs
-  for(auto const& func : _actualVars) {
-    auto hint = static_cast<RooAbsReal*>(func)->plotSamplingHint(obs, xlo, xhi);
+  for(auto *func : static_range_cast<RooAbsReal*>(_actualVars)) {
+    auto hint = func->plotSamplingHint(obs, xlo, xhi);
     if (hint) {
       return hint;
     }

--- a/roofit/roofitcore/src/RooSuperCategory.cxx
+++ b/roofit/roofitcore/src/RooSuperCategory.cxx
@@ -93,8 +93,7 @@ bool RooSuperCategory::setIndex(Int_t index, bool printError)
   }
 
   bool error = false;
-  for (auto arg : _multiCat->_catSet) {
-    auto cat = static_cast<RooAbsCategoryLValue*>(arg);
+  for (auto* cat : static_range_cast<RooAbsCategoryLValue*>(_multiCat->_catSet)) {
     if (cat->empty()) {
       if (printError) {
          coutE(InputArguments) << __func__ << ": Found a category with zero states. Cannot set state for '"

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -833,8 +833,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
                   << " Negative log likelihood evaluates to infinity " << std::endl
                   << " Non-const Parameter values : ";
       RooArgList p(*constrainedParams);
-      for (std::size_t i = 0; i < p.size(); ++i) {
-         RooRealVar * v = dynamic_cast<RooRealVar *>(&p[i] );
+      for (auto *v : dynamic_range_cast<RooRealVar *>(p)) {
          if (v!=nullptr) ccoutE(Eval) << v->GetName() << " = " << v->getVal() << "   ";
       }
       ccoutE(Eval) << std::endl;

--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -131,8 +131,8 @@ namespace RooStats {
       }
       fResult->add(RooArgSet(*fBuiltSet), weight);
 
-      for (RooAbsArg* v : *fBuiltSet) {
-         if (RooRealVar* var= dynamic_cast<RooRealVar*>(v)) {
+      for (auto* var : dynamic_range_cast<RooRealVar*>(*fBuiltSet)) {
+         if (var) {
             // Invalidate values in case we don't set some of them next time round (eg. if fit not done)
             var->setVal(std::numeric_limits<double>::quiet_NaN());
             var->removeError();

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -1225,8 +1225,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
          RooArgList  genObs(*bkgdata->get(0));
          RooStats::PrintListContent(genObs, oocoutP(nullptr,Generation) );
          nObs = 0;
-         for (std::size_t i = 0; i < genObs.size(); ++i) {
-            RooRealVar * x = dynamic_cast<RooRealVar*>(&genObs[i]);
+         for (auto *x : dynamic_range_cast<RooRealVar*>(genObs)) {
             if (x) nObs += x->getVal();
          }
       }

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -233,12 +233,11 @@ bool LikelihoodInterval::CreateMinimizer() {
 
    // need to restore values and errors for POI
    if (fBestFitParams) {
-      for (std::size_t i = 0; i < params.size(); ++i) {
-         RooRealVar & par =  static_cast<RooRealVar &>( params[i]);
-         RooRealVar * fitPar =  static_cast<RooRealVar *> (fBestFitParams->find(par.GetName() ) );
+      for (auto *par : static_range_cast<RooRealVar *>(params)) {
+         RooRealVar * fitPar =  static_cast<RooRealVar *> (fBestFitParams->find(par->GetName() ) );
          if (fitPar) {
-            par.setVal( fitPar->getVal() );
-            par.setError( fitPar->getError() );
+            par->setVal( fitPar->getVal() );
+            par->setError( fitPar->getError() );
          }
       }
    }

--- a/roofit/roostats/src/LikelihoodIntervalPlot.cxx
+++ b/roofit/roostats/src/LikelihoodIntervalPlot.cxx
@@ -338,11 +338,10 @@ void LikelihoodIntervalPlot::Draw(const Option_t *options)
 
       RooArgList params(*newProfile->getVariables());
       // set values and error for the POI to the best fit values
-      for (std::size_t i = 0; i < params.size(); ++i) {
-         RooRealVar & par =  static_cast<RooRealVar &>( params[i]);
-         RooRealVar * fitPar =  static_cast<RooRealVar *> (fInterval->GetBestFitParameters()->find(par.GetName() ) );
+      for (auto *par : static_range_cast<RooRealVar *>(params)) {
+         RooRealVar * fitPar =  static_cast<RooRealVar *> (fInterval->GetBestFitParameters()->find(par->GetName() ) );
          if (fitPar) {
-            par.setVal( fitPar->getVal() );
+            par->setVal( fitPar->getVal() );
          }
       }
       // do a profile evaluation to start from the best fit values of parameters

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -237,12 +237,11 @@ LikelihoodInterval* ProfileLikelihoodCalculator::GetInterval() const {
    // t.b.f. " RooProfileLL should keep and provide possibility to query on global minimum
    // set POI to fit value (this will speed up profileLL calculation of global minimum)
    const RooArgList & fitParams = fFitResult->floatParsFinal();
-   for (std::size_t i = 0; i < fitParams.size(); ++i) {
-      RooRealVar & fitPar =  static_cast<RooRealVar &>( fitParams[i]);
-      RooRealVar * par = static_cast<RooRealVar*>(fPOI.find( fitPar.GetName() ));
+   for (auto *fitPar : static_range_cast<RooRealVar *>(fitParams)) {
+      RooRealVar * par = static_cast<RooRealVar*>(fPOI.find( fitPar->GetName() ));
       if (par) {
-         par->setVal( fitPar.getVal() );
-         par->setError( fitPar.getError() );
+         par->setVal( fitPar->getVal() );
+         par->setError( fitPar->getError() );
       }
    }
 


### PR DESCRIPTION
The `static_range_cast` and `dynamic_range_cast` are RooFit helper functions to iterate over polymorphic collections like `RooArgSet` and `RooArgList`. Using them instead of casting in a separate line makes the code more concise with fewer lines and throw-away temoprary variables.