### PR TITLE
[test] Use correct stl include

### DIFF
--- a/roottest/root/meta/autoloading/headerParsingOnDemand/h1.h
+++ b/roottest/root/meta/autoloading/headerParsingOnDemand/h1.h
@@ -33,7 +33,7 @@ public:
 template <class T>
 class myClass4{
 public:
-   void myMethod(const T*const**&& ){}; // Unluky signature but interesting for this test ;-)
+   void myMethod(const T*const**&& ){}; // Unlucky signature but interesting for this test ;-)
 };
 
 //--------------------
@@ -56,7 +56,7 @@ private:
    const myTemplate<T***const>**const* dummy;
 };
 
-#include <queue>
+#include <set>
 //--------------------
 template <class T>
 class myClass8{


### PR DESCRIPTION
and fix a typo.

The problem addressed is not a blocker, however could become an issue in a future version of the stl library in case the implicit include is not any more happening.
