### PR TITLE
[io] Add error message in TFile::Open if LoadPlugin fails

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1150,8 +1150,10 @@ void TFile::DrawMap(const char *keys, Option_t *option)
 {
    TPluginHandler *h;
    if ((h = gROOT->GetPluginManager()->FindHandler("TFileDrawMap"))) {
-      if (h->LoadPlugin() == -1)
+      if (h->LoadPlugin() == -1) {
+         ::Error("TFile::Open", "Failed to load plugin TFileDrawMap");
          return;
+      }
       h->ExecPlugin(3, this, keys, option);
    }
 }
@@ -3964,8 +3966,10 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
 
             // Network files
             if ((h = gROOT->GetPluginManager()->FindHandler("TFile", name))) {
-               if (h->LoadPlugin() == -1)
+               if (h->LoadPlugin() == -1) {
+                  ::Error("TFile::Open", "Failed to load plugin %s", name.Data());
                   return nullptr;
+               }
                f = (TFile*) h->ExecPlugin(5, name.Data(), option, ftitle, compress, netopt);
             }
 
@@ -3973,8 +3977,10 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
 
             // Web files
             if ((h = gROOT->GetPluginManager()->FindHandler("TFile", name))) {
-               if (h->LoadPlugin() == -1)
+               if (h->LoadPlugin() == -1) {
+                  ::Error("TFile::Open", "Failed to load plugin %s", name.Data());
                   return nullptr;
+               }
                f = (TFile*) h->ExecPlugin(2, name.Data(), option);
             }
 
@@ -3992,8 +3998,10 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
 
             // no recognized specification: try the plugin manager
             if ((h = gROOT->GetPluginManager()->FindHandler("TFile", name.Data()))) {
-               if (h->LoadPlugin() == -1)
+               if (h->LoadPlugin() == -1) {
+                  ::Error("TFile::Open", "Failed to load plugin %s", name.Data());
                   return nullptr;
+               }
                f = (TFile *)h->ExecPlugin(4, name.Data(), option, ftitle, compress);
             } else {
                // Just try to open it locally but via TFile::Open, so that we pick-up the correct


### PR DESCRIPTION
This makes some failures more understandable, e.g. if you try to open a remote file with a version of root that has no xrootd support. It's not a *great* error, but at least it directs you closer to the cause of the error.
Practical example:

Before the change:
```
$ rootcp --recreate root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root copy_remote.root
Error in <rootcp>: Failed to open file 'root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root'
```

After the change:

```
$ rootcp --recreate root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root copy_remote.root 
Error in <TPluginHandler::LoadPluginImpl>: Failed to load plugin NetxNG
Error in <TPluginHandler::LoadPluginImpl>: Failed to load plugin NetxNG
Error in <rootcp>: Failed to open file 'root://eospublic.cern.ch//eos/root-eos/h1/dstarmb.root'
```
