### PR TITLE
Add Aaron to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 # Coarse-grained ownership
 * @dpiparo
 /bindings/ @guitargeek @vepadulano
+/bindings/pyroot/cppyy @aaronj0 @guitargeek
 /core/ @dpiparo @pcanal
 /documentation/ @couet @dpiparo
 /fonts/ @bellenot @linev
@@ -23,7 +24,8 @@
 /icons/ @bellenot @linev
 /interpreter/ @dpiparo @hahnjo
 /interpreter/llvm-project/ @vgvassilev @hahnjo
-interpreter/cling/tools/packaging @vgvassilev @hahnjo
+/interpreter/cling/tools/packaging/ @vgvassilev @hahnjo
+/interpreter/CppInterOp/ @aaronj0 @vgvassilev
 /io/ @pcanal @jblomer
 /io/xml/ @pcanal @linev
 /main/ @pcanal @dpiparo


### PR DESCRIPTION
Add Aaron to codeowners so he gets automatic review requests.

Also, make the formatting of paths consistent by always including the leading slash (`/`).