### PR TITLE
[CMake] Link only what is used: drop unused explicit library deps

### DIFF
--- a/graf3d/csg/CMakeLists.txt
+++ b/graf3d/csg/CMakeLists.txt
@@ -9,6 +9,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RCsg
      CsgOps.h
   SOURCES
      CsgOps.cxx
-  DEPENDENCIES
-     MathCore   
+  LIBRARIES
+     MathCore
 )

--- a/gui/webgui6/CMakeLists.txt
+++ b/gui/webgui6/CMakeLists.txt
@@ -26,7 +26,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(WebGui6
     src/TWebSnapshot.cxx
   DEPENDENCIES
     Core
-    RIO
     Gpad
+    RIO
     ROOTWebDisplay
+    Thread
 )

--- a/hist/hbook/CMakeLists.txt
+++ b/hist/hbook/CMakeLists.txt
@@ -25,7 +25,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Hbook
     minicern
   DEPENDENCIES
     Hist
-    Matrix
     Tree
     Graf
     TreePlayer

--- a/hist/histpainter/CMakeLists.txt
+++ b/hist/histpainter/CMakeLists.txt
@@ -29,5 +29,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistPainter
     Graf
     Hist
     MathCore
+  LIBRARIES
     Matrix
 )

--- a/hist/spectrum/CMakeLists.txt
+++ b/hist/spectrum/CMakeLists.txt
@@ -29,5 +29,4 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Spectrum
     -writeEmptyRootPCM
   DEPENDENCIES
     Hist
-    Matrix
 )

--- a/io/io/CMakeLists.txt
+++ b/io/io/CMakeLists.txt
@@ -60,9 +60,9 @@ ROOT_LINKER_LIBRARY(RIO
   $<TARGET_OBJECTS:RootPcmObjs>
   LIBRARIES
     ${CMAKE_DL_LIBS}
+    Thread
   DEPENDENCIES
     Core
-    Thread
 )
 
 target_include_directories(RIO PRIVATE ${CMAKE_SOURCE_DIR}/core/clib/res)

--- a/net/davix/CMakeLists.txt
+++ b/net/davix/CMakeLists.txt
@@ -20,6 +20,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RDAVIX
     src/TDavixSystem.cxx
   LIBRARIES
     Davix::Davix
+    Thread
   DEPENDENCIES
     Net
     RIO

--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -54,9 +54,9 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RHTTP
     ${_civetweb_libs}
     ${FASTCGI_LIBRARY}
     ${CMAKE_DL_LIBS}
+    Thread
   DEPENDENCIES
     RIO
-    Thread
 )
 
 if(builtin_civetweb)

--- a/roofit/histfactory/CMakeLists.txt
+++ b/roofit/histfactory/CMakeLists.txt
@@ -60,7 +60,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(HistFactory
     Tree
     RIO
     Hist
-    Matrix
     MathCore
     Graf
     Gpad

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -98,7 +98,7 @@ if (roofit_multiprocess)
 endif()
 
 if(mathmore)
-  list(APPEND ROOFITMORE_LIBRARIES RooFitMore)
+  list(APPEND ROOFITMORE_LIBRARIES RooFitMore MathMore)
 endif()
 
 #--stressRooFit----------------------------------------------------------------------------------

--- a/roofit/roofitmore/CMakeLists.txt
+++ b/roofit/roofitmore/CMakeLists.txt
@@ -40,16 +40,15 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitMore
   LINKDEF
     LinkDef.h
   DEPENDENCIES
-    ${ROOT_MATHMORE_LIBRARY}
     Core
     RooFitCore
     RooFit
     Hist
-    Matrix
     Tree
     RIO
+  LIBRARIES
+    ${ROOT_MATHMORE_LIBRARY}
     MathCore
-    Foam
   ${EXTRA_DICT_OPTS}
 )
 

--- a/roofit/roostats/CMakeLists.txt
+++ b/roofit/roostats/CMakeLists.txt
@@ -126,10 +126,11 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooStats
     Hist
     Matrix
     MathCore
-    Minuit
-    Foam
     Graf
     Gpad
+  LIBRARIES
+    Minuit
+    Foam
   ${EXTRA_DICT_OPTS}
 )
 

--- a/tree/ntuple/test/CMakeLists.txt
+++ b/tree/ntuple/test/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 ROOT_ADD_GTEST(ntuple_field_name ntuple_field_name.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_join_table ntuple_join_table.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_merger ntuple_merger.cxx ntuple_test.cxx
-  LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB Tree xxHash::xxHash
+  LIBRARIES ROOTNTuple CustomStruct ZLIB::ZLIB Tree MathCore xxHash::xxHash
   INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/tree/tree/inc)
 ROOT_ADD_GTEST(ntuple_metrics ntuple_metrics.cxx LIBRARIES ROOTNTuple)
 ROOT_ADD_GTEST(ntuple_model ntuple_model.cxx LIBRARIES ROOTNTuple CustomStruct)

--- a/tree/tree/CMakeLists.txt
+++ b/tree/tree/CMakeLists.txt
@@ -10,7 +10,7 @@
 ############################################################################
 
 if (imt)
-  list(APPEND TREE_EXTRA_DEPENDENCIES Imt)
+  list(APPEND TREE_EXTRA_LIBRARIES Imt)
 endif(imt)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(Tree
@@ -124,12 +124,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Tree
   DICTIONARY_OPTIONS
     -writeEmptyRootPCM
   DEPENDENCIES
-    ${TREE_EXTRA_DEPENDENCIES}
     Net
     RIO
-    MathCore
   LIBRARIES
     ${ROOT_ATOMIC_LIBS}
+    ${TREE_EXTRA_LIBRARIES}
+    Thread
+    MathCore
 )
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)


### PR DESCRIPTION
Address #20731 by removing explicitly-linked-but-unused libraries reported by `ldd -u`. The recurring offenders all came from foundational libraries exporting internal-only dependencies through their PUBLIC link interface (CMake DEPENDENCIES), so every consumer inherited them. These are now PRIVATE (CMake LIBRARIES), and genuinely-spurious links dropped:

  * RIO: Thread -> `PRIVATE` (TFilePrefetch only holds a TThread* member)
  * Tree: Imt/Net/MathCore -> `PRIVATE`, declares its own Thread
          (RIO stays PUBLIC: TBufferSQL/TTreeCache derive from RIO types)
  * RHTTP/HistPainter/RooStats/RooFitMore/RCsg: internal deps -> PRIVATE
  * Hbook/Spectrum/HistFactory: spurious Matrix/Foam removed
  * ntuple_merger/stressRooFit tests: declare the deps they actually use

RIO -> Thread alone cuts Thread over-linking from 62 reports to 2; in total the tree drops from 510 reports (77 libs) to 422 (69), and every library still links cleanly under `-Wl`, `--no-undefined`.

This closes #20731: the remaining reports are not over-linking and PUBLIC/PRIVATE cannot remove them. They are either inline-header dependencies (e.g. Tree using TMath: a real compile dependency with no exported symbol, which `ldd -u` mis-flags) or deliberate public API (Hist exposes TVectorD/TMatrixD; TMessage derives from TBufferFile).

Closes #20731.

🤖 Done with the help of AI.