### PR TITLE
Profile schema backend fixes

### DIFF
--- a/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
@@ -502,7 +502,7 @@ public:
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Print a string that represents the tree of the (sub)fields and columns of an RNTuple in a format which a
    /// performance profile visualizer can render
-   void PrintSchemaProfile(ESchemaProfileFormat format, std::ostream &output = std::cout) const;
+   void PrintSchemaProfile([[maybe_unused]] ESchemaProfileFormat format, std::ostream &output = std::cout) const;
 };
 } // namespace Experimental
 } // namespace ROOT

--- a/tree/ntupleutil/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/src/RNTupleInspector.cxx
@@ -670,8 +670,8 @@ void ROOT::Experimental::RNTupleInspector::PrintSchemaProfile(ESchemaProfileForm
          std::size_t columnSize = columnInfo.GetCompressedSize();
 
          SpeedscopeFrame columnSpeedscopeFrame;
-         columnSpeedscopeFrame.fPrimaryString = tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId()) +
-                                                " [col#" + std::to_string(columnDescriptor.GetPhysicalId()) + "]";
+         columnSpeedscopeFrame.fPrimaryString = "[col#" + std::to_string(columnDescriptor.GetPhysicalId()) + "]" +
+                                                tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId());
          columnSpeedscopeFrame.fSecondaryString =
             ROOT::Internal::RColumnElementBase::GetColumnTypeName(columnDescriptor.GetType());
          columnSpeedscopeFrame.fOpeningPosition = positionCursor;

--- a/tree/ntupleutil/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/src/RNTupleInspector.cxx
@@ -568,8 +568,7 @@ void ROOT::Experimental::RNTupleInspector::PrintFieldTreeAsDot(const ROOT::RFiel
 namespace {
 
 struct SpeedscopeFrame {
-   std::string fPrimaryString;
-   std::string fSecondaryString;
+   std::string fString;
    std::uint64_t fOpeningPosition = 0;
    std::uint64_t fClosingPosition = 0;
 };
@@ -582,10 +581,7 @@ static void PrintSpeedscopeFrames(const std::vector<SpeedscopeFrame> &frames, st
    output << "      \"frames\":[\n";
 
    for (std::size_t i = 0; i < frames.size(); ++i) {
-      output << "         { \"name\":\"" << frames[i].fPrimaryString
-             << "\", \"file\":\"Type: " << frames[i].fSecondaryString
-             << ", Size: " << frames[i].fClosingPosition - frames[i].fOpeningPosition << "B\" }"
-             << (i + 1 < frames.size() ? ",\n" : "\n");
+      output << "         { \"name\":\"" << frames[i].fString << "\" }" << (i + 1 < frames.size() ? ",\n" : "\n");
    }
 
    output << "      ]\n";
@@ -650,12 +646,12 @@ void ROOT::Experimental::RNTupleInspector::PrintSchemaProfile(ESchemaProfileForm
    // Returns size of the visited field
    auto visitFieldsRecursive = [&](auto &self, const ROOT::RFieldDescriptor &fieldDescriptor) -> std::size_t {
       SpeedscopeFrame fieldSpeedscopeFrame;
-      fieldSpeedscopeFrame.fPrimaryString = tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId());
-      fieldSpeedscopeFrame.fSecondaryString = fieldDescriptor.GetTypeName();
+      fieldSpeedscopeFrame.fString =
+         tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId()) + " (" + fieldDescriptor.GetTypeName() + ")";
       fieldSpeedscopeFrame.fOpeningPosition = positionCursor;
       frames.push_back(fieldSpeedscopeFrame);
 
-      const std::size_t fieldSpeedscopeFrameIndex = frames.size() - 1;
+      std::size_t fieldSpeedscopeFrameIndex = frames.size() - 1;
 
       std::size_t subTreeSize = 0;
       const auto &childIds = fieldDescriptor.GetLinkIds();
@@ -670,10 +666,10 @@ void ROOT::Experimental::RNTupleInspector::PrintSchemaProfile(ESchemaProfileForm
          std::size_t columnSize = columnInfo.GetCompressedSize();
 
          SpeedscopeFrame columnSpeedscopeFrame;
-         columnSpeedscopeFrame.fPrimaryString = "[col#" + std::to_string(columnDescriptor.GetPhysicalId()) + "]" +
-                                                tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId());
-         columnSpeedscopeFrame.fSecondaryString =
-            ROOT::Internal::RColumnElementBase::GetColumnTypeName(columnDescriptor.GetType());
+         columnSpeedscopeFrame.fString =
+            "[col#" + std::to_string(columnDescriptor.GetPhysicalId()) + "] " +
+            tupleDescriptor.GetQualifiedFieldName(fieldDescriptor.GetId()) + " (" +
+            ROOT::Internal::RColumnElementBase::GetColumnTypeName(columnDescriptor.GetType()) + ")";
          columnSpeedscopeFrame.fOpeningPosition = positionCursor;
          positionCursor += columnSize;
          columnSpeedscopeFrame.fClosingPosition = positionCursor;

--- a/tree/ntupleutil/src/RNTupleInspector.cxx
+++ b/tree/ntupleutil/src/RNTupleInspector.cxx
@@ -686,7 +686,11 @@ void ROOT::Experimental::RNTupleInspector::PrintSchemaProfile(ESchemaProfileForm
       return subTreeSize;
    };
 
-   visitFieldsRecursive(visitFieldsRecursive, rootFieldDescriptor);
+   const auto &topLevelIds = rootFieldDescriptor.GetLinkIds();
+   for (const auto &childId : topLevelIds) {
+      const auto &childFieldDescriptor = tupleDescriptor.GetFieldDescriptor(childId);
+      visitFieldsRecursive(visitFieldsRecursive, childFieldDescriptor);
+   }
 
    PrintSpeedscopeFrames(frames, output);
 }

--- a/tree/ntupleutil/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/test/ntuple_inspector.cxx
@@ -882,14 +882,14 @@ TEST(RNTupleInspector, SchemaProfile)
    std::ostringstream schemaProfileStream;
    inspector->PrintSchemaProfile(ROOT::Experimental::ESchemaProfileFormat::kSpeedscopeJSON, schemaProfileStream);
    const std::string schemaProfile = schemaProfileStream.str();
-   const std::string expected = R"({
+   const std::string expected = R"foo({
    "$schema":"https://www.speedscope.app/file-format-schema.json",
    "shared":{
       "frames":[
-         { "name":"float1", "file":"Type: float, Size: 40B" },
-         { "name":"[col#0]float1", "file":"Type: SplitReal32, Size: 40B" },
-         { "name":"int", "file":"Type: std::int32_t, Size: 40B" },
-         { "name":"[col#1]int", "file":"Type: SplitInt32, Size: 40B" }
+         { "name":"float1 (float)" },
+         { "name":"[col#0] float1 (SplitReal32)" },
+         { "name":"int (std::int32_t)" },
+         { "name":"[col#1] int (SplitInt32)" }
       ]
    },
    "profiles":[
@@ -912,6 +912,6 @@ TEST(RNTupleInspector, SchemaProfile)
       }
    ]
 }
-)";
+)foo";
    EXPECT_EQ(schemaProfile, expected);
 }

--- a/tree/ntupleutil/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/test/ntuple_inspector.cxx
@@ -887,9 +887,9 @@ TEST(RNTupleInspector, SchemaProfile)
    "shared":{
       "frames":[
          { "name":"float1", "file":"Type: float, Size: 40B" },
-         { "name":"float1 [col#0]", "file":"Type: SplitReal32, Size: 40B" },
+         { "name":"[col#0]float1", "file":"Type: SplitReal32, Size: 40B" },
          { "name":"int", "file":"Type: std::int32_t, Size: 40B" },
-         { "name":"int [col#1]", "file":"Type: SplitInt32, Size: 40B" }
+         { "name":"[col#1]int", "file":"Type: SplitInt32, Size: 40B" }
       ]
    },
    "profiles":[

--- a/tree/ntupleutil/test/ntuple_inspector.cxx
+++ b/tree/ntupleutil/test/ntuple_inspector.cxx
@@ -886,7 +886,6 @@ TEST(RNTupleInspector, SchemaProfile)
    "$schema":"https://www.speedscope.app/file-format-schema.json",
    "shared":{
       "frames":[
-         { "name":"", "file":"Type: , Size: 80B" },
          { "name":"float1", "file":"Type: float, Size: 40B" },
          { "name":"float1 [col#0]", "file":"Type: SplitReal32, Size: 40B" },
          { "name":"int", "file":"Type: std::int32_t, Size: 40B" },
@@ -903,14 +902,12 @@ TEST(RNTupleInspector, SchemaProfile)
          "events":[
             {"type":"O","frame":0,"at":0},
             {"type":"O","frame":1,"at":0},
-            {"type":"O","frame":2,"at":0},
-            {"type":"C","frame":2,"at":40},
             {"type":"C","frame":1,"at":40},
+            {"type":"C","frame":0,"at":40},
+            {"type":"O","frame":2,"at":40},
             {"type":"O","frame":3,"at":40},
-            {"type":"O","frame":4,"at":40},
-            {"type":"C","frame":4,"at":80},
             {"type":"C","frame":3,"at":80},
-            {"type":"C","frame":0,"at":80}
+            {"type":"C","frame":2,"at":80}
          ]
       }
    ]


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

All of them in relation to `PrintSchemaProfile` method in `RNTupleInspector` class for the currently only supported format `kSpeedscopeJSON`.

### Functional changes:

- Remove root field.
- Move column number to the front of the name string in order to attempt to trigger Speedcope to paint column frames in similar colors in order to distinguish them from field frames.
- Move all information of frames into a single string to avoid trailing `:` character.

### Fixes:

- Add `maybe_unused` attribute to `format` to silence the warning that states that right now it is unused.

## Checklist:

- [ x ] tested changes locally <- on the tree/ntupleutil/test/ntuple_inspector suite
- [ ] updated the docs (if necessary) <- I don't believe it's necessary for the changes I made

This PR fixes # 

