### PR TITLE
[cppyy] Fix std::string return-type tests to match Pythonizations

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/test/test_regression.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_regression.py
@@ -473,7 +473,6 @@ class TestREGRESSION:
 
         assert a != b             # derived class' C++ operator!= called
 
-    @mark.xfail(strict=True)
     def test18_operator_plus_overloads(self):
         """operator+(string, string) should return a string"""
 
@@ -485,7 +484,10 @@ class TestREGRESSION:
         assert a == 'a'
         assert b == 'b'
 
-        assert type(a+b) == cppyy.gbl.std.string
+        # Expect same return type as other funcs returning a std::string in
+        # C++, which might be different from gbl.std.string on the Python side
+        # depending on the enabled Pythonizations.
+        assert type(a + b) == type(cppyy.gbl.std.to_string(42))
         assert a+b == 'ab'
 
     def test19_std_string_hash(self):

--- a/bindings/pyroot/cppyy/cppyy/test/test_templates.py
+++ b/bindings/pyroot/cppyy/cppyy/test/test_templates.py
@@ -1142,7 +1142,6 @@ class TestTEMPLATES:
         assert ns.testptr
         assert cppyy.gbl.std.vector[ns.testptr]
 
-    @mark.xfail(strict=True)
     def test34_cstring_template_argument(self):
         """`const char*` use over std::string"""
 
@@ -1160,7 +1159,10 @@ class TestTEMPLATES:
 
         ns = cppyy.gbl.CStringTemplateArg
 
-        assert type(ns.stringify("Alice")) == cppyy.gbl.std.string
+        # Expect same return type as other funcs returning a std::string in
+        # C++, which might be different from gbl.std.string on the Python side
+        # depending on the enabled Pythonizations.
+        assert type(ns.stringify("Alice")) == type(cppyy.gbl.std.to_string(42))
         assert ns.stringify("Alice", "Bob")                          == "Alice Bob "
         assert ns.stringify(1, 2, 3)                                 == "1 2 3 "
         assert ns.stringify["const char*"]("Aap")                    == "Aap "


### PR DESCRIPTION
Un-xfail test18_operator_plus_overloads and
test34_cstring_template_argument, which check that C++ functions returning a `std::string` produce a string on the Python side.

These tests previously asserted the return type was exactly `cppyy.gbl.std.string`. That assumption is too strict: depending on which Pythonizations are enabled, a `std::string` returned from C++ may map to a different Python-side type. Compare instead against the type produced by a known `std::string`-returning function, `std::to_string(42)`, so the tests verify consistent behavior rather than one specific type.
