### PR TITLE
[cling] Fix bookkeeping corruption when unloading files

### DIFF
--- a/core/metacling/test/TClingLoadUnloadFileTests.cxx
+++ b/core/metacling/test/TClingLoadUnloadFileTests.cxx
@@ -75,9 +75,6 @@ void remove_n_library_artifacts(const std::string &basename, unsigned int n)
 
 TEST(TClingLoadUnloadFile, ConcurrentLoadUnloadSameLib)
 {
-   GTEST_SKIP() << "fails sporadically, see "
-                << "https://github.com/root-project/root/issues/14121";
-
    ROOT::EnableThreadSafety();
 
    std::string basename{"concurrent_load_unload_same_lib"};
@@ -102,9 +99,6 @@ TEST(TClingLoadUnloadFile, ConcurrentLoadUnloadSameLib)
 
 TEST(TClingLoadUnloadFile, ConcurrentLoadUnloadOneLibPerThread)
 {
-   GTEST_SKIP() << "fails sporadically, see "
-                << "https://github.com/root-project/root/issues/14121";
-
    ROOT::EnableThreadSafety();
 
    std::string basename{"concurrent_load_unload_one_lib_per_thread"};

--- a/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaSema.h
@@ -37,7 +37,6 @@ namespace cling {
     bool m_IsQuitRequested;
 
     llvm::DenseMap<const clang::FileEntry*, const Transaction*> m_FEToTransaction;
-    llvm::DenseMap<const Transaction*, const clang::FileEntry*> m_TransactionToFE;
   public:
     enum SwitchMode {
       kOff = 0,

--- a/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaSema.cpp
@@ -213,14 +213,23 @@ namespace cling {
       return AR_Success;
 
     const Transaction* unloadPoint = (*TI).second;
+    // Erase the entry before reverting: as of now the file is no longer
+    // registered as loaded, whatever the outcome of the reversion.
+    m_FEToTransaction.erase(TI);
     if (interpreterHasTransaction(m_Interpreter, unloadPoint)) {
       // Revert all the transactions that came after `unloadPoint'.
       while (m_Interpreter.getLastTransaction() != unloadPoint) {
-        if (const auto ThisFE = m_TransactionToFE[m_Interpreter.getLastTransaction()]) {
-          auto I = m_FEToTransaction.find(ThisFE);
-          if (I != m_FEToTransaction.end())
-            m_FEToTransaction.erase(I);
-        }
+        const Transaction* T = m_Interpreter.getLastTransaction();
+        // Any file whose unload point is `T' can no longer be reverted: drop
+        // its registration. This must not be left behind: `T' is deallocated
+        // during the reversion and its address may be reused by a future
+        // transaction, which would alias the stale entry.
+        llvm::SmallVector<const clang::FileEntry*, 2> revertedFiles;
+        for (const auto &Entry : m_FEToTransaction)
+          if (Entry.second == T)
+            revertedFiles.push_back(Entry.first);
+        for (const clang::FileEntry* RFE : revertedFiles)
+          m_FEToTransaction.erase(RFE);
         m_Interpreter.unload(/*numberOfTransactions=*/1);
       }
 
@@ -231,7 +240,6 @@ namespace cling {
       m_MetaProcessor.getOuts() << "!!!ERROR: Transaction for file: " << file
                                 << " has already been unloaded\n";
     }
-    m_FEToTransaction.erase(TI);
     return AR_Success;
   }
 
@@ -495,9 +503,7 @@ namespace cling {
       return;
     }
 
-    if (*FE && !m_FEToTransaction[*FE]) {
+    if (*FE && !m_FEToTransaction[*FE])
       m_FEToTransaction[*FE] = unloadPoint;
-      m_TransactionToFE[unloadPoint] = *FE;
-    }
   }
 } // end namespace cling


### PR DESCRIPTION
MetaSema keeps a map of file entries to "unload points" (the transaction to revert to when unloading that file). It also kept a reverse map, m_TransactionToFE, whose entries were never removed. Since the TransactionPool recycles Transaction objects in place, a stale reverse entry could alias a completely unrelated, newly created transaction.

When reverting transactions in actOnUCommand, such a stale entry could make the loop erase the m_FEToTransaction entry of the very file being unloaded. The function then erased the same entry again through the iterator `TI` obtained before the loop. DenseMap::erase(iterator) decrements the entry count unconditionally, so the second erase made the count underflow to ~2^32. Subsequent insertions then kept doubling the bucket table until an allocation of several GB failed, aborting with std::bad_alloc ("LLVM ERROR: out of memory").

With repeated concurrent gInterpreter->LoadFile()/UnloadFile() calls (all serialized by the interpreter lock, so this is not a data race), this corrupted the map on every run of the TClingLoadUnloadFile tests and sporadically crashed them, depending on when a table grow happened to be triggered.

Fix the bookkeeping instead of relying on the reverse map:

- Erase the file's entry once, up front, while the iterator is still valid: whatever the outcome of the reversion, the file is no longer registered as loaded afterwards.
- While reverting, drop the registration of any file whose unload point is the transaction about to be destroyed, by scanning the (small) forward map. This also handles multiple files sharing one unload point, which the reverse map could not represent.
- Remove m_TransactionToFE entirely.

Closes https://github.com/root-project/root/issues/14121

🤖 Done with the help of AI.