### PR TITLE
[ntuple] move fDirectIO inside fShared in RNTupleFileWriter

### DIFF
--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -156,9 +156,6 @@ private:
       /// aligned to kBlockAlign...
       static constexpr std::size_t kHeaderBlockSize = 4096;
 
-      /// Whether the C file stream has been opened with Direct I/O, introducing alignment requirements.
-      bool fDirectIO = false;
-
       /// Data that is shared between a "main" RImplSimple and all its clones.
       /// Note that only the main file will write the header and footer, while all the clones are only
       /// used to (sequentially) push data into the same underlying file from multiple locations.
@@ -169,6 +166,8 @@ private:
          std::uint64_t fFilePos = 0;
          /// Keeps track of the next key offset
          std::uint64_t fKeyOffset = 0;
+         /// Whether the C file stream has been opened with Direct I/O, introducing alignment requirements.
+         bool fDirectIO = false;
 
          // fHeaderBlock and fBlock are raw pointers because we have to manually call operator new and delete.
          unsigned char *fHeaderBlock = nullptr;

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -1045,7 +1045,7 @@ void ROOT::Internal::RNTupleFileWriter::RImplSimple::Flush()
 
    std::size_t lastBlockSize = shared.fFilePos - shared.fBlockOffset;
    R__ASSERT(lastBlockSize <= shared.fBlockSize);
-   if (fDirectIO) {
+   if (shared.fDirectIO) {
       // Round up to a multiple of kBlockAlign.
       lastBlockSize += kBlockAlign - 1;
       lastBlockSize = (lastBlockSize / kBlockAlign) * kBlockAlign;
@@ -1287,9 +1287,9 @@ ROOT::Internal::RNTupleFileWriter::Recreate(std::string_view ntupleName, std::st
    auto writer =
       std::unique_ptr<RNTupleFileWriter>(new RNTupleFileWriter(ntupleName, options.GetMaxKeySize(), /*hidden=*/false));
    RImplSimple &fileSimple = std::get<RImplSimple>(writer->fFile);
-   fileSimple.fDirectIO = options.GetUseDirectIO();
    fileSimple.AllocateBuffers(options.GetWriteBufferSize());
    fileSimple.fShared->fFile = fileStream;
+   fileSimple.fShared->fDirectIO = options.GetUseDirectIO();
    writer->fFileName = fileName;
 
    int defaultCompression = options.GetCompression();
@@ -1345,7 +1345,6 @@ ROOT::Internal::RNTupleFileWriter::CloneAsHidden(std::string_view ntupleName) co
          new RNTupleFileWriter(ntupleName, fNTupleAnchor.GetMaxKeySize(), /*hidden=*/true));
       auto &clonedFile = std::get<RImplSimple>(writer->fFile);
       clonedFile.fShared = file->fShared;
-      clonedFile.fDirectIO = file->fDirectIO;
       return writer;
    }
    // TODO: support also RFile-based writers


### PR DESCRIPTION
`fDirectIO` must always be synced among all clones and the main Writer.