### PR TITLE
[HS3] Deduplicate HistFactory modifiers during HS3 export

### DIFF
--- a/roofit/doc/developers/roofit_hs3.md
+++ b/roofit/doc/developers/roofit_hs3.md
@@ -16,15 +16,6 @@ with other statistical frameworks, and also ease of manipulation, it
 may be useful to store statistical models in text form. This library
 sets out to achieve exactly that, exporting to and importing from JSON.
 
-### Backend
-
-The default backend for this is the `nlohmann` JSON implementation,
-which ships with ROOT as a builtin dependency and will import from and
-export to JSON.
-In the past, RapidYAML (`RYML`) was supported, but the effort to keep
-this implementation up to date was too high. YML users could use YML to
-JSON converters to migrate.
-
 ### Usage
 
 The main class providing import from and export to JSON is the

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -145,18 +145,12 @@ public:
    readBinnedData(const RooFit::Detail::JSONNode &n, const std::string &namecomp, RooArgSet const &vars);
 
    bool importJSON(std::string const &filename);
-   bool importYML(std::string const &filename);
    bool importJSON(std::istream &os);
-   bool importYML(std::istream &os);
    bool exportJSON(std::string const &fileName);
-   bool exportYML(std::string const &fileName);
    bool exportJSON(std::ostream &os);
-   bool exportYML(std::ostream &os);
 
    std::string exportJSONtoString();
-   std::string exportYMLtoString();
    bool importJSONfromString(const std::string &s);
-   bool importYMLfromString(const std::string &s);
    void importJSONElement(const std::string &name, const std::string &jsonString);
    void importVariableElement(const RooFit::Detail::JSONNode &n);
 

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -769,9 +769,12 @@ struct HistoSys {
    RooAbsReal const *param = nullptr;
    std::vector<double> low;
    std::vector<double> high;
+   // Used to validate duplicate RooFit modifiers. This is intentionally not serialized until HS3 defines the
+   // structured histosys interpolation representation.
+   int interpolationCode = 4;
    RooAbsPdf const *constraint = nullptr;
-   HistoSys(const std::string &n, RooAbsReal *const p, RooHistFunc *l, RooHistFunc *h, const RooAbsPdf *c)
-      : name(n), param(p), constraint(c)
+   HistoSys(const std::string &n, RooAbsReal *const p, RooHistFunc *l, RooHistFunc *h, int i, const RooAbsPdf *c)
+      : name(n), param(p), interpolationCode(i), constraint(c)
    {
       low.assign(l->dataHist().weightArray(), l->dataHist().weightArray() + l->dataHist().numEntries());
       high.assign(h->dataHist().weightArray(), h->dataHist().weightArray() + h->dataHist().numEntries());
@@ -904,7 +907,7 @@ NormSys parseOverallModifierFormula(const std::string &s, RooFormulaVar *formula
    return sys;
 }
 
-void collectElements(RooArgSet &elems, RooAbsArg *arg)
+void collectElements(RooArgList &elems, RooAbsArg *arg)
 {
    if (auto prod = dynamic_cast<RooProduct *>(arg)) {
       for (const auto &e : prod->components()) {
@@ -1085,7 +1088,7 @@ Channel readChannel(RooJSONFactoryWSTool *tool, const std::string &pdfname, cons
          }
       };
 
-      RooArgSet elems;
+      RooArgList elems;
       collectElements(elems, func);
       collectElements(elems, sumpdf->coefList().at(sampleidx));
       processElements(elems, processElements);
@@ -1113,7 +1116,7 @@ Channel readChannel(RooJSONFactoryWSTool *tool, const std::string &pdfname, cons
                   if (!constraint && !var->isConstant()) {
                      RooJSONFactoryWSTool::error("cannot find constraint for " + std::string(var->GetName()));
                   } else {
-                     sample.histosys.emplace_back(sysname, var, lo, hi, constraint);
+                     sample.histosys.emplace_back(sysname, var, lo, hi, pip->interpolationCodes()[i], constraint);
                   }
                }
             }
@@ -1192,6 +1195,154 @@ Channel readChannel(RooJSONFactoryWSTool *tool, const std::string &pdfname, cons
 
    sortByName(channel.samples);
    return channel;
+}
+
+bool hasSameMetadata(const RooAbsArg *lhs, const RooAbsArg *rhs)
+{
+   if (!lhs || !rhs) {
+      return lhs == rhs;
+   }
+   return std::string{lhs->GetName()} == rhs->GetName() && lhs->IsA() == rhs->IsA();
+}
+
+[[noreturn]] void duplicateModifierError(const Channel &channel, const Sample &sample, std::string_view type,
+                                         std::string_view name, std::string_view reason)
+{
+   std::stringstream ss;
+   ss << "cannot combine duplicate modifier '" << name << "' of type '" << type << "' in sample '" << sample.name
+      << "' of channel '" << channel.name << "': " << reason;
+   RooJSONFactoryWSTool::error(ss.str().c_str());
+}
+
+void warnDuplicateModifiersCombined(const Channel &channel, const Sample &sample, std::string_view type,
+                                    std::string_view name, std::size_t count)
+{
+   std::stringstream ss;
+   ss << "combined " << count << " duplicate modifiers named '" << name << "' of type '" << type << "' in sample '"
+      << sample.name << "' of channel '" << channel.name << "'";
+   RooJSONFactoryWSTool::warning(ss.str());
+}
+
+// Multiplicatively combining two normsys is only faithful when the interpolation is done in log-space, so that
+// f1(alpha) * f2(alpha) is again representable by a single normsys with the multiplied lo/hi factors. This holds for
+// the piecewise-exponential code 1 (exact everywhere) and for the default code 4 (exact at the +-1 sigma anchors and in
+// the exponential extrapolation region). The linear-space codes (e.g. 0 and 2) would turn the product into a shape that
+// cannot be represented by a single normsys, so those must not be merged.
+bool normSysSupportsMultiplicativeMerge(int interpolationCode)
+{
+   return interpolationCode == 1 || interpolationCode == 4;
+}
+
+// Combines runs of adjacent modifiers that share the same name (the container is sorted by name beforehand) into a
+// single modifier. The shared metadata (constraint, parameter and interpolation code) must be identical across the
+// duplicates; the type-specific `combine` callable performs the actual merge and any additional validation.
+template <class Modifiers, class CombineFn>
+void mergeDuplicateModifiers(const Channel &channel, const Sample &sample, Modifiers &modifiers,
+                             std::string_view type, CombineFn combine)
+{
+   Modifiers mergedModifiers;
+   mergedModifiers.reserve(modifiers.size());
+
+   for (std::size_t begin = 0; begin < modifiers.size();) {
+      std::size_t end = begin + 1;
+      while (end < modifiers.size() && modifiers[end].name == modifiers[begin].name) {
+         ++end;
+      }
+
+      auto merged = modifiers[begin];
+      for (std::size_t i = begin + 1; i < end; ++i) {
+         const auto &modifier = modifiers[i];
+         if (!hasSameMetadata(merged.constraint, modifier.constraint)) {
+            duplicateModifierError(channel, sample, type, merged.name, "constraint metadata differs");
+         }
+         if (!hasSameMetadata(merged.param, modifier.param)) {
+            duplicateModifierError(channel, sample, type, merged.name, "parameter metadata differs");
+         }
+         if (merged.interpolationCode != modifier.interpolationCode) {
+            duplicateModifierError(channel, sample, type, merged.name, "interpolation codes differ");
+         }
+         combine(merged, modifier);
+      }
+
+      if (end - begin > 1) {
+         warnDuplicateModifiersCombined(channel, sample, type, merged.name, end - begin);
+      }
+      mergedModifiers.emplace_back(std::move(merged));
+      begin = end;
+   }
+
+   modifiers = std::move(mergedModifiers);
+}
+
+void mergeDuplicateNormSys(const Channel &channel, Sample &sample)
+{
+   mergeDuplicateModifiers(channel, sample, sample.normsys, "normsys",
+                           [&](NormSys &merged, const NormSys &modifier) {
+                              if (!normSysSupportsMultiplicativeMerge(merged.interpolationCode)) {
+                                 duplicateModifierError(
+                                    channel, sample, "normsys", merged.name,
+                                    "multiplicative combination is only valid for log-space interpolation codes");
+                              }
+                              merged.low *= modifier.low;
+                              merged.high *= modifier.high;
+                           });
+}
+
+void mergeDuplicateHistoSys(const Channel &channel, Sample &sample)
+{
+   const std::size_t nBins = sample.hist.size();
+   mergeDuplicateModifiers(channel, sample, sample.histosys, "histosys",
+                           [&](HistoSys &merged, const HistoSys &modifier) {
+                              if (merged.interpolationCode != 4) {
+                                 duplicateModifierError(
+                                    channel, sample, "histosys", merged.name,
+                                    "non-default interpolation cannot currently be represented by the HS3 exporter");
+                              }
+                              if (merged.low.size() != nBins || merged.high.size() != nBins ||
+                                  modifier.low.size() != nBins || modifier.high.size() != nBins) {
+                                 duplicateModifierError(channel, sample, "histosys", merged.name,
+                                                        "histogram binning differs");
+                              }
+                              for (std::size_t bin = 0; bin < nBins; ++bin) {
+                                 merged.low[bin] += modifier.low[bin] - sample.hist[bin];
+                                 merged.high[bin] += modifier.high[bin] - sample.hist[bin];
+                              }
+                           });
+}
+
+void ensureUniqueModifiers(const Channel &channel, const Sample &sample)
+{
+   std::set<std::pair<std::string, std::string>> seen;
+   auto add = [&](std::string type, const std::string &name) {
+      if (!seen.emplace(type, name).second) {
+         duplicateModifierError(channel, sample, type, name,
+                                "this modifier type cannot be combined without changing its meaning");
+      }
+   };
+
+   for (const auto &modifier : sample.normfactors)
+      add("normfactor", modifier.name);
+   for (const auto &modifier : sample.normsys)
+      add("normsys", modifier.name);
+   for (const auto &modifier : sample.histosys)
+      add("histosys", modifier.name);
+   for (const auto &modifier : sample.shapesys)
+      add("shapesys", modifier.name);
+   for (const auto &modifier : sample.otherElements)
+      add("custom", modifier.name);
+   for (const auto &modifier : sample.tmpElements)
+      add("custom", modifier.name);
+   if (sample.useBarlowBeestonLight)
+      add(::Literals::staterror, ::Literals::staterror);
+}
+
+void canonicalizeModifiers(Channel &channel)
+{
+   for (auto &sample : channel.samples) {
+      mergeDuplicateNormSys(channel, sample);
+      mergeDuplicateHistoSys(channel, sample);
+      ensureUniqueModifiers(channel, sample);
+   }
 }
 
 void configureStatError(Channel &channel)
@@ -1423,6 +1574,8 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
          return false;
       }
    }
+
+   canonicalizeModifiers(channel);
 
    // stat error handling
    configureStatError(channel);

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -331,6 +331,20 @@ double poissonTau(RooPoisson const &constraint, RooAbsArg const &gamma)
    return std::numeric_limits<double>::quiet_NaN();
 }
 
+// Returns the relative uncertainty encoded by a gamma constraint pdf. Only RooPoisson (via its tau) and RooGaussian
+// (via sigma/mean) are supported; anything else raises an error.
+double constraintRelError(RooAbsPdf const &constraint, RooAbsArg const &gamma)
+{
+   if (auto constraintP = dynamic_cast<RooPoisson const *>(&constraint)) {
+      return 1. / std::sqrt(poissonTau(*constraintP, gamma));
+   }
+   if (auto constraintG = dynamic_cast<RooGaussian const *>(&constraint)) {
+      return constraintG->getSigma().getVal() / constraintG->getMean().getVal();
+   }
+   RooJSONFactoryWSTool::error("currently, only RooPoisson and RooGaussian are supported as constraint types");
+   return std::numeric_limits<double>::quiet_NaN();
+}
+
 bool importHistSample(RooJSONFactoryWSTool &tool, RooDataHist &dh, RooArgSet const &varlist,
                       RooAbsArg const *mcStatObject, const std::string &fprefix, const JSONNode &p,
                       RooArgSet &constraints)
@@ -1138,16 +1152,7 @@ Channel readChannel(RooJSONFactoryWSTool *tool, const std::string &pdfname, cons
                channel.tot_yield[idx] += sample.hist[idx - 1];
                channel.tot_yield2[idx] += (sample.hist[idx - 1] * sample.hist[idx - 1]);
                if (constraint) {
-                  if (RooPoisson *constraint_p = dynamic_cast<RooPoisson *>(constraint)) {
-                     double erel = 1. / std::sqrt(poissonTau(*constraint_p, *g));
-                     channel.rel_errors[idx] = erel;
-                  } else if (RooGaussian *constraint_g = dynamic_cast<RooGaussian *>(constraint)) {
-                     double erel = constraint_g->getSigma().getVal() / constraint_g->getMean().getVal();
-                     channel.rel_errors[idx] = erel;
-                  } else {
-                     RooJSONFactoryWSTool::error(
-                        "currently, only RooPoisson and RooGaussian are supported as constraint types");
-                  }
+                  channel.rel_errors[idx] = constraintRelError(*constraint, *g);
                }
             }
             sample.useBarlowBeestonLight = true;
@@ -1173,15 +1178,9 @@ Channel readChannel(RooJSONFactoryWSTool *tool, const std::string &pdfname, cons
                if (!constraint) {
                   sys.constraints.push_back(0.0);
                   sys.constraintPdfs.push_back(nullptr);
-               } else if (auto constraint_p = dynamic_cast<RooPoisson *>(constraint)) {
-                  sys.constraints.push_back(1. / std::sqrt(poissonTau(*constraint_p, *g)));
-                  sys.constraintPdfs.push_back(constraint_p);
-               } else if (auto constraint_g = dynamic_cast<RooGaussian *>(constraint)) {
-                  sys.constraints.push_back(constraint_g->getSigma().getVal() / constraint_g->getMean().getVal());
-                  sys.constraintPdfs.push_back(constraint_g);
                } else {
-                  RooJSONFactoryWSTool::error(
-                     "currently, only RooPoisson and RooGaussian are supported as constraint types");
+                  sys.constraints.push_back(constraintRelError(*constraint, *g));
+                  sys.constraintPdfs.push_back(constraint);
                }
             }
             sample.shapesys.emplace_back(std::move(sys));

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -973,12 +973,6 @@ void addNormFactor(RooRealVar const *par, Sample &sample, RooWorkspace *ws)
       sample.normfactors.emplace_back(*par);
 }
 
-namespace {
-
-bool verbose = false;
-
-}
-
 struct Channel {
    std::string name;
    std::vector<Sample> samples;
@@ -1548,17 +1542,11 @@ bool tryExportHistFactory(RooJSONFactoryWSTool *tool, const std::string &pdfname
 {
    // some preliminary checks
    if (!sumpdf) {
-      if (verbose) {
-         std::cout << pdfname << " is not a sumpdf" << std::endl;
-      }
       return false;
    }
 
    for (RooAbsArg *sample : sumpdf->funcList()) {
       if (!dynamic_cast<RooProduct *>(sample) && !dynamic_cast<RooRealSumPdf *>(sample)) {
-         if (verbose)
-            std::cout << "sample " << sample->GetName() << " is no RooProduct or RooRealSumPdf in " << pdfname
-                      << std::endl;
          return false;
       }
    }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -232,7 +232,10 @@ template <bool DivideByBinWidth>
 bool importBinWidthFunction(RooJSONFactoryWSTool *tool, const JSONNode &p)
 {
    std::string name(RooJSONFactoryWSTool::name(p));
-   RooHistFunc *hf = static_cast<RooHistFunc *>(tool->request<RooAbsReal>(p["histogram"].val(), name));
+   RooHistFunc *hf = dynamic_cast<RooHistFunc *>(tool->request<RooAbsReal>(p["histogram"].val(), name));
+   if (!hf) {
+      RooJSONFactoryWSTool::error("histogram '" + p["histogram"].val() + "' of '" + name + "' is not a RooHistFunc");
+   }
    tool->wsEmplace<RooBinWidthFunction>(name, *hf, DivideByBinWidth);
    return true;
 }
@@ -325,6 +328,9 @@ bool importDecay(RooJSONFactoryWSTool *tool, const JSONNode &p)
    RooRealVar *t = tool->requestArg<RooRealVar>(p, "t");
    RooAbsReal *tau = tool->requestArg<RooAbsReal>(p, "tau");
    RooResolutionModel *model = dynamic_cast<RooResolutionModel *>(tool->requestArg<RooAbsPdf>(p, "resolutionModel"));
+   if (!model) {
+      RooJSONFactoryWSTool::error("resolutionModel of '" + name + "' is not a RooResolutionModel");
+   }
    RooDecay::DecayType decayType = static_cast<RooDecay::DecayType>(p["decayType"].val_int());
    tool->wsEmplace<RooDecay>(name, *t, *tau, *model, decayType);
    return true;

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -924,7 +924,6 @@ bool exportRealIntegral(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode 
    auto *integral = static_cast<const RooRealIntegral *>(func);
    elem["type"] << key;
    std::string integrand = integral->integrand().GetName();
-   // elem["integrand"] << RooJSONFactoryWSTool::sanitizeName(integrand);
    elem["integrand"] << integrand;
    if (integral->intRange()) {
       elem["domain"] << integral->intRange();

--- a/roofit/hs3/src/JSONIO.cxx
+++ b/roofit/hs3/src/JSONIO.cxx
@@ -20,7 +20,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <sstream>
 
 // Include raw strings with initial export and import keys in JSON

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1081,7 +1081,6 @@ std::string RooJSONFactoryWSTool::exportTransformed(const RooAbsReal *original, 
  */
 void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::string> &exportedObjectNames)
 {
-   // const std::string name = sanitizeName(func.GetName());
    std::string name = func.GetName();
 
    // if this element was already exported, skip
@@ -1618,7 +1617,6 @@ void RooJSONFactoryWSTool::exportData(RooAbsData const &data)
    for (int i = 0; i < data.numEntries(); ++i) {
       data.get(i);
       coords.append_child().fill_seq(variables, [](auto x) { return static_cast<RooRealVar *>(x)->getVal(); });
-      std::string datasetName = data.GetName();
       if (data.isWeighted()) {
          weightVals.push_back(data.weight());
          if (data.weight() != 1.)

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <stack>
 #include <stdexcept>
 
@@ -154,35 +155,12 @@ bool matches(const RooJSONFactoryWSTool::CombinedData &data, const RooSimultaneo
  */
 bool isNumber(const std::string &str)
 {
-   bool seen_digit = false;
-   bool seen_dot = false;
-   bool seen_e = false;
-   bool after_e = false;
-   bool sign_allowed = true;
-
-   for (size_t i = 0; i < str.size(); ++i) {
-      char c = str[i];
-
-      if (std::isdigit(c)) {
-         seen_digit = true;
-         sign_allowed = false;
-      } else if ((c == '+' || c == '-') && sign_allowed) {
-         // Sign allowed at the beginning or right after 'e'/'E'
-         sign_allowed = false;
-      } else if (c == '.' && !seen_dot && !after_e) {
-         seen_dot = true;
-         sign_allowed = false;
-      } else if ((c == 'e' || c == 'E') && seen_digit && !seen_e) {
-         seen_e = true;
-         after_e = true;
-         sign_allowed = true; // allow sign immediately after 'e'
-         seen_digit = false;  // reset: we now expect digits after e
-      } else {
-         return false;
-      }
-   }
-
-   return seen_digit;
+   // Parse with the same mechanism as toDouble() and require that the whole string is consumed, so that isNumber(s) is
+   // true exactly when toDouble(s) can turn the entire string into a value. (std::from_chars for floating-point types
+   // is not portably available on all platforms ROOT supports, so we rely on the stream extraction instead.)
+   std::istringstream stream(str);
+   double value = 0.0;
+   return (stream >> value) && stream.eof();
 }
 
 /**

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -2403,7 +2403,7 @@ void RooJSONFactoryWSTool::importVariableElement(const JSONNode &elementNode)
  */
 std::ostream &RooJSONFactoryWSTool::warning(std::string const &str)
 {
-   return RooMsgService::instance().log(nullptr, RooFit::MsgLevel::ERROR, RooFit::IO) << str << std::endl;
+   return RooMsgService::instance().log(nullptr, RooFit::MsgLevel::WARNING, RooFit::IO) << str << std::endl;
 }
 
 /**

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -2041,18 +2041,6 @@ bool RooJSONFactoryWSTool::importJSONfromString(const std::string &s)
 }
 
 /**
- * @brief Import the workspace from a YML string.
- *
- * @param s The YML string containing the workspace data.
- * @return bool Returns true on successful import, false otherwise.
- */
-bool RooJSONFactoryWSTool::importYMLfromString(const std::string &s)
-{
-   std::stringstream ss(s);
-   return importYML(ss);
-}
-
-/**
  * @brief Export the workspace to a JSON string.
  *
  * @return std::string The JSON string representing the exported workspace.
@@ -2061,18 +2049,6 @@ std::string RooJSONFactoryWSTool::exportJSONtoString()
 {
    std::stringstream ss;
    exportJSON(ss);
-   return ss.str();
-}
-
-/**
- * @brief Export the workspace to a YML string.
- *
- * @return std::string The YML string representing the exported workspace.
- */
-std::string RooJSONFactoryWSTool::exportYMLtoString()
-{
-   std::stringstream ss;
-   exportYML(ss);
    return ss.str();
 }
 
@@ -2129,35 +2105,6 @@ bool RooJSONFactoryWSTool::exportJSON(std::string const &filename)
    if (!out.is_open())
       RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid output file '" + filename + "'.");
    return this->exportJSON(out);
-}
-
-/**
- * @brief Export the workspace to YML format and write to the output stream.
- *
- * @param os The output stream to write the YML data to.
- * @return bool Returns true on successful export, false otherwise.
- */
-bool RooJSONFactoryWSTool::exportYML(std::ostream &os)
-{
-   std::unique_ptr<JSONTree> tree = createNewJSONTree();
-   JSONNode &n = tree->rootnode();
-   this->exportAllObjects(n);
-   n.writeYML(os);
-   return true;
-}
-
-/**
- * @brief Export the workspace to YML format and write to the specified file.
- *
- * @param filename The name of the YML file to create and write the data to.
- * @return bool Returns true on successful export, false otherwise.
- */
-bool RooJSONFactoryWSTool::exportYML(std::string const &filename)
-{
-   std::ofstream out(filename.c_str());
-   if (!out.is_open())
-      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid output file '" + filename + "'.");
-   return this->exportYML(out);
 }
 
 bool RooJSONFactoryWSTool::hasAttribute(const std::string &obj, const std::string &attrib)
@@ -2364,37 +2311,6 @@ bool RooJSONFactoryWSTool::importJSON(std::string const &filename)
    if (!infile.is_open())
       RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid input file '" + filename + "'.");
    return this->importJSON(infile);
-}
-
-/**
- * @brief Imports a YML file from the given input stream to the workspace.
- *
- * @param is The input stream containing the YML data.
- * @return bool Returns true on successful import, false otherwise.
- */
-bool RooJSONFactoryWSTool::importYML(std::istream &is)
-{
-   // import a YML file to the workspace
-   std::unique_ptr<JSONTree> tree = JSONTree::create(is);
-   JSONNode const &rootnode = tree->rootnode();
-   this->importAllNodes(rootnode);
-   importParameterStepWidths(*this->workspace(), rootnode);
-   return true;
-}
-
-/**
- * @brief Imports a YML file from the given filename to the workspace.
- *
- * @param filename The name of the YML file to import.
- * @return bool Returns true on successful import, false otherwise.
- */
-bool RooJSONFactoryWSTool::importYML(std::string const &filename)
-{
-   // import a YML file to the workspace
-   std::ifstream infile(filename.c_str());
-   if (!infile.is_open())
-      RooJSONFactoryWSTool::error("RooJSONFactoryWSTool() invalid input file '" + filename + "'.");
-   return this->importYML(infile);
 }
 
 void RooJSONFactoryWSTool::importJSONElement(const std::string &name, const std::string &jsonString)

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -667,7 +667,7 @@ void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, cons
    JSONNode const *pdfNameNode = mcAuxNode ? mcAuxNode->find("pdfName") : nullptr;
    std::string const pdfName = pdfNameNode ? pdfNameNode->val() : "simPdf";
 
-   RooAbsPdf *pdf = static_cast<RooSimultaneous *>(workspace.pdf(pdfName));
+   RooAbsPdf *pdf = workspace.pdf(pdfName);
 
    if (!pdf) {
       // if there is no simultaneous pdf, we can check whether there is only one pdf in the list
@@ -686,7 +686,7 @@ void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, cons
          }
          RooSimultaneous simPdf{simPdfName.c_str(), simPdfName.c_str(), pdfMap, indexCat};
          workspace.import(simPdf, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
-         pdf = static_cast<RooSimultaneous *>(workspace.pdf(simPdfName));
+         pdf = workspace.pdf(simPdfName);
       }
    }
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -127,32 +127,13 @@ std::vector<std::string> valsToStringVec(JSONNode const &node)
    return out;
 }
 
-/**
- * @brief Check if the number of components in CombinedData matches the number of categories in the RooSimultaneous PDF.
- *
- * This function checks whether the number of components in the provided CombinedData 'data' matches the number of
- * categories in the provided RooSimultaneous PDF 'pdf'.
- *
- * @param data The reference to the CombinedData to be checked.
- * @param pdf The pointer to the RooSimultaneous PDF for comparison.
- * @return bool Returns true if the number of components in 'data' matches the number of categories in 'pdf'; otherwise,
- * returns false.
- */
+// True if the number of components in `data` matches the number of categories in `pdf`.
 bool matches(const RooJSONFactoryWSTool::CombinedData &data, const RooSimultaneous *pdf)
 {
    return data.components.size() == pdf->indexCat().size();
 }
 
-/**
- * @brief Check if a string represents a valid number.
- *
- * This function checks whether the provided string 'str' represents a valid number.
- * The function returns true if the entire string can be parsed as a number (integer or floating-point); otherwise, it
- * returns false.
- *
- * @param str The string to be checked.
- * @return bool Returns true if the string 'str' represents a valid number; otherwise, returns false.
- */
+// True if the entire string parses as a number (integer or floating-point).
 bool isNumber(const std::string &str)
 {
    // Parse with the same mechanism as toDouble() and require that the whole string is consumed, so that isNumber(s) is
@@ -163,20 +144,7 @@ bool isNumber(const std::string &str)
    return (stream >> value) && stream.eof();
 }
 
-/**
- * @brief Configure a RooRealVar based on information from a JSONNode.
- *
- * This function configures the provided RooRealVar 'v' based on the information provided in the JSONNode 'p'.
- * The JSONNode 'p' contains information about various properties of the RooRealVar, such as its value, error, number of
- * bins, etc. The function reads these properties from the JSONNode and sets the corresponding properties of the
- * RooRealVar accordingly.
- *
- * @param domains The reference to the RooFit::JSONIO::Detail::Domains containing domain information for variables (not
- * used in this function).
- * @param p The JSONNode containing information about the properties of the RooRealVar 'v'.
- * @param v The reference to the RooRealVar to be configured.
- * @return void
- */
+// Configure `v` (value, error, binning, constness) from the JSON node `p`.
 void configureVariable(RooFit::JSONIO::Detail::Domains &domains, const JSONNode &p, RooRealVar &v)
 {
    if (!p.has_child("name")) {
@@ -241,16 +209,7 @@ void genIndicesHelper(std::vector<std::vector<int>> &combinations, std::vector<i
    }
 }
 
-/**
- * @brief Import attributes from a JSONNode into a RooAbsArg.
- *
- * This function imports attributes, represented by the provided JSONNode 'node', into the provided RooAbsArg 'arg'.
- * The attributes are read from the JSONNode and applied to the RooAbsArg.
- *
- * @param arg The pointer to the RooAbsArg to which the attributes will be imported.
- * @param node The JSONNode containing information about the attributes to be imported.
- * @return void
- */
+// Import string attributes ("dict") and boolean tags ("tags") from `node` onto `arg`.
 void importAttributes(RooAbsArg *arg, JSONNode const &node)
 {
    if (auto seq = node.find("dict")) {
@@ -408,16 +367,7 @@ std::string generate(const RooFit::JSONIO::ImportExpression &ex, const JSONNode 
    return expression.str();
 }
 
-/**
- * @brief Generate bin indices for a set of RooRealVars.
- *
- * This function generates all possible combinations of bin indices for the provided RooArgSet 'vars' containing
- * RooRealVars. Each bin index represents a possible bin selection for the corresponding RooRealVar. The bin indices are
- * stored in a vector of vectors, where each inner vector represents a combination of bin indices for all RooRealVars.
- *
- * @param vars The RooArgSet containing the RooRealVars for which bin indices will be generated.
- * @return std::vector<std::vector<int>> A vector of vectors containing all possible combinations of bin indices.
- */
+// Generate all combinations of bin indices for the RooRealVars in `vars`.
 std::vector<std::vector<int>> generateBinIndices(const RooArgSet &vars)
 {
    std::vector<std::vector<int>> combinations;
@@ -437,30 +387,14 @@ JSONNode const *findRooFitInternal(JSONNode const &node, Keys_t const &...keys)
    return node.find("misc", "ROOT_internal", keys...);
 }
 
-/**
- * @brief Check if a RooAbsArg is a literal constant variable.
- *
- * This function checks whether the provided RooAbsArg 'arg' is a literal constant variable.
- * A literal constant variable is a RooConstVar with a numeric value as a name.
- *
- * @param arg The reference to the RooAbsArg to be checked.
- * @return bool Returns true if 'arg' is a literal constant variable; otherwise, returns false.
- */
+// True if `arg` is a RooConstVar whose name is a plain number (i.e. a literal constant).
 bool isLiteralConstVar(RooAbsArg const &arg)
 {
    bool isRooConstVar = dynamic_cast<RooConstVar const *>(&arg);
    return isRooConstVar && isNumber(arg.GetName());
 }
 
-/**
- * @brief Export attributes of a RooAbsArg to a JSONNode.
- *
- * This function exports the attributes of the provided RooAbsArg 'arg' to the JSONNode 'rootnode'.
- *
- * @param arg The pointer to the RooAbsArg from which attributes will be exported.
- * @param rootnode The JSONNode to which the attributes will be exported.
- * @return void
- */
+// Export the string attributes and tags of `arg` into the ROOT-internal attributes node.
 void exportAttributes(const RooAbsArg *arg, JSONNode &rootnode)
 {
    // If this RooConst is a literal number, we don't need to export the attributes.
@@ -502,19 +436,7 @@ void exportAttributes(const RooAbsArg *arg, JSONNode &rootnode)
    }
 }
 
-/**
- * @brief Create several observables in the workspace.
- *
- * This function obtains a list of observables from the provided
- * RooWorkspace 'ws' based on their names given in the 'axes" field of
- * the JSONNode 'node'.  The observables are added to the RooArgSet
- * 'out'.
- *
- * @param ws The RooWorkspace in which the observables will be created.
- * @param node The JSONNode containing information about the observables to be created.
- * @param out The RooAbsCollection to which the created observables will be added.
- * @return void
- */
+// Collect the observables named in the "axes" field of `node` from the workspace into `out`.
 void getObservables(RooWorkspace const &ws, const JSONNode &node, RooAbsCollection &out)
 {
    for (const auto &p : node["axes"].children()) {
@@ -529,17 +451,7 @@ void getObservables(RooWorkspace const &ws, const JSONNode &node, RooAbsCollecti
    }
 }
 
-/**
- * @brief Import data from the JSONNode into the workspace.
- *
- * This function imports data, represented by the provided JSONNode 'p', into the workspace represented by the provided
- * RooWorkspace. The data information is read from the JSONNode and added to the workspace.
- *
- * @param p The JSONNode representing the data to be imported.
- * @param workspace The RooWorkspace to which the data will be imported.
- * @return std::unique_ptr<RooAbsData> A unique pointer to the RooAbsData object representing the imported data.
- *                                     The caller is responsible for managing the memory of the returned object.
- */
+// Create a RooAbsData (binned or unbinned) from the JSON node `p`.
 std::unique_ptr<RooAbsData> loadData(const JSONNode &p, RooWorkspace &workspace)
 {
    std::string name(RooJSONFactoryWSTool::name(p));
@@ -602,21 +514,7 @@ std::unique_ptr<RooAbsData> loadData(const JSONNode &p, RooWorkspace &workspace)
    return nullptr;
 }
 
-/**
- * @brief Import an analysis from the JSONNode into the workspace.
- *
- * This function imports an analysis, represented by the provided JSONNodes 'analysisNode' and 'likelihoodsNode',
- * into the workspace represented by the provided RooWorkspace. The analysis information is read from the JSONNodes
- * and added to the workspace as one or more RooFit::ModelConfig objects.
- *
- * @param rootnode The root JSONNode representing the entire JSON file.
- * @param analysisNode The JSONNode representing the analysis to be imported.
- * @param likelihoodsNode The JSONNode containing information about likelihoods associated with the analysis.
- * @param domainsNode The JSONNode containing information about domains associated with the analysis.
- * @param workspace The RooWorkspace to which the analysis will be imported.
- * @param datasets A vector of unique pointers to RooAbsData objects representing the data associated with the analysis.
- * @return void
- */
+// Import an analysis (likelihood + domains) as one or more ModelConfig objects into the workspace.
 void importAnalysis(const JSONNode &rootnode, const JSONNode &analysisNode, const JSONNode &likelihoodsNode,
                     const JSONNode &domainsNode, RooWorkspace &workspace,
                     const std::vector<std::unique_ptr<RooAbsData>> &datasets)
@@ -996,16 +894,7 @@ RooAbsReal *RooJSONFactoryWSTool::requestImpl<RooAbsReal>(const std::string &obj
    return nullptr;
 }
 
-/**
- * @brief Export a variable from the workspace to a JSONNode.
- *
- * This function exports a variable, represented by the provided RooAbsArg pointer 'v', from the workspace to a
- * JSONNode. The variable's information is added to the JSONNode as key-value pairs.
- *
- * @param v The pointer to the RooAbsArg representing the variable to be exported.
- * @param node The JSONNode to which the variable will be exported.
- * @return void
- */
+// Export a single variable (RooRealVar or RooConstVar) `v` as a named child of `node`.
 void RooJSONFactoryWSTool::exportVariable(const RooAbsArg *v, JSONNode &node, bool storeConstant, bool storeBins)
 {
    auto *cv = dynamic_cast<const RooConstVar *>(v);
@@ -1038,16 +927,7 @@ void RooJSONFactoryWSTool::exportVariable(const RooAbsArg *v, JSONNode &node, bo
    }
 }
 
-/**
- * @brief Export variables from the workspace to a JSONNode.
- *
- * This function exports variables, represented by the provided RooArgSet, from the workspace to a JSONNode.
- * The variables' information is added to the JSONNode as key-value pairs.
- *
- * @param allElems The RooArgSet representing the variables to be exported.
- * @param n The JSONNode to which the variables will be exported.
- * @return void
- */
+// Export all variables in `allElems` as a sequence under `n`.
 void RooJSONFactoryWSTool::exportVariables(const RooArgSet &allElems, JSONNode &n, bool storeConstant, bool storeBins)
 {
    // export a list of RooRealVar objects
@@ -1068,17 +948,8 @@ std::string RooJSONFactoryWSTool::exportTransformed(const RooAbsReal *original, 
    return newname;
 }
 
-/**
- * @brief Export an object from the workspace to a JSONNode.
- *
- * This function exports an object, represented by the provided RooAbsArg, from the workspace to a JSONNode.
- * The object's information is added to the JSONNode as key-value pairs.
- *
- * @param func The RooAbsArg representing the object to be exported.
- * @param exportedObjectNames A set of strings containing names of previously exported objects to avoid duplicates.
- *                            This set is updated with the name of the newly exported object.
- * @return void
- */
+// Export a single object `func` (pdf, function, variable or category) to the output JSON, recording its name in
+// `exportedObjectNames` to avoid exporting it twice.
 void RooJSONFactoryWSTool::exportObject(RooAbsArg const &func, std::set<std::string> &exportedObjectNames)
 {
    std::string name = func.GetName();
@@ -1423,16 +1294,6 @@ void RooJSONFactoryWSTool::exportArray(std::size_t n, double const *contents, JS
    }
 }
 
-/**
- * @brief Export a RooAbsCategory object to a JSONNode.
- *
- * This function exports a RooAbsCategory object, represented by the provided categories and indices,
- * to a JSONNode. The category labels and corresponding indices are added to the JSONNode as key-value pairs.
- *
- * @param cat The RooAbsCategory object to be exported.
- * @param node The JSONNode to which the category data will be exported.
- * @return void
- */
 namespace {
 
 // Turn an arbitrary string into a valid variable name, but refuse to change the
@@ -1451,6 +1312,16 @@ std::string makeValidNameOrError(std::string const &in)
 
 } // namespace
 
+/**
+ * @brief Export a RooAbsCategory object to a JSONNode.
+ *
+ * This function exports a RooAbsCategory object, represented by the provided categories and indices,
+ * to a JSONNode. The category labels and corresponding indices are added to the JSONNode as key-value pairs.
+ *
+ * @param cat The RooAbsCategory object to be exported.
+ * @param node The JSONNode to which the category data will be exported.
+ * @return void
+ */
 void RooJSONFactoryWSTool::exportCategory(RooAbsCategory const &cat, JSONNode &node)
 {
    auto &labels = node["labels"].set_seq();
@@ -1462,16 +1333,8 @@ void RooJSONFactoryWSTool::exportCategory(RooAbsCategory const &cat, JSONNode &n
    }
 }
 
-/**
- * @brief Export combined data from the workspace to a custom struct.
- *
- * This function exports combined data from the workspace, represented by the provided RooAbsData object,
- * to a CombinedData struct. The struct contains information such as variables, categories,
- * and bin contents of the combined data.
- *
- * @param data The RooAbsData object representing the combined data to be exported.
- * @return CombinedData A custom struct containing the exported combined data.
- */
+// Split `data` by its index category into per-channel datasets and export each, returning the resulting
+// component-name map.
 RooJSONFactoryWSTool::CombinedData RooJSONFactoryWSTool::exportCombinedData(RooAbsData const &data)
 {
    // find category observables
@@ -1527,15 +1390,7 @@ RooJSONFactoryWSTool::CombinedData RooJSONFactoryWSTool::exportCombinedData(RooA
    return datamap;
 }
 
-/**
- * @brief Export data from the workspace to a JSONNode.
- *
- * This function exports data represented by the provided RooAbsData object,
- * to a JSONNode. The data's information is added as key-value pairs to the JSONNode.
- *
- * @param data The RooAbsData object representing the data to be exported.
- * @return void
- */
+// Export a single dataset `data` (binned or unbinned) to the output JSON.
 void RooJSONFactoryWSTool::exportData(RooAbsData const &data)
 {
    // find category observables
@@ -1721,15 +1576,7 @@ RooJSONFactoryWSTool::readBinnedData(const JSONNode &n, const std::string &name,
    return dh;
 }
 
-/**
- * @brief Import a variable from the JSONNode into the workspace.
- *
- * This function imports a variable from the given JSONNode into the workspace.
- * The variable's information is read from the JSONNode and added to the workspace.
- *
- * @param p The JSONNode representing the variable to be imported.
- * @return void
- */
+// Import a single variable (RooRealVar or RooConstVar) from the JSON node `p` into the workspace.
 void RooJSONFactoryWSTool::importVariable(const JSONNode &p)
 {
    // import a RooRealVar object
@@ -1754,15 +1601,7 @@ void RooJSONFactoryWSTool::importVariable(const JSONNode &p)
    configureVariable(*_domains, p, wsEmplace<RooRealVar>(name, 1.));
 }
 
-/**
- * @brief Import all dependants (servers) of a node into the workspace.
- *
- * This function imports all the dependants (servers) of the given JSONNode into the workspace.
- * The dependants' information is read from the JSONNode and added to the workspace.
- *
- * @param n The JSONNode representing the node whose dependants are to be imported.
- * @return void
- */
+// Import all dependants (variables, functions and distributions) of node `n` into the workspace.
 void RooJSONFactoryWSTool::importDependants(const JSONNode &n)
 {
    // import all the dependants of an object
@@ -1899,15 +1738,7 @@ void RooJSONFactoryWSTool::exportSingleModelConfig(JSONNode &rootnode, RooFit::M
    modelConfigAux["mcName"] << mc.GetName();
 }
 
-/**
- * @brief Export all objects in the workspace to a JSONNode.
- *
- * This function exports all the objects in the workspace to the provided JSONNode.
- * The objects' information is added as key-value pairs to the JSONNode.
- *
- * @param n The JSONNode to which the objects will be exported.
- * @return void
- */
+// Export all top-level pdfs, functions, datasets and ModelConfigs of the workspace into `n`.
 void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
 {
    _domains = std::make_unique<RooFit::JSONIO::Detail::Domains>();
@@ -2127,12 +1958,7 @@ void RooJSONFactoryWSTool::setStringAttribute(const std::string &obj, const std:
    dict[attrib] << value;
 }
 
-/**
- * @brief Imports all nodes of the JSON data and adds them to the workspace.
- *
- * @param n The JSONNode representing the root node of the JSON data.
- * @return void
- */
+// Import all nodes of the JSON document rooted at `n` into the workspace.
 void RooJSONFactoryWSTool::importAllNodes(const JSONNode &n)
 {
    // Per HS3 standard, the hs3_version in the metadata is required. So we

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -26,11 +26,15 @@
 #include <RooMultiVarGaussian.h>
 #include <RooPoisson.h>
 #include <RooProdPdf.h>
+#include <RooProduct.h>
 #include <RooRealIntegral.h>
+#include <RooRealSumPdf.h>
 #include <RooRealVar.h>
 #include <RooSimultaneous.h>
 #include <RooSpline.h>
 #include <RooStats/HistFactory/ParamHistFunc.h>
+#include <RooStats/HistFactory/FlexibleInterpVar.h>
+#include <RooStats/HistFactory/PiecewiseInterpolation.h>
 #include <RooWorkspace.h>
 
 #include <cmath>
@@ -1306,6 +1310,437 @@ TEST(RooFitHS3, HistFactoryZeroYieldBin)
       EXPECT_TRUE(std::isfinite(rrv->getMin())) << "Non-finite gamma min for " << name;
       EXPECT_TRUE(std::isfinite(rrv->getMax())) << "Non-finite gamma max for " << name;
    }
+}
+
+TEST(RooFitHS3, HistFactoryDuplicateModifiersAreCombined)
+{
+   const std::string jsonStr = R"({
+      "metadata": {"hs3_version": "0.1.90"},
+      "distributions": [
+         {
+            "name": "model_channel0",
+            "type": "histfactory_dist",
+            "axes": [
+               {"name": "x", "min": 0.0, "max": 2.0, "nbins": 2}
+            ],
+            "samples": [
+               {
+                  "name": "sig",
+                  "data": {"contents": [10.0, 20.0]},
+                  "modifiers": [
+                     {
+                        "name": "norm",
+                        "parameter": "alpha_norm",
+                        "type": "normsys",
+                        "interpolation": 1,
+                        "data": {"lo": 0.8, "hi": 1.2}
+                     },
+                     {
+                        "name": "norm",
+                        "parameter": "alpha_norm",
+                        "type": "normsys",
+                        "interpolation": 1,
+                        "data": {"lo": 0.9, "hi": 1.1}
+                     },
+                     {
+                        "name": "poly",
+                        "parameter": "alpha_poly",
+                        "type": "normsys",
+                        "data": {"lo": 0.8, "hi": 1.2}
+                     },
+                     {
+                        "name": "poly",
+                        "parameter": "alpha_poly",
+                        "type": "normsys",
+                        "data": {"lo": 0.75, "hi": 1.25}
+                     },
+                     {
+                        "name": "shape_input_1",
+                        "parameter": "alpha_shape",
+                        "type": "histosys",
+                        "data": {
+                           "lo": {"contents": [8.0, 18.0]},
+                           "hi": {"contents": [12.0, 22.0]}
+                        }
+                     },
+                     {
+                        "name": "shape_input_2",
+                        "parameter": "alpha_shape",
+                        "type": "histosys",
+                        "data": {
+                           "lo": {"contents": [9.0, 16.0]},
+                           "hi": {"contents": [11.0, 24.0]}
+                        }
+                     }
+                  ]
+               }
+            ]
+         }
+      ]
+   })";
+
+   RooWorkspace ws1{"ws_duplicate_modifiers"};
+   ASSERT_TRUE(RooJSONFactoryWSTool{ws1}.importJSONfromString(jsonStr));
+
+   std::string exported;
+   std::string warnings;
+   {
+      RooHelpers::HijackMessageStream warningMessages{RooFit::WARNING, RooFit::IO};
+      exported = RooJSONFactoryWSTool{ws1}.exportJSONtoString();
+      warnings = warningMessages.str();
+   }
+
+   EXPECT_NE(warnings.find("combined 2 duplicate modifiers named 'norm' of type 'normsys'"), std::string::npos)
+      << warnings;
+   EXPECT_NE(warnings.find("combined 2 duplicate modifiers named 'poly' of type 'normsys'"), std::string::npos)
+      << warnings;
+   EXPECT_NE(warnings.find("combined 2 duplicate modifiers named 'shape' of type 'histosys'"), std::string::npos)
+      << warnings;
+
+   auto count = [&](std::string_view text) {
+      std::size_t result = 0;
+      for (std::size_t pos = 0; (pos = exported.find(text, pos)) != std::string::npos; pos += text.size()) {
+         ++result;
+      }
+      return result;
+   };
+   EXPECT_EQ(count("\"name\":\"norm\""), 1u) << exported;
+   EXPECT_EQ(count("\"name\":\"poly\""), 1u) << exported;
+   EXPECT_EQ(count("\"name\":\"shape\""), 1u) << exported;
+
+   RooWorkspace ws2{"ws_duplicate_modifiers_roundtrip"};
+   ASSERT_TRUE(RooJSONFactoryWSTool{ws2}.importJSONfromString(exported));
+
+   auto *normInterp = dynamic_cast<RooStats::HistFactory::FlexibleInterpVar *>(ws2.function("sig_channel0_epsilon"));
+   ASSERT_NE(normInterp, nullptr);
+   ASSERT_EQ(normInterp->variables().size(), 2u);
+   for (std::size_t i = 0; i < normInterp->variables().size(); ++i) {
+      const std::string parameterName = normInterp->variables().at(i)->GetName();
+      if (parameterName == "alpha_norm") {
+         EXPECT_DOUBLE_EQ(normInterp->low()[i], 0.8 * 0.9);
+         EXPECT_DOUBLE_EQ(normInterp->high()[i], 1.2 * 1.1);
+         EXPECT_EQ(normInterp->interpolationCodes()[i], 1);
+      } else if (parameterName == "alpha_poly") {
+         EXPECT_DOUBLE_EQ(normInterp->low()[i], 0.8 * 0.75);
+         EXPECT_DOUBLE_EQ(normInterp->high()[i], 1.2 * 1.25);
+         EXPECT_EQ(normInterp->interpolationCodes()[i], 4);
+      } else {
+         FAIL() << "Unexpected normsys parameter " << parameterName;
+      }
+   }
+
+   auto *shapeInterp = dynamic_cast<PiecewiseInterpolation *>(ws2.function("histoSys_model_channel0_sig"));
+   ASSERT_NE(shapeInterp, nullptr);
+   ASSERT_EQ(shapeInterp->paramList().size(), 1u);
+   EXPECT_EQ(shapeInterp->interpolationCodes()[0], 4);
+   auto *shapeLow = dynamic_cast<RooHistFunc *>(shapeInterp->lowList().at(0));
+   auto *shapeHigh = dynamic_cast<RooHistFunc *>(shapeInterp->highList().at(0));
+   ASSERT_NE(shapeLow, nullptr);
+   ASSERT_NE(shapeHigh, nullptr);
+   EXPECT_DOUBLE_EQ(shapeLow->dataHist().weight(0), 7.0);
+   EXPECT_DOUBLE_EQ(shapeLow->dataHist().weight(1), 14.0);
+   EXPECT_DOUBLE_EQ(shapeHigh->dataHist().weight(0), 13.0);
+   EXPECT_DOUBLE_EQ(shapeHigh->dataHist().weight(1), 26.0);
+
+   auto samplePrediction = [](RooWorkspace &ws, int bin, double norm, double poly, double shape) {
+      auto &x = *ws.var("x");
+      x.setBin(bin);
+      ws.var("alpha_norm")->setVal(norm);
+      ws.var("alpha_poly")->setVal(poly);
+      ws.var("alpha_shape")->setVal(shape);
+      auto &shapeFunction = *ws.function("model_channel0_sig_shapes");
+      auto &scaleFunction = *ws.function("model_channel0_sig_scaleFactors");
+      RooArgSet observables{x};
+      return shapeFunction.getVal(observables) * scaleFunction.getVal();
+   };
+
+   struct ParameterPoint {
+      double norm;
+      double poly;
+      double shape;
+   };
+   // The code-4 normsys product is exactly representable by its combined
+   // anchors at -1, 0, and +1. The code-1 normsys and additive histosys are
+   // also tested away from their anchors.
+   const ParameterPoint points[]{{-0.6, -1.0, 0.35}, {0.8, 0.0, -0.4}, {1.3, 1.0, 1.2}};
+   for (const auto &point : points) {
+      for (int bin = 0; bin < 2; ++bin) {
+         const double before = samplePrediction(ws1, bin, point.norm, point.poly, point.shape);
+         const double after = samplePrediction(ws2, bin, point.norm, point.poly, point.shape);
+         EXPECT_NEAR(after, before, std::abs(before) * 1e-13)
+            << "bin=" << bin << ", norm=" << point.norm << ", poly=" << point.poly << ", shape=" << point.shape;
+      }
+   }
+
+   // The operation must be logged as a warning, not as an error.
+   RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
+   RooJSONFactoryWSTool::warning("duplicate-modifier warning-level sentinel");
+   EXPECT_TRUE(errorMessages.str().empty()) << errorMessages.str();
+}
+
+struct IncompatibleModifierCase {
+   std::string name;
+   std::string modifiers;
+   std::string extraDistributions;
+   std::string expectedReason;
+};
+
+std::string makeIncompatibleModifierWorkspace(const IncompatibleModifierCase &testCase)
+{
+   return R"({
+      "metadata": {"hs3_version": "0.1.90"},
+      "domains": [
+         {
+            "name": "default_domain",
+            "type": "product_domain",
+            "axes": [
+               {"name": "alpha_dup", "min": -5.0, "max": 5.0},
+               {"name": "dup", "min": -5.0, "max": 5.0}
+            ]
+         }
+      ],
+      "parameter_points": [
+         {
+            "name": "default_values",
+            "parameters": [
+               {"name": "alpha_dup", "value": 0.0},
+               {"name": "dup", "value": 0.0}
+            ]
+         }
+      ],
+      "distributions": [)" +
+          testCase.extraDistributions + R"(
+         {
+            "name": "model_channel0",
+            "type": "histfactory_dist",
+            "axes": [
+               {"name": "x", "min": 0.0, "max": 2.0, "nbins": 2}
+            ],
+            "samples": [
+               {
+                  "name": "sig",
+                  "data": {"contents": [10.0, 20.0]},
+                  "modifiers": [)" +
+          testCase.modifiers + R"(
+                  ]
+               }
+            ]
+         }
+      ]
+   })";
+}
+
+class HistFactoryIncompatibleDuplicateModifiers : public testing::TestWithParam<IncompatibleModifierCase> {};
+
+TEST_P(HistFactoryIncompatibleDuplicateModifiers, ExportFails)
+{
+   const auto &testCase = GetParam();
+   RooWorkspace ws{"ws_incompatible_duplicate_modifiers"};
+   ASSERT_TRUE(RooJSONFactoryWSTool{ws}.importJSONfromString(makeIncompatibleModifierWorkspace(testCase)));
+
+   bool threw = false;
+   std::string exported;
+   std::string errors;
+   {
+      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
+      try {
+         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
+      } catch (const std::runtime_error &) {
+         threw = true;
+      }
+      errors = errorMessages.str();
+   }
+
+   EXPECT_TRUE(threw);
+   EXPECT_TRUE(exported.empty()) << "A HistFactory object was returned despite incompatible duplicate modifiers";
+   EXPECT_NE(errors.find(testCase.expectedReason), std::string::npos) << errors;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+   HistFactory, HistFactoryIncompatibleDuplicateModifiers,
+   testing::Values(IncompatibleModifierCase{"Parameter",
+                                            R"(
+            {
+               "name": "input_1", "parameter": "alpha_dup", "type": "normsys", "constraint": "sharedConstraint",
+               "interpolation": 1, "data": {"lo": 0.8, "hi": 1.2}
+            },
+            {
+               "name": "input_2", "parameter": "dup", "type": "normsys", "constraint": "sharedConstraint",
+               "interpolation": 1, "data": {"lo": 0.9, "hi": 1.1}
+            })",
+                                            R"(
+            {
+               "name": "sharedConstraint", "type": "gaussian_dist", "x": "alpha_dup", "mean": "dup", "sigma": 1.0
+            },)",
+                                            "parameter metadata differs"},
+                   IncompatibleModifierCase{"Interpolation",
+                                            R"(
+            {
+               "name": "input_1", "parameter": "alpha_dup", "type": "normsys",
+               "interpolation": 1, "data": {"lo": 0.8, "hi": 1.2}
+            },
+            {
+               "name": "input_2", "parameter": "alpha_dup", "type": "normsys",
+               "interpolation": 4, "data": {"lo": 0.9, "hi": 1.1}
+            })",
+                                            "", "interpolation codes differ"},
+                   IncompatibleModifierCase{"Constraint",
+                                            R"(
+            {
+               "name": "input_1", "parameter": "alpha_dup", "type": "normsys",
+               "interpolation": 1, "data": {"lo": 0.8, "hi": 1.2}
+            },
+            {
+               "name": "input_2", "parameter": "dup", "type": "normsys",
+               "interpolation": 1, "data": {"lo": 0.9, "hi": 1.1}
+            })",
+                                            "", "constraint metadata differs"},
+                   IncompatibleModifierCase{"UnrepresentableNormFactor",
+                                            R"(
+            {"name": "mu", "type": "normfactor"},
+            {"name": "mu", "type": "normfactor"})",
+                                            "", "cannot be combined without changing its meaning"},
+                   IncompatibleModifierCase{"LinearSpaceNormSys",
+                                            R"(
+            {
+               "name": "input_1", "parameter": "alpha_dup", "type": "normsys",
+               "interpolation": 0, "data": {"lo": 0.8, "hi": 1.2}
+            },
+            {
+               "name": "input_2", "parameter": "alpha_dup", "type": "normsys",
+               "interpolation": 0, "data": {"lo": 0.9, "hi": 1.1}
+            })",
+                                            "", "multiplicative combination is only valid for log-space"}),
+   [](const testing::TestParamInfo<IncompatibleModifierCase> &paramInfo) { return paramInfo.param.name; });
+
+TEST(RooFitHS3, HistFactoryDuplicateHistoSysWithDifferentBinningFails)
+{
+   RooRealVar x{"x", "x", 0.0, 2.0};
+   x.setBins(2);
+   RooRealVar y{"y", "y", 0.0, 3.0};
+   y.setBins(3);
+
+   RooDataHist nominalData{"nominalData", "nominalData", RooArgList{x}};
+   nominalData.set(0, 10.0);
+   nominalData.set(1, 20.0);
+   RooDataHist lowData1{"lowData1", "lowData1", RooArgList{x}};
+   lowData1.set(0, 8.0);
+   lowData1.set(1, 18.0);
+   RooDataHist highData1{"highData1", "highData1", RooArgList{x}};
+   highData1.set(0, 12.0);
+   highData1.set(1, 22.0);
+   RooDataHist lowData2{"lowData2", "lowData2", RooArgList{y}};
+   RooDataHist highData2{"highData2", "highData2", RooArgList{y}};
+   for (int i = 0; i < 3; ++i) {
+      lowData2.set(i, 7.0 + i);
+      highData2.set(i, 13.0 + i);
+   }
+
+   RooHistFunc nominal{"nominal", "nominal", RooArgSet{x}, nominalData};
+   RooHistFunc low1{"low1", "low1", RooArgSet{x}, lowData1};
+   RooHistFunc high1{"high1", "high1", RooArgSet{x}, highData1};
+   RooHistFunc low2{"low2", "low2", RooArgSet{y}, lowData2};
+   RooHistFunc high2{"high2", "high2", RooArgSet{y}, highData2};
+
+   RooRealVar alphaShape{"alpha_shape", "alpha_shape", 0.0, -5.0, 5.0};
+   alphaShape.setConstant(true);
+   RooArgList parameters;
+   parameters.add(alphaShape);
+   parameters.add(alphaShape);
+   RooArgList lowVariations{low1, low2};
+   RooArgList highVariations{high1, high2};
+   PiecewiseInterpolation interpolation{"duplicate_shape", "duplicate_shape", nominal, lowVariations,
+                                        highVariations, parameters};
+   interpolation.setAllInterpCodes(4);
+
+   RooProduct sampleShapes{"sample_shapes", "sample_shapes", RooArgList{interpolation}};
+   RooConstVar sampleScale{"sample_scale", "sample_scale", 1.0};
+   RooRealSumPdf model{"model_channel0", "model_channel0", RooArgList{sampleShapes}, RooArgList{sampleScale}, true};
+
+   RooWorkspace ws{"ws_incompatible_histosys_binning"};
+   ws.import(model, RooFit::Silence());
+
+   bool threw = false;
+   std::string exported;
+   std::string errors;
+   {
+      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
+      try {
+         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
+      } catch (const std::runtime_error &) {
+         threw = true;
+      }
+      errors = errorMessages.str();
+   }
+
+   EXPECT_TRUE(threw);
+   EXPECT_TRUE(exported.empty());
+   EXPECT_NE(errors.find("histogram binning differs"), std::string::npos) << errors;
+}
+
+TEST(RooFitHS3, HistFactoryDuplicateHistoSysWithNonDefaultInterpolationFails)
+{
+   RooRealVar x{"x", "x", 0.0, 2.0};
+   x.setBins(2);
+
+   RooDataHist nominalData{"nominalData", "nominalData", RooArgList{x}};
+   nominalData.set(0, 10.0);
+   nominalData.set(1, 20.0);
+   RooDataHist lowData1{"lowData1", "lowData1", RooArgList{x}};
+   lowData1.set(0, 8.0);
+   lowData1.set(1, 18.0);
+   RooDataHist highData1{"highData1", "highData1", RooArgList{x}};
+   highData1.set(0, 12.0);
+   highData1.set(1, 22.0);
+   RooDataHist lowData2{"lowData2", "lowData2", RooArgList{x}};
+   lowData2.set(0, 9.0);
+   lowData2.set(1, 16.0);
+   RooDataHist highData2{"highData2", "highData2", RooArgList{x}};
+   highData2.set(0, 11.0);
+   highData2.set(1, 24.0);
+
+   RooHistFunc nominal{"nominal", "nominal", RooArgSet{x}, nominalData};
+   RooHistFunc low1{"low1", "low1", RooArgSet{x}, lowData1};
+   RooHistFunc high1{"high1", "high1", RooArgSet{x}, highData1};
+   RooHistFunc low2{"low2", "low2", RooArgSet{x}, lowData2};
+   RooHistFunc high2{"high2", "high2", RooArgSet{x}, highData2};
+
+   RooRealVar alphaShape{"alpha_shape", "alpha_shape", 0.0, -5.0, 5.0};
+   alphaShape.setConstant(true);
+   RooArgList parameters;
+   parameters.add(alphaShape);
+   parameters.add(alphaShape);
+   RooArgList lowVariations{low1, low2};
+   RooArgList highVariations{high1, high2};
+   PiecewiseInterpolation interpolation{"duplicate_shape", "duplicate_shape", nominal,
+                                        lowVariations,     highVariations,    parameters};
+   interpolation.setAllInterpCodes(2);
+
+   RooProduct sampleShapes{"sample_shapes", "sample_shapes", RooArgList{interpolation}};
+   RooConstVar sampleScale{"sample_scale", "sample_scale", 1.0};
+   RooRealSumPdf model{"model_channel0", "model_channel0", RooArgList{sampleShapes}, RooArgList{sampleScale}, true};
+
+   RooWorkspace ws{"ws_incompatible_histosys_interpolation"};
+   ws.import(model, RooFit::Silence());
+
+   bool threw = false;
+   std::string exported;
+   std::string errors;
+   {
+      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
+      try {
+         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
+      } catch (const std::runtime_error &) {
+         threw = true;
+      }
+      errors = errorMessages.str();
+   }
+
+   EXPECT_TRUE(threw);
+   EXPECT_TRUE(exported.empty());
+   EXPECT_NE(errors.find("non-default interpolation cannot currently be represented by the HS3 exporter"),
+             std::string::npos)
+      << errors;
 }
 
 TEST(RooFitHS3, HistFactoryConstraintKeyMigration)

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -38,6 +38,9 @@
 #include <RooWorkspace.h>
 
 #include <cmath>
+#include <memory>
+#include <string_view>
+#include <vector>
 
 #include <TROOT.h>
 
@@ -189,6 +192,90 @@ public:
 private:
    bool _oldValue;
 };
+
+// Runs `action` and returns everything that was logged at the given message level and topic while it ran.
+template <class Action>
+std::string captureMessages(RooFit::MsgLevel level, RooFit::MsgTopic topic, Action &&action)
+{
+   RooHelpers::HijackMessageStream stream{level, topic};
+   action();
+   return stream.str();
+}
+
+// Counts the number of (non-overlapping) occurrences of `needle` in `haystack`.
+std::size_t countOccurrences(std::string_view haystack, std::string_view needle)
+{
+   std::size_t result = 0;
+   for (std::size_t pos = 0; (pos = haystack.find(needle, pos)) != std::string_view::npos; pos += needle.size()) {
+      ++result;
+   }
+   return result;
+}
+
+// Asserts that exporting `ws` to HS3 throws and logs an error message containing `expectedReason`.
+void expectExportThrowsWithError(RooWorkspace &ws, std::string const &expectedReason)
+{
+   bool threw = false;
+   std::string exported;
+   const std::string errors = captureMessages(RooFit::ERROR, RooFit::IO, [&] {
+      try {
+         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
+      } catch (const std::runtime_error &) {
+         threw = true;
+      }
+   });
+
+   EXPECT_TRUE(threw);
+   EXPECT_TRUE(exported.empty()) << "A HistFactory object was returned despite incompatible duplicate modifiers";
+   EXPECT_NE(errors.find(expectedReason), std::string::npos) << errors;
+}
+
+// Builds a single-bin-observable RooDataHist filled with the given bin contents. Returns an owning pointer so that it
+// can be handed to the RooHistFunc constructor that takes ownership (the const-reference overload keeps only an unowned
+// pointer, which would dangle for a temporary).
+std::unique_ptr<RooDataHist> makeDataHist(std::string const &name, RooRealVar &obs, std::vector<double> const &contents)
+{
+   auto dh = std::make_unique<RooDataHist>(name.c_str(), name.c_str(), RooArgList{obs});
+   for (std::size_t i = 0; i < contents.size(); ++i) {
+      dh->set(i, contents[i], -1.0);
+   }
+   return dh;
+}
+
+// Imports a "model_channel0" RooRealSumPdf with a single sample whose shape carries two histosys variations sharing the
+// same parameter (i.e. a duplicate histosys). The first variation always lives on a 2-bin observable "x"; the second
+// variation lives on `obs2` if given, or on the same "x" otherwise. Used to check that incompatible duplicates are
+// rejected on export.
+void importDuplicateHistoSysModel(RooWorkspace &ws, int interpCode, std::vector<double> const &low2Contents,
+                                  std::vector<double> const &high2Contents, RooRealVar *obs2 = nullptr)
+{
+   RooRealVar x{"x", "x", 0.0, 2.0};
+   x.setBins(2);
+   RooRealVar &var2Obs = obs2 ? *obs2 : x;
+
+   RooHistFunc nominal{"nominal", "nominal", RooArgSet{x}, makeDataHist("nominalData", x, {10.0, 20.0})};
+   RooHistFunc low1{"low1", "low1", RooArgSet{x}, makeDataHist("lowData1", x, {8.0, 18.0})};
+   RooHistFunc high1{"high1", "high1", RooArgSet{x}, makeDataHist("highData1", x, {12.0, 22.0})};
+   RooHistFunc low2{"low2", "low2", RooArgSet{var2Obs}, makeDataHist("lowData2", var2Obs, low2Contents)};
+   RooHistFunc high2{"high2", "high2", RooArgSet{var2Obs}, makeDataHist("highData2", var2Obs, high2Contents)};
+
+   RooRealVar alphaShape{"alpha_shape", "alpha_shape", 0.0, -5.0, 5.0};
+   alphaShape.setConstant(true);
+   RooArgList parameters;
+   parameters.add(alphaShape);
+   parameters.add(alphaShape);
+   RooArgList lowVariations{low1, low2};
+   RooArgList highVariations{high1, high2};
+   PiecewiseInterpolation interpolation{"duplicate_shape", "duplicate_shape", nominal,
+                                        lowVariations,     highVariations,    parameters};
+   interpolation.setAllInterpCodes(interpCode);
+
+   RooProduct sampleShapes{"sample_shapes", "sample_shapes", RooArgList{interpolation}};
+   RooConstVar sampleScale{"sample_scale", "sample_scale", 1.0};
+   RooRealSumPdf model{"model_channel0", "model_channel0", RooArgList{sampleShapes}, RooArgList{sampleScale}, true};
+
+   ws.import(model, RooFit::Silence());
+}
 
 } // namespace
 
@@ -1383,12 +1470,9 @@ TEST(RooFitHS3, HistFactoryDuplicateModifiersAreCombined)
    ASSERT_TRUE(RooJSONFactoryWSTool{ws1}.importJSONfromString(jsonStr));
 
    std::string exported;
-   std::string warnings;
-   {
-      RooHelpers::HijackMessageStream warningMessages{RooFit::WARNING, RooFit::IO};
+   const std::string warnings = captureMessages(RooFit::WARNING, RooFit::IO, [&] {
       exported = RooJSONFactoryWSTool{ws1}.exportJSONtoString();
-      warnings = warningMessages.str();
-   }
+   });
 
    EXPECT_NE(warnings.find("combined 2 duplicate modifiers named 'norm' of type 'normsys'"), std::string::npos)
       << warnings;
@@ -1397,16 +1481,9 @@ TEST(RooFitHS3, HistFactoryDuplicateModifiersAreCombined)
    EXPECT_NE(warnings.find("combined 2 duplicate modifiers named 'shape' of type 'histosys'"), std::string::npos)
       << warnings;
 
-   auto count = [&](std::string_view text) {
-      std::size_t result = 0;
-      for (std::size_t pos = 0; (pos = exported.find(text, pos)) != std::string::npos; pos += text.size()) {
-         ++result;
-      }
-      return result;
-   };
-   EXPECT_EQ(count("\"name\":\"norm\""), 1u) << exported;
-   EXPECT_EQ(count("\"name\":\"poly\""), 1u) << exported;
-   EXPECT_EQ(count("\"name\":\"shape\""), 1u) << exported;
+   EXPECT_EQ(countOccurrences(exported, "\"name\":\"norm\""), 1u) << exported;
+   EXPECT_EQ(countOccurrences(exported, "\"name\":\"poly\""), 1u) << exported;
+   EXPECT_EQ(countOccurrences(exported, "\"name\":\"shape\""), 1u) << exported;
 
    RooWorkspace ws2{"ws_duplicate_modifiers_roundtrip"};
    ASSERT_TRUE(RooJSONFactoryWSTool{ws2}.importJSONfromString(exported));
@@ -1473,9 +1550,10 @@ TEST(RooFitHS3, HistFactoryDuplicateModifiersAreCombined)
    }
 
    // The operation must be logged as a warning, not as an error.
-   RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
-   RooJSONFactoryWSTool::warning("duplicate-modifier warning-level sentinel");
-   EXPECT_TRUE(errorMessages.str().empty()) << errorMessages.str();
+   const std::string sentinelErrors = captureMessages(RooFit::ERROR, RooFit::IO, [] {
+      RooJSONFactoryWSTool::warning("duplicate-modifier warning-level sentinel");
+   });
+   EXPECT_TRUE(sentinelErrors.empty()) << sentinelErrors;
 }
 
 struct IncompatibleModifierCase {
@@ -1538,22 +1616,7 @@ TEST_P(HistFactoryIncompatibleDuplicateModifiers, ExportFails)
    RooWorkspace ws{"ws_incompatible_duplicate_modifiers"};
    ASSERT_TRUE(RooJSONFactoryWSTool{ws}.importJSONfromString(makeIncompatibleModifierWorkspace(testCase)));
 
-   bool threw = false;
-   std::string exported;
-   std::string errors;
-   {
-      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
-      try {
-         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
-      } catch (const std::runtime_error &) {
-         threw = true;
-      }
-      errors = errorMessages.str();
-   }
-
-   EXPECT_TRUE(threw);
-   EXPECT_TRUE(exported.empty()) << "A HistFactory object was returned despite incompatible duplicate modifiers";
-   EXPECT_NE(errors.find(testCase.expectedReason), std::string::npos) << errors;
+   expectExportThrowsWithError(ws, testCase.expectedReason);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1615,132 +1678,21 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(RooFitHS3, HistFactoryDuplicateHistoSysWithDifferentBinningFails)
 {
-   RooRealVar x{"x", "x", 0.0, 2.0};
-   x.setBins(2);
    RooRealVar y{"y", "y", 0.0, 3.0};
    y.setBins(3);
 
-   RooDataHist nominalData{"nominalData", "nominalData", RooArgList{x}};
-   nominalData.set(0, 10.0);
-   nominalData.set(1, 20.0);
-   RooDataHist lowData1{"lowData1", "lowData1", RooArgList{x}};
-   lowData1.set(0, 8.0);
-   lowData1.set(1, 18.0);
-   RooDataHist highData1{"highData1", "highData1", RooArgList{x}};
-   highData1.set(0, 12.0);
-   highData1.set(1, 22.0);
-   RooDataHist lowData2{"lowData2", "lowData2", RooArgList{y}};
-   RooDataHist highData2{"highData2", "highData2", RooArgList{y}};
-   for (int i = 0; i < 3; ++i) {
-      lowData2.set(i, 7.0 + i);
-      highData2.set(i, 13.0 + i);
-   }
-
-   RooHistFunc nominal{"nominal", "nominal", RooArgSet{x}, nominalData};
-   RooHistFunc low1{"low1", "low1", RooArgSet{x}, lowData1};
-   RooHistFunc high1{"high1", "high1", RooArgSet{x}, highData1};
-   RooHistFunc low2{"low2", "low2", RooArgSet{y}, lowData2};
-   RooHistFunc high2{"high2", "high2", RooArgSet{y}, highData2};
-
-   RooRealVar alphaShape{"alpha_shape", "alpha_shape", 0.0, -5.0, 5.0};
-   alphaShape.setConstant(true);
-   RooArgList parameters;
-   parameters.add(alphaShape);
-   parameters.add(alphaShape);
-   RooArgList lowVariations{low1, low2};
-   RooArgList highVariations{high1, high2};
-   PiecewiseInterpolation interpolation{"duplicate_shape", "duplicate_shape", nominal, lowVariations,
-                                        highVariations, parameters};
-   interpolation.setAllInterpCodes(4);
-
-   RooProduct sampleShapes{"sample_shapes", "sample_shapes", RooArgList{interpolation}};
-   RooConstVar sampleScale{"sample_scale", "sample_scale", 1.0};
-   RooRealSumPdf model{"model_channel0", "model_channel0", RooArgList{sampleShapes}, RooArgList{sampleScale}, true};
-
    RooWorkspace ws{"ws_incompatible_histosys_binning"};
-   ws.import(model, RooFit::Silence());
+   importDuplicateHistoSysModel(ws, /*interpCode=*/4, /*low2=*/{7.0, 8.0, 9.0}, /*high2=*/{13.0, 14.0, 15.0}, &y);
 
-   bool threw = false;
-   std::string exported;
-   std::string errors;
-   {
-      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
-      try {
-         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
-      } catch (const std::runtime_error &) {
-         threw = true;
-      }
-      errors = errorMessages.str();
-   }
-
-   EXPECT_TRUE(threw);
-   EXPECT_TRUE(exported.empty());
-   EXPECT_NE(errors.find("histogram binning differs"), std::string::npos) << errors;
+   expectExportThrowsWithError(ws, "histogram binning differs");
 }
 
 TEST(RooFitHS3, HistFactoryDuplicateHistoSysWithNonDefaultInterpolationFails)
 {
-   RooRealVar x{"x", "x", 0.0, 2.0};
-   x.setBins(2);
-
-   RooDataHist nominalData{"nominalData", "nominalData", RooArgList{x}};
-   nominalData.set(0, 10.0);
-   nominalData.set(1, 20.0);
-   RooDataHist lowData1{"lowData1", "lowData1", RooArgList{x}};
-   lowData1.set(0, 8.0);
-   lowData1.set(1, 18.0);
-   RooDataHist highData1{"highData1", "highData1", RooArgList{x}};
-   highData1.set(0, 12.0);
-   highData1.set(1, 22.0);
-   RooDataHist lowData2{"lowData2", "lowData2", RooArgList{x}};
-   lowData2.set(0, 9.0);
-   lowData2.set(1, 16.0);
-   RooDataHist highData2{"highData2", "highData2", RooArgList{x}};
-   highData2.set(0, 11.0);
-   highData2.set(1, 24.0);
-
-   RooHistFunc nominal{"nominal", "nominal", RooArgSet{x}, nominalData};
-   RooHistFunc low1{"low1", "low1", RooArgSet{x}, lowData1};
-   RooHistFunc high1{"high1", "high1", RooArgSet{x}, highData1};
-   RooHistFunc low2{"low2", "low2", RooArgSet{x}, lowData2};
-   RooHistFunc high2{"high2", "high2", RooArgSet{x}, highData2};
-
-   RooRealVar alphaShape{"alpha_shape", "alpha_shape", 0.0, -5.0, 5.0};
-   alphaShape.setConstant(true);
-   RooArgList parameters;
-   parameters.add(alphaShape);
-   parameters.add(alphaShape);
-   RooArgList lowVariations{low1, low2};
-   RooArgList highVariations{high1, high2};
-   PiecewiseInterpolation interpolation{"duplicate_shape", "duplicate_shape", nominal,
-                                        lowVariations,     highVariations,    parameters};
-   interpolation.setAllInterpCodes(2);
-
-   RooProduct sampleShapes{"sample_shapes", "sample_shapes", RooArgList{interpolation}};
-   RooConstVar sampleScale{"sample_scale", "sample_scale", 1.0};
-   RooRealSumPdf model{"model_channel0", "model_channel0", RooArgList{sampleShapes}, RooArgList{sampleScale}, true};
-
    RooWorkspace ws{"ws_incompatible_histosys_interpolation"};
-   ws.import(model, RooFit::Silence());
+   importDuplicateHistoSysModel(ws, /*interpCode=*/2, /*low2=*/{9.0, 16.0}, /*high2=*/{11.0, 24.0});
 
-   bool threw = false;
-   std::string exported;
-   std::string errors;
-   {
-      RooHelpers::HijackMessageStream errorMessages{RooFit::ERROR, RooFit::IO};
-      try {
-         exported = RooJSONFactoryWSTool{ws}.exportJSONtoString();
-      } catch (const std::runtime_error &) {
-         threw = true;
-      }
-      errors = errorMessages.str();
-   }
-
-   EXPECT_TRUE(threw);
-   EXPECT_TRUE(exported.empty());
-   EXPECT_NE(errors.find("non-default interpolation cannot currently be represented by the HS3 exporter"),
-             std::string::npos)
-      << errors;
+   expectExportThrowsWithError(ws, "non-default interpolation cannot currently be represented by the HS3 exporter");
 }
 
 TEST(RooFitHS3, HistFactoryConstraintKeyMigration)

--- a/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
+++ b/roofit/jsoninterface/inc/RooFit/Detail/JSONInterface.h
@@ -210,17 +210,7 @@ public:
    static std::unique_ptr<JSONTree> create(std::istream &is);
    static std::unique_ptr<JSONTree> create(std::string const &str);
 
-   static std::string getBackend();
-   static void setBackend(std::string const &name);
-
-   static bool hasBackend(std::string const &name);
-
 private:
-   // Internally, we store the backend type with an enum to be more memory efficient.
-   enum class Backend { NlohmannJson, Ryml };
-
-   static Backend &getBackendEnum();
-
    template <typename... Args>
    static std::unique_ptr<JSONTree> createImpl(Args &&...args);
 };

--- a/roofit/jsoninterface/src/JSONInterface.cxx
+++ b/roofit/jsoninterface/src/JSONInterface.cxx
@@ -13,9 +13,6 @@
 #include <RooFit/Detail/JSONInterface.h>
 
 #include "JSONParser.h"
-#ifdef ROOFIT_WITH_RYML
-#include "RYMLParser.h"
-#endif
 
 #include <sstream>
 
@@ -79,13 +76,6 @@ std::ostream &operator<<(std::ostream &os, JSONNode const &s)
 template <typename... Args>
 std::unique_ptr<JSONTree> JSONTree::createImpl(Args &&...args)
 {
-   if (getBackendEnum() == Backend::Ryml) {
-#ifdef ROOFIT_WITH_RYML
-      return std::make_unique<TRYMLTree>(std::forward<Args>(args)...);
-#else
-      throw std::runtime_error("Requesting JSON tree with rapidyaml backend, which is currently unsupported.");
-#endif
-   }
    return std::make_unique<TJSONTree>(std::forward<Args>(args)...);
 }
 
@@ -103,47 +93,6 @@ std::unique_ptr<JSONTree> JSONTree::create(std::string const &str)
 {
    std::stringstream ss{str};
    return JSONTree::create(ss);
-}
-
-/// Check if ROOT was compiled with support for a certain JSON backend library.
-/// \param[in] name Name of the backend.
-bool JSONTree::hasBackend(std::string const &name)
-{
-   if (name == "rapidyaml") {
-#ifdef ROOFIT_WITH_RYML
-      return true;
-#else
-      return false;
-#endif
-   }
-   if (name == "nlohmann-json")
-      return true;
-   return false;
-}
-
-JSONTree::Backend &JSONTree::getBackendEnum()
-{
-   static Backend backend = Backend::NlohmannJson;
-   return backend;
-}
-
-/// Returns the name of the library that serves as the backend for the JSON
-/// interface, which is either `"nlohmann-json"` or `"rapidyaml"`.
-/// \return Backend name as a string.
-std::string JSONTree::getBackend()
-{
-   return getBackendEnum() == Backend::Ryml ? "rapidyaml" : "nlohmann-json";
-}
-
-/// Set the library that serves as the backend for the JSON interface. Note that the `"rapidyaml"` backend is only
-/// supported if rapidyaml was found on the system when ROOT was compiled. \param[in] name Name of the backend, can be
-/// either `"nlohmann-json"` or `"rapidyaml"`.
-void JSONTree::setBackend(std::string const &name)
-{
-   if (name == "rapidyaml")
-      getBackendEnum() = Backend::Ryml;
-   if (name == "nlohmann-json")
-      getBackendEnum() = Backend::NlohmannJson;
 }
 
 } // namespace Detail


### PR DESCRIPTION
## Motivation

RooFit allows a reconstructed HistFactory sample to contain multiple modifiers with the same name and type. HS3, however, requires modifiers within a sample to be unique by `(name, type)`.

Previously, the HistFactory exporter could therefore produce invalid HS3 when serializing such RooFit workspaces.

## Changes

This PR canonicalizes HistFactory modifiers before serializing a channel:

- Duplicate `normsys` modifiers are combined by multiplying their `lo` and `hi` anchors.
- Duplicate `histosys` modifiers are combined additively around the nominal histogram:

  ```text
  combined variation = nominal + Σ(variation - nominal)
  ```

- Compatible duplicates are exported as a single modifier.
- A RooFit `WARNING/IO` message is emitted for every combined group, identifying the channel, sample, modifier name and type, and number of duplicates.
- Shared constraints are queued for export only once.
- Modifier ordering remains deterministic.

Duplicates are considered compatible only if their parameter, interpolation code, constraint metadata, and—where applicable—histogram binning agree. Incompatible duplicates produce a descriptive RooFit `ERROR/IO` message and throw, preventing the HistFactory object from being exported.

A final uniqueness check rejects any remaining duplicate modifier type that cannot be represented safely as a standard HS3 modifier.

## Additional fixes

- Correct `RooJSONFactoryWSTool::warning()` to log at `RooFit::WARNING` rather than `RooFit::ERROR`.
- Preserve duplicate RooFit factors during modifier reconstruction so that the exporter can detect and handle them explicitly.
- Fix the HS3 round-trip test helper, which previously evaluated the original object twice instead of evaluating the imported object.

## Tests

The new tests cover:

- Merging compatible duplicate `normsys` and `histosys` modifiers.
- Correct multiplication of `normsys` anchors.
- Correct addition of `histosys` deviations around the nominal histogram.
- Warning emission at RooFit `WARNING` level.
- Bin-by-bin agreement, including normalization, between the original and round-tripped channel predictions.
- Rejection of duplicates with mismatched:
  - parameter names;
  - interpolation codes;
  - constraint names or types;
  - histogram binning.
- Rejection of duplicate modifier types that cannot be combined safely.

The complete `testRooFitHS3` test suite passes. The motivating workspace was also successfully exported with no remaining duplicate `(name, type)` modifier groups.

## Interpolation note

For code-4 `normsys` modifiers, multiplying the `lo` and `hi` anchors preserves the combined response at nuisance values `-1`, `0`, and `+1`. A single code-4 interpolation cannot, in general, exactly reproduce the product of multiple interpolations between those anchors.

@cburgard @stalbrec 