### PR TITLE
[roottest] disable warning on unused private fields in roottest

### DIFF
--- a/roottest/CMakeLists.txt
+++ b/roottest/CMakeLists.txt
@@ -118,5 +118,10 @@ include(SearchInstalledSoftwareRoottest)
 ROOTTEST_COMPILE_MACRO(scripts/utils.cc
                        FIXTURES_SETUP roottest-scripts-utils-fixture)
 
+if(NOT MSVC)
+  # roottest contains a ton of test classes that have unused members
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field")
+endif()
+
 message("-- Scanning subdirectories for tests...")
 ROOTTEST_ADD_TESTDIRS()

--- a/roottest/root/meta/autoloading/headerParsingOnDemand/h1.h
+++ b/roottest/root/meta/autoloading/headerParsingOnDemand/h1.h
@@ -27,13 +27,13 @@ private:
 template <class T>
 class myClass3{
 public:
-   void myMethod(T a){};
+   void myMethod(T ){};
 };
 
 template <class T>
 class myClass4{
 public:
-   void myMethod(const T*const**&& a){}; // Unluky signature but interesting for this test ;-)
+   void myMethod(const T*const**&& ){}; // Unluky signature but interesting for this test ;-)
 };
 
 //--------------------


### PR DESCRIPTION
Removes a bunch of roottest errors with `dev=on`
