### PR TITLE
[cmake] On a fresh configure, remove possibly outdated pcms.

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -419,24 +419,11 @@ def cmake_configure(options, buildtype):
     options = f"{options} -DROOT_COMPILEDATA_IGNORE_BUILD_NODE_CHANGES=ON"
 
     result = subprocess_with_log(f"""
-        cmake -S '{srcdir}' -B '{builddir}' -DCMAKE_BUILD_TYPE={buildtype} {options}
+        cmake --fresh -S '{srcdir}' -B '{builddir}' -DCMAKE_BUILD_TYPE={buildtype} {options}
     """)
 
     if result != 0:
         die(result, "Failed cmake generation step")
-
-
-@github_log_group("Dump existing configuration")
-def cmake_dump_config():
-    # Print CMake cached config
-    srcdir = os.path.join(WORKDIR, "src")
-    builddir = os.path.join(WORKDIR, "build")
-    result = subprocess_with_log(f"""
-        cmake -S '{srcdir}' -B '{builddir}' -N -L
-    """)
-
-    if result != 0:
-        die(result, "Failed cmake cache print step")
 
 
 @github_log_group("Dump requested build configuration")
@@ -466,10 +453,7 @@ def build(options, buildtype):
         if result != 0:
             die(result, "Failed to create build directory")
 
-    if not os.path.exists(os.path.join(WORKDIR, "build", "CMakeCache.txt")):
-        cmake_configure(options, buildtype)
-    else:
-        cmake_dump_config()
+    cmake_configure(options, buildtype)
 
     dump_requested_config(options)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,15 @@ if(MSVC)
 endif()
 
 if(runtime_cxxmodules)
+  if(NOT ROOT_CONFIGURED_FROM_CACHE)
+    # When using cmake --fresh (or changing the toolchain), remove possibly stale pcms that are not tracked by CMake
+    set(ROOT_CONFIGURED_FROM_CACHE True CACHE BOOL "Shows if ROOT is configured from an existing CMake cache")
+    mark_as_advanced(ROOT_CONFIGURED_FROM_CACHE)
+    file(GLOB_RECURSE left_over_pcms ${CMAKE_BINARY_DIR}/*.pcm)
+    if(left_over_pcms)
+      file(REMOVE ${left_over_pcms})
+    endif()
+  endif()
   # Dummy target that does nothing, we don't need a PCH for modules.
   # Onepcm target has all dependencies needed for allDict.cxx.pch, which allow
   # to test hsimple.C after all C++ modules are updated.


### PR DESCRIPTION
When CMake is run without an existing cache, or with `cmake --fresh`, remove leftover pcms in `lib/`. This can fix a build with broken pcms that don't get regenerated without needing to clean the entire build.

Furthermore, ensure that we always run the cmake configure step in the CI. Previously, that step would be skipped when there was an existing CMake cache. This can prevent ROOT from picking up new build option overrides, or from reacting to changes in the build containers (changes may only arrive once the precompiled artifacts are updated on S3).
Now, the desired configure command is run with `cmake --fresh [...]` on every build. If headers and build dependencies don't change, only the modules and dictionaries get rebuilt. The tests start to run at about 7 minutes into the CI job.

### More details
The underlying problem is the fact that rootcling_stage1 builds some pcms as side effects (e.g. std.pcm), and CMake doesn't know about these. It therefore can't know if they are out of date, and it can neither instruct the build-system generator to clean them when the clean target is invoked, nor can it rebuild them if they are out of date (broken).
Moreover, changes in the toolchain or in packages installed in the container might not be detected, since the build folder might have been generated in a different container than the one it's running on.

Although wiping the pcms only cures the symptoms (we should at some point build a full dependency tree with all pcms), it can make the life of the developers a bit better right now by avoiding all "pcm out of date" errors.