### PR TITLE
[CI] When tests fail on Windows, rerun them with `--rerun-failed -j1`

### DIFF
--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -57,9 +57,9 @@ def main():
     if pull_request:
         # We check whether the PR is done from a branch that has the same name of
         # the target branch in the ROOT repository using base_ref and head_ref:
-        # - The base_ref is e.g. "master" or "v6-38-00-patches" 
+        # - The base_ref is e.g. "master" or "v6-38-00-patches"
         # - The head_ref for PRs is formatted as <PR branch>:<Fork branch> e.g. "refs/pull/20742/head:cppyy_fixup"
-        if not ":" in args.head_ref:
+        if ":" not in args.head_ref:
             build_utils.print_error(f"This has been identified as a PR build. However, the head-ref is {args.head_ref}.")
         branch_in_fork = args.head_ref.split(":")[-1]
         if branch_in_fork == args.base_ref:
@@ -85,7 +85,7 @@ def main():
 
     if "minimal" in platform_options and platform_options["minimal"] == "ON":
         options_dict = platform_options
-        print(f"Minimal build detected in the platform options. Ignoring global configuration.")
+        print("Minimal build detected in the platform options. Ignoring global configuration.")
     else:
         options_dict.update(platform_options)
         print(f"Build option overrides for {args.platform_config}:")

--- a/.github/workflows/root-ci-config/build_root.py
+++ b/.github/workflows/root-ci-config/build_root.py
@@ -372,6 +372,12 @@ def run_ctest(extra_ctest_flags: str) -> int:
         {setupROOTEnv}
         ctest --output-on-failure --parallel {os.cpu_count()} --output-junit TestResults.xml {extra_ctest_flags}
     """)
+    if WINDOWS and ctest_result != 0:
+        ctest_result = subprocess_with_log(f"""
+            cd '{builddir}'
+            {setupROOTEnv}
+            ctest --output-on-failure --rerun-failed --output-junit TestResults.xml {extra_ctest_flags}
+        """)
 
     return ctest_result
 


### PR DESCRIPTION
The rationale of this PR (~~to be confirmed~~) is that tests that invoke builds can fail if another test tries to build a file that both tests depend on (or two tests try to build the same file). If this is true, rerunning the build with only a single process might unlock the files, and allow the tests to pass.

**Update 1**: The exact same problem is discussed [here](https://github.com/dotnet/msbuild/issues/9462), and the proposed solution is to build again, but not in parallel.

**Update 2**: The last run on Windows 64 demonstrates that this approach did actually work. Whereas four tests failed when ctest was running all in parallel, going back to the failed tests with `-j1` made them pass without problems:
```
2026-07-13T12:15:27.2297305Z 	3464 - roottest-root-treeformula-schemaEvolution-schemaRun3a (Disabled)
2026-07-13T12:15:27.2297663Z 	3465 - roottest-root-treeformula-schemaEvolution-schemaRun4 (Disabled)
2026-07-13T12:15:27.2298096Z 	3466 - roottest-root-treeformula-schemaEvolution-schemaRun4a (Disabled)
2026-07-13T12:15:27.2298426Z 	3482 - roottest-root-treeformula-string-string (Disabled)
2026-07-13T12:15:27.2298617Z 
2026-07-13T12:15:27.2298693Z The following tests FAILED:
2026-07-13T12:15:27.2298934Z 	1525 - roottest-cling-reflex-properties-libgen-build (Failed)
2026-07-13T12:15:27.2299231Z 	1526 - roottest-cling-reflex-properties_rflx (Not Run)
2026-07-13T12:15:27.2299587Z 	2699 - roottest-root-meta-autoloading-ROOT-12378-libatlas00-libgen-build (Failed)
2026-07-13T12:15:27.2299988Z 	2702 - roottest-root-meta-autoloading-ROOT-12378-testtypedef (Not Run)
2026-07-13T12:15:27.6166226Z Errors while running CTest
2026-07-13T12:15:27.6687187Z [0m[1m
2026-07-13T12:15:27.6687399Z cd 'C:/ROOT-CI\build'
2026-07-13T12:15:27.6687530Z 
2026-07-13T12:15:27.6687830Z ctest --output-on-failure --rerun-failed --output-junit TestResults.xml --repeat until-pass:5 --build-config Release
2026-07-13T12:15:27.6688757Z [0m
2026-07-13T12:15:27.8924616Z [90mTest project C:/ROOT-CI/build
2026-07-13T12:15:28.4902321Z     Start    1: cmake-build-all
2026-07-13T12:17:13.3726111Z 1/7 Test    #1: cmake-build-all .....................................................   Passed  104.88 sec
2026-07-13T12:17:13.3732456Z     Start 1525: roottest-cling-reflex-properties-libgen-build
2026-07-13T12:18:05.2364984Z 2/7 Test #1525: roottest-cling-reflex-properties-libgen-build .......................   Passed   51.86 sec
2026-07-13T12:18:05.2367962Z     Start 1526: roottest-cling-reflex-properties_rflx
2026-07-13T12:18:05.8526453Z 3/7 Test #1526: roottest-cling-reflex-properties_rflx ...............................   Passed    0.62 sec
2026-07-13T12:18:05.8529718Z     Start 2699: roottest-root-meta-autoloading-ROOT-12378-libatlas00-libgen-build
2026-07-13T12:18:56.6832474Z 4/7 Test #2699: roottest-root-meta-autoloading-ROOT-12378-libatlas00-libgen-build ...   Passed   50.83 sec
2026-07-13T12:18:56.6836520Z     Start 2700: roottest-root-meta-autoloading-ROOT-12378-libatlas01-libgen-build
2026-07-13T12:19:47.0619008Z 5/7 Test #2700: roottest-root-meta-autoloading-ROOT-12378-libatlas01-libgen-build ...   Passed   50.38 sec
2026-07-13T12:19:47.0623461Z     Start 2701: roottest-root-meta-autoloading-ROOT-12378-libatlas02-libgen-build
2026-07-13T12:20:37.9852414Z 6/7 Test #2701: roottest-root-meta-autoloading-ROOT-12378-libatlas02-libgen-build ...   Passed   50.92 sec
2026-07-13T12:20:37.9856236Z     Start 2702: roottest-root-meta-autoloading-ROOT-12378-testtypedef
2026-07-13T12:20:38.5791313Z 7/7 Test #2702: roottest-root-meta-autoloading-ROOT-12378-testtypedef ...............   Passed    0.59 sec
2026-07-13T12:20:38.5864142Z 
2026-07-13T12:20:38.5864317Z 100% tests passed, 0 tests failed out of 7
2026-07-13T12:20:38.5864498Z 
2026-07-13T12:20:38.5864586Z Total Test time (real) = 310.69 sec
2026-07-13T12:20:38.6303837Z [0m
2026-07-13T12:20:38.6304110Z ** Elapsed time for group "Run tests" 1:00:28.7

```