### PR TITLE
[ci] Fix treatment of spaces in overrides

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -92,10 +92,17 @@ def main():
         build_utils.print_options_diff(options_dict, last_options)
 
     if args.overrides is not None:
-        overrides = ' '.join(args.overrides).split('@')
         print("Build option overrides from command line:")
         last_options = dict(options_dict)
-        options_dict.update((arg.split("=", maxsplit=1) for arg in overrides))
+        # `args.overrides` contains a list of ['key1=value1', 'key2=value2', ...]
+        # Neither keys nor values are allowed to contain whitespaces (as they get passed as separate arguments in
+        # that case).
+        # For cases where the value itself needs to have a space, we encode it as '@' in the yaml.
+        split_args = [arg.split("=", maxsplit=1) for arg in args.overrides]
+        for i in range(len(split_args)):
+            [k, v] = split_args[i]
+            split_args[i] = [k, v.replace('@', ' ')]
+        options_dict.update(split_args)
         build_utils.print_options_diff(options_dict, last_options)
 
     ctest_custom_flags = ""

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -156,7 +156,7 @@ jobs:
           HOME: /Users/sftnight
           INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') && !matrix.platform == 'mac15' && !matrix.platform == 'mac26'}}
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
-          OVERRIDES: ${{ join( matrix.overrides, '@') }}
+          OVERRIDES: ${{ join( matrix.overrides, ' ') }}
         run: |
           [ -d "${VIRTUAL_ENV_DIR}" ] && source ${VIRTUAL_ENV_DIR}/bin/activate
           echo "Python is now $(which python3) $(python3 --version)"
@@ -170,7 +170,7 @@ jobs:
                     --head_sha        ${{ github.event.pull_request.head.sha }}             \
                     --repository      ${{ github.server_url }}/${{ github.repository }}     \
                     --platform        ${{ matrix.platform }}                                \
-                    --overrides       "${GLOBAL_OVERRIDES}" "${OVERRIDES}"
+                    --overrides       ${GLOBAL_OVERRIDES} ${OVERRIDES}
 
       - name: Workflow dispatch
         if: ${{ github.event_name == 'workflow_dispatch' && !matrix.is_special }}
@@ -420,7 +420,7 @@ jobs:
             platform_config: alma10-minimal
             is_special: true
             property: "asan"
-            overrides: ["ROOT_CTEST_CUSTOM_FLAGS='-E \\(^tutorial-\\|cppinterop-CppInterOpTest\\|roottest-cling-specialobj-runf02$\\|roottest-root-collection-DeleteWarning$\\|roottest-root-io-evolution-fixarr2$\\|roottest-root-meta-rlibmap$\\|roottest-root-treeproxy-vectorint-vectorint$\\)'"]
+            overrides: ["ROOT_CTEST_CUSTOM_FLAGS=-E@\\(^tutorial-\\|cppinterop-CppInterOpTest\\|roottest-cling-specialobj-runf02$\\|roottest-root-collection-DeleteWarning$\\|roottest-root-io-evolution-fixarr2$\\|roottest-root-meta-rlibmap$\\|roottest-root-treeproxy-vectorint-vectorint$\\)"]
           # Fedora Rawhide with Python freethreading+debug build
           - image: rawhide
             python_venv: "/py-venv-3.15td/ROOT-CI"


### PR DESCRIPTION
Instead of passing a single @-separated argument to build_root.py --overrides, use @ to signify space in each key=value argument.

Partially undoes #22618