### PR TITLE
build(minuit2): modernize standalone CMake

### DIFF
--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15...4.4)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
   project(Minuit2 LANGUAGES CXX)

--- a/math/minuit2/Minuit2Config.cmake.in
+++ b/math/minuit2/Minuit2Config.cmake.in
@@ -5,38 +5,10 @@ set(minuit2_mpi @minuit2_mpi@)
 
 if(minuit2_omp)
     find_dependency(OpenMP REQUIRED)
-
-    if(OpenMP_FOUND OR OpenMP_CXX_FOUND)
-        # For CMake < 3.9, we need to make the target ourselves
-        if(NOT TARGET OpenMP::OpenMP_CXX)
-            add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
-            set_property(TARGET OpenMP::OpenMP_CXX
-                         PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
-            # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
-            set_property(TARGET OpenMP::OpenMP_CXX
-                         PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS})
-
-            find_dependency(Threads REQUIRED)
-        endif()
-    endif()
 endif()
 
 if(minuit2_mpi)
     find_dependency(MPI REQUIRED)
-
-    # For supporting CMake < 3.9:
-    if(MPI_FOUND OR MPI_CXX_FOUND)
-        if(NOT TARGET MPI::MPI_CXX)
-            add_library(MPI::MPI_CXX IMPORTED INTERFACE)
-
-            set_property(TARGET MPI::MPI_CXX
-                         PROPERTY INTERFACE_COMPILE_OPTIONS ${MPI_CXX_COMPILE_FLAGS})
-            set_property(TARGET MPI::MPI_CXX
-                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${MPI_CXX_INCLUDE_PATH}") 
-            set_property(TARGET MPI::MPI_CXX
-                         PROPERTY INTERFACE_LINK_LIBRARIES ${MPI_CXX_LINK_FLAGS} ${MPI_CXX_LIBRARIES})
-        endif()
-    endif()
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/Minuit2Targets.cmake")

--- a/math/minuit2/StandAlone.cmake
+++ b/math/minuit2/StandAlone.cmake
@@ -1,9 +1,10 @@
 # Use the minimum C++ standard of ROOT by default
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-set(CMAKE_CXX_EXTENSIONS OFF FALSE CACHE BOOL "")
+set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "")
 
 include(FeatureSummary)
 include(CMakeDependentOption)
+include(GNUInstallDirs)
 
 # Check to see if we are inside ROOT and set a smart default
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../rootx/src/rootx.cxx")
@@ -45,7 +46,7 @@ include(copy_standalone.cmake)
 set(SPAN_HEADERS RSpan.hxx span.hxx)
 copy_standalone(SOURCE ../../core/foundation/inc/ROOT DESTINATION inc/ROOT OUTPUT SPAN_HEADERS
                 FILES ${SPAN_HEADERS})
-install(FILES ${SPAN_HEADERS} DESTINATION include/Minuit2/ROOT)
+install(FILES ${SPAN_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Minuit2/ROOT)
 
 
 # Copy these files in if needed
@@ -120,28 +121,27 @@ write_basic_package_version_file(
 # Now, install the Interface targets
 install(TARGETS Minuit2Common
         EXPORT Minuit2Targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
 
 # Install the export set
 install(EXPORT Minuit2Targets
         FILE Minuit2Targets.cmake
         NAMESPACE Minuit2::
-        DESTINATION lib/cmake/Minuit2
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Minuit2
         )
 
 # Adding the Minuit2Config file
 configure_file(Minuit2Config.cmake.in Minuit2Config.cmake @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Minuit2Config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/Minuit2ConfigVersion.cmake"
-        DESTINATION lib/cmake/Minuit2
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Minuit2
         )
 
 # Allow build directory to work for CMake import
 export(TARGETS Minuit2Common Minuit2Math Minuit2 NAMESPACE Minuit2:: FILE Minuit2Targets.cmake)
-export(PACKAGE Minuit2)
 
 # Only add tests and docs if this is the main project
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/math/minuit2/copy_standalone.cmake
+++ b/math/minuit2/copy_standalone.cmake
@@ -42,9 +42,6 @@ endfunction()
 
 set_property(GLOBAL PROPERTY COPY_STANDALONE_LISTING "")
 
-# Needed for CMake 3.4 and lower:
-include(CMakeParseArguments)
-
 function(COPY_STANDALONE)
 
     # CMake keyword arguments

--- a/math/minuit2/examples/simple/CMakeLists.txt
+++ b/math/minuit2/examples/simple/CMakeLists.txt
@@ -4,7 +4,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15...4.4)
 # This is a test of the Minuit2 CMake build system.
 
 project(Quad1F LANGUAGES CXX)

--- a/math/minuit2/src/CMakeLists.txt
+++ b/math/minuit2/src/CMakeLists.txt
@@ -165,10 +165,10 @@ target_include_directories(
     Minuit2
     PUBLIC
     $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/inc>
-    $<INSTALL_INTERFACE:include/Minuit2>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Minuit2>
     )
 
-target_compile_features(Minuit2 PUBLIC cxx_nullptr cxx_nonstatic_member_init)
+target_compile_features(Minuit2 PUBLIC cxx_std_17)
 set_target_properties(Minuit2 PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(Minuit2 PUBLIC Minuit2Math Minuit2Common)
@@ -179,4 +179,4 @@ install(TARGETS Minuit2
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 
-install(FILES ${MINUIT2_HEADERS} DESTINATION include/Minuit2/Minuit2)
+install(FILES ${MINUIT2_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Minuit2/Minuit2)

--- a/math/minuit2/src/math/CMakeLists.txt
+++ b/math/minuit2/src/math/CMakeLists.txt
@@ -58,15 +58,17 @@ target_include_directories(
     Minuit2Math
     PUBLIC
     $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/inc>
-    $<INSTALL_INTERFACE:include/Minuit2>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/Minuit2>
     )
 
-# We need to add the ROOT mathcore directories if build inside of ROOT without standalone)
+# We need to add the ROOT mathcore and foundation (for ROOT/RSpan.hxx)
+# directories if built inside of ROOT without standalone
 if(minuit2_inroot AND NOT minuit2_standalone)
     target_include_directories(
         Minuit2Math
         PUBLIC
         $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/../mathcore/inc>
+        $<BUILD_INTERFACE:${Minuit2_SOURCE_DIR}/../../core/foundation/inc>
         )
 endif()
 
@@ -85,7 +87,7 @@ target_compile_definitions(
 
 target_link_libraries(Minuit2Math PUBLIC Minuit2Common)
 
-target_compile_features(Minuit2Math PUBLIC cxx_auto_type cxx_static_assert)
+target_compile_features(Minuit2Math PUBLIC cxx_std_17)
 set_target_properties(Minuit2Math PROPERTIES CXX_EXTENSIONS OFF)
 
 install(TARGETS Minuit2Math
@@ -94,5 +96,5 @@ install(TARGETS Minuit2Math
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 
-install(FILES ${FIT_HEADERS} DESTINATION include/Minuit2/Fit)
-install(FILES ${MATH_HEADERS} DESTINATION include/Minuit2/Math)
+install(FILES ${FIT_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Minuit2/Fit)
+install(FILES ${MATH_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Minuit2/Math)

--- a/math/minuit2/test/CMakeLists.txt
+++ b/math/minuit2/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 if(NOT DEFINED ROOT_SOURCE_DIR)
-   cmake_minimum_required(VERSION 3.10)
+   cmake_minimum_required(VERSION 3.15...4.4)
    project(minuit2_tests)
    find_package(ROOT REQUIRED)
    include(${ROOT_USE_FILE})

--- a/math/minuit2/test/MnTutorial/CMakeLists.txt
+++ b/math/minuit2/test/MnTutorial/CMakeLists.txt
@@ -13,6 +13,25 @@ add_minuit2_test(Quad8F Quad8FMain.cxx Quad8F.h)
 
 add_minuit2_test(Quad12F Quad12FMain.cxx Quad12F.h)
 
+# Pass the parent's configuration through to the nested build; otherwise
+# ctest picks a platform-dependent default that can mismatch the parent
+# (e.g. Debug vs Release with Visual Studio generators)
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_isMultiConfig)
+    set(_exampleBuildConfig --build-config $<CONFIG>)
+    set(_exampleBuildType "")
+    set(_exampleTestConfig -C $<CONFIG>)
+else()
+    set(_exampleBuildConfig "")
+    set(_exampleBuildType "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+    set(_exampleTestConfig "")
+endif()
+if(CMAKE_GENERATOR_PLATFORM)
+    set(_exampleGeneratorPlatform --build-generator-platform "${CMAKE_GENERATOR_PLATFORM}")
+else()
+    set(_exampleGeneratorPlatform "")
+endif()
+
 add_test(
     NAME ExampleCMakeBuild
     COMMAND "${CMAKE_CTEST_COMMAND}"
@@ -20,5 +39,8 @@ add_test(
             "${Minuit2_SOURCE_DIR}/examples/simple/"
             "${CMAKE_CURRENT_BINARY_DIR}/simple/"
             --build-generator "${CMAKE_GENERATOR}"
-            --test-command "${CMAKE_CTEST_COMMAND}"
+            ${_exampleGeneratorPlatform}
+            ${_exampleBuildConfig}
+            --build-options "-DMinuit2_DIR=${Minuit2_BINARY_DIR}" ${_exampleBuildType}
+            --test-command "${CMAKE_CTEST_COMMAND}" ${_exampleTestConfig}
     )


### PR DESCRIPTION
# This Pull request:

I was updating from the standalone build (which does work again, thanks for fixing that at some point!), but I noticed some issues. I fixed those, then asked Claude Fable to review, and it found some more. The problems I hit were:

* This requires C++17, but we only had old C++11 partial compile features, so the `ExampleCMakeBuild` broke (on Windows only, due to the C++14 compiler default here)
* `ExampleCMakeBuild` didn't support multi-generators (Windows)
* The package registry was causing problems - newer CMake (3.15+) drops it anyway.

I bumped this to 3.15-4.4, since 3.15+ is scikit-bulid-core's minimum (and works for the standalone build), and you should always have a maximum, and 4.4 is the most recent (therefore testable) version.

## Changes or fixes:

:robot: Summarized by Claude:

- Add `core/foundation/inc` include for `ROOT/RSpan.hxx` in the in-root non-standalone build, which failed to compile
- Pass `Minuit2_DIR` to the `ExampleCMakeBuild` test instead of relying on the user package registry, which CMP0090 (3.15) disables; drop the now-inert `export(PACKAGE)`
- Pass the parent's configuration through to the `ExampleCMakeBuild` nested build (`CMAKE_BUILD_TYPE` for single-config generators, `--build-config` and the generator platform for multi-config), instead of letting ctest pick a platform-dependent default that can mismatch the parent on Windows
- Use `GNUInstallDirs` so libraries install to `lib64` where appropriate; `Minuit2Common` previously hardcoded `lib` and the other targets expanded an empty `CMAKE_INSTALL_LIBDIR`
- Drop CMake < 3.9 imported-target fallbacks from `Minuit2Config.cmake.in`
- Fix `CMAKE_CXX_EXTENSIONS` cache value typo (`OFF FALSE`)

## Checklist:

- [x] tested changes locally
- updated the docs (if necessary)


Assisted-by: ClaudeCode:claude-fable-5
