### PR TITLE
[webgui] remove experimental notice from comments

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/RAnyObjectHolder.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RAnyObjectHolder.hxx
@@ -19,7 +19,6 @@ namespace Browsable {
 \brief Holder of any object instance. Normally used with TFile, where any object can be read. Normally RShread or RUnique should be used
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RAnyObjectHolder : public RHolder {

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -28,7 +28,6 @@ class RItem;
 \brief Basic element of browsable hierarchy. Provides access to data, creates iterator if any
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RElement {

--- a/gui/browsable/inc/ROOT/Browsable/RGroup.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RGroup.hxx
@@ -19,7 +19,6 @@ namespace Browsable {
 \brief Group of browsable elements - combines several different elements together.
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-11-22
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RGroup : public RElement {

--- a/gui/browsable/inc/ROOT/Browsable/RHolder.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RHolder.hxx
@@ -27,7 +27,6 @@ namespace Browsable {
 \brief Basic class for object holder of any kind. Could be used to transfer shared_ptr or unique_ptr or plain pointer
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RHolder {

--- a/gui/browsable/inc/ROOT/Browsable/RLevelIter.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RLevelIter.hxx
@@ -23,7 +23,6 @@ class RItem;
 \brief Iterator over single level hierarchy like any array, keys list, ...
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RLevelIter {

--- a/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RProvider.hxx
@@ -30,7 +30,6 @@ namespace Browsable {
 \brief Provider of different browsing methods for supported classes
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-14
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 

--- a/gui/browsable/inc/ROOT/Browsable/RShared.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RShared.hxx
@@ -19,7 +19,6 @@ namespace Browsable {
 \brief Holder of with shared_ptr<T> instance. Should be used to transfer shared_ptr<T> in browsable methods
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 template<class T>

--- a/gui/browsable/inc/ROOT/Browsable/RUnique.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RUnique.hxx
@@ -19,7 +19,6 @@ namespace Browsable {
 \brief Holder of with unique_ptr<T> instance. Should be used to transfer unique_ptr<T> in browsable methods
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 template<class T>

--- a/gui/browsable/inc/ROOT/Browsable/RWrapper.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RWrapper.hxx
@@ -20,7 +20,6 @@ namespace Browsable {
 \brief Wrapper for other element - to provide different name
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-11-22
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RWrapper : public RElement {

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -23,7 +23,6 @@ namespace Browsable {
 \brief Access to TObject basic properties for RBrowsable
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-01-11
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 

--- a/gui/browsable/inc/ROOT/Browsable/TObjectHolder.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectHolder.hxx
@@ -19,7 +19,6 @@ namespace Browsable {
 \brief Holder of TObject instance. Should not be used very often, while ownership is undefined for it
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class TObjectHolder : public RHolder {

--- a/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectItem.hxx
@@ -21,7 +21,6 @@ namespace Browsable {
 \brief Representation of single item in the file browser for generic TObject object
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2019-10-19
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class TObjectItem : public RItem {

--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -36,7 +36,6 @@ using namespace std::string_literals;
 \brief Base class for provider of RNTuple drawing
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-09
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
 class RFieldProvider : public RProvider {

--- a/gui/browsable/src/RNTupleDraw6Provider.cxx
+++ b/gui/browsable/src/RNTupleDraw6Provider.cxx
@@ -19,8 +19,6 @@
 \brief Provider for RNTuple drawing on TCanvas
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2021-03-09
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is
-welcome!
 */
 
 class RNTupleDraw6Provider : public RProvider {

--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -9,8 +9,6 @@
 /// \file
 /// \author Sergey Linev <S.Linev@gsi.de>
 /// \date 2019-10-15
-/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
-/// is welcome!
 
 
 #include <ROOT/Browsable/RSysFile.hxx>

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -1,6 +1,5 @@
 // Authors: Bertrand Bellenot <bertrand.bellenot@cern.ch> Sergey Linev <S.Linev@gsi.de>
 // Date: 2019-02-28
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2019-10-14
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserGeomWidget.cxx
+++ b/gui/browserv7/src/RBrowserGeomWidget.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-01-22
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-01-25
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-01-25
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserTreeWidget.cxx
+++ b/gui/browserv7/src/RBrowserTreeWidget.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2022-10-07
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserWidget.cxx
+++ b/gui/browserv7/src/RBrowserWidget.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-01-22
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-01-22
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RFileDialog.cxx
+++ b/gui/browserv7/src/RFileDialog.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2019-10-31
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/gui/browserv7/src/RWebBrowserImp.cxx
+++ b/gui/browserv7/src/RWebBrowserImp.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2021-02-11
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
+++ b/gui/cefdisplay/inc/RCefWebDisplayHandle.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2020-08-21
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/inc/gui_handler.h
+++ b/gui/cefdisplay/inc/gui_handler.h
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/inc/simple_app.h
+++ b/gui/cefdisplay/inc/simple_app.h
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 // Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that

--- a/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
+++ b/gui/cefdisplay/src/RCefWebDisplayHandle.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2020-08-21
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/src/cef_main.cxx
+++ b/gui/cefdisplay/src/cef_main.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 // Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that

--- a/gui/cefdisplay/src/gui_handler.cxx
+++ b/gui/cefdisplay/src/gui_handler.cxx
@@ -1,7 +1,6 @@
 /// \file gui_handler.cxx
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/src/gui_handler_linux.cxx
+++ b/gui/cefdisplay/src/gui_handler_linux.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/src/gui_handler_mac.mm
+++ b/gui/cefdisplay/src/gui_handler_mac.mm
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/cefdisplay/src/gui_handler_win.cc
+++ b/gui/cefdisplay/src/gui_handler_win.cc
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 // Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that

--- a/gui/cefdisplay/src/simple_app.cxx
+++ b/gui/cefdisplay/src/simple_app.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 // Copyright (c) 2013 The Chromium Embedded Framework Authors. All rights
 // reserved. Use of this source code is governed by a BSD-style license that

--- a/gui/qt6webdisplay/rootqt6.cpp
+++ b/gui/qt6webdisplay/rootqt6.cpp
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt6webdisplay/rooturlschemehandler.cpp
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rooturlschemehandler.h
+++ b/gui/qt6webdisplay/rooturlschemehandler.h
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rootwebpage.cpp
+++ b/gui/qt6webdisplay/rootwebpage.cpp
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rootwebpage.h
+++ b/gui/qt6webdisplay/rootwebpage.h
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rootwebview.cpp
+++ b/gui/qt6webdisplay/rootwebview.cpp
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/qt6webdisplay/rootwebview.h
+++ b/gui/qt6webdisplay/rootwebview.h
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <S.Linev@gsi.de>
 // Date: 2017-06-29
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2018-10-24
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -10,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RWebDisplayArgs
-#define ROOT7_RWebDisplayArgs
+#ifndef ROOT_RWebDisplayArgs
+#define ROOT_RWebDisplayArgs
 
 #include <string>
 #include <memory>

--- a/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayHandle.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2018-10-17
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -10,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RWebDisplayHandle
-#define ROOT7_RWebDisplayHandle
+#ifndef ROOT_RWebDisplayHandle
+#define ROOT_RWebDisplayHandle
 
 #include <ROOT/RWebDisplayArgs.hxx>
 

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2017-10-16
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -10,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RWebWindow
-#define ROOT7_RWebWindow
+#ifndef ROOT_RWebWindow
+#define ROOT_RWebWindow
 
 #include <ROOT/RWebDisplayHandle.hxx>
 

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2017-10-16
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -10,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RWebWindowsManager
-#define ROOT7_RWebWindowsManager
+#ifndef ROOT_RWebWindowsManager
+#define ROOT_RWebWindowsManager
 
 #include <memory>
 #include <string>

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2018-10-24
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2018-10-17
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/gui/webdisplay/src/RWebWindow.cxx
+++ b/gui/webdisplay/src/RWebWindow.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2017-10-16
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/gui/webdisplay/src/RWebWindowWSHandler.hxx
+++ b/gui/webdisplay/src/RWebWindowWSHandler.hxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2018-08-20
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
@@ -10,8 +9,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT7_RWebWindowWSHandler
-#define ROOT7_RWebWindowWSHandler
+#ifndef ROOT_RWebWindowWSHandler
+#define ROOT_RWebWindowWSHandler
 
 #include "THttpWSHandler.h"
 #include "TEnv.h"

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -1,6 +1,5 @@
 // Author: Sergey Linev <s.linev@gsi.de>
 // Date: 2017-10-16
-// Warning: This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *


### PR DESCRIPTION
While webdisplay and RBrowser classes already moved out from `Experimental` namespace,
one can also remove correspondent comments.

Some of the classes already 9 years old.