### PR TITLE
[io] consistently use TNetXNGFile ^[x]?root[s]?:// URLs

### DIFF
--- a/etc/plugins/ROOT@@Internal@@RRawFile/P020_RRawFileNetXNG.C
+++ b/etc/plugins/ROOT@@Internal@@RRawFile/P020_RRawFileNetXNG.C
@@ -2,7 +2,7 @@ void P020_RRawFileNetXNG()
 {
    gPluginMgr->AddHandler(
       "ROOT::Internal::RRawFile",
-      "^root[s]?:",
+      "^[x]?root[s]?:",
       "ROOT::Internal::RRawFileNetXNG",
       "NetxNG",
       "RRawFileNetXNG(std::string_view, ROOT::Internal::RRawFile::ROptions)");

--- a/etc/plugins/TFile/P100_TXNetFile.C
+++ b/etc/plugins/TFile/P100_TXNetFile.C
@@ -1,5 +1,5 @@
 void P100_TXNetFile()
 {
-   gPluginMgr->AddHandler("TFile", "^[x]?root:", "TNetXNGFile",
+   gPluginMgr->AddHandler("TFile", "^[x]?root[s]?:", "TNetXNGFile",
       "NetxNG", "TNetXNGFile(const char*,Option_t*,const char*,Int_t,Int_t,Bool_t)");
 }


### PR DESCRIPTION
Make sure that
  - RRawFile uses TNetXNGFile for xroot:// and xroots:// URLs (and not only root://, roots://)
  - TFile uses TNetXNGFile for roots:// and xroots:// URLs (and not only root://, xroot://)
