### PR TITLE
[tmva][sofie] fix padding order for Conv operator in Keras parser

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/layers/conv.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/_sofie/_parser/_keras/layers/conv.py
@@ -64,7 +64,7 @@ def MakeKerasConv(layer):
         padding_bottom = padding_height - padding_top
         padding_left = math.floor(padding_width / 2)
         padding_right = padding_width - padding_left
-        fAttrPads = [padding_top, padding_bottom, padding_left, padding_right]
+        fAttrPads = [padding_top, padding_left, padding_bottom, padding_right]
     else:
         raise RuntimeError(
             "TMVA::SOFIE - RModel Keras Parser doesn't yet supports Convolution layer with padding " + fKerasPadding

--- a/bindings/pyroot/pythonizations/test/generate_keras_functional.py
+++ b/bindings/pyroot/pythonizations/test/generate_keras_functional.py
@@ -104,6 +104,13 @@ def generate_keras_functional(dst_dir):
     model = models.Model(inp, out)
     train_and_save(model, "Conv2D_padding_same_dilation")
 
+    # Conv2D padding_same with an asymmetric (non-square) kernel, so that the height and width
+    # padding amounts differ.
+    inp = layers.Input(shape=(8, 8, 3))
+    out = layers.Conv2D(4, (3, 5), padding='same', data_format='channels_last', activation='relu')(inp)
+    model = models.Model(inp, out)
+    train_and_save(model, "Conv2D_padding_same_asymmetric_kernel")
+
     # Conv2D padding_valid
     inp = layers.Input(shape=(8, 8, 3))
     out = layers.Conv2D(4, (3, 3), padding='valid', data_format='channels_last', activation='elu')(inp)

--- a/bindings/pyroot/pythonizations/test/generate_keras_sequential.py
+++ b/bindings/pyroot/pythonizations/test/generate_keras_sequential.py
@@ -95,6 +95,14 @@ def generate_keras_sequential(dst_dir):
     ])
     train_and_save(model, "Conv2D_padding_same_dilation")
 
+    # Conv2D padding_same with an asymmetric (non-square) kernel, so that the height and width
+    # padding amounts differ.
+    model = models.Sequential([
+        layers.Input(shape=(8, 8, 3)),
+        layers.Conv2D(4, (3, 5), padding='same', data_format='channels_last', activation='relu')
+    ])
+    train_and_save(model, "Conv2D_padding_same_asymmetric_kernel")
+
     # Conv2D padding_valid
     model = models.Sequential([
         layers.Input(shape=(8, 8, 3)),

--- a/bindings/pyroot/pythonizations/test/sofie_keras_parser.py
+++ b/bindings/pyroot/pythonizations/test/sofie_keras_parser.py
@@ -23,6 +23,7 @@ models = [
     "Conv2D_channels_first_padding_same_stride2",
     "Conv2D_padding_same",
     "Conv2D_padding_same_dilation",
+    "Conv2D_padding_same_asymmetric_kernel",
     "Conv2D_padding_valid",
     "Dense",
     "ELU",


### PR DESCRIPTION
This PR fixes the padding order for the Conv operator in the Keras parser to align with the ONNX specification mentioned here: https://onnx.ai/onnx/operators/onnx__Conv.html. It also adds a test for the Conv operator on an asymmetric kernel to verify its validity.