### PR TITLE
[RF] Remove confusing `RooMinimizer::Strategy` enum

### DIFF
--- a/README/ReleaseNotes/v642/index.md
+++ b/README/ReleaseNotes/v642/index.md
@@ -77,6 +77,10 @@ maps) will now obtain different, mathematically consistent values.
 
 ## RooFit
 
+### Small changes
+
+* The `RooMinimizer::Strategy` enum has been removed. It named the Minuit strategies that are usually referred to just by integers, but caused confusion because it didn't include the unnamed "Strategy 3". Since people usually set the strategy with integer values anyway, it was decided that the simplest solution to avoid the confusion was simply to remove the `RooMinimizer::Strategy` enum
+
 ### Removal of the the constant term optimization for legacy test statistic classes
 
 The **RooFit::Optimize()** option (constant term optimization) has been deprecated in ROOT 6.40 its functionality was now removed.

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -133,7 +133,6 @@ public:
 
    ~RooMinimizer() override;
 
-   enum Strategy { Speed = 0, Balance = 1, Robustness = 2 };
    enum PrintLevel { None = -1, Reduced = 0, Normal = 1, ExtraForProblem = 2, Maximum = 3 };
 
    // Setters on _theFitter


### PR DESCRIPTION
The `RooMinimizer::Strategy` enum has been removed. It named the Minuit strategies that are usually referred to just by integers, but caused confusion because it didn't include the unnamed "Strategy 3". Since people usually set the strategy with integer values anyway, it was decided that the simplest solution to avoid the confusion was simply to remove the `RooMinimizer::Strategy` enum.

This was discussed with @will-cern and @alexander-held