### PR TITLE
[tutorials][ML] Fix wrong file name in tutorial index.

### DIFF
--- a/tutorials/machine_learning/index.md
+++ b/tutorials/machine_learning/index.md
@@ -137,6 +137,6 @@
 | ml_dataloader_NumPy.py | Loading batches of events from a ROOT dataset as Python generators of numpy arrays. |
 | ml_dataloader_PyTorch.py | Loading batches of events from a ROOT dataset into a basic PyTorch workflow. |
 | ml_dataloader_TensorFlow.py | Loading batches of events from a ROOT dataset into a basic TensorFlow workflow. |
-| ml_dataloader_Higgs_Classification | Loading batches of events from different files for a data-normalization workflow. |
+| ml_dataloader_Higgs_Classification.py | Loading batches of events from different files for a data-normalization workflow. |
 | ml_dataloader_resampling.py | Loading batches of events from an imbalanced ROOT dataset and balancing them. | 
 


### PR DESCRIPTION


# This Pull request: puts the Higgs Classification ML tutorial in the correct section.

## Changes or fixes: https://github.com/root-project/root/pull/22595/ had an typo in the index.md


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

