### PR TITLE
[ci] add clang-tidy code analysis

### DIFF
--- a/.ci/tidy_script.sh
+++ b/.ci/tidy_script.sh
@@ -1,34 +1,35 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
-CLANG_TIDY_CHECKS='-*'
-if [[ $TOOL == clang-tidy-analyzer ]]; then
-  CLANG_TIDY_CHECKS+=',clang-analyzer-*,-clang-analyzer-alpha*,bugprone*'
-elif [[ $TOOL == clang-tidy-modernize ]]; then
-  CLANG_TIDY_CHECKS+=',modernize*'
+echo "Running $(realpath $0) from $PWD"
+
+WORKSPACE="${GITHUB_WORKSPACE:-${PWD}}"
+echo "Setting WORKSPACE to $WORKSPACE"
+
+SRC_DIR="${WORKSPACE}/ROOT-CI/src"
+BUILD_DIR="${WORKSPACE}/ROOT-CI/build"
+
+mkdir -v -p "$SRC_DIR" "$BUILD_DIR"
+
+cmake -B "$BUILD_DIR" -S $SRC_DIR \
+  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
+  -Dminimal=on -Dasserts=on
+
+clang-tidy --version
+
+HAVE_RUN=0
+EXIT_CODE=0
+for f in $(find "$SRC_DIR" -mindepth 2 -not -path '*/interpreter/*' -not -path '*/roofit/*' -name .clang-tidy); do
+   set -x
+   run-clang-tidy -use-color 1 -j $(nproc) -p "$BUILD_DIR" -config-file "$f" "$(dirname $f)/" || EXIT_CODE=1
+   set +x
+   HAVE_RUN=1
+done
+
+if [ $HAVE_RUN -eq 0 ]; then
+   echo "clang-tidy ran nowhere; that doesn't seem right."
+   exit 1
 fi
 
-echo "Running clang-tidy only against the changes in branch $TRAVIS_BRANCH."
-
-cd ../root/
-
-# Workaround for travis issue: travis-ci/travis-ci#6069
-git remote set-branches --add origin master
-git fetch
-
-# clang-tidy-diff.py not installed on travis
-wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/release_50/clang-tidy/tool/clang-tidy-diff.py
-
-RESULT_OUTPUT="$(git diff -U0 origin/master | python clang-tidy-diff.py -p1 -clang-tidy-binary $(which clang-tidy) \
-                 -checks=$CLANG_TIDY_CHECKS)"
-if [[ $? -eq 0 ]]; then
-  echo "$TOOL passed."
-  exit 0
-else
-  echo "To reproduce it locally please run"
-  echo -e "\tgit checkout $TRAVIS_BRANCH"
-  echo -e "Command: git diff -U0 $TRAVIS_BRANCH..origin/master | clang-tidy-diff.py -p1 -clang-tidy-binary \$(which clang-tidy) -checks=$CLANG_TIDY_CHECKS"
-  echo "$RESULT_OUTPUT"
-  exit 1
-fi
+exit $EXIT_CODE

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      TRAVIS_BRANCH: ${{ github.base_ref }} 
+      TRAVIS_BRANCH: ${{ github.base_ref }}
       TRAVIS_PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.html_url }}
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
@@ -47,6 +47,55 @@ jobs:
       run: |
         PATH=/usr/lib/llvm-20/bin:${PATH}
         .ci/format_script.sh
+
+  clang-tidy:
+    # For any event that is not a PR, the CI will always run. In PRs, the CI
+    # can be skipped if the tag [skip-ci] is written in the title.
+    if: |
+       (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
+       (github.event_name == 'pull_request' && !(
+         contains(github.event.pull_request.title, '[skip-ci]') ||
+         contains(github.event.pull_request.labels.*.name, 'skip ci') ||
+         contains(github.event.pull_request.labels.*.name, 'skip code analysis')
+       ))
+
+    runs-on:
+       - self-hosted
+       - linux
+       - x64
+
+    container:
+      image: registry.cern.ch/root-ci/alma10:buildready
+      options: '--security-opt label=disable --rm'
+      env:
+        OS_APPLICATION_CREDENTIAL_ID: '7f5b64a265244623a3a933308569bdba'
+        OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        OS_AUTH_TYPE: 'v3applicationcredential'
+        OS_AUTH_URL: 'https://keystone.cern.ch/v3'
+        OS_IDENTITY_API_VERSION: 3
+        OS_INTERFACE: 'public'
+        OS_REGION_NAME: 'cern'
+        PYTHONUNBUFFERED: true
+
+    env:
+       TRAVIS_BRANCH: ${{ github.base_ref }}
+       TRAVIS_PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.html_url }}
+       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
+       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+
+    steps:
+       - uses: actions/checkout@v6
+         with:
+            fetch-depth: 1
+            ref: ${{ github.event.pull_request.head.sha }}
+            path: ROOT-CI/src
+       - name: Fetch base sha
+         run: cd ROOT-CI/src && git fetch --depth=1 origin +${{github.event.pull_request.base.sha}}:origin/base_sha
+       - name: Determine merge base
+         run: echo "MERGE_BASE=$(cd ROOT-CI/src && git merge-base ${{ github.event.pull_request.base.sha }} HEAD)" >> $GITHUB_ENV
+       - name: run clang-tidy script
+         run: |
+            ROOT-CI/src/.ci/tidy_script.sh
 
   ruff:
     if: |

--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -103,7 +103,12 @@ extern void SysError(const char *location, const char *msgfmt, ...)
 __attribute__((format(printf, 2, 3)))
 #endif
 ;
-extern void Fatal(const char *location, const char *msgfmt, ...)
+#ifdef __clang_analyzer__
+// The __attribute__((analyzer_noreturn)) is still very new and possibly not available
+[[noreturn]] void Fatal(const char *location, const char *msgfmt, ...)
+#else
+void Fatal(const char *location, const char *msgfmt, ...)
+#endif
 #if defined(__GNUC__)
 __attribute__((format(printf, 2, 3)))
 #endif

--- a/core/foundation/src/TError.cxx
+++ b/core/foundation/src/TError.cxx
@@ -270,4 +270,8 @@ void Fatal(const char *location, const char *fmt, ...)
    va_start(ap, fmt);
    ErrorHandler(kFatal, location, fmt, ap);
    va_end(ap);
+#ifdef __clang_analyzer__
+   // Under clang-tidy, Fatal() is [[noreturn]]
+   abort();
+#endif
 }

--- a/tree/ntuple/.clang-tidy
+++ b/tree/ntuple/.clang-tidy
@@ -1,0 +1,61 @@
+InheritParentConfig: 'True'
+
+CheckOptions:
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           'R__ASSERT'
+  - key:             misc-const-correctness.AnalyzeValues
+    value:           false
+  - key:             misc-const-correctness.AnalyzePointers
+    value:           false
+  - key:             misc-include-cleaner.IgnoreHeaders
+    value:           'RSpan.hxx'
+  - key:             misc-override-with-different-visibility.DisallowedVisibilityChange
+    value:           'widening'
+
+Checks: 'bugprone-*,
+   -bugprone-assignment-in-if-condition,
+   -bugprone-branch-clone,
+   -bugprone-derived-method-shadowing-base-method,
+   -bugprone-easily-swappable-parameters,
+   -bugprone-implicit-widening-of-multiplication-result,
+   -bugprone-incorrect-enable-if,
+   -bugprone-macro-parentheses,
+   -bugprone-multi-level-implicit-pointer-conversion,
+   -bugprone-narrowing-conversions,
+   -bugprone-not-null-terminated-result,
+   -bugprone-random-generator-seed,
+   -bugprone-reserved-identifier,
+   -bugprone-signed-char-misuse,
+   -bugprone-std-namespace-modification,
+   -bugprone-switch-missing-default-case,
+   -bugprone-throwing-static-initialization,
+   -bugprone-too-small-loop-variable,
+   -bugprone-unchecked-optional-access,
+   -bugprone-unhandled-self-assignment,
+   -bugprone-unused-return-value,
+   -bugprone-virtual-near-miss,
+   cppcoreguidelines-virtual-class-destructor,
+   -clang-analyzer-optin.core.EnumCastOutOfRange,
+   misc-*,
+   -misc-non-private-member-variables-in-classes,
+   -misc-include-cleaner,
+   -misc-misplaced-const,
+   -misc-multiple-inheritance,
+   -misc-no-recursion,
+   -misc-non-private-member-variables-in-classes,
+   -misc-predictable-rand,
+   -misc-unconventional-assign-operator,
+   -misc-use-anonymous-namespace,
+   performance-*,
+   -performance-enum-size,
+   -performance-inefficient-string-concatenation,
+   -performance-no-int-to-ptr,
+   -performance-noexcept-swap,
+   -performance-noexcept-move-constructor,
+   readability-duplicate-include,
+   readability-delete-null-pointer,
+   readability-misleading-indentation,
+   readability-redundant-control-flow,
+   readability-redundant-declaration,
+   readability-redundant-function-ptr-dereference,
+   readability-reference-to-constructed-temporary'

--- a/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
+++ b/tree/ntuple/inc/ROOT/RField/RFieldSoA.hxx
@@ -95,7 +95,7 @@ class RSoAField : public RFieldBase {
    /// For a nested SoA struct (either as a member of as a base class), use their fRecordMemberFields in this class,
    /// i.e. "unroll" the vectors in the nested SoA struct into the SoA base class.
    void GraftNestedMemberFields(const RSoAField &nestedSoA, std::size_t offsetInParent,
-                                std::function<RFieldBase *(const std::string &)> fnRecordFieldFinder);
+                                const std::function<RFieldBase *(const std::string &)> &fnRecordFieldFinder);
 
    void ReconstructSplitFields() const;
 

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -715,7 +715,7 @@ private:
 
    std::uint64_t fNPhysicalColumns = 0; ///< Updated by the descriptor builder when columns are added
 
-   std::set<unsigned int> fFeatureFlags;
+   std::set<unsigned int> fFeatureFlags; // needs to be ordered
    std::unordered_map<ROOT::DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<ROOT::DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
 

--- a/tree/ntuple/src/RField.cxx
+++ b/tree/ntuple/src/RField.cxx
@@ -1027,6 +1027,7 @@ void *ROOT::RUniquePtrField::PrepareRead(void *to, bool hasOnDiskValue)
    if (isValidValue && !hasOnDiskValue) {
       ptr->release();
       fItemDeleter->operator()(valuePtr, false /* dtorOnly */);
+      valuePtr = nullptr;
    } else if (!isValidValue && hasOnDiskValue) {
       valuePtr = CallCreateObjectRawPtrOn(*fSubfields[0]);
       ptr->reset(reinterpret_cast<char *>(valuePtr));

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -688,7 +688,7 @@ ROOT::Experimental::RSoAField::RSoAField(std::string_view fieldName, std::string
 
 void ROOT::Experimental::RSoAField::GraftNestedMemberFields(
    const RSoAField &nestedSoA, std::size_t offsetInParent,
-   std::function<RFieldBase *(const std::string &)> fnRecordFieldFinder)
+   const std::function<RFieldBase *(const std::string &)> &fnRecordFieldFinder)
 {
    const std::size_t nNestedRecordMemberFields = nestedSoA.fRecordMemberFields.size();
 

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -55,10 +55,6 @@
 #endif
 #endif /* R__LITTLE_ENDIAN */
 
-using ROOT::Internal::RNTupleCompressor;
-using ROOT::Internal::RNTupleDecompressor;
-using ROOT::Internal::RNTupleSerializer;
-
 namespace {
 
 // The following types are used to read and write the TFile binary format

--- a/tree/ntuple/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/src/RNTupleDescriptor.cxx
@@ -618,6 +618,9 @@ std::vector<std::uint64_t> ROOT::RNTupleDescriptor::GetFeatureFlags() const
          flags = 0;
          base += 64;
       }
+      // Note that in the following iterations of the outer loop over fFeatureFlags, we can never have the situation
+      // where base is larger than the feature flag, because they are stored ordered in the std::set.
+      assert(f >= base);
       f -= base;
       flags |= std::uint64_t(1) << f;
    }

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -1261,15 +1261,14 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       }
    }
 
-#define SKIP_OR_ABORT(errMsg)                                                         \
-   do {                                                                               \
-      if (mergeOpts.fErrBehavior == ENTupleMergeErrBehavior::kSkip) {                 \
-         R__LOG_WARNING(NTupleMergeLog()) << "Skipping RNTuple due to: " << (errMsg); \
-         continue;                                                                    \
-      } else {                                                                        \
-         return R__FAIL(errMsg);                                                      \
-      }                                                                               \
-   } while (0)
+   // NOTE: don't wrap this in a do {} while (0)! It uses continue!
+#define SKIP_OR_ABORT(errMsg)                                                      \
+   if (mergeOpts.fErrBehavior == ENTupleMergeErrBehavior::kSkip) {                 \
+      R__LOG_WARNING(NTupleMergeLog()) << "Skipping RNTuple due to: " << (errMsg); \
+      continue;                                                                    \
+   } else {                                                                        \
+      return R__FAIL(errMsg);                                                      \
+   }
 
    // Merge main loop
    for (RPageSource *source : sources) {
@@ -1305,7 +1304,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       auto descCmpRes = CompareDescriptorStructure(mergeData.fDstDescriptor, srcDescriptor.GetRef());
       if (!descCmpRes) {
          SKIP_OR_ABORT(std::string("Source RNTuple has an incompatible schema with the destination:\n") +
-                       descCmpRes.GetError()->GetReport());
+                       descCmpRes.GetError()->GetReport())
       }
       auto descCmp = descCmpRes.Unwrap();
 
@@ -1316,7 +1315,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
          for (const auto *field : descCmp.fExtraDstFields) {
             msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
          }
-         SKIP_OR_ABORT(msg);
+         SKIP_OR_ABORT(msg)
       }
 
       // handle extra src fields
@@ -1332,7 +1331,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
             for (const auto *field : descCmp.fExtraSrcFields) {
                msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }
-            SKIP_OR_ABORT(msg);
+            SKIP_OR_ABORT(msg)
          }
       }
 

--- a/tree/ntuple/src/RNTupleMerger.cxx
+++ b/tree/ntuple/src/RNTupleMerger.cxx
@@ -1381,15 +1381,14 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       }
    }
 
-#define SKIP_OR_ABORT(errMsg)                                                         \
-   do {                                                                               \
-      if (mergeOpts.fErrBehavior == ENTupleMergeErrBehavior::kSkip) {                 \
-         R__LOG_WARNING(NTupleMergeLog()) << "Skipping RNTuple due to: " << (errMsg); \
-         continue;                                                                    \
-      } else {                                                                        \
-         return R__FAIL(errMsg);                                                      \
-      }                                                                               \
-   } while (0)
+   // NOTE: don't wrap this in a do {} while (0)! It uses continue!
+#define SKIP_OR_ABORT(errMsg)                                                      \
+   if (mergeOpts.fErrBehavior == ENTupleMergeErrBehavior::kSkip) {                 \
+      R__LOG_WARNING(NTupleMergeLog()) << "Skipping RNTuple due to: " << (errMsg); \
+      continue;                                                                    \
+   } else {                                                                        \
+      return R__FAIL(errMsg);                                                      \
+   }
 
    // Merge main loop
    for (RPageSource *source : sources) {
@@ -1425,7 +1424,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
       auto descCmpRes = CompareDescriptorStructure(mergeData.fDstDescriptor, srcDescriptor.GetRef());
       if (!descCmpRes) {
          SKIP_OR_ABORT(std::string("Source RNTuple has an incompatible schema with the destination:\n") +
-                       descCmpRes.GetError()->GetReport());
+                       descCmpRes.GetError()->GetReport())
       }
       auto descCmp = descCmpRes.Unwrap();
 
@@ -1436,7 +1435,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
          for (const auto *field : descCmp.fExtraDstFields) {
             msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
          }
-         SKIP_OR_ABORT(msg);
+         SKIP_OR_ABORT(msg)
       }
 
       // handle extra src fields
@@ -1452,7 +1451,7 @@ ROOT::RResult<void> RNTupleMerger::Merge(std::span<RPageSource *> sources, const
             for (const auto *field : descCmp.fExtraSrcFields) {
                msg += "\n  " + field->GetFieldName() + " : " + field->GetTypeName();
             }
-            SKIP_OR_ABORT(msg);
+            SKIP_OR_ABORT(msg)
          }
       }
 

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -956,11 +956,11 @@ ROOT::Internal::RNTupleSerializer::DeserializeEnvelope(const void *buffer, std::
    if (bufSize < minEnvelopeSize)
       return R__FAIL("invalid envelope buffer, too short");
 
-   auto bytes = reinterpret_cast<const unsigned char *>(buffer);
-   auto base = bytes;
+   const auto *bytes = reinterpret_cast<const unsigned char *>(buffer);
+   const auto *base = bytes;
 
    std::uint64_t typeAndSize;
-   bytes += DeserializeUInt64(bytes, typeAndSize);
+   DeserializeUInt64(bytes, typeAndSize);
 
    std::uint16_t envelopeType = typeAndSize & 0xFFFF;
    if (envelopeType != expectedType) {

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -967,11 +967,11 @@ ROOT::Internal::RNTupleSerializer::DeserializeEnvelope(const void *buffer, std::
    if (bufSize < minEnvelopeSize)
       return R__FAIL("invalid envelope buffer, too short");
 
-   auto bytes = reinterpret_cast<const unsigned char *>(buffer);
-   auto base = bytes;
+   const auto *bytes = reinterpret_cast<const unsigned char *>(buffer);
+   const auto *base = bytes;
 
    std::uint64_t typeAndSize;
-   bytes += DeserializeUInt64(bytes, typeAndSize);
+   DeserializeUInt64(bytes, typeAndSize);
 
    std::uint16_t envelopeType = typeAndSize & 0xFFFF;
    if (envelopeType != expectedType) {

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -46,8 +46,6 @@ using ROOT::Internal::RColumn;
 using ROOT::Internal::RColumnDescriptorBuilder;
 using ROOT::Internal::RColumnElementBase;
 using ROOT::Internal::RExtraTypeInfoDescriptorBuilder;
-using ROOT::Internal::RFieldDescriptorBuilder;
-using ROOT::Internal::RNTupleSerializer;
 
 using ROOT::Experimental::Internal::RNTupleAttrSetDescriptorBuilder;
 

--- a/tree/ntuple/src/RPageStorage.cxx
+++ b/tree/ntuple/src/RPageStorage.cxx
@@ -50,8 +50,6 @@ using ROOT::Internal::RColumn;
 using ROOT::Internal::RColumnDescriptorBuilder;
 using ROOT::Internal::RColumnElementBase;
 using ROOT::Internal::RExtraTypeInfoDescriptorBuilder;
-using ROOT::Internal::RFieldDescriptorBuilder;
-using ROOT::Internal::RNTupleSerializer;
 
 using ROOT::Experimental::Internal::RNTupleAttrSetDescriptorBuilder;
 

--- a/tree/ntuple/src/RPageStorageFile.cxx
+++ b/tree/ntuple/src/RPageStorageFile.cxx
@@ -46,10 +46,7 @@ using ROOT::Experimental::Detail::RNTupleAtomicTimer;
 using ROOT::Experimental::Detail::RNTupleCalcPerf;
 using ROOT::Experimental::Detail::RNTupleMetrics;
 using ROOT::Internal::RCluster;
-using ROOT::Internal::RNTupleCompressor;
-using ROOT::Internal::RNTupleDecompressor;
 using ROOT::Internal::RNTupleFileWriter;
-using ROOT::Internal::RNTupleSerializer;
 using ROOT::Internal::ROnDiskPage;
 using ROOT::Internal::ROnDiskPageMap;
 


### PR DESCRIPTION
Currently only checks the tree/ntuple code part. Other parts can plug in themselves by creating a `.clang-tidy` config file.