### PR TITLE
[cmake] Fix CMake 4.4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,7 +603,7 @@ add_custom_target(dist COMMAND cpack --config CPackConfig.cmake)
 get_cmake_property(variables CACHE_VARIABLES)
 foreach(var ${variables})
   if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
-     (NOT ${${var}} STREQUAL "") AND
+     (NOT "${${var}}" STREQUAL "") AND
      (NOT ${var} MATCHES "NOTFOUND"))
     if (var MATCHES "^QT_")
       # filter out the very long list of Qt libraries and include dirs


### PR DESCRIPTION
# This Pull request:

Fixes compatibility with CMake 4.4.0 by adding some missing quoting.

The loop in `CMakeLists.txt` that assembles the `root-config --config`
arguments guards each cache variable with:

```cmake
if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
   (NOT ${${var}} STREQUAL "") AND
   (NOT ${var} MATCHES "NOTFOUND"))
```

CMake silently accepted this until 4.4, which now propagates errors from
parenthesised `if()` sub-expressions so configuration aborts with `Unknown arguments specified`. See https://gitlab.kitware.com/cmake/cmake/-/issues/26424.

🤖 The diff and reproducer (below) were generated with AI 🤖

### Reproducer

Minimal, ROOT-independent `CMakeLists.txt`:

```cmake
cmake_minimum_required(VERSION 3.20)
project(repro NONE)

# A cache STRING whose value is a list, like ROOT's CLING_LIBRARIES
set(CLING_LIBRARIES "clingInterpreter;clingMetaProcessor;clingUtils" CACHE STRING "")
set(var CLING_LIBRARIES)

if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
   (NOT ${${var}} STREQUAL "") AND
   (NOT ${var} MATCHES "NOTFOUND"))
  message(STATUS "matched ${var}")
endif()
```

`cmake -S . -B build` with **CMake 4.4.0**:

```
CMake Error at CMakeLists.txt:8 (if):
  if given arguments:
    "(" "var" "MATCHES" "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)" ")" "AND" "(" "NOT" "clingInterpreter" "clingMetaProcessor" "clingUtils" "STREQUAL" "" ")" "AND" "(" "NOT" "CLING_LIBRARIES" "MATCHES" "NOTFOUND" ")"
  Unknown arguments specified
-- Configuring incomplete, errors occurred!
```

The same input configures cleanly on CMake 4.3 and below.

## Changes or fixes:

* Compatibility with CMake 4.4.0

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)