### PR TITLE
Add a protection against undefined fPainter

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -620,6 +620,7 @@ void TCanvas::Build()
    } else {
       //normal mode with a screen window
       // Set default physical canvas attributes
+      if (!fPainter) return;
       fPainter->SelectDrawable(fCanvasID);
       fPainter->SetAttFill({1, 1001});    //Set color index for fill area
       fPainter->SetAttLine({1, 1, 1});    //Set color index for lines


### PR DESCRIPTION
In TCanvas::Build when a canvas is drawn from a TFile, fPainter is not defined and we get a crash. This problem was reported here: https://root-forum.cern.ch/t/segfault-when-drawing-canvas-stored-in-file/

This PR add a simple protection to avoid the crash. It fixes the problem. The canvas is Drawn as before. 
May be @linev has a better fix has he did several changes in that area recently: https://github.com/root-project/root/commits/master/graf2d/gpad/src/TCanvas.cxx

