### PR TITLE
[v6.40][minicern] Move address computation to 64 bit

### DIFF
--- a/misc/minicern/CMakeLists.txt
+++ b/misc/minicern/CMakeLists.txt
@@ -12,9 +12,11 @@ ROOT_LINKER_LIBRARY(minicern *.c *.f TYPE STATIC)
 set_property(TARGET minicern PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(minicern ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
 
-# Disable optimization since it some cases was causing crashes.
 # Disable warnings, since what has worked for 40 years...
 # (see https://sft.its.cern.ch/jira/browse/ROOT-9179 for the warnings)
-set_target_properties(minicern PROPERTIES COMPILE_FLAGS "-O0 -w")
-# set_target_properties(minicern PROPERTIES COMPILE_FLAGS "-fsanitize=undefined -fsanitize=address")
-# target_link_options(minicern BEFORE PUBLIC -fsanitize=undefined PUBLIC -fsanitize=address)
+target_compile_options(minicern PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:-w>")
+
+# The offset computations between common blocks go wrong an arm64 with -O2.
+# This is not a proper fix, but getting it right would require rewriting zebra's
+# distance between common blocks logic ...
+target_compile_options(minicern PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:-O0>")

--- a/misc/minicern/src/kernlib.f
+++ b/misc/minicern/src/kernlib.f
@@ -87,6 +87,9 @@
 *-------------------------------------------------------------------------------
 
       FUNCTION LOCF (IVAR)
+      IMPLICIT NONE
+      INTEGER :: NADUPW, LADUPW
+      INTEGER*8 :: LOCF, IVAR, J
       DIMENSION    IVAR(9)
       PARAMETER    (NADUPW=4, LADUPW=2)
       J = LOC(IVAR)
@@ -94,6 +97,10 @@
       END
 
       FUNCTION LOCFR (VAR)
+      IMPLICIT NONE
+      REAL :: VAR
+      INTEGER :: NADUPW, LADUPW, LOCFR
+      INTEGER*8 :: J
       DIMENSION    VAR(9)
       PARAMETER    (NADUPW=4, LADUPW=2)
       J = LOC(VAR)

--- a/misc/minicern/src/zebra.f
+++ b/misc/minicern/src/zebra.f
@@ -3,6 +3,8 @@
 * This file contains the zebra's package subset needed to build h2root.
 * It cannot be used by any zebra application because many zebra functionalities
 * are missing.
+* See https://cds.cern.ch/record/2296399/files/zebra.pdf for explanation of the
+* variables.
 *
 *-------------------------------------------------------------------------------
 


### PR DESCRIPTION
minicern uses the `LOC` function to compute the address of objects. It shifts them by 2 bits, but was doing this in 32 bits. This lead integer overflows, which were used subsequently to compute the distance between two common blocks.