### PR TITLE
[cmake] Produce python .dist-info metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,9 @@ if(pyroot)
   set(PYTESTS_WILLFAIL WILLFAIL)
 endif()
 
+#---Insert Python metadata for ROOT import package----------------------------------------------
+include(InstallPythonMetadata)
+
 #---Configure Testing using CTest----------------------------------------------------------------
 configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/CTestCustom.cmake ${CMAKE_BINARY_DIR} COPYONLY)
 if(testing)

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -184,6 +184,8 @@ endif()
 
 ROOT_ADD_PYUNITTEST(regression_18441 regression_18441.py)
 
+ROOT_ADD_PYUNITTEST(package_metadata package_metadata.py)
+
 if(NOT MSVC OR CMAKE_SIZEOF_VOID_P EQUAL 8 OR win_broken_tests)
     # Test the conversion and low level views of interpreter-defined C++ arrays to NumPy
     # We do not run this test on Windows x86 due to an interpreter issue with arrays:

--- a/bindings/pyroot/pythonizations/test/package_metadata.py
+++ b/bindings/pyroot/pythonizations/test/package_metadata.py
@@ -1,0 +1,10 @@
+import importlib.metadata as meta
+import unittest
+
+
+class PackageMetadata(unittest.TestCase):
+    def test_query_metadata(self):
+        try:
+            meta.version("ROOT")
+        except Exception:
+            raise AssertionError("importlib failed to access .dist-info metadata for ROOT package")

--- a/cmake/modules/InstallPythonMetadata.cmake
+++ b/cmake/modules/InstallPythonMetadata.cmake
@@ -1,0 +1,18 @@
+# Installs Python METADATA and INSTALLER files for compatibility with importlib.metadata
+# The presence of INSTALLER (along with intentionally neglecting RECORD) prevents 
+# package managers from uninstalling or otherwise touching the ROOT import package if 
+# it wasn't installed via a wheel.
+# See: https://packaging.python.org/en/latest/specifications/recording-installed-packages/
+
+# scikit-build-core handles metadata so only do this for non-wheel builds to avoid conflict
+if(NOT _wheel_build AND pyroot AND Python3_FOUND)
+  if(MSVC)
+    set(DISTINFO_INSTALL_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  else()
+    set(DISTINFO_INSTALL_DIR "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  endif()
+
+  configure_file("${CMAKE_SOURCE_DIR}/config/METADATA.in" "${DISTINFO_INSTALL_DIR}/root-${ROOT_VERSION}.dist-info/METADATA" @ONLY NEWLINE_STYLE UNIX)
+  file(WRITE "${DISTINFO_INSTALL_DIR}/root-${ROOT_VERSION}.dist-info/INSTALLER" "CMake")
+  install(DIRECTORY "${DISTINFO_INSTALL_DIR}/root-${ROOT_VERSION}.dist-info" DESTINATION "${CMAKE_INSTALL_PYTHONDIR}")
+endif()

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -192,6 +192,7 @@ option(roottest "Build roottest (implies testing=ON)" OFF)
 option(test_roofit_hs3testsuite "Setup and use the HS3 conformance test suite (requires network)" OFF)
 option(testing "Enable testing with CTest" OFF)
 option(asan "Build ROOT with address sanitizer instrumentation (only GCC is currently supported)" OFF)
+option(_wheel_build "ROOT is being packaged as a wheel, do not install .dist-info metadata" OFF)
 
 set(gcctoolchain "" CACHE PATH "Set path to GCC toolchain used to build llvm/clang")
 

--- a/config/METADATA.in
+++ b/config/METADATA.in
@@ -1,0 +1,3 @@
+Metadata-Version: 2.2
+Name: root
+Version: @ROOT_VERSION@

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ opengl="OFF"
 runtime_cxxmodules="ON"
 fail-on-missing="ON"
 
+# Prevent CMake from producing its own .dist-info metadata
+_wheel_build="ON"
+
 # Explicitly list components that gminimal implicitly turns off as documentation
 # tmva-pymva and tpython are disabled for manylinux compatibility
 # see https://peps.python.org/pep-0513/#libpythonx-y-so-1 

--- a/test/PostInstall/CMakeLists.txt
+++ b/test/PostInstall/CMakeLists.txt
@@ -36,5 +36,11 @@ if(BUILD_TESTING)
       PROPERTIES ENVIRONMENT PYTHONPATH=${ROOT_LIBRARY_DIR}
                  PASS_REGULAR_EXPRESSION "myHistoName"
     )
+    add_test(NAME python-package-metadata
+      COMMAND ${Python3_EXECUTABLE} -c "import importlib.metadata as meta, ROOT; meta.version(\"ROOT\")"
+    )
+    set_tests_properties(python-package-metadata
+      PROPERTIES ENVIRONMENT PYTHONPATH=${ROOT_LIBRARY_DIR}
+    )
   endif()
 endif()


### PR DESCRIPTION
# This Pull request:
Makes the ROOT Python import package compatible with `importlib.metadata`'s metadata system.
## Changes or fixes:
Adds a cmake module that places a METADATA and INSTALLER files inside a `root-<version>.dist-info` folder on the `PYTHONPATH`, which importlib.metadata can access to query e.g. distribution package version. <br>
This metadata is already present in the wheel distribution courtesy of the build backend, but is absent in all other ROOT distributions. `importlib.metadata.version()` [will throw an exception if called on a ROOT source build](https://github.com/root-project/root/blob/b15d1a8110550ee8cd67598aed6fbc5d1a377e27/bindings/pyroot/pythonizations/python/ROOT/__init__.py#L194), but works just fine for wheels. This PR's change standardizes this behavior.<br>

See https://packaging.python.org/en/latest/specifications/recording-installed-packages/ for python's official spec.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

