### PR TITLE
[graf2d] Further simplify freetype resource cleanup.

### DIFF
--- a/graf2d/graf/inc/TTF.h
+++ b/graf2d/graf/inc/TTF.h
@@ -68,6 +68,7 @@ public:
       FT_Vector  fPos;          ///< position of glyph origin
       FT_Glyph   fImage{nullptr}; ///< glyph image
       TTGlyph(UInt_t indx = 0) : fIndex(indx) {}
+      ~TTGlyph();
    };
 
    TTF() {}

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -35,6 +35,11 @@ const Float_t kScale = 0.93376068;
 Bool_t TTFhandle::fgHinting = kFALSE;
 Bool_t TTFhandle::fgSmoothing = kTRUE;
 
+/// Free all resources of this glyph.
+TTF::TTGlyph::~TTGlyph()
+{
+   FT_Done_Glyph(fImage);
+}
 
 struct TTFontHandle {
    std::string name;
@@ -66,8 +71,6 @@ struct TTFhandle::FT_Library_Wrapper {
       }
       return _library;
    }
-
-   bool InitCompleted() const { return _library != nullptr; }
 
    ~FT_Library_Wrapper()
    {
@@ -278,15 +281,6 @@ FT_BitmapGlyph TTFhandle::GetGlyphBitmap(UInt_t n, Bool_t smooth)
 
 void TTFhandle::CleanupGlyphs()
 {
-   bool is_lib = fFT_Library.InitCompleted();
-
-   for(auto &glyph : fGlyphs) {
-      // clear existing image if there is one
-      if (glyph.fImage && is_lib) {
-         FT_Done_Glyph(glyph.fImage);
-         glyph.fImage = nullptr;
-      }
-   }
    fGlyphs.clear();
 }
 

--- a/graf2d/graf/src/TTF.cxx
+++ b/graf2d/graf/src/TTF.cxx
@@ -83,7 +83,11 @@ thread_local TTFhandle::FT_Library_Wrapper TTFhandle::fFT_Library;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TTFhandle::TTFhandle() = default;
+TTFhandle::TTFhandle()
+{
+   // Ensure that there's a freetype library in our thread
+   fFT_Library.Get();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
In looking for a memory leak (which turned out to be a freetype issue [1]), it became evident that TTGlyph can actually handle its own cleanup, allowing for simplifying the code.

[1] https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1399
