### PR TITLE
[core] Handle non-space whitespace in TClassEdit::CleanType

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1303,9 +1303,16 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
    const char* c;
 
    for(c=typeDesc;*c;c++) {
-      if (c[0]==' ') {
+      if (std::isspace(c[0])) {
          if (kbl)       continue;
          if (!isalnum(c[ 1]) && c[ 1] !='_')    continue;
+         if (c[0] != ' ') {
+            // Significant whitespace other than ' ' (e.g. \n in a multi-line
+            // class name from a selection XML) is replaced by a plain space.
+            result += ' ';
+            kbl = 1;
+            continue;
+         }
       }
       if (kbl && (mode>=2 || parensStack.empty())) { //remove "const' etc...
          int done = 0;

--- a/core/foundation/test/testClassEdit.cxx
+++ b/core/foundation/test/testClassEdit.cxx
@@ -375,3 +375,20 @@ TEST(TClassEdit, SplitType)
    auto si = (TStreamerInfo*) c->GetStreamerInfo();
    si->ls("noaddr");
 }
+
+TEST(TClassEdit, MultiLineName)
+{
+   // A class name in a selection XML can span multiple lines. Whitespace
+   // other than ' ' used to empty out the template arguments it preceded,
+   // e.g. "Foo<,vector<float>,>" (https://github.com/root-project/root/issues/22359).
+   const char *name = "Foo<\n  std::vector<int>, std::vector<float>,\n\tunsigned int,\n  Bar ::Ref<std::vector<int>>>";
+   TClassEdit::TSplitType split(name, (TClassEdit::EModType)(TClassEdit::kLong64 | TClassEdit::kDropStd));
+   std::string out;
+   split.ShortType(out, TClassEdit::kLong64 | TClassEdit::kDropStd);
+   EXPECT_STREQ("Foo<vector<int>,vector<float>,unsigned int,Bar::Ref<vector<int> > >", out.c_str());
+
+   // Whitespace that separates two identifiers is significant and must be
+   // kept as a single plain space.
+   EXPECT_STREQ("unsigned int", TClassEdit::CleanType("unsigned\nint").c_str());
+   EXPECT_STREQ("Foo<int>", TClassEdit::CleanType("\n Foo<\n  int\n>").c_str());
+}


### PR DESCRIPTION
A class name in a selection XML can span multiple lines. `CleanType()` only treated `' '` as a blank, so a newline was kept in the cleaned name and, when the template arguments were later re-processed individually, an argument starting with a newline was truncated to an empty string. This corrupted the rootmap entries and the alternate name registrations (e.g. `"Foo<,vector<float>,>"`), leading to `"Second registration of ..."` errors from `TClassTable::AddAlternate` at library load time.

Treat all whitespace like a space: drop it where a space would be dropped, and emit a single plain space where it separates two identifiers.

Closes #22359.

🤖 Done with the help of AI.