### PR TITLE
[DO NOT MERGE] Test what happens if TNetXNGFile enforces only valid open modes

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -177,8 +177,11 @@ TNetXNGFile::TNetXNGFile(const char *url, const char *lurl, Option_t *mode, cons
    fReadvIorMax = 2097136;
    fReadvIovMax = 1024;
 
-   if (ParseOpenMode(mode, fOption, fMode, kTRUE)<0) {
-      Error("Open", "could not parse open mode %s", mode);
+   if (ParseOpenMode(mode, fOption, fMode, kFALSE) < 0) {
+      Error(
+         "Open",
+         "Error parsing open mode \"%s\". Valid values are: \"CREATE\", \"NEW\", \"READ\", \"RECREATE\", \"UPDATE\".",
+         mode);
       MakeZombie();
       return;
    }


### PR DESCRIPTION
This is related to https://github.com/root-project/root/pull/22778 . Since it would be a backwards-incompatible change, I would like to see what the CI reports