### PR TITLE
[cmake][interop][win] Fix compiler error C1128

### DIFF
--- a/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
+++ b/interpreter/CppInterOp/lib/CppInterOp/CMakeLists.txt
@@ -275,3 +275,6 @@ string(REPLACE ";" "\;" _VER CPPINTEROP_VERSION)
 set_source_files_properties(CppInterOp.cpp PROPERTIES COMPILE_DEFINITIONS
   "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\";CPPINTEROP_VERSION=\"${_VAR}\""
 )
+if(MSVC)
+  set_source_files_properties(CppInterOp.cpp COMPILE_FLAGS /bigobj)
+endif()


### PR DESCRIPTION
Fix the following error on Windows when compiling with ASAN=ON:
```
interpreter\CppInterOp\lib\CppInterOp\CppInterOp.cpp(1,1): error C1128:
number of sections exceeded object file format limit: compile with /bigobj
```