### PR TITLE
[RF] Avoid invalid comparisons in RooStats Python tutorials

### DIFF
--- a/tutorials/roofit/roostats/StandardBayesianMCMCDemo.py
+++ b/tutorials/roofit/roostats/StandardBayesianMCMCDemo.py
@@ -158,7 +158,7 @@ def StandardBayesianMCMCDemo(infile="", workspaceName="combined", modelConfigNam
         c2.Divide(nx, ny)
 
     # draw a scatter plot of chain results for poi vs each nuisance parameters
-    nuis = ROOT.kNone
+    nuis = ROOT.nullptr
     iPad = 1  # iPad, that's funny
 
     for nuis in mc.GetNuisanceParameters():

--- a/tutorials/roofit/roostats/StandardHistFactoryPlotsWithCategories.py
+++ b/tutorials/roofit/roostats/StandardHistFactoryPlotsWithCategories.py
@@ -116,8 +116,8 @@ def StandardHistFactoryPlotsWithCategories(
     mc.GetNuisanceParameters().Print("v")
     nPlotsMax = 1000
     print(f" check expectedData by category")
-    simData = ROOT.kNone
-    simPdf = ROOT.kNone
+    simData = ROOT.nullptr
+    simPdf = ROOT.nullptr
     if str(mc.GetPdf().ClassName()) == "RooSimultaneous":
         print(f"Is a simultaneous PDF")
         simPdf = mc.GetPdf()

--- a/tutorials/roofit/roostats/StandardHypoTestDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestDemo.py
@@ -443,7 +443,7 @@ def StandardHypoTestDemo(
         writeResult = True
         ROOT.Info("StandardHypoTestDemo", "Detailed output will be written in output result file")
 
-    if htr != ROOT.kNone and writeResult:
+    if htr != ROOT.nullptr and writeResult:
 
         # write to a file the results
         calcTypeName = "Freq" if (calcType == 0) else ("Hybr" if (calcType == 1) else ("Asym"))

--- a/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
+++ b/tutorials/roofit/roostats/StandardHypoTestInvDemo.py
@@ -286,7 +286,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
             ROOT.Info("StandardHypoTestInvDemo", "detailed output will be written in output result file")
 
         # write result in a file
-        if r != ROOT.kNone and self.mWriteResult:
+        if r != ROOT.nullptr and self.mWriteResult:
 
             # write to a file the results
             calcType = "Freq" if (calculatorType == 0) else ("Hybr" if (calculatorType == 1) else "Asym")
@@ -689,7 +689,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
             return 0
 
         # set the test statistic
-        testStat = 0
+        testStat = ROOT.nullptr
         if testStatType == 0:
             testStat = slrts
         if testStatType == 1 or testStatType == 11:
@@ -701,7 +701,7 @@ class HypoTestInvTool_plus(ROOT.RooStats.HypoTestInvTool):
         if testStatType == 6:
             testStat = nevtts
 
-        if testStat == 0:
+        if testStat == ROOT.nullptr:
             Error(
                 "StandardHypoTestInvDemo",
                 "Invalid - test statistic type = {testStatType} supported values are only :\n\t\t\t 0 (SLR) "
@@ -1103,7 +1103,7 @@ def StandardHypoTestInvDemo(
     w = file.Get(wsName)
     r = 0
     print(w, "\t", filename)
-    if w != ROOT.kNone:
+    if w != ROOT.nullptr:
         r = calc.RunInverter(
             w,
             modelSBName,

--- a/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
+++ b/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
@@ -194,7 +194,7 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
 
     # --------------------------------------------
     # show use of MCMCCalculator utility in RooStats
-    mcInt = ROOT.kNone
+    mcInt = ROOT.nullptr
 
     if doMCMC:
         # turn some messages back on
@@ -255,7 +255,7 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
             forContour.SetLineColor(ROOT.kRed)
             forContour.Draw("cont2,same")
 
-    mcPlot = ROOT.kNone
+    mcPlot = ROOT.nullptr
     if mcInt:
         print(f"MCMC actual confidence level: ", mcInt.GetActualConfidenceLevel())
         mcPlot = ROOT.RooStats.MCMCIntervalPlot(mcInt)

--- a/tutorials/roofit/roostats/rs_numberCountingCombination.py
+++ b/tutorials/roofit/roostats/rs_numberCountingCombination.py
@@ -118,7 +118,7 @@ def rs_numberCountingCombination_expected():
 
     # Step 6, Use the Calculator to get a HypoTestResult
     htr = plc.GetHypoTest()
-    assert htr != 0
+    assert htr != ROOT.nullptr
     print("-------------------------------------------------")
     print("The p-value for the null is ", htr.NullPValue())
     print("Corresponding to a significance of ", htr.Significance())


### PR DESCRIPTION
In the RooStats Python tutorials, there are some comparisons in place that would be fragile or in C++, like comparisons of RooStats types with integers (only possible in C++ with the literal zero), or with unrelated enum values. The Python bindings will become more strict about these situations and deter you from doing these comparisons.

Therefore, this commit changes the comparisons to valid `nullptr` comparisons.