### PR TITLE
[build] Update cibuildwheel's version to 4.1.0

### DIFF
--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Build wheel
-      uses: pypa/cibuildwheel@v3.4.1
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_BUILD: ${{ inputs.build-tag }}
 


### PR DESCRIPTION
# This Pull request:
Updates `cibuildwheel`'s version to 4.1.0
## Changes or fixes:
`cibuildwheel` 4.1.0 uses an updated `manylinux_2_28` container (2026.06.04-1 vs the previous 2026.03.20-1), which in turn ships `auditwheel` 6.7.0 which fixes a bug [(see release notes)](https://github.com/pypa/auditwheel/releases/tag/6.7.0) in how RPATHs were set in previous versions. This bug previously prevented linking against ROOT wheel (pip) distributions without workarounds.  

Comparing `readelf -d libfreetype-2f3b32b6.so.6.16.1` output between libraries bundled by `auditwheel` 6.7.0 and `auditwheel` 6.6.0 respectively (note the missing RPATH in 6.6.0's version):
```
 0x000000000000000f (RPATH)              Library rpath: [$ORIGIN]
 0x0000000000000001 (NEEDED)             Shared library: [libbz2-a1e77c99.so.1.0.6]
 0x0000000000000001 (NEEDED)             Shared library: [libpng16-57ce35be.so.16.34.0]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [libfreetype-2f3b32b6.so.6.16.1]
 ```
 vs.
 ```
 0x0000000000000001 (NEEDED)             Shared library: [libbz2-a1e77c99.so.1.0.6]
 0x0000000000000001 (NEEDED)             Shared library: [libpng16-57ce35be.so.16.34.0]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000e (SONAME)             Library soname: [libfreetype-2f3b32b6.so.6.16.1]
 ```


## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR addresses some of the issues faced in #22654 