### PR TITLE
[UHI] Exclude TProfile2Poly from the UHI interface

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_th2.py
@@ -83,7 +83,9 @@ _th2_derived_classes_to_pythonize = [
     # "TH2PolyBin", Does not derive from TH2
     "TProfile2D",
     # "TProfile2PolyBin", Derives from TH2PolyBin which does not derive from TH2
-    "TProfile2Poly",
+    # "TProfile2Poly", # Like TH2Poly (its base), its bins are polygons addressed by a
+    #                  # single global bin number, not an (i, j) grid, so it does not fit
+    #                  # the rectangular UHI plotting/indexing model.
 ]
 
 for klass in _th2_derived_classes_to_pythonize:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_uhi/__init__.py
@@ -51,7 +51,6 @@ values_func_dict: dict[str, Callable] = {
     "TH3C": _values_by_copy,
     "TProfile": _values_by_copy,
     "TProfile2D": _values_by_copy,
-    "TProfile2Poly": _values_by_copy,
     "TProfile3D": _values_by_copy,
 }
 

--- a/bindings/pyroot/pythonizations/test/uhi_indexing.py
+++ b/bindings/pyroot/pythonizations/test/uhi_indexing.py
@@ -16,7 +16,7 @@ def _special_setting(hist):
     # For these classes, SetBinContent works differently than for other classes,
     # as in it does not set the bin content to the specified value, but does some other calculations
     # for that, these classes will be tested differently
-    return isinstance(hist, (ROOT.TProfile, ROOT.TProfile2D, ROOT.TProfile2Poly, ROOT.TProfile3D))
+    return isinstance(hist, (ROOT.TProfile, ROOT.TProfile2D, ROOT.TProfile3D))
 
 
 def _get_index_for_dimension(hist, index):

--- a/bindings/pyroot/pythonizations/test/uhi_plotting.py
+++ b/bindings/pyroot/pythonizations/test/uhi_plotting.py
@@ -12,9 +12,7 @@ from uhi.typing.plottable import PlottableHistogram
 
 def _not_writable(hist):
     # For these classes, the values() method always returns a copy so writable=True is not supported.
-    return isinstance(
-        hist, (ROOT.TH1C, ROOT.TH2C, ROOT.TH3C, ROOT.TProfile, ROOT.TProfile2D, ROOT.TProfile2Poly, ROOT.TProfile3D)
-    )
+    return isinstance(hist, (ROOT.TH1C, ROOT.TH2C, ROOT.TH3C, ROOT.TProfile, ROOT.TProfile2D, ROOT.TProfile3D))
 
 
 class TestTH1Plotting:


### PR DESCRIPTION
TProfile2Poly derives from TH2Poly, whose bins are polygons addressed by a single global bin number rather than an (i, j) grid. The UHI plotting and indexing pythonizations assume rectangular axes and access bins via the 2-D GetBinContent(i, j) / GetBinContent(*bin) overloads, which are not implemented for TH2Poly and only ever returned a dummy 0.

As a result UHI support for TProfile2Poly was silently meaningless: the indexing and plotting tests compared 0 against 0 and passed vacuously, and a grid-constructed TProfile2Poly has no addressable bins at all (`GetNumberOfBins() == 0`).

TH2Poly was already deliberately left out of the pythonized class list for this reason; TProfile2Poly had been included by oversight. and should also not be included.