### PR TITLE
[RF] Make RooAbsDataHelper::Exec well-formed for an empty parameter pack

### DIFF
--- a/roofit/roofitcore/inc/RooAbsDataHelper.h
+++ b/roofit/roofitcore/inc/RooAbsDataHelper.h
@@ -143,9 +143,10 @@ public:
    void Exec(unsigned int slot, ColumnTypes... values)
    {
       std::vector<double> &vector = _events[slot];
-      for (auto &&val : {static_cast<double>(values)...}) {
-         vector.push_back(val);
-      }
+      // A fold expression is used instead of iterating over a
+      // std::initializer_list so that this compiles also with an empty pack
+      // (an instantiation that RDataFrame requires to be well-formed).
+      (vector.push_back(static_cast<double>(values)), ...);
 
       ExecImpl(sizeof...(values), vector);
    }


### PR DESCRIPTION
The body of RooAbsDataHelper::Exec used a range-based for loop over a braced-init-list of the parameter pack:

    for (auto &&val : {static_cast<double>(values)...})

With an empty pack this becomes `for (auto &&val : {})`, which is ill-formed since the element type cannot be deduced from an empty list.

The empty-pack instantiation is required to be well-formed by RDataFrame: instantiating Book<RInferredType, Helper> (as done when booking the helper from Python without explicit column types) compiles the no-columns branch of Book, which instantiates
RAction<Helper, ..., TypeList<>> and with it Exec<>.

This went unnoticed so far because cling's TClingCallFunc happens to skip the vtable-driven instantiation of the ill-formed virtual RAction::Run in the never-taken branch. The stricter wrapper compilation in CppInterOp surfaces the error, which made rf408_RDataFrameToRooFit.py fail with cppyy on top of CppInterOp.

Use a fold expression instead, which is valid for an empty pack.

🤖 Done with the help of AI.