### PR TITLE
Test fixes

### DIFF
--- a/tree/dataframe/test/dataframe_hist.cxx
+++ b/tree/dataframe/test/dataframe_hist.cxx
@@ -31,6 +31,9 @@ public:
    RDFHist()
    {
       fDiag.optionalDiag(kWarning, "", "Filling RHist is experimental", /*matchFullMessage=*/false);
+      fDiag.optionalDiag(kWarning, "cling",
+                         "expected alignment (8 bytes) exceeds the actual alignment (4 bytes) [-Watomic-alignment]",
+                         false);
       if (GetParam())
          ROOT::EnableImplicitMT(4);
    }

--- a/tree/ntuple/test/ntuple_modelext.cxx
+++ b/tree/ntuple/test/ntuple_modelext.cxx
@@ -810,12 +810,12 @@ TEST(RNTuple, ModelExtensionRecordNested)
       modelUpdater->AddField(std::make_unique<RField<double>>("ptHP"), "r1.r2.r3.r4");
       modelUpdater->CommitUpdate();
 
-      EXPECT_EQ(2 * sizeof(double), writer->GetModel().GetConstField("r1").GetValueSize());
-      entry = writer->CreateEntry();
       struct FloatAndDouble {
          float pt;
          double ptHP;
       };
+      EXPECT_EQ(sizeof(FloatAndDouble), writer->GetModel().GetConstField("r1").GetValueSize());
+      entry = writer->CreateEntry();
 
       auto ptrFloatAndDouble = static_cast<FloatAndDouble *>(entry->GetPtr<void>("r1").get());
       ptrFloatAndDouble->pt = 2.0;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

* The old TUUID constructor can create either version 1 or 3
  Do not fail test if version 3 is returned.

* Do not fail test on 32 bit due to mis-aligned atomic

* Compare size to the size of the struct
  Do not assume it is 2 * sizeof(double), which is not true on 32 bit.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

