### PR TITLE
[Minuit2] Code modernization

### DIFF
--- a/math/minuit2/inc/Minuit2/ContoursError.h
+++ b/math/minuit2/inc/Minuit2/ContoursError.h
@@ -31,11 +31,7 @@ public:
    {
    }
 
-   ContoursError(const ContoursError &cont)
-      : fParX(cont.fParX), fParY(cont.fParY), fPoints(cont.fPoints), fXMinos(cont.fXMinos), fYMinos(cont.fYMinos),
-        fNFcn(cont.fNFcn)
-   {
-   }
+   ContoursError(const ContoursError &cont) = default;
 
    ContoursError &operator()(const ContoursError &cont)
    {

--- a/math/minuit2/inc/Minuit2/MinosError.h
+++ b/math/minuit2/inc/Minuit2/MinosError.h
@@ -32,10 +32,7 @@ public:
    {
    }
 
-   MinosError(const MinosError &err)
-      : fParameter(err.fParameter), fMinParValue(err.fMinParValue), fUpper(err.fUpper), fLower(err.fLower)
-   {
-   }
+   MinosError(const MinosError &err) = default;
 
    MinosError &operator=(const MinosError &) = default;
 

--- a/math/minuit2/inc/Minuit2/MinuitParameter.h
+++ b/math/minuit2/inc/Minuit2/MinuitParameter.h
@@ -66,29 +66,9 @@ public:
       }
    }
 
-   MinuitParameter(const MinuitParameter &par)
-      : fNum(par.fNum), fValue(par.fValue), fError(par.fError), fConst(par.fConst), fFix(par.fFix),
-        fLoLimit(par.fLoLimit), fUpLimit(par.fUpLimit), fLoLimValid(par.fLoLimValid), fUpLimValid(par.fUpLimValid),
-        fName(par.fName)
-   {
-   }
+   MinuitParameter(const MinuitParameter &par) = default;
 
-   MinuitParameter &operator=(const MinuitParameter &par)
-   {
-      if (this != &par) {
-         fNum = par.fNum;
-         fName = par.fName;
-         fValue = par.fValue;
-         fError = par.fError;
-         fConst = par.fConst;
-         fFix = par.fFix;
-         fLoLimit = par.fLoLimit;
-         fUpLimit = par.fUpLimit;
-         fLoLimValid = par.fLoLimValid;
-         fUpLimValid = par.fUpLimValid;
-      }
-      return *this;
-   }
+   MinuitParameter &operator=(const MinuitParameter &par) = default;
 
    // access methods
    unsigned int Number() const { return fNum; }

--- a/math/minuit2/inc/Minuit2/MnCross.h
+++ b/math/minuit2/inc/Minuit2/MnCross.h
@@ -64,11 +64,7 @@ public:
    {
    }
 
-   MnCross(const MnCross &cross)
-      : fValue(cross.fValue), fState(cross.fState), fNFcn(cross.fNFcn), fValid(cross.fValid), fLimset(cross.fLimset),
-        fMaxFcn(cross.fMaxFcn), fNewMin(cross.fNewMin)
-   {
-   }
+   MnCross(const MnCross &cross) = default;
 
    MnCross &operator=(const MnCross &) = default;
 

--- a/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
@@ -44,11 +44,11 @@ public:
    {
    }
 
-   MnFumiliMinimize(const MnFumiliMinimize &migr)
-      : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer),
-        fFCN(migr.Fcnbase())
-   {
-   }
+   /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
+   MnFumiliMinimize(const MnFumiliMinimize &) = default;
+
+   // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
+   MnFumiliMinimize &operator=(const MnFumiliMinimize &) = delete;
 
    FumiliMinimizer &Minimizer() override { return fMinimizer; }
    const FumiliMinimizer &Minimizer() const override { return fMinimizer; }
@@ -61,10 +61,6 @@ public:
 private:
    FumiliMinimizer fMinimizer;
    const FumiliFCNBase &fFCN;
-
-private:
-   // forbidden assignment of migrad (const FumiliFCNBase& = )
-   MnFumiliMinimize &operator=(const MnFumiliMinimize &) { return *this; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MnGlobalCorrelationCoeff.h
+++ b/math/minuit2/inc/Minuit2/MnGlobalCorrelationCoeff.h
@@ -25,7 +25,7 @@ namespace Minuit2 {
 class MnGlobalCorrelationCoeff {
 
 public:
-   MnGlobalCorrelationCoeff() : fGlobalCC(std::vector<double>()), fValid(false) {}
+   MnGlobalCorrelationCoeff() : fValid(false) {}
 
    MnGlobalCorrelationCoeff(const MnAlgebraicSymMatrix &);
 

--- a/math/minuit2/inc/Minuit2/MnMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnMinimize.h
@@ -36,20 +36,17 @@ public:
    {
    }
 
-   MnMinimize(const MnMinimize &migr)
-      : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer)
-   {
-   }
+   /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
+   MnMinimize(const MnMinimize &) = default;
+
+   // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
+   MnMinimize &operator=(const MnMinimize &) = delete;
 
    ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
    const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
 private:
    CombinedMinimizer fMinimizer;
-
-private:
-   // forbidden assignment operator
-   MnMinimize &operator=(const MnMinimize &) { return *this; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MnScan.h
+++ b/math/minuit2/inc/Minuit2/MnScan.h
@@ -39,10 +39,11 @@ public:
    {
    }
 
-   MnScan(const MnScan &migr)
-      : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer)
-   {
-   }
+   /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
+   MnScan(const MnScan &) = default;
+
+   // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
+   MnScan &operator=(const MnScan &) = delete;
 
    ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
    const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
@@ -52,9 +53,6 @@ public:
 
 private:
    ScanMinimizer fMinimizer;
-
-   /// forbidden assignment (const FCNBase& = )
-   MnScan &operator=(const MnScan &) { return *this; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MnSimplex.h
+++ b/math/minuit2/inc/Minuit2/MnSimplex.h
@@ -41,20 +41,17 @@ public:
    {
    }
 
-   MnSimplex(const MnSimplex &migr)
-      : MnApplication(migr.Fcnbase(), migr.State(), migr.Strategy(), migr.NumOfCalls()), fMinimizer(migr.fMinimizer)
-   {
-   }
+   /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
+   MnSimplex(const MnSimplex &) = default;
+
+   // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
+   MnSimplex &operator=(const MnSimplex &) = delete;
 
    ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
    const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
 private:
    SimplexMinimizer fMinimizer;
-
-private:
-   // forbidden assignment of migrad (const FCNBase& = )
-   MnSimplex &operator=(const MnSimplex &) { return *this; }
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/MnUserCovariance.h
+++ b/math/minuit2/inc/Minuit2/MnUserCovariance.h
@@ -65,8 +65,8 @@ public:
 
    void Scale(double f)
    {
-      for (unsigned int i = 0; i < fData.size(); i++)
-         fData[i] *= f;
+      for (double &x : fData)
+         x *= f;
    }
 
    const std::vector<double> &Data() const { return fData; }

--- a/math/minuit2/inc/Minuit2/MnUserParameterState.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameterState.h
@@ -36,15 +36,7 @@ class MnUserParameterState {
 
 public:
    /// default constructor (invalid state)
-   MnUserParameterState()
-      : fValid(false),
-        fCovStatus(-1),
-        fParameters(MnUserParameters()),
-        fCovariance(MnUserCovariance()),
-        fIntParameters(std::vector<double>()),
-        fIntCovariance(MnUserCovariance())
-   {
-   }
+   MnUserParameterState() : fValid(false), fCovStatus(-1) {}
 
    /// construct from user parameters (before minimization)
    MnUserParameterState(std::span<const double>, std::span<const double>);

--- a/math/minuit2/inc/Minuit2/MnUserParameters.h
+++ b/math/minuit2/inc/Minuit2/MnUserParameters.h
@@ -36,17 +36,13 @@ class MnMachinePrecision;
 class MnUserParameters {
 
 public:
-   MnUserParameters() : fTransformation(MnUserTransformation()) {}
+   MnUserParameters() = default;
 
    MnUserParameters(std::span<const double>, std::span<const double>);
 
-   MnUserParameters(const MnUserParameters &par) : fTransformation(par.fTransformation) {}
+   MnUserParameters(const MnUserParameters &par) = default;
 
-   MnUserParameters &operator=(const MnUserParameters &par)
-   {
-      fTransformation = par.fTransformation;
-      return *this;
-   }
+   MnUserParameters &operator=(const MnUserParameters &par) = default;
 
    const MnUserTransformation &Trafo() const { return fTransformation; }
 

--- a/math/minuit2/inc/Minuit2/MnUserTransformation.h
+++ b/math/minuit2/inc/Minuit2/MnUserTransformation.h
@@ -38,36 +38,13 @@ class MnUserCovariance;
 class MnUserTransformation {
 
 public:
-   MnUserTransformation()
-      : fPrecision(MnMachinePrecision()), fParameters(std::vector<MinuitParameter>()),
-        fExtOfInt(std::vector<unsigned int>()), fDoubleLimTrafo(SinParameterTransformation()),
-        fUpperLimTrafo(SqrtUpParameterTransformation()), fLowerLimTrafo(SqrtLowParameterTransformation()),
-        fCache(std::vector<double>())
-   {
-   }
+   MnUserTransformation() = default;
 
    MnUserTransformation(std::span<const double>, std::span<const double>);
 
-   MnUserTransformation(const MnUserTransformation &trafo)
-      : fPrecision(trafo.fPrecision), fParameters(trafo.fParameters), fExtOfInt(trafo.fExtOfInt),
-        fDoubleLimTrafo(trafo.fDoubleLimTrafo), fUpperLimTrafo(trafo.fUpperLimTrafo),
-        fLowerLimTrafo(trafo.fLowerLimTrafo), fCache(trafo.fCache)
-   {
-   }
+   MnUserTransformation(const MnUserTransformation &trafo) = default;
 
-   MnUserTransformation &operator=(const MnUserTransformation &trafo)
-   {
-      if (this != &trafo) {
-         fPrecision = trafo.fPrecision;
-         fParameters = trafo.fParameters;
-         fExtOfInt = trafo.fExtOfInt;
-         fDoubleLimTrafo = trafo.fDoubleLimTrafo;
-         fUpperLimTrafo = trafo.fUpperLimTrafo;
-         fLowerLimTrafo = trafo.fLowerLimTrafo;
-         fCache = trafo.fCache;
-      }
-      return *this;
-   }
+   MnUserTransformation &operator=(const MnUserTransformation &trafo) = default;
 
    //#ifdef MINUIT2_THREAD_SAFE
    // thread-safe version (do not use cache)

--- a/math/minuit2/src/FumiliStandardChi2FCN.cxx
+++ b/math/minuit2/src/FumiliStandardChi2FCN.cxx
@@ -64,8 +64,6 @@ void FumiliStandardChi2FCN::EvaluateAll(std::vector<double> const &par)
    std::vector<double> &h = Hessian();
    int npar = par.size();
    double chi2 = 0;
-   grad.resize(npar);
-   h.resize(static_cast<unsigned int>(0.5 * npar * (npar + 1)));
    // reset Elements
    grad.assign(npar, 0.0);
    h.assign(static_cast<unsigned int>(0.5 * npar * (npar + 1)), 0.0);

--- a/math/minuit2/src/FumiliStandardMaximumLikelihoodFCN.cxx
+++ b/math/minuit2/src/FumiliStandardMaximumLikelihoodFCN.cxx
@@ -68,8 +68,6 @@ void FumiliStandardMaximumLikelihoodFCN::EvaluateAll(std::vector<double> const &
    std::vector<double> &h = Hessian();
    int npar = par.size();
    double logLikelihood = 0;
-   grad.resize(npar);
-   h.resize(static_cast<unsigned int>(0.5 * npar * (npar + 1)));
    grad.assign(npar, 0.0);
    h.assign(static_cast<unsigned int>(0.5 * npar * (npar + 1)), 0.0);
 

--- a/math/minuit2/src/NegativeG2LineSearch.cxx
+++ b/math/minuit2/src/NegativeG2LineSearch.cxx
@@ -144,11 +144,8 @@ bool NegativeG2LineSearch::HasNegativeG2(const FunctionGradient &grad, const MnM
    // check if function gradient has any component which is negative
 
    for (unsigned int i = 0; i < grad.Vec().size(); i++)
-
-      if (grad.G2()(i) <= 0) {
-
+      if (grad.G2()(i) <= 0)
          return true;
-      }
 
    return false;
 }


### PR DESCRIPTION
  * Change verbose hand-written constructors and copy assignments to `default` or `delete` where possible
  * The four MnApplication subclasses made consistent with MnMigrad (which was already modernized): defaulted copy ctor + = deleted assignment, dropping the hand-written copy ctor and the duplicated private: section.
  * Redundant initializers and minor loop cleanups