### PR TITLE
[tmva][sofie] Use `double` for accumulator in numeric differentiation result

### DIFF
--- a/tmva/sofie/test/TestCladAutodiff.cxx
+++ b/tmva/sofie/test/TestCladAutodiff.cxx
@@ -39,15 +39,33 @@ float Linear_16_outer_wrapper(TMVA_SOFIE_Linear_16::Session const &session, floa
    return Linear_16_wrapper(session, input);
 }
 
+// Separate evaluation function for the numeric differentiation that
+// accumulates in double: with a float accumulator, the rounding error of the
+// output sum is comparable to the eps-induced change that the central
+// difference measures, so the numeric derivative would be dominated by
+// cancellation noise.
+double Linear_16_num_eval(TMVA_SOFIE_Linear_16::Session const &session, float const *input)
+{
+   float out[160]{};
+   double output_sum = 0.0;
+
+   TMVA_SOFIE_Linear_16::doInfer(session, input, out);
+
+   for (std::size_t i = 0; i < std::size(out); ++i) {
+      output_sum += out[i];
+   }
+   return output_sum;
+}
+
 float Linear_16_wrapper_num_diff(TMVA_SOFIE_Linear_16::Session const &session, float *input, std::size_t i)
 {
    const float origVal = input[i];
 
    const float eps = 1e-3;
    input[i] = origVal - eps;
-   float funcValDown = Linear_16_wrapper(session, input);
+   double funcValDown = Linear_16_num_eval(session, input);
    input[i] = origVal + eps;
-   float funcValUp = Linear_16_wrapper(session, input);
+   double funcValUp = Linear_16_num_eval(session, input);
    input[i] = origVal;
 
    return (funcValUp - funcValDown) / (2 * eps);


### PR DESCRIPTION
Use `double` for the accumulator in the computation of the numerically differentiated reference result. This should fix the platform-dependent test failure that we are seeing see only on Fedora 44 (master and 6.40):

```txt
1359/3779 Test  #474: tmva-sofie-test-TestCladAutodiff ..................................................................***Failed    1.72 sec
-- TEST COMMAND --
cd /github/home/ROOT-CI/build/tmva/sofie/test
./TestCladAutodiff
-- BEGIN TEST OUTPUT --
Running main() from /builddir/build/BUILD/gtest-1.17.0-build/googletest-1.17.0/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ONNXClad
[ RUN      ] ONNXClad.Linear16
/github/home/ROOT-CI/src/tmva/sofie/test/TestCladAutodiff.cxx:109: Failure
Failed
Mismatch at index 1233 analytic=0.02939869649708271 numeric=0.026702878996729851 diff=0.0026958175003528595

[  FAILED  ] ONNXClad.Linear16 (1637 ms)
[----------] 1 test from ONNXClad (1637 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1642 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ONNXClad.Linear16

 1 FAILED TEST

-- END TEST OUTPUT --
CMake Error at /github/home/ROOT-CI/src/cmake/modules/RootTestDriver.cmake:210 (message):
  got exit code 1 but expected 0
```