### PR TITLE
[cling] Anchor the interpreter's clang driver on $ROOTSYS/bin

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1428,6 +1428,23 @@ namespace {
 #endif
     // Add host specific includes, -resource-dir if necessary, and -isysroot
     std::string ClingBin = GetExecutablePath(argv[0]);
+#ifdef __linux__
+    // On Linux GetExecutablePath() resolves /proc/self/exe, i.e. the path of
+    // the *embedding* application rather than of ROOT/cling itself. clang's
+    // driver derives its installed-dir (and hence its GCC-installation and
+    // C-system-header sysroot detection) from this path. When libCore is loaded
+    // by an executable that does not live next to the ROOT installation, the
+    // sysroot is misdetected and the interpreter fails to find the C system
+    // headers (e.g. assert.h) even though they are present in the installation.
+    // Anchor the driver on $ROOTSYS/bin instead, mirroring how -resource-dir is
+    // already made ROOTSYS-relative below. LLVMDir is $ROOTSYS/etc/cling.
+    if (LLVMDir) {
+      llvm::SmallString<512> rootDriver(LLVMDir);
+      llvm::sys::path::append(rootDriver, "..", "..", "bin", "rootcling");
+      llvm::sys::path::remove_dots(rootDriver, /*remove_dot_dot=*/true);
+      ClingBin.assign(rootDriver.data(), rootDriver.size());
+    }
+#endif
     AddHostArguments(ClingBin, argvCompile, LLVMDir, COpts);
 
     // Be explicit about the stdlib on OS X


### PR DESCRIPTION
This PR fixes conda-forge/root-feedstock#372. I debugged the issue with the help of LLMs and the final patch was written by an LLM. Normally I would have cleaned up the comment but in this case I think it might be warrented.

<hr/>

🤖 Below is a mostly LLM generated explanation of what the problem is but I think it explains the situation:

On Linux `GetExecutablePath()` resolves `/proc/self/exe`, i.e. the path of the embedding application rather than of ROOT/cling itself.

clang's driver derives its installed directory -- and therefore its GCC-installation and C-system-header sysroot detection -- from that path. When libCore is embedded in an executable that does not live next to the ROOT installation (e.g. a user application built against a relocatable / conda-forge ROOT), the sysroot is misdetected and the interpreter cannot find the C system headers (assert.h, time.h, ...) even though they ship with the installation. It surfaces as:

    C system headers (glibc/Xcode/Windows SDK) must be installed.
    fatal error: 'assert.h' file not found

The resource dir and `-I` include paths are already made ROOTSYS-relative in `TCling`; only the sysroot was still left to clang's `/proc/self/exe`-based install-dir guess. Anchor the driver on $ROOTSYS/bin (reusing the `LLVMDir` / resource-dir location that is already `ROOTSYS`-relative) so toolchain and sysroot detection follow the ROOT installation regardless of where the host executable lives.