### PR TITLE
[RF] Delete fit objects before plotting in rf619_discrete_profiling.py

### DIFF
--- a/tutorials/roofit/roofit/rf619_discrete_profiling.py
+++ b/tutorials/roofit/roofit/rf619_discrete_profiling.py
@@ -166,6 +166,11 @@ for i in range(nMeanPoints):
     minim.minimize("Minuit2", "Migrad")
     profileGraph.SetPoint(i, meanVal, nll.getVal())
 
+# The fit objects are not needed anymore. Delete them already before the
+# plotting phase, so that the NLL evaluation machinery is not torn down at
+# interpreter shutdown, where the order of cleanups is less controlled.
+del minim
+del nll
 
 c = ROOT.TCanvas("c_rf619", "NLL vs Mean for Different Discrete Combinations", 1200, 400)
 c.Divide(3, 1)


### PR DESCRIPTION
The Python version of this tutorial sporadically crashes on CI (and deterministically in some local invocations) with memory corruption that is detected in cling's JIT at interpreter shutdown, e.g. as "StringMapImpl::RemoveKey(): Didn't find key?" on builds with LLVM assertions, or as a segfault in llvm::Module::dropAllReferences() / MDNode::dropAllReferences() during ~TCling.

Watchpoint forensics show recycled heap blocks that end up shared between the NLL evaluation machinery (RooFit::Evaluator data-token bookkeeping on the compiled model clones) and IR objects of modules that cling JITs during the plotting phase, with the final stale write coming from RooFit::Evaluator::~Evaluator() at interpreter shutdown.

Deleting the minimizer and the NLL right after the fits closes that window: the evaluator and the owned graph clones are torn down at a well-defined point before the plotting phase compiles new wrappers, and not during the less controlled interpreter shutdown. With this change the previously reproducible crash (8/8 failing runs in a bare invocation) disappears (8/8 + 3/3 ctest passing).

This is a workaround at the tutorial level; the underlying overlapping heap ownership deserves a separate AddressSanitizer investigation.