### PR TITLE
[Python][CodeQL] Avoid explicitly returning a value from __init__

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooargset.py
@@ -40,8 +40,9 @@ class RooArgSet(RooAbsCollection):
                 FutureWarning,
                 stacklevel=2,
             )
-            return self._init(*args[0], **kwargs)
-        return self._init(*args, **kwargs)
+            self._init(*args[0], **kwargs)
+            return
+        self._init(*args, **kwargs)
 
     def __getitem__(self, key):
         import ROOT


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Minor cleanup: [CodeQL](https://github.com/root-project/root/security/quality/rules/py%2Fexplicit-return-in-init) flags explicit returns from `__init__` since Python raises `TypeError` if it returns anything other than `None`. `self._init` currently returns `None`, so there's no behavior change here 
