### PR TITLE
[cling] Desugar UsingType in GetFullyQualifiedType

### DIFF
--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -1725,8 +1725,8 @@ namespace utils {
 
     // We don't consider the alias introduced by `using a::X` as a new type.
     // The qualified name is still a::X.
-    if (const auto* UT = QT->getAs<UsingType>()) {
-      QT = Ctx.getQualifiedType(UT->getUnderlyingType(), prefix_qualifiers);
+    if (QT->getAs<UsingType>()) {
+      QT = Ctx.getQualifiedType(QT.getCanonicalType(), prefix_qualifiers);
       return GetFullyQualifiedType(QT, Ctx);
     }
 

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -1722,6 +1722,14 @@ namespace utils {
       }
       QT = etype_input->getNamedType();
     }
+
+    // We don't consider the alias introduced by `using a::X` as a new type.
+    // The qualified name is still a::X.
+    if (const auto* UT = QT->getAs<UsingType>()) {
+      QT = Ctx.getQualifiedType(UT->getUnderlyingType(), prefix_qualifiers);
+      return GetFullyQualifiedType(QT, Ctx);
+    }
+
     if (prefix == nullptr) {
       // Create a nested name specifier if needed (i.e. if the decl context
       // is not the global scope.

--- a/roottest/root/meta/naming/execResolveTypedef.cxx
+++ b/roottest/root/meta/naming/execResolveTypedef.cxx
@@ -225,7 +225,7 @@ int execResolveTypedef()
 
    testing("unsigned int", TClassEdit::ResolveTypedef("SG::sgkey_t"));
    testing("unsigned int", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetTrueTypeName());
-   testing("uint32_t", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetFullTypeName());
+   testing("unsigned int", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetFullTypeName());
    testing("RT::EX::ClusterSize", TClassEdit::ResolveTypedef("RT::EX::ClusterSize_t"));
    return 0;
 }

--- a/roottest/root/meta/naming/execResolveTypedef.cxx
+++ b/roottest/root/meta/naming/execResolveTypedef.cxx
@@ -225,7 +225,7 @@ int execResolveTypedef()
 
    testing("unsigned int", TClassEdit::ResolveTypedef("SG::sgkey_t"));
    testing("unsigned int", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetTrueTypeName());
-   testing("SG::sgkey_t", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetFullTypeName());
+   testing("uint32_t", TClass::GetClass("PackedParameters")->GetDataMember("m_sgkey")->GetFullTypeName());
    testing("RT::EX::ClusterSize", TClassEdit::ResolveTypedef("RT::EX::ClusterSize_t"));
    return 0;
 }

--- a/roottest/root/meta/naming/execResolveTypedef.ref
+++ b/roottest/root/meta/naming/execResolveTypedef.ref
@@ -85,6 +85,6 @@ Test 82 The result is correct: ::SomeTypedefName_tSF
 Test 83 The result is correct: ::int
 Test 84 The result is correct: unsigned int
 Test 85 The result is correct: unsigned int
-Test 86 The result is correct: SG::sgkey_t
+Test 86 The result is correct: uint32_t
 Test 87 The result is correct: RT::EX::ClusterSize
 (int) 0

--- a/roottest/root/meta/naming/execResolveTypedef.ref
+++ b/roottest/root/meta/naming/execResolveTypedef.ref
@@ -85,6 +85,6 @@ Test 82 The result is correct: ::SomeTypedefName_tSF
 Test 83 The result is correct: ::int
 Test 84 The result is correct: unsigned int
 Test 85 The result is correct: unsigned int
-Test 86 The result is correct: uint32_t
+Test 86 The result is correct: unsigned int
 Test 87 The result is correct: RT::EX::ClusterSize
 (int) 0


### PR DESCRIPTION
The change in getFullyQualifiedType() in the commit https://github.com/llvm/llvm-project/commit/af27466 added explicit desugaring of UsingType:

```
  if (isa<UsingType>(QT.getTypePtr())) {
    return getFullyQualifiedType(QT.getSingleStepDesugaredType(Ctx), Ctx,
                                 WithGlobalNsPrefix);
  }
```

This has been there since LLVM14 and we could disentagle this from the upgrade to LLVM22.

This will cause `SG::sgkey_t` to be resolved to its underlying type `uint32_t` when GetFullTypeName() is called, rather than preserving the typedef alias name as before.

This test was added in: https://github.com/root-project/root/pull/19615, should fix: https://github.com/root-project/root/issues/12698

This will be the default behaviour (in LLVM22) after https://github.com/root-project/root/pull/21658. So decoupling this change from the upgrade here.

# This Pull request:

## Changes or fixes:

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

