### PR TITLE
[rootx] Stop generating rootx's cmdline help via argparse2help.py

### DIFF
--- a/core/base/res/TApplicationCmdlineHelp.h
+++ b/core/base/res/TApplicationCmdlineHelp.h
@@ -1,0 +1,37 @@
+constexpr static const char *kCommandLineOptionsHelp = R"RAW(
+usage: root [-b] [-x] [-e] [-n] [-t] [-q] [-l] [-config] [-h|--help] [--version]
+            [--notebook] [--web=<type|off>] [dir] [data1.root...dataN.root] [file1.C...fileN.C]
+            [file1_C.so...fileN_C.so] [anyfile1..anyfileN] [-- [macro args]]
+
+
+root is an interactive interpreter of C++ code using Cling and the ROOT framework.
+For more information on ROOT, please refer to https://root.cern/
+An extensive Users Guide and API Reference are available from that website.
+
+
+OPTIONS:
+  -b, --batch                          Run in batch mode without graphics
+  -x, --exit-on-exceptions             Exit on exceptions
+  -e, --execute                        Execute the command passed between single quotes
+  -n, --no-logon-logoff                Do not execute logon and logoff macros as specified in .rootrc
+  -t, --enable-threading               Enable thread-safety and implicit multi-threading (IMT)
+  -q, --quit-after-processing          Exit after processing command line macro files
+  -l, --no-banner                      Do not show the ROOT banner
+  -config                              print ./configure options
+  -h, -?, --help                       Show summary of options
+  --version                            Show the ROOT version
+  --notebook                           Execute ROOT notebook
+  --web                                Use web-based display for graphics, browser, geometry [deprecated, use "web=on" instead]
+  --web=<type>                         Use the specified web-based display such as chrome, firefox, qt6
+                                       For more options see the documentation of TROOT::SetWebDisplay()
+  --web=off                            Disable any kind of web-based display
+  [dir]                                if dir is a valid directory cd to it before executing
+  [data1.root...dataN.root]            Open the given ROOT files; remote protocols (such as http://) are supported
+  [file1.C...fileN.C]                  Execute the ROOT macro file1.C ... fileN.C
+                                       Compilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/
+  [file1_C.so...fileN_C.so]            Load and execute file1_C.so ... fileN_C.so (or .dll if on Windows)
+                                       They should be already-compiled ROOT macros (shared libraries) or:
+                                       regular user shared libraries e.g. userlib.so with a function userlib(args)
+  [anyfile1..anyfileN]                 All other arguments pointing to existing files will be checked to see if they are ROOT Files (checking the MIME type inside the file) and if they are not they will be handled as a ROOT macro file
+  [-- [macro args]]                    Any arguments after a `--` will be treated as arguments to the last macro passed as a positional argument (e.g. `root myMacro.C -- 1 2 3` will be equivalent to `root "myMacro.C(1,2,3)"`)
+)RAW";

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -50,45 +50,7 @@ TApplication (see TRint).
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
-
-// TODO: deduplicate this with rootx.cxx
-constexpr static const char *kCommandLineOptionsHelp = R"RAW(
-usage: root [-b] [-x] [-e] [-n] [-t] [-q] [-l] [-config] [-h|--help] [--version]
-            [--notebook] [--web=<type|off>] [dir] [data1.root...dataN.root] [file1.C...fileN.C]
-            [file1_C.so...fileN_C.so] [anyfile1..anyfileN] [-- [macro args]]
-
-
-root is an interactive interpreter of C++ code using Cling and the ROOT framework.
-For more information on ROOT, please refer to https://root.cern/
-An extensive Users Guide and API Reference are available from that website.
-
-
-OPTIONS:
-  -b, --batch                          Run in batch mode without graphics
-  -x, --exit-on-exceptions             Exit on exceptions
-  -e, --execute                        Execute the command passed between single quotes
-  -n, --no-logon-logoff                Do not execute logon and logoff macros as specified in .rootrc
-  -t, --enable-threading               Enable thread-safety and implicit multi-threading (IMT)
-  -q, --quit-after-processing          Exit after processing command line macro files
-  -l, --no-banner                      Do not show the ROOT banner
-  -config                              print ./configure options
-  -h, -?, --help                       Show summary of options
-  --version                            Show the ROOT version
-  --notebook                           Execute ROOT notebook
-  --web                                Use web-based display for graphics, browser, geometry [deprecated, use "web=on" instead]
-  --web=<type>                         Use the specified web-based display such as chrome, firefox, qt6
-                                       For more options see the documentation of TROOT::SetWebDisplay()
-  --web=off                            Disable any kind of web-based display
-  [dir]                                if dir is a valid directory cd to it before executing
-  [data1.root...dataN.root]            Open the given ROOT files; remote protocols (such as http://) are supported
-  [file1.C...fileN.C]                  Execute the ROOT macro file1.C ... fileN.C
-                                       Compilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/
-  [file1_C.so...fileN_C.so]            Load and execute file1_C.so ... fileN_C.so (or .dll if on Windows)
-                                       They should be already-compiled ROOT macros (shared libraries) or:
-                                       regular user shared libraries e.g. userlib.so with a function userlib(args)
-  [anyfile1..anyfileN]                 All other arguments pointing to existing files will be checked to see if they are ROOT Files (checking the MIME type inside the file) and if they are not they will be handled as a ROOT macro file
-  [-- [macro args]]                    Any arguments after a `--` will be treated as arguments to the last macro passed as a positional argument (e.g. `root myMacro.C -- 1 2 3` will be equivalent to `root "myMacro.C(1,2,3)"`)
-)RAW";
+#include "../res/TApplicationCmdlineHelp.h"
 
 TApplication *gApplication = nullptr;
 Bool_t TApplication::fgGraphNeeded = kFALSE;

--- a/rootx/CMakeLists.txt
+++ b/rootx/CMakeLists.txt
@@ -15,14 +15,10 @@ if (CMAKE_SYSTEM_NAME MATCHES FreeBSD)
   target_link_libraries(root PRIVATE util procstat)
 endif()
 
-generateHeader(root
-  ${CMAKE_SOURCE_DIR}/core/base/src/root-argparse.py
-  ${CMAKE_BINARY_DIR}/ginclude/rootCommandLineOptionsHelp.h
-)
-
 target_include_directories(root PRIVATE
   ${CMAKE_SOURCE_DIR}/core/foundation/inc
   ${CMAKE_SOURCE_DIR}/core/base/inc
+  ${CMAKE_SOURCE_DIR}/core/base/res
   ${CMAKE_SOURCE_DIR}/core/clib/inc    # for snprintf.h
   ${CMAKE_SOURCE_DIR}/core/meta/inc    # for TGenericClassInfo.h
   ${CMAKE_BINARY_DIR}/ginclude         # for RConfigure.h and rootCommandLineOptionsHelp.h

--- a/rootx/src/rootx.cxx
+++ b/rootx/src/rootx.cxx
@@ -14,7 +14,7 @@
 #include "RConfigure.h"
 #include "Rtypes.h"
 #include "snprintf.h"
-#include "rootCommandLineOptionsHelp.h"
+#include "TApplicationCmdlineHelp.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -153,11 +153,6 @@ static void WaitChild()
    exit(0);
 }
 
-static void PrintUsage()
-{
-   fprintf(stderr, kCommandLineOptionsHelp);
-}
-
 int main(int argc, char **argv)
 {
    char **argvv;
@@ -184,7 +179,7 @@ int main(int argc, char **argv)
    for (i = 1; i < argc; i++) {
       if (!strcmp(argv[i], "-?") || !strncmp(argv[i], "-h", 2) ||
           !strncmp(argv[i], "--help", 6)) {
-         PrintUsage();
+         fprintf(stderr, kCommandLineOptionsHelp);
          return 0;
       }
    }


### PR DESCRIPTION
The help message of `rootx` is now shared with `TApplication`, since it's effectively the same.

`root-argparse.py` can *almost* be removed now, but it is still needed to generate the manual page.