### PR TITLE
[asan] Fix argv array for PyROOT applications

### DIFF
--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -46,7 +46,8 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
       char **argv = nullptr;
 
       if (ignoreCmdLineOpts) {
-         argv = new char *[argc];
+         // Last argv must be null (see https://en.cppreference.com/cpp/language/main_function)
+         argv = new char *[argc + 1]{};
       } else {
          // Retrieve sys.argv list from Python
          PyObject *argl = PySys_GetObject("argv");
@@ -57,7 +58,8 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
                argc = static_cast<int>(size);
          }
 
-         argv = new char *[argc];
+         // Last argv must be null (see https://en.cppreference.com/cpp/language/main_function)
+         argv = new char *[argc + 1]{};
 
          for (int i = 1; i < argc; ++i) {
             PyObject *item = PyList_GetItem(argl, i);

--- a/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
+++ b/bindings/pyroot/pythonizations/src/RPyROOTApplication.cxx
@@ -47,7 +47,7 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
 
       if (ignoreCmdLineOpts) {
          // Last argv must be null (see https://en.cppreference.com/cpp/language/main_function)
-         argv = new char *[argc + 1]{};
+         argv = new char *[argc + 1] {};
       } else {
          // Retrieve sys.argv list from Python
          PyObject *argl = PySys_GetObject("argv");
@@ -59,7 +59,7 @@ bool PyROOT::RPyROOTApplication::CreateApplication(int ignoreCmdLineOpts)
          }
 
          // Last argv must be null (see https://en.cppreference.com/cpp/language/main_function)
-         argv = new char *[argc + 1]{};
+         argv = new char *[argc + 1] {};
 
          for (int i = 1; i < argc; ++i) {
             PyObject *item = PyList_GetItem(argl, i);


### PR DESCRIPTION
Pick these changes from https://github.com/root-project/root/pull/22746:
- The argv array for PyROOT applications was one element too small
This fixes 20 failing pyunittests on Windows. Thanks @hageboeck!