### PR TITLE
[gdml] Resolve material fractions by exact reference

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -1310,7 +1310,6 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TGeoMixture *mix = nullptr;
    TGeoMaterial *mat = nullptr;
    TString tempconst = "";
-   TString matname;
    Bool_t composite = kFALSE;
 
    if (z == 1) {
@@ -1546,17 +1545,21 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       Double_t weight;
 
       for (fractions f = fracmap.begin(); f != fracmap.end(); ++f) {
-         matname = f->first;
-         matname = NameShort(matname);
+         TGeoMaterial *mattmp = nullptr;
+         auto material = fmatmap.find(f->first);
+         if (material != fmatmap.end())
+            mattmp = (TGeoMaterial *)material->second;
+         else {
+            auto mixture = fmixmap.find(f->first);
+            if (mixture != fmixmap.end())
+               mattmp = (TGeoMixture *)mixture->second;
+         }
+         auto element = felemap.find(f->first);
 
-         TGeoMaterial *mattmp = (TGeoMaterial *)gGeoManager->GetListOfMaterials()->FindObject(matname);
-
-         if (mattmp || (felemap.find(f->first) != felemap.end())) {
+         if ((composite && element != felemap.end()) || (!composite && (mattmp || element != felemap.end()))) {
             if (composite) {
                natoms = (Int_t)f->second;
-
-               mix->AddElement(felemap[f->first], natoms);
-
+               mix->AddElement((TGeoElement *)element->second, natoms);
             }
 
             else {
@@ -1564,7 +1567,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
                if (mattmp) {
                   mix->AddElement(mattmp, weight);
                } else {
-                  mix->AddElement(felemap[f->first], weight);
+                  mix->AddElement((TGeoElement *)element->second, weight);
                }
             }
          }
@@ -1573,13 +1576,16 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
    medid = medid + 1;
 
+   if (mixflag == 1)
+      fmixmap[local_name.Data()] = mix;
+   else if (mixflag == 0)
+      fmatmap[local_name.Data()] = mat;
+
    TGeoMedium *med = mgr->GetMedium(NameShort(name));
    if (!med) {
       if (mixflag == 1) {
-         fmixmap[local_name.Data()] = mix;
          med = new TGeoMedium(NameShort(name), medid, mix);
       } else if (mixflag == 0) {
-         fmatmap[local_name.Data()] = mat;
          med = new TGeoMedium(NameShort(name), medid, mat);
       }
    } else if (gDebug >= 2) {

--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -6,8 +6,12 @@
 
 if(gdml)
   configure_file(no_extrusion.gdml no_extrusion.gdml COPYONLY)
+  configure_file(material_name_collision.gdml material_name_collision.gdml COPYONLY)
   ROOT_ADD_GTEST(material_units
     test_material_units.cxx
+    LIBRARIES Geom)
+  ROOT_ADD_GTEST(gdml_material_name_collision
+    test_gdml_material_name_collision.cxx
     LIBRARIES Geom)
   ROOT_ADD_GTEST(boolean_extrusion
     test_boolean_extrusion.cxx

--- a/geom/test/material_name_collision.gdml
+++ b/geom/test/material_name_collision.gdml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <define/>
+  <materials>
+    <element Z="26" formula="FE" name="Iron0xaaa"><atom unit="g/mole" value="55.845"/></element>
+    <element Z="28" formula="NI" name="Nickel0xbbb"><atom unit="g/mole" value="58.693"/></element>
+    <material name="Iron0xccc" state="solid">
+      <D unit="g/cm3" value="7.87"/><fraction n="1" ref="Iron0xaaa"/>
+    </material>
+    <material name="Alloy0xddd" state="solid">
+      <D unit="g/cm3" value="8.2"/>
+      <fraction n="0.5" ref="Iron0xaaa"/><fraction n="0.5" ref="Nickel0xbbb"/>
+    </material>
+  </materials>
+  <solids>
+    <box lunit="mm" name="world0x1a" x="1000" y="1000" z="1000"/>
+    <box lunit="mm" name="cube0x1b" x="100" y="100" z="100"/>
+  </solids>
+  <structure>
+    <volume name="ironVol0x2a"><materialref ref="Iron0xccc"/><solidref ref="cube0x1b"/></volume>
+    <volume name="World0x2c"><materialref ref="Alloy0xddd"/><solidref ref="world0x1a"/>
+      <physvol name="ironPV"><volumeref ref="ironVol0x2a"/></physvol></volume>
+  </structure>
+  <setup name="Default" version="1.0"><world ref="World0x2c"/></setup>
+</gdml>

--- a/geom/test/test_gdml_material_name_collision.cxx
+++ b/geom/test/test_gdml_material_name_collision.cxx
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include <TGeoElement.h>
+#include <TGeoManager.h>
+#include <TGeoMaterial.h>
+
+TEST(Geometry, GDMLMaterialElementNameCollision)
+{
+   auto geom = TGeoManager::Import("material_name_collision.gdml");
+   ASSERT_NE(geom, nullptr);
+
+   auto iron = geom->GetMaterial("Iron");
+   ASSERT_NE(iron, nullptr);
+   ASSERT_TRUE(iron->IsMixture());
+   auto ironMixture = static_cast<TGeoMixture *>(iron);
+   ASSERT_EQ(iron->GetNelements(), 1);
+   EXPECT_STREQ(iron->GetElement(0)->GetName(), "FE");
+   EXPECT_DOUBLE_EQ(ironMixture->GetWmixt()[0], 1.0);
+
+   auto alloy = geom->GetMaterial("Alloy");
+   ASSERT_NE(alloy, nullptr);
+   ASSERT_TRUE(alloy->IsMixture());
+   auto alloyMixture = static_cast<TGeoMixture *>(alloy);
+   ASSERT_EQ(alloy->GetNelements(), 2);
+   EXPECT_STREQ(alloy->GetElement(0)->GetName(), "FE");
+   EXPECT_STREQ(alloy->GetElement(1)->GetName(), "NI");
+   EXPECT_DOUBLE_EQ(alloyMixture->GetWmixt()[0], 0.5);
+   EXPECT_DOUBLE_EQ(alloyMixture->GetWmixt()[1], 0.5);
+}


### PR DESCRIPTION
# This Pull request:
GDML fraction references were resolved using names after stripping 0x... pointer suffixes. This could make an element reference resolve to an unrelated material with the same shortened name, silently producing incomplete or empty mixtures.

## Changes or fixes:
Resolve fractions through the exact GDML element, material, and mixture identifiers before constructing the TGeoMixture.
A regression test covers both a pure material and an alloy whose element and material names collide after suffix stripping.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #22831

