### PR TITLE
[io] Fix an asan buffer overflow detection in TBufferFile.

### DIFF
--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -824,7 +824,10 @@ Int_t TBufferFile::ReadArray(Int_t *&ii)
 
    if (ShouldNotReadCollection(l, n)) return 0;
 
-   if (!ii) ii = new Int_t[n];
+   // Allocate a buffer for this array if the caller hasn't done so.
+   // Note: Offset arrays require one more element than n claims, so we need to overallocate.
+   if (!ii)
+      ii = new Int_t[n + 1];
 
 #ifdef R__BYTESWAP
 # ifdef USE_BSWAPCPY


### PR DESCRIPTION
As a followup to fe1be25, increase the auto-allocated array buffer by one element. In fe1be25 (PR #22165), the external allocation in TBasket (size == fNevBufSize) was replaced with an automatic allocation in `TBufferFile::ReadArray(Int_t)`, whose size was the number of elements read from the file.
However, when `ReadArray(Int_t)` is used as an offset array, it is assumed to contain one more element than visible from the size field stored on disc. See here:
https://github.com/root-project/root/blob/da08f4652336a1f50220d94309cc20c6f4472cc4/tree/tree/src/TBasket.cxx#L1250-L1279

The auto-allocated buffer needs to be large enough to cover this case, so here we propose to generally over-allocate the buffer by one int.

To give some numbers from this particular case:
Before #22165, the offset array buffer was sized using `fNevBufSize`, 1000 in this case.
After the PR, it was 84, but we would have needed 85 elements to fit it.
What we propose is to overallocate all buffer for `ReadArray(Int_t)`, leading to generally smaller buffers for offset arrays, and to one additional int for arrays that are not used as offset arrays.

Thanks to @silverweed for helping to investigate.

