### PR TITLE
[RF] Fix various memory leaks caused by not deleting return values

### DIFF
--- a/roofit/histfactory/src/HistFactoryModelUtils.cxx
+++ b/roofit/histfactory/src/HistFactoryModelUtils.cxx
@@ -56,7 +56,7 @@ namespace HistFactory{
     if( ! FoundSumPdf ) {
       if(verbose) {
    std::cout << "Failed to find RooRealSumPdf for channel: " << sim_channel->GetName() << std::endl;
-   sim_channel->getComponents()->Print("V");
+   components->Print("V");
       }
       sum_pdf=nullptr;
       //throw std::runtime_error("Failed to find RooRealSumPdf for channel");

--- a/roofit/roofit/test/testFitPerf.cxx
+++ b/roofit/roofit/test/testFitPerf.cxx
@@ -549,7 +549,7 @@ int FitUsingRooFit(TTree *tree, TF1 *func)
       int level = 3;
       std::cout << "num entries = " << data.numEntries() << std::endl;
       bool save = true;
-      (pdf.getVariables())->Print("v"); // print the parameters
+      std::unique_ptr<RooArgSet>{pdf.getVariables()}->Print("v"); // print the parameters
 #else
       int level = -1;
       bool save = false;
@@ -630,7 +630,7 @@ int FitUsingRooFit2(TTree *tree)
       int level = 3;
       std::cout << "num entries = " << data.numEntries() << std::endl;
       bool save = true;
-      (pdf[N - 1]->getVariables())->Print("v"); // print the parameters
+      std::unique_ptr<RooArgSet>{pdf[N - 1]->getVariables()}->Print("v"); // print the parameters
       std::cout << "\n\nDo the fit now \n\n";
 #else
       int level = -1;

--- a/roofit/roofit/test/vectorisedPDFs/VectorisedPDFTests.cxx
+++ b/roofit/roofit/test/vectorisedPDFs/VectorisedPDFTests.cxx
@@ -457,7 +457,7 @@ std::unique_ptr<RooFitResult> PDFTest::runBatchFit(RooAbsPdf *pdf)
    kickParameters();
    makePlots(::testing::UnitTest::GetInstance()->current_test_info()->name() + std::string("_batch_prefit"));
 
-   auto pars = pdf->getParameters(*_dataFit);
+   std::unique_ptr<RooArgSet> pars{pdf->getParameters(*_dataFit)};
    *pars = _parameters;
 
    for (unsigned int index = 0; index < pars->size(); ++index) {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2247,10 +2247,10 @@ RooPlot* RooAbsReal::plotAsymOn(RooPlot *frame, const RooAbsCategoryLValue& asym
 
 
   // Take out data-projected dependents from projectedVars
-  RooArgSet* projDataNeededVars = nullptr ;
+  std::unique_ptr<RooArgSet> projDataNeededVars;
   if (o.projData) {
-    projDataNeededVars = projectedVars.selectCommon(projDataVars);
-    projectedVars.remove(projDataVars,true,true) ;
+     projDataNeededVars.reset(projectedVars.selectCommon(projDataVars));
+     projectedVars.remove(projDataVars, true, true);
   }
 
   // Take out plotted asymmetry from projection

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -53,6 +53,7 @@ For general multiprocessing in ROOT, please refer to the TProcessExecutor class.
 #endif
 
 #include <cstdlib>
+#include <memory>
 #include <sstream>
 #include "RooRealMPFE.h"
 #include "RooArgSet.h"
@@ -170,7 +171,7 @@ void RooRealMPFE::initVars()
   _saveVars.removeAll() ;
 
   // Retrieve non-constant parameters
-  auto vars = _arg->getParameters(RooArgSet());
+  std::unique_ptr<RooArgSet> vars{_arg->getParameters(RooArgSet())};
   // RooArgSet *ncVars = vars->selectByAttrib("Constant", false);
   RooArgList varList(*vars) ;
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -829,6 +829,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 
   std::vector<RooArgSet*> nsetList ;
   std::vector<std::unique_ptr<RooArgSet>> argObsList ;
+  std::vector<std::unique_ptr<RooArgSet>> ownedNsets;
 
   // Now need to attach branch buffers of clones
   for (const auto arg : cloneSet) {
@@ -844,8 +845,8 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
 //       std::cout << "RooVectorDataStore::cacheArgs() cached node " << arg->GetName() << " has a normalization set specification CATNormSet = " << catNset << std::endl ;
 
       RooArgSet anset = RooHelpers::selectFromArgSet(nset ? *nset : RooArgSet{}, catNset);
-      normSet = anset.selectCommon(*argObs);
-
+      ownedNsets.emplace_back(anset.selectCommon(*argObs));
+      normSet = ownedNsets.back().get();
     }
     const char* catCset = arg->getStringAttribute("CATCondSet") ;
     if (catCset) {

--- a/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
@@ -129,7 +129,7 @@ void RooAbsL::initClones(RooAbsPdf &inpdf, RooAbsData &indata)
    // ******************************************************************
 
    // Attach FUNC to data set
-   auto _funcObsSet = pdf_->getObservables(indata);
+   std::unique_ptr<RooArgSet> _funcObsSet{pdf_->getObservables(indata)};
 
    if (pdf_->getAttribute("BinnedLikelihood")) {
       pdf_->setAttribute("BinnedLikelihoodActive");

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -245,8 +245,8 @@ bool AsymptoticCalculator::Initialize() const {
    if (!fNominalAsimov) {
       if (verbose >= 0)
          oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimov data will be generated using fitted nuisance parameter values" << std::endl;
-      RooArgSet * tmp = (RooArgSet*) poiAlt.snapshot();
-      fAsimovData = MakeAsimovData( data, *GetNullModel(), poiAlt, fAsimovGlobObs,tmp);
+      std::unique_ptr<RooArgSet> tmp{static_cast<RooArgSet *>(poiAlt.snapshot())};
+      fAsimovData = MakeAsimovData(data, *GetNullModel(), poiAlt, fAsimovGlobObs, tmp.get());
    }
 
    else {

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -1237,7 +1237,8 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       inverter.SetData(*bkgdata);
 
       // print global observables
-      auto gobs = bModel->GetPdf()->getVariables()->selectCommon(* sbModel->GetGlobalObservables() );
+      std::unique_ptr<RooArgSet> bModelVars{bModel->GetPdf()->getVariables()};
+      std::unique_ptr<RooAbsCollection> gobs{bModelVars->selectCommon(*sbModel->GetGlobalObservables())};
       gobs->Print("v");
 
       HypoTestInverterResult * r  = inverter.GetInterval();

--- a/roofit/roostats/src/LikelihoodIntervalPlot.cxx
+++ b/roofit/roostats/src/LikelihoodIntervalPlot.cxx
@@ -194,7 +194,8 @@ void LikelihoodIntervalPlot::Draw(const Option_t *options)
       const double xcont_min = fInterval->LowerLimit(*myparam);
       const double xcont_max = fInterval->UpperLimit(*myparam);
 
-      RooRealVar* myarg = static_cast<RooRealVar *>(newProfile->getVariables()->find(myparam->GetName()));
+      std::unique_ptr<RooArgSet> vars{newProfile->getVariables()};
+      RooRealVar *myarg = static_cast<RooRealVar *>(vars->find(myparam->GetName()));
       double x1 = myarg->getMin();
       double x2 = myarg->getMax();
 
@@ -336,7 +337,8 @@ void LikelihoodIntervalPlot::Draw(const Option_t *options)
       double cont_level = ROOT::Math::chisquared_quantile(fInterval->ConfidenceLevel(),fNdimPlot); // level for -2log LR
       cont_level = cont_level/2; // since we are plotting -log LR
 
-      RooArgList params(*newProfile->getVariables());
+      std::unique_ptr<RooArgSet> vars{newProfile->getVariables()};
+      RooArgList params(*vars);
       // set values and error for the POI to the best fit values
       for (std::size_t i = 0; i < params.size(); ++i) {
          RooRealVar & par =  static_cast<RooRealVar &>( params[i]);

--- a/roofit/roostats/src/PdfProposal.cxx
+++ b/roofit/roostats/src/PdfProposal.cxx
@@ -177,8 +177,9 @@ double PdfProposal::GetProposalDensity(RooArgSet& x1, RooArgSet& x2)
 
 void PdfProposal::AddMapping(RooRealVar& proposalParam, RooAbsReal& update)
 {
-   fMaster.add(*update.getParameters(static_cast<RooAbsData const*>(nullptr)));
-   if (update.getParameters(static_cast<RooAbsData const*>(nullptr))->empty())
+   std::unique_ptr<RooArgSet> params{update.getParameters(static_cast<RooAbsData const *>(nullptr))};
+   fMaster.add(*params);
+   if (params->empty())
       fMaster.add(update);
    fMap.insert(std::pair<RooRealVar*, RooAbsReal*>(&proposalParam, &update));
 }

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -466,7 +466,8 @@ void SPlot::AddSWeight(RooAbsPdf *pdf, const RooArgList &yieldsTmp, const RooArg
   }
 
   const Int_t nspec = yieldsTmp.size();
-  RooArgList yields = *static_cast<RooArgList*>(yieldsTmp.snapshot(false));
+  std::unique_ptr<RooArgList> yieldsSnapshot{static_cast<RooArgList *>(yieldsTmp.snapshot(false))};
+  RooArgList &yields = *yieldsSnapshot;
 
   if (RooMsgService::instance().isActive(this, RooFit::InputArguments, RooFit::DEBUG)) {
     coutI(InputArguments) << "Printing Yields" << std::endl;

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -37,8 +37,10 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
 
    // strip pdfs of constraints (which cancel out in the ratio) to avoid unnecessary computations and computational errors
    if (fFirstEval) {
-      fNullPdf = RooStats::MakeUnconstrainedPdf(*fNullPdf, *fNullPdf->getObservables(data));
-      fAltPdf  = RooStats::MakeUnconstrainedPdf(*fAltPdf , *fAltPdf->getObservables(data) );
+      std::unique_ptr<RooArgSet> nullObs{fNullPdf->getObservables(data)};
+      fNullPdf = RooStats::MakeUnconstrainedPdf(*fNullPdf, *nullObs);
+      std::unique_ptr<RooArgSet> altObs{fAltPdf->getObservables(data)};
+      fAltPdf = RooStats::MakeUnconstrainedPdf(*fAltPdf, *altObs);
    }
 
    fFirstEval = false;

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -302,7 +302,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       std::unique_ptr<RooArgSet> allVarsImpDens{fImportanceDensities[fIndexGenDensity]->getVariables()};
       allVars->add(*allVarsImpDens);
    }
-   const RooArgSet* saveVars = (const RooArgSet*)allVars->snapshot();
+   std::unique_ptr<const RooArgSet> saveVars{static_cast<const RooArgSet *>(allVars->snapshot())};
 
    double globalWeight = 1.0;
    if(fNuisanceParametersSampler) { // use nuisance parameters?
@@ -413,10 +413,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       ooccoutD(nullptr,InputArguments) << "weights["<<j<<"]: " << weights[j] << std::endl;
    }
 
-
-
    allVars->assign(*saveVars);
-   delete saveVars;
 
    return data;
 }

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -8905,9 +8905,9 @@ TH1 *xRooNode::BuildHistogram(RooAbsLValue *v, bool empty, bool errors, int binS
             for (auto pdf : bins()) {
                // auto _pdf =
                // pdf->get<RooAbsPdf>()->createProjection(*pdf->get<RooAbsPdf>()->getObservables(*_obs.get<RooArgList>()));
-               auto _pdf =
-                  new xRooProjectedPdf(TString::Format("%s_projection", pdf->GetName()), "", *pdf->get<RooAbsPdf>(),
-                                       *pdf->get<RooAbsPdf>()->getObservables(*_obs.get<RooArgList>()));
+               std::unique_ptr<RooArgSet> projObs{pdf->get<RooAbsPdf>()->getObservables(*_obs.get<RooArgList>())};
+               auto _pdf = new xRooProjectedPdf(TString::Format("%s_projection", pdf->GetName()), "",
+                                                *pdf->get<RooAbsPdf>(), *projObs);
                if (hasRange) {
                   dynamic_cast<RooAbsPdf *>(_pdf)->setNormRange("coordRange");
                }


### PR DESCRIPTION
Fix various memory leaks from cases where functions that return an owned return value were used without deleting the return value.

This is addressed by using `std::unique_ptr`.