### PR TITLE
Use different output filenames in tests pdftitle.cxx and pdfurl.cxx

### DIFF
--- a/graf2d/gpad/test/pdftitle.cxx
+++ b/graf2d/gpad/test/pdftitle.cxx
@@ -5,7 +5,7 @@
 
 TEST(TPad, PDFTitle)
 {
-    const TString pdfFile = "output.pdf";
+    const TString pdfFile = "pdftitle.pdf";
 
     // Generate a multi-page PDF with a title
     TCanvas c;

--- a/graf2d/gpad/test/pdfurl.cxx
+++ b/graf2d/gpad/test/pdfurl.cxx
@@ -6,7 +6,7 @@
 
 TEST(TPad, PDFUrl)
 {
-   const TString pdfFile = "output.pdf";
+   const TString pdfFile = "pdfurl.pdf";
 
    // Generate a multi-page PDF with page titles and #url in TLatex
    TCanvas c1;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This avoids failures when one test overwrites the other's output:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from TPad
[ RUN      ] TPad.PDFUrl
ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'TCanvas::Print':
pdf file output.pdf has been created
ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'TCanvas::Print':
Current canvas added to pdf file output.pdf
ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'TCanvas::Print':
Current canvas added to pdf file output.pdf
ROOT::TestSupport::ForbidDiagnostics::handler(): Diagnostic in 'TCanvas::Print':
pdf file output.pdf has been closed
/builddir/build/BUILD/root-6.40.02/graf2d/gpad/test/pdfurl.cxx:33: Failure
Expected equality of these values:
  statCode
    Which is: 1
  0
PDF file was not created.
[  FAILED  ] TPad.PDFUrl (373 ms)
[----------] 1 test from TPad (373 ms total)
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (374 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TPad.PDFUrl
 1 FAILED TEST
```
## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

