### PR TITLE
Avoid spurious message about missing rdict when .pcm  already found

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -2354,7 +2354,22 @@ void TCling::RegisterModule(const char* modulename,
       llvm::sys::path::remove_filename(pcmFileNameFullPath);
       llvm::sys::path::append(pcmFileNameFullPath,
                               ROOT::TMetaUtils::GetModuleFileName(modulename));
-      LoadPCM(pcmFileNameFullPath.str().str());
+      // A library built with C++ modules may ship only its .pcm and no
+      // <lib>_rdict.pcm (the dictionary payload then lives in the C++ module).
+      // In that case probing the legacy rootpcm makes LoadPCM emit a spurious
+      // "ROOT PCM ... file does not exist" error followed by an in-memory
+      // candidate dump. Skip the probe only when the C++ module was loaded AND
+      // there is genuinely no rootpcm to load -- neither registered in-memory
+      // (an embedded rdict, the check mirrors LoadPCM) nor present on disk. For
+      // libraries without a C++ module the behaviour is unchanged, so a truly
+      // missing rootpcm is still reported.
+      std::string pcmPath = pcmFileNameFullPath.str().str();
+      std::string pcmRealPath = llvm::sys::fs::is_symlink_file(pcmPath)
+                                   ? ROOT::TMetaUtils::GetRealPath(pcmPath)
+                                   : pcmPath;
+      if (!ModuleWasSuccessfullyLoaded || fPendingRdicts.count(pcmRealPath) ||
+          llvm::sys::fs::exists(pcmRealPath))
+         LoadPCM(pcmPath);
    }
 
    { // scope within which diagnostics are de-activated


### PR DESCRIPTION
# This Pull request:

I just built TJAlien as a proper CXX module using ROOT_STANDARD_LIBRARY_PACKAGE. It seems to work and the Cling AutoParse is now gone, sensibly reducing our per process overhead when opening files from the AliEn. As I side effect I started getting messages:

```
[3462153:propagation-service]: Info in <TCling::LoadPCM>: In-memory ROOT PCM candidate /home/eulisse/src/sw/ubuntu2204_x86-64/ROOT/alice-v6-36-00-local4/lib/libTMVAUtils_rdict.pcm
...
...
```

which are apparently harmless (fetching files from alien works just fine), yet annoying. 

I am in the process of validating this, and I would like to have your opinion on it.

## Changes or fixes:

This avoids looking up for a _rdict.pcm is the associated module was already loaded via the shared library.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)