### PR TITLE
[ntuple] Fix entry loading across joined chains

### DIFF
--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -393,8 +393,7 @@ void ROOT::Experimental::RNTupleChainProcessor::AddEntriesToJoinTable(Internal::
    for (unsigned i = 0; i < fInnerProcessors.size(); ++i) {
       const auto &innerProc = fInnerProcessors[i];
       // TODO can this be done (more) lazily? I.e. only when a match cannot be found in the current inner proc?
-      // At this stage, we don't want to fully initialize (i.e. set the entry of) the inner processor yet
-      innerProc->Initialize(nullptr);
+      innerProc->Initialize(fEntry);
       innerProc->AddEntriesToJoinTable(joinTable, entryOffset);
       entryOffset += innerProc->GetNEntries();
    }
@@ -556,9 +555,7 @@ ROOT::NTupleSize_t ROOT::Experimental::RNTupleJoinProcessor::LoadEntry(ROOT::NTu
       SetAuxiliaryFieldValidity(false);
    } else {
       SetAuxiliaryFieldValidity(true);
-      for (const auto &fieldIdx : fAuxiliaryFieldIdxs) {
-         fEntry->ReadValue(fieldIdx, entryIdx);
-      }
+      fAuxiliaryProcessor->LoadEntry(entryIdx);
    }
 
    return entryNumber;

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -556,6 +556,91 @@ TEST_F(RNTupleProcessorTest, JoinedChainMissingEntries)
    EXPECT_EQ(10, proc->GetNEntriesProcessed());
 }
 
+TEST(RNTupleProcessor, JoinedChainCrossedEntries)
+{
+   FileRaii fileGuard1("ntuple_processor_test_chained_join_crossed1.root");
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto fldI = model->MakeField<std::uint32_t>("i");
+      auto fldX = model->MakeField<float>("x");
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard1.GetPath());
+
+      *fldI = 0;
+      *fldX = 0.f;
+      writer->Fill();
+
+      *fldI = 1;
+      *fldX = 1.f;
+      writer->Fill();
+   }
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto fldI = model->MakeField<std::uint32_t>("i");
+      auto fldY = model->MakeField<float>("y");
+
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard1.GetPath().c_str(), "UPDATE"));
+      auto writer = ROOT::RNTupleWriter::Append(std::move(model), "ntuple_aux", *file);
+
+      *fldI = 0;
+      *fldY = 0.f;
+      writer->Fill();
+
+      *fldI = 2;
+      *fldY = 2.f;
+      writer->Fill();
+   }
+
+   FileRaii fileGuard2("ntuple_processor_test_chained_join_crossed2.root");
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto fldI = model->MakeField<std::uint32_t>("i");
+      auto fldX = model->MakeField<float>("x");
+
+      auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard2.GetPath());
+
+      *fldI = 2;
+      *fldX = 2.f;
+      writer->Fill();
+
+      *fldI = 3;
+      *fldX = 3.f;
+      writer->Fill();
+   }
+   {
+      auto model = ROOT::RNTupleModel::Create();
+      auto fldI = model->MakeField<std::uint32_t>("i");
+      auto fldY = model->MakeField<float>("y");
+
+      auto file = std::unique_ptr<TFile>(TFile::Open(fileGuard2.GetPath().c_str(), "UPDATE"));
+      auto writer = ROOT::RNTupleWriter::Append(std::move(model), "ntuple_aux", *file);
+
+      *fldI = 1;
+      *fldY = 1.f;
+      writer->Fill();
+
+      *fldI = 3;
+      *fldY = 3.f;
+      writer->Fill();
+   }
+
+   auto chain_primary =
+      RNTupleProcessor::CreateChain({{"ntuple", fileGuard1.GetPath()}, {"ntuple", fileGuard2.GetPath()}});
+   auto chain_auxiliary =
+      RNTupleProcessor::CreateChain({{"ntuple_aux", fileGuard1.GetPath()}, {"ntuple_aux", fileGuard2.GetPath()}});
+   auto proc = RNTupleProcessor::CreateJoin(std::move(chain_primary), std::move(chain_auxiliary), {"i"});
+
+   auto x = proc->RequestField<float>("x");
+   auto y = proc->RequestField<float>("ntuple_aux.y");
+
+   for (auto idx : *proc) {
+      EXPECT_EQ(idx, static_cast<int>(*x));
+      EXPECT_FLOAT_EQ(*x, *y);
+   }
+
+   EXPECT_EQ(proc->GetNEntriesProcessed(), 4);
+}
+
 TEST_F(RNTupleProcessorTest, JoinedJoinComposedPrimary)
 {
    auto primaryProc =


### PR DESCRIPTION
This is a two-part fix related to the same bug, where in the case of a chained join, entries from the auxiliary chain couldn't be loaded, in particular when the entries are scattered across the chain.

1. Rather than individually loading the values in the auxiliary processor, call `LoadEntry` on it to ensure the entry number is resolved correctly.
2. Upon building the join table of a chain, do not initialize the inner processors with a nullptr entry. This caused them to each have their own entry rather than the shared one, and therefore they didn't have the necessary fields.

- [x] tested changes locally
- [x] updated the docs (if necessary)