### PR TITLE
[DO NOT MERGE][ntuple] Use std::string_view consistently in signatures 

### DIFF
--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -202,7 +202,7 @@ namespace TClassEdit {
 
    void        Init(TClassEdit::TInterpreterLookupHelper *helper);
 
-   std::string CleanType (const char *typeDesc,int mode = 0,const char **tail = nullptr);
+   std::string CleanType (std::string_view typeDesc,int mode = 0,const char **tail = nullptr);
    inline bool IsArtificial(std::string_view name) { return name.find('@') != name.npos; }
    bool        IsDefAlloc(const char *alloc, const char *classname);
    bool        IsDefAlloc(const char *alloc, const char *keyclassname, const char *valueclassname);

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1286,7 +1286,7 @@ int TClassEdit::GetSplit(const char *type, vector<string>& output, int &nestedLo
 ///      CleanType(" A<B, C< D, E> > *,F,G>") returns "A<B,C<D,E> >*"
 ////////////////////////////////////////////////////////////////////////////
 
-string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
+string TClassEdit::CleanType(std::string_view typeDesc, int mode, const char **tail)
 {
    constexpr static std::array<const char *, 3> remove{"class", "const", "volatile"};
    constexpr static auto lengths = []() constexpr {
@@ -1297,12 +1297,13 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
    }();
 
    string result;
-   result.reserve(strlen(typeDesc)*2);
+   result.reserve(typeDesc.size()*2);
    int kbl=1;
    std::vector<char> parensStack;
-   const char* c;
+   const char* c = nullptr;
 
-   for(c=typeDesc;*c;c++) {
+   for(auto i = 0u; i < typeDesc.size(); ++i) {
+      c = typeDesc.data() + i;
       if (std::isspace(c[0])) {
          if (kbl)       continue;
          if (!isalnum(c[ 1]) && c[ 1] !='_')    continue;
@@ -1328,7 +1329,7 @@ string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
             // make sure that the 'keyword' is not part of a longer indentifier
             if (isalnum(c[rlen]) || c[rlen]=='_' ||  c[rlen]=='$') continue;
 
-            c+=rlen-1; done = 1; break;
+            c+=rlen-1; i+=rlen-1; done = 1; break;
          }
          if (done) continue;
       }

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -597,8 +597,8 @@ public:
    static void           AddClassToDeclIdMap(TDictionary::DeclId_t id, TClass* cl);
    static void           RemoveClass(TClass *cl);
    static void           RemoveClassDeclId(TDictionary::DeclId_t id);
-   static TClass        *GetClass(const char *name, Bool_t load = kTRUE, Bool_t silent = kFALSE);
-   static TClass        *GetClass(const char *name, Bool_t load, Bool_t silent, size_t hint_pair_offset, size_t hint_pair_size);
+   static TClass        *GetClass(std::string_view name, Bool_t load = kTRUE, Bool_t silent = kFALSE);
+   static TClass        *GetClass(std::string_view name, Bool_t load, Bool_t silent, size_t hint_pair_offset, size_t hint_pair_size);
    static TClass        *GetClass(const std::type_info &typeinfo, Bool_t load = kTRUE, Bool_t silent = kFALSE, size_t hint_pair_offset = 0, size_t hint_pair_size = 0);
    static TClass        *GetClass(ClassInfo_t *info, Bool_t load = kTRUE, Bool_t silent = kFALSE);
    template<typename T>

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -88,6 +88,8 @@ In order to access the name of a class within the ROOT type system, the method T
 #include "TThreadSlots.h"
 #include "ThreadLocalStorage.h"
 
+#include <ROOT/StringUtils.hxx>
+
 #include <cstdio>
 #include <cctype>
 #include <set>
@@ -2991,26 +2993,28 @@ TVirtualIsAProxy* TClass::GetIsAProxy() const
 /// (to anything) or set the `rootrc` key `Root.TClass.GetClass.AutoParsing` to
 /// `false`.
 
-TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent)
+TClass *TClass::GetClass(std::string_view name, Bool_t load, Bool_t silent)
 {
    return TClass::GetClass(name, load, silent, 0, 0);
 }
 
-TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hint_pair_offset, size_t hint_pair_size)
+TClass *TClass::GetClass(std::string_view name, Bool_t load, Bool_t silent, size_t hint_pair_offset, size_t hint_pair_size)
 {
-   if (!name || !name[0]) return nullptr;
+   if (name.empty()) return nullptr;
 
-   if (strstr(name, "(anonymous)")) return nullptr;
-   if (strstr(name, "(unnamed)")) return nullptr;
-   if (strncmp(name,"class ",6)==0) name += 6;
-   if (strncmp(name,"struct ",7)==0) name += 7;
+   if (name.find("(anonymous)") != std::string_view::npos) return nullptr;
+   if (name.find("(unnamed)") != std::string_view::npos) return nullptr;
+   if (ROOT::StartsWith(name, "class ")) name = name.substr(6);
+   if (ROOT::StartsWith(name, "struct ")) name = name.substr(7);
 
    if (!gROOT->GetListOfClasses())  return nullptr;
 
+   std::string nameStr = std::string(name);
+   
    // FindObject will take the read lock before actually getting the
    // TClass pointer so we will need not get a partially initialized
    // object.
-   TClass *cl = (TClass*)gROOT->GetListOfClasses()->FindObject(name);
+   TClass *cl = (TClass*)gROOT->GetListOfClasses()->FindObject(nameStr.c_str());
 
    // Early return to release the lock without having to execute the
    // long-ish normalization.
@@ -3022,7 +3026,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    // Now that we got the write lock, another thread may have constructed the
    // TClass while we were waiting, so we need to do the checks again.
 
-   cl = (TClass*)gROOT->GetListOfClasses()->FindObject(name);
+   cl = (TClass*)gROOT->GetListOfClasses()->FindObject(nameStr.c_str());
    if (cl) {
       if (cl->IsLoaded() || cl->TestBit(kUnloading))
          return cl;
@@ -3058,7 +3062,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
 
    // To avoid spurious auto parsing, let's check if the name as-is is
    // known in the TClassTable.
-   if (DictFuncPtr_t dict = TClassTable::GetDictNorm(name)) {
+   if (DictFuncPtr_t dict = TClassTable::GetDictNorm(nameStr.c_str())) {
       // The name is normalized, so the result of the first search is
       // authoritative.
       if (!cl && !load)
@@ -3094,7 +3098,7 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
       // First look at known types but without triggering any loads
       {
          THashTable *typeTable = dynamic_cast<THashTable *>(gROOT->GetListOfTypes());
-         TDataType *type = (TDataType *)typeTable->THashTable::FindObject(name);
+         TDataType *type = (TDataType *)typeTable->THashTable::FindObject(nameStr.c_str());
          if (type) {
             if (type->GetType() > 0)
                // This is a numerical type
@@ -3282,13 +3286,13 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
          gInterpreter->GetInterpreterTypeName(normalizedName.c_str(), alternative, kTRUE);
          if (alternative.empty())
             return nullptr;
-         const char *altname = alternative.c_str();
-         if (strncmp(altname, "std::", 5) == 0) {
+         std::string_view altname = alternative;
+         if (ROOT::StartsWith(altname, "std::")) {
             // For namespace (for example std::__1), GetInterpreterTypeName does
             // not strip std::, so we must do it explicitly here.
-            altname += 5;
+            altname = altname.substr(5);
          }
-         if (altname != normalizedName && strcmp(altname, name) != 0) {
+         if (altname != normalizedName && altname != name) {
             // altname now contains the full name of the class including a possible
             // namespace if there has been a using namespace statement.
 

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -106,7 +106,6 @@ public:
    const char *GetMsgPrefix() const { return fMsgPrefix; }
    void        SetMsgPrefix(const char *prefix);
    const char *GetMergeOptions() { return fMergeOptions; }
-   void        SetMergeOptions(const TString &options) { fMergeOptions = options; }
    void        SetMergeOptions(const std::string_view &options) { fMergeOptions = options; }
    void        SetIOFeatures(ROOT::TIOFeatures &features) { fIOFeatures = &features; }
    /// Add object names for PartialMerge().

--- a/tree/ntuple/inc/ROOT/RField.hxx
+++ b/tree/ntuple/inc/ROOT/RField.hxx
@@ -185,7 +185,7 @@ private:
    ROOT::DescriptorId_t
    LookupMember(const ROOT::RNTupleDescriptor &desc, std::string_view memberName, ROOT::DescriptorId_t classFieldId);
    /// Sets fStagingClass according to the given name and version
-   void SetStagingClass(const std::string &className, unsigned int classVersion);
+   void SetStagingClass(std::string_view className, unsigned int classVersion);
    /// If there are rules with inputs (source members), create the staging area according to the TClass instance
    /// that corresponds to the on-disk field.
    void PrepareStagingArea(const std::vector<const TSchemaRule *> &rules, const ROOT::RNTupleDescriptor &desc,
@@ -555,7 +555,7 @@ namespace Internal {
 /// type renormalization of the demangled type name T. The failure case, however, needs to additionally check for
 /// ROOT-specific special cases.
 template <class T>
-bool IsMatchingFieldType(const std::string &actualTypeName)
+bool IsMatchingFieldType(std::string_view actualTypeName)
 {
    return IsMatchingFieldType(actualTypeName, ROOT::RField<T>::TypeName(), typeid(T));
 }

--- a/tree/ntuple/inc/ROOT/RFieldBase.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldBase.hxx
@@ -62,7 +62,7 @@ void CallCommitClusterOnField(RFieldBase &);
 void CallConnectPageSinkOnField(RFieldBase &, ROOT::Internal::RPageSink &, ROOT::NTupleSize_t firstEntry = 0);
 void CallConnectPageSourceOnField(RFieldBase &, ROOT::Internal::RPageSource &);
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
+CallFieldBaseCreate(std::string_view fieldName, std::string_view typeName, const ROOT::RCreateFieldOptions &options,
                     const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 } // namespace Internal
@@ -97,7 +97,7 @@ class RFieldBase {
    friend void Internal::CallConnectPageSinkOnField(RFieldBase &, ROOT::Internal::RPageSink &, ROOT::NTupleSize_t);
    friend void Internal::CallConnectPageSourceOnField(RFieldBase &, ROOT::Internal::RPageSource &);
    friend ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-   Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
+   Internal::CallFieldBaseCreate(std::string_view fieldName, std::string_view typeName,
                                  const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
                                  ROOT::DescriptorId_t fieldId);
 
@@ -566,7 +566,7 @@ protected:
    /// normalized type name and type alias.
    /// `desc` and `fieldId` must be passed if `options.fEmulateUnknownTypes` is true, otherwise they can be left blank.
    static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName, const ROOT::RCreateFieldOptions &options,
+   Create(std::string_view fieldName, std::string_view typeName, const ROOT::RCreateFieldOptions &options,
           const ROOT::RNTupleDescriptor *desc, ROOT::DescriptorId_t fieldId);
 
 public:
@@ -605,12 +605,11 @@ public:
    /// Factory method to create a field from a certain type given as string.
    /// Note that the provided type name must be a valid C++ type name. Template arguments of templated types
    /// must be type names or integers (e.g., no expressions).
-   static RResult<std::unique_ptr<RFieldBase>>
-   Create(const std::string &fieldName, const std::string &typeName);
+   static RResult<std::unique_ptr<RFieldBase>> Create(std::string_view fieldName, std::string_view typeName);
 
    /// Checks if the given type is supported by RNTuple. In case of success, the result vector is empty.
    /// Otherwise there is an error record for each failing subfield (subtype).
-   static std::vector<RCheckResult> Check(const std::string &fieldName, const std::string &typeName);
+   static std::vector<RCheckResult> Check(std::string_view fieldName, std::string_view typeName);
 
    /// Generates an object of the field type and allocates new initialized memory according to the type.
    /// Implemented at the end of this header because the implementation is using RField<T>::TypeName()

--- a/tree/ntuple/inc/ROOT/RFieldUtils.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldUtils.hxx
@@ -27,10 +27,10 @@ namespace Internal {
 /// template arguments (hence "Prefix").
 /// Furthermore, if the type is a C-style array, rules are applied to the base type and the C style array
 /// is then mapped to an std::array.
-std::string GetCanonicalTypePrefix(const std::string &typeName);
+std::string GetCanonicalTypePrefix(std::string_view typeName);
 
 /// Given a type name normalized by ROOT meta, renormalize it for RNTuple. E.g., insert std::prefix.
-std::string GetRenormalizedTypeName(const std::string &metaNormalizedName);
+std::string GetRenormalizedTypeName(std::string_view metaNormalizedName);
 
 /// Given a type info ask ROOT meta to demangle it, then renormalize the resulting type name for RNTuple. Useful to
 /// ensure that e.g. fundamental types are normalized to the type used by RNTuple (e.g. int -> std::int32_t).
@@ -42,18 +42,18 @@ std::string GetRenormalizedTypeName(const std::type_info &ti);
 /// to ensure correct reconstruction of objects from disk.
 /// If the function returns true, renormalizedAlias contains the RNTuple normalized name that should be used as
 /// type alias.
-bool NeedsMetaNameAsAlias(const std::string &metaNormalizedName, std::string &renormalizedAlias,
+bool NeedsMetaNameAsAlias(std::string_view metaNormalizedName, std::string &renormalizedAlias,
                           bool isArgInTemplatedUserClass = false /* used in recursion */);
 
 /// Applies all RNTuple type normalization rules except typedef resolution.
-std::string GetNormalizedUnresolvedTypeName(const std::string &origName);
+std::string GetNormalizedUnresolvedTypeName(std::string_view origName);
 
 /// Appends 'll' or 'ull' to the where necessary and strips the suffix if not needed.
-std::string GetNormalizedInteger(const std::string &intTemplateArg);
+std::string GetNormalizedInteger(std::string_view intTemplateArg);
 std::string GetNormalizedInteger(long long val);
 std::string GetNormalizedInteger(unsigned long long val);
-long long ParseIntTypeToken(const std::string &intToken);
-unsigned long long ParseUIntTypeToken(const std::string &uintToken);
+long long ParseIntTypeToken(std::string_view intToken);
+unsigned long long ParseUIntTypeToken(std::string_view uintToken);
 
 /// Possible settings for the "rntuple.streamerMode" class attribute in the dictionary.
 enum class ERNTupleSerializationMode {

--- a/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/inc/ROOT/RFieldVisitor.hxx
@@ -253,7 +253,7 @@ The functions in this class format strings which are displayed by RNTupleReader:
 class RNTupleFormatter {
 public:
    // Can abbreviate long strings, e.g. ("ExampleString" , space= 8) => "Examp..."
-   static std::string FitString(const std::string &str, int availableSpace);
+   static std::string FitString(std::string_view str, int availableSpace);
 };
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RMiniFile.hxx
+++ b/tree/ntuple/inc/ROOT/RMiniFile.hxx
@@ -197,8 +197,8 @@ private:
       /// Writes a TKey including the data record, given by buffer, into fFile; returns the file offset to the payload.
       /// The payload is already compressed
       std::uint64_t WriteKey(const void *buffer, std::size_t nbytes, std::size_t len, std::int64_t offset = -1,
-                             std::uint64_t directoryOffset = 100, const std::string &className = "",
-                             const std::string &objectName = "", const std::string &title = "");
+                             std::uint64_t directoryOffset = 100, std::string_view className = "",
+                             std::string_view objectName = "", std::string_view title = "");
       /// Reserves an RBlob opaque key as data record and returns the offset of the record. If keyBuffer is specified,
       /// it must be written *before* the returned offset. (Note that the array type is purely documentation, the
       /// argument is actually just a pointer.)

--- a/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleDescriptor.hxx
@@ -1537,22 +1537,22 @@ public:
       fField.fProjectionSourceId = id;
       return *this;
    }
-   RFieldDescriptorBuilder &FieldName(const std::string &fieldName)
+   RFieldDescriptorBuilder &FieldName(std::string_view fieldName)
    {
       fField.fFieldName = fieldName;
       return *this;
    }
-   RFieldDescriptorBuilder &FieldDescription(const std::string &fieldDescription)
+   RFieldDescriptorBuilder &FieldDescription(std::string_view fieldDescription)
    {
       fField.fFieldDescription = fieldDescription;
       return *this;
    }
-   RFieldDescriptorBuilder &TypeName(const std::string &typeName)
+   RFieldDescriptorBuilder &TypeName(std::string_view typeName)
    {
       fField.fTypeName = typeName;
       return *this;
    }
-   RFieldDescriptorBuilder &TypeAlias(const std::string &typeAlias)
+   RFieldDescriptorBuilder &TypeAlias(std::string_view typeAlias)
    {
       fField.fTypeAlias = typeAlias;
       return *this;
@@ -1723,12 +1723,12 @@ public:
       fExtraTypeInfo.fTypeVersion = typeVersion;
       return *this;
    }
-   RExtraTypeInfoDescriptorBuilder &TypeName(const std::string &typeName)
+   RExtraTypeInfoDescriptorBuilder &TypeName(std::string_view typeName)
    {
       fExtraTypeInfo.fTypeName = typeName;
       return *this;
    }
-   RExtraTypeInfoDescriptorBuilder &Content(const std::string &content)
+   RExtraTypeInfoDescriptorBuilder &Content(std::string_view content)
    {
       fExtraTypeInfo.fContent = content;
       return *this;

--- a/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
@@ -59,8 +59,10 @@ private:
    bool fIsEnabled = false;
 
 public:
-   RNTuplePerfCounter(const std::string &name, const std::string &unit, const std::string &desc)
-      : fName(name), fUnit(unit), fDescription(desc) {}
+   RNTuplePerfCounter(std::string_view name, std::string_view unit, std::string_view desc)
+      : fName(name), fUnit(unit), fDescription(desc)
+   {
+   }
    virtual ~RNTuplePerfCounter();
    void Enable() { fIsEnabled = true; }
    bool IsEnabled() const { return fIsEnabled; }
@@ -86,7 +88,7 @@ private:
    std::int64_t fCounter = 0;
 
 public:
-   RNTuplePlainCounter(const std::string &name, const std::string &unit, const std::string &desc)
+   RNTuplePlainCounter(std::string_view name, std::string_view unit, std::string_view desc)
       : RNTuplePerfCounter(name, unit, desc)
    {
    }
@@ -113,8 +115,10 @@ private:
    std::atomic<std::int64_t> fCounter{0};
 
 public:
-   RNTupleAtomicCounter(const std::string &name, const std::string &unit, const std::string &desc)
-      : RNTuplePerfCounter(name, unit, desc) { }
+   RNTupleAtomicCounter(std::string_view name, std::string_view unit, std::string_view desc)
+      : RNTuplePerfCounter(name, unit, desc)
+   {
+   }
 
    R__ALWAYS_INLINE
    void Inc() {
@@ -175,8 +179,8 @@ private:
    const MetricFunc_t fFunc;
 
 public:
-   RNTupleCalcPerf(const std::string &name, const std::string &unit, const std::string &desc,
-                   RNTupleMetrics &metrics, MetricFunc_t &&func)
+   RNTupleCalcPerf(std::string_view name, std::string_view unit, std::string_view desc, RNTupleMetrics &metrics,
+                   MetricFunc_t &&func)
       : RNTuplePerfCounter(name, unit, desc), fMetrics(metrics), fFunc(std::move(func))
    {
    }
@@ -211,7 +215,7 @@ When printing, the value is converted from ticks to nanoseconds.
 template <typename BaseCounterT>
 class RNTupleTickCounter : public BaseCounterT {
 public:
-   RNTupleTickCounter(const std::string &name, const std::string &unit, const std::string &desc)
+   RNTupleTickCounter(std::string_view name, std::string_view unit, std::string_view desc)
       : BaseCounterT(name, unit, desc)
    {
       R__ASSERT(unit == "ns");
@@ -294,10 +298,10 @@ private:
    std::string fName;
    bool fIsEnabled = false;
 
-   bool Contains(const std::string &name) const;
+   bool Contains(std::string_view name) const;
 
 public:
-   explicit RNTupleMetrics(const std::string &name) : fName(name) {}
+   explicit RNTupleMetrics(std::string_view name) : fName(name) {}
    RNTupleMetrics(const RNTupleMetrics &other) = delete;
    RNTupleMetrics & operator=(const RNTupleMetrics &other) = delete;
    RNTupleMetrics(RNTupleMetrics &&other) = default;
@@ -306,7 +310,7 @@ public:
 
    // TODO(jblomer): return a reference
    template <typename CounterPtrT, class... Args>
-   CounterPtrT MakeCounter(const std::string &name, Args&&... args)
+   CounterPtrT MakeCounter(std::string_view name, Args &&...args)
    {
       R__ASSERT(!Contains(name));
       auto counter = std::make_unique<std::remove_pointer_t<CounterPtrT>>(name, std::forward<Args>(args)...);
@@ -323,7 +327,7 @@ public:
 
    void ObserveMetrics(RNTupleMetrics &observee);
 
-   void Print(std::ostream &output, const std::string &prefix = "") const;
+   void Print(std::ostream &output, std::string_view prefix = "") const;
    void Enable();
    bool IsEnabled() const { return fIsEnabled; }
 };

--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -59,7 +59,7 @@ private:
 
 public:
    RNTupleOpenSpec(std::string_view n, TDirectory *s) : fNTupleName(n), fStorage(s) {}
-   RNTupleOpenSpec(std::string_view n, const std::string &s) : fNTupleName(n), fStorage(s) {}
+   RNTupleOpenSpec(std::string_view n, std::string_view s) : fNTupleName(n), fStorage(std::string(s)) {}
 
    std::unique_ptr<ROOT::Internal::RPageSource> CreatePageSource() const;
 };
@@ -314,7 +314,7 @@ protected:
    ///
    /// In case the field was already present in the entry, the index of the existing field is returned.
    virtual Internal::RNTupleProcessorEntry::FieldIndex_t
-   AddFieldToEntry(const std::string &fieldName, const std::string &typeName, void *valuePtr,
+   AddFieldToEntry(std::string_view fieldName, std::string_view typeName, void *valuePtr,
                    const Internal::RNTupleProcessorProvenance &provenance) = 0;
 
    /////////////////////////////////////////////////////////////////////////////
@@ -385,7 +385,7 @@ public:
    /// invalid data. After passing a pointer to `RequestField`, we *strongly* recommend only accessing its data through
    /// the interface of the returned `RNTupleProcessorOptionalPtr`, to ensure that only valid data can be read.
    template <typename T>
-   RNTupleProcessorOptionalPtr<T> RequestField(const std::string &fieldName, void *valuePtr = nullptr)
+   RNTupleProcessorOptionalPtr<T> RequestField(std::string_view fieldName, void *valuePtr = nullptr)
    {
       Initialize(fEntry);
       std::string typeName{};
@@ -412,7 +412,7 @@ public:
    /// invalid data. After passing a pointer to `RequestField`, we *strongly* recommend only accessing its data through
    /// the interface of the returned `RNTupleProcessorOptionalPtr`, to ensure that only valid data can be read.
    RNTupleProcessorOptionalPtr<void>
-   RequestField(const std::string &fieldName, const std::string &typeName, void *valuePtr = nullptr)
+   RequestField(std::string_view fieldName, std::string_view typeName, void *valuePtr = nullptr)
    {
       Initialize(fEntry);
       auto fieldIdx = AddFieldToEntry(fieldName, typeName, valuePtr, Internal::RNTupleProcessorProvenance());
@@ -590,7 +590,7 @@ private:
    /// \return The newly created field.
    /// \throws ROOT::RException In case the requested field cannot be found on disk.
    std::unique_ptr<ROOT::RFieldBase>
-   CreateAndConnectField(const std::string &qualifiedFieldName, const std::string &typeName);
+   CreateAndConnectField(std::string_view qualifiedFieldName, std::string_view typeName);
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Initialize the processor by creating an (initially empty) `fEntry`, or setting an existing one.
@@ -631,7 +631,7 @@ private:
    ///
    /// \sa RNTupleProcessor::AddFieldToEntry()
    Internal::RNTupleProcessorEntry::FieldIndex_t AddFieldToEntry(
-      const std::string &fieldName, const std::string &typeName, void *valuePtr = nullptr,
+      std::string_view fieldName, std::string_view typeName, void *valuePtr = nullptr,
       const Internal::RNTupleProcessorProvenance &provenance = Internal::RNTupleProcessorProvenance()) final;
 
    /////////////////////////////////////////////////////////////////////////////
@@ -726,7 +726,7 @@ private:
    ///
    /// \sa RNTupleProcessor::AddFieldToEntry()
    Internal::RNTupleProcessorEntry::FieldIndex_t AddFieldToEntry(
-      const std::string &fieldName, const std::string &typeName, void *valuePtr = nullptr,
+      std::string_view fieldName, std::string_view typeName, void *valuePtr = nullptr,
       const Internal::RNTupleProcessorProvenance &provenance = Internal::RNTupleProcessorProvenance()) final;
 
    /////////////////////////////////////////////////////////////////////////////
@@ -826,7 +826,7 @@ private:
    ///
    /// \sa RNTupleProcessor::AddFieldToEntry()
    Internal::RNTupleProcessorEntry::FieldIndex_t AddFieldToEntry(
-      const std::string &fieldName, const std::string &typeName, void *valuePtr = nullptr,
+      std::string_view fieldName, std::string_view typeName, void *valuePtr = nullptr,
       const Internal::RNTupleProcessorProvenance &provenance = Internal::RNTupleProcessorProvenance()) final;
 
    /////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessorEntry.hxx
@@ -41,7 +41,7 @@ private:
 
 public:
    RNTupleProcessorProvenance() = default;
-   RNTupleProcessorProvenance(const std::string &provenance) : fProvenance(provenance) {}
+   RNTupleProcessorProvenance(std::string_view provenance) : fProvenance(provenance) {}
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the full processor provenance, in the form of "x.y.z".
@@ -53,12 +53,12 @@ public:
    /// \param[in] processorName Name of the processor to add.
    ///
    /// \return The updated provenance.
-   RNTupleProcessorProvenance Evolve(const std::string &processorName) const
+   RNTupleProcessorProvenance Evolve(std::string_view processorName) const
    {
       if (fProvenance.empty())
          return RNTupleProcessorProvenance(processorName);
 
-      return RNTupleProcessorProvenance(fProvenance + "." + processorName);
+      return RNTupleProcessorProvenance(fProvenance + "." + std::string(processorName));
    }
 
    /////////////////////////////////////////////////////////////////////////////
@@ -173,7 +173,7 @@ public:
    /// \param[in] provenance Processor provenance of the field.
    ///
    /// \return The field index of the newly added field.
-   FieldIndex_t AddField(const std::string &qualifiedFieldName, std::unique_ptr<ROOT::RFieldBase> field, void *valuePtr,
+   FieldIndex_t AddField(std::string_view qualifiedFieldName, std::unique_ptr<ROOT::RFieldBase> field, void *valuePtr,
                          const RNTupleProcessorProvenance &provenance);
 
    /////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleSerialize.hxx
@@ -222,7 +222,7 @@ public:
    static std::uint32_t SerializeUInt64(std::uint64_t val, void *buffer);
    static std::uint32_t DeserializeUInt64(const void *buffer, std::uint64_t &val);
 
-   static std::uint32_t SerializeString(const std::string &val, void *buffer);
+   static std::uint32_t SerializeString(std::string_view val, void *buffer);
    static RResult<std::uint32_t> DeserializeString(const void *buffer, std::uint64_t bufSize, std::string &val);
 
    /// While we could just interpret the enums as ints, we make the translation explicit
@@ -313,7 +313,7 @@ public:
 
    // Helper functions to (de-)serialize the streamer info type extra information
    static std::string SerializeStreamerInfos(const StreamerInfoMap_t &infos);
-   static RResult<StreamerInfoMap_t> DeserializeStreamerInfos(const std::string &extraTypeInfoContent);
+   static RResult<StreamerInfoMap_t> DeserializeStreamerInfos(std::string_view extraTypeInfoContent);
 }; // class RNTupleSerializer
 
 } // namespace Internal

--- a/tree/ntuple/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleView.hxx
@@ -321,8 +321,7 @@ private:
    ROOT::RField<RNTupleCardinality<std::uint64_t>> fField;
    ROOT::RFieldBase::RValue fValue;
 
-   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, const std::string &fieldName,
-                         ROOT::Internal::RPageSource *source)
+   RNTupleCollectionView(ROOT::DescriptorId_t fieldId, std::string_view fieldName, ROOT::Internal::RPageSource *source)
       : fSource(source), fField(fieldName), fValue(fField.CreateValue())
    {
       fField.SetOnDiskId(fieldId);

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -493,7 +493,7 @@ ROOT::RFieldBase::Create(std::string_view fieldName, std::string_view typeName,
       }
 
       if (!result) {
-         auto cl = TClass::GetClass(std::string(typeName).c_str());
+         auto cl = TClass::GetClass(typeName);
 
          if (cl && cl->GetState() > TClass::kForwardDeclared) {
             createContextGuard.AddClassToStack(resolvedType);

--- a/tree/ntuple/src/RFieldBase.cxx
+++ b/tree/ntuple/src/RFieldBase.cxx
@@ -54,11 +54,11 @@ public:
       fCreateContext.fContinueOnError = fOriginalContinueOnError;
    }
 
-   void AddClassToStack(const std::string &cl)
+   void AddClassToStack(std::string_view cl)
    {
       if (std::find(fCreateContext.fClassesOnStack.begin(), fCreateContext.fClassesOnStack.end(), cl) !=
           fCreateContext.fClassesOnStack.end()) {
-         throw ROOT::RException(R__FAIL("cyclic class definition: " + cl));
+         throw ROOT::RException(R__FAIL("cyclic class definition: " + std::string(cl)));
       }
       fCreateContext.fClassesOnStack.emplace_back(cl);
    }
@@ -87,7 +87,7 @@ void ROOT::Internal::CallConnectPageSourceOnField(RFieldBase &field, ROOT::Inter
 }
 
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-ROOT::Internal::CallFieldBaseCreate(const std::string &fieldName, const std::string &typeName,
+ROOT::Internal::CallFieldBaseCreate(std::string_view fieldName, std::string_view typeName,
                                     const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
                                     ROOT::DescriptorId_t fieldId)
 {
@@ -261,14 +261,14 @@ std::string ROOT::RFieldBase::GetQualifiedFieldName() const
 }
 
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeName)
+ROOT::RFieldBase::Create(std::string_view fieldName, std::string_view typeName)
 {
    return R__FORWARD_RESULT(
       RFieldBase::Create(fieldName, typeName, ROOT::RCreateFieldOptions{}, nullptr, ROOT::kInvalidDescriptorId));
 }
 
 std::vector<ROOT::RFieldBase::RCheckResult>
-ROOT::RFieldBase::Check(const std::string &fieldName, const std::string &typeName)
+ROOT::RFieldBase::Check(std::string_view fieldName, std::string_view typeName)
 {
    RFieldZero fieldZero;
    ROOT::RCreateFieldOptions cfOpts{};
@@ -290,14 +290,15 @@ ROOT::RFieldBase::Check(const std::string &fieldName, const std::string &typeNam
 }
 
 ROOT::RResult<std::unique_ptr<ROOT::RFieldBase>>
-ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeName,
+ROOT::RFieldBase::Create(std::string_view fieldName, std::string_view typeName,
                          const ROOT::RCreateFieldOptions &options, const ROOT::RNTupleDescriptor *desc,
                          ROOT::DescriptorId_t fieldId)
 {
    using ROOT::Internal::ParseUIntTypeToken;
    using ROOT::Internal::TokenizeTypeList;
 
-   const auto resolvedType = ROOT::Internal::GetCanonicalTypePrefix(TClassEdit::ResolveTypedef(typeName.c_str()));
+   const auto resolvedType =
+      ROOT::Internal::GetCanonicalTypePrefix(TClassEdit::ResolveTypedef(std::string(typeName).c_str()));
 
    thread_local CreateContext createContext;
    CreateContextGuard createContextGuard(createContext);
@@ -316,7 +317,7 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
    };
 
    if (resolvedType.empty())
-      return R__FORWARD_RESULT(fnFail("no type name specified for field '" + fieldName + "'"));
+      return R__FORWARD_RESULT(fnFail("no type name specified for field '" + std::string(fieldName) + "'"));
 
    std::unique_ptr<ROOT::RFieldBase> result;
 
@@ -492,7 +493,7 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
       }
 
       if (!result) {
-         auto cl = TClass::GetClass(typeName.c_str());
+         auto cl = TClass::GetClass(std::string(typeName).c_str());
 
          if (cl && cl->GetState() > TClass::kForwardDeclared) {
             createContextGuard.AddClassToStack(resolvedType);
@@ -535,7 +536,7 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
                return recordField;
             } else if (fieldDesc.GetStructure() == ENTupleStructure::kCollection) {
                if (fieldDesc.GetLinkIds().size() != 1)
-                  throw ROOT::RException(R__FAIL("invalid structure for collection field " + fieldName));
+                  throw ROOT::RException(R__FAIL("invalid structure for collection field " + std::string(fieldName)));
 
                auto itemFieldId = fieldDesc.GetLinkIds()[0];
                const auto &itemFieldDesc = desc->GetFieldDescriptor(itemFieldId);
@@ -581,7 +582,7 @@ ROOT::RFieldBase::Create(const std::string &fieldName, const std::string &typeNa
       }
       return result;
    }
-   return R__FORWARD_RESULT(fnFail("unknown type: " + typeName, RInvalidField::ECategory::kUnknownType));
+   return R__FORWARD_RESULT(fnFail("unknown type: " + std::string(typeName), RInvalidField::ECategory::kUnknownType));
 }
 
 const ROOT::RFieldBase::RColumnRepresentations &ROOT::RFieldBase::GetColumnRepresentations() const

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -413,14 +413,14 @@ ROOT::DescriptorId_t ROOT::RClassField::LookupMember(const ROOT::RNTupleDescript
    return ROOT::kInvalidDescriptorId;
 }
 
-void ROOT::RClassField::SetStagingClass(const std::string &className, unsigned int classVersion)
+void ROOT::RClassField::SetStagingClass(std::string_view className, unsigned int classVersion)
 {
-   TClass::GetClass(className.c_str())->GetStreamerInfo(classVersion);
+   TClass::GetClass(std::string(className).c_str())->GetStreamerInfo(classVersion);
    if (classVersion != GetTypeVersion() || className != GetTypeName()) {
-      fStagingClass = TClass::GetClass((className + std::string("@@") + std::to_string(classVersion)).c_str());
+      fStagingClass = TClass::GetClass((std::string(className) + "@@" + std::to_string(classVersion)).c_str());
       if (!fStagingClass) {
          // For a rename rule, we may simply ask for the old class name
-         fStagingClass = TClass::GetClass(className.c_str());
+         fStagingClass = TClass::GetClass(std::string(className).c_str());
       }
    } else {
       fStagingClass = fClass;

--- a/tree/ntuple/src/RFieldMeta.cxx
+++ b/tree/ntuple/src/RFieldMeta.cxx
@@ -57,7 +57,7 @@ namespace {
 
 TClass *EnsureValidClass(std::string_view className)
 {
-   auto cl = TClass::GetClass(std::string(className).c_str());
+   auto cl = TClass::GetClass(className);
    if (cl == nullptr) {
       throw ROOT::RException(R__FAIL("RField: no I/O support for type " + std::string(className)));
    }
@@ -415,12 +415,12 @@ ROOT::DescriptorId_t ROOT::RClassField::LookupMember(const ROOT::RNTupleDescript
 
 void ROOT::RClassField::SetStagingClass(std::string_view className, unsigned int classVersion)
 {
-   TClass::GetClass(std::string(className).c_str())->GetStreamerInfo(classVersion);
+   TClass::GetClass(className)->GetStreamerInfo(classVersion);
    if (classVersion != GetTypeVersion() || className != GetTypeName()) {
       fStagingClass = TClass::GetClass((std::string(className) + "@@" + std::to_string(classVersion)).c_str());
       if (!fStagingClass) {
          // For a rename rule, we may simply ask for the old class name
-         fStagingClass = TClass::GetClass(std::string(className).c_str());
+         fStagingClass = TClass::GetClass(className);
       }
    } else {
       fStagingClass = fClass;

--- a/tree/ntuple/src/RFieldUtils.cxx
+++ b/tree/ntuple/src/RFieldUtils.cxx
@@ -27,7 +27,7 @@
 
 namespace {
 
-std::string GetRenormalizedDemangledTypeName(const std::string &demangledName, bool renormalizeStdString);
+std::string GetRenormalizedDemangledTypeName(std::string_view demangledName, bool renormalizeStdString);
 
 const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
    {"Bool_t", "bool"},
@@ -66,7 +66,7 @@ const std::unordered_map<std::string_view, std::string_view> typeTranslationMap{
 // Any types used as a template argument of user classes will keep [U]Long64_t template arguments for the type alias,
 // e.g. MyClass<std::vector<Long64_t>> will normalize to `MyClass<std::vector<std::int64_t>>` but keep the original
 // spelling in the type alias.
-bool IsUserClass(const std::string &typeName)
+bool IsUserClass(std::string_view typeName)
 {
    return typeName.rfind("std::", 0) != 0 && typeName.rfind("ROOT::VecOps::RVec<", 0) != 0;
 }
@@ -148,7 +148,7 @@ std::string GetNormalizedTemplateArg(const std::string &arg, bool keepQualifier,
 }
 
 using AnglePos = std::pair<std::string::size_type, std::string::size_type>;
-std::vector<AnglePos> FindTemplateAngleBrackets(const std::string &typeName)
+std::vector<AnglePos> FindTemplateAngleBrackets(std::string_view typeName)
 {
    std::vector<AnglePos> result;
    std::string::size_type currentPos = 0;
@@ -391,7 +391,7 @@ void NormalizeTemplateArguments(std::string &templatedTypeName, int maxTemplateA
 }
 
 // Given a type name normalized by ROOT Meta, return the type name normalized according to the RNTuple rules.
-std::string GetRenormalizedMetaTypeName(const std::string &metaNormalizedName)
+std::string GetRenormalizedMetaTypeName(std::string_view metaNormalizedName)
 {
    auto canonicalTypePrefix = ROOT::Internal::GetCanonicalTypePrefix(metaNormalizedName);
    // RNTuple resolves Double32_t for the normalized type name but keeps Double32_t for the type alias
@@ -412,7 +412,7 @@ std::string GetRenormalizedMetaTypeName(const std::string &metaNormalizedName)
 
 // Given a demangled name ("normalized by the compiler"), return the type name normalized according to the
 // RNTuple rules.
-std::string GetRenormalizedDemangledTypeName(const std::string &demangledName, bool renormalizeStdString)
+std::string GetRenormalizedDemangledTypeName(std::string_view demangledName, bool renormalizeStdString)
 {
    std::string tn{demangledName};
    RemoveSpaceBefore(tn, '[');
@@ -446,7 +446,7 @@ std::string GetRenormalizedDemangledTypeName(const std::string &demangledName, b
    }
 
    std::string normName{canonicalTypePrefix};
-   NormalizeTemplateArguments(normName, maxTemplateArgs, [renormalizeStdString](const std::string &n) {
+   NormalizeTemplateArguments(normName, maxTemplateArgs, [renormalizeStdString](std::string_view n) {
       return GetRenormalizedDemangledTypeName(n, renormalizeStdString);
    });
    // In RenormalizeStdString(), we normalize the demangled type name of `std::string`,
@@ -460,10 +460,10 @@ std::string GetRenormalizedDemangledTypeName(const std::string &demangledName, b
 
 } // namespace
 
-std::string ROOT::Internal::GetCanonicalTypePrefix(const std::string &typeName)
+std::string ROOT::Internal::GetCanonicalTypePrefix(std::string_view typeName)
 {
    // Remove outer cv qualifiers and extra white spaces
-   const std::string cleanedType = TClassEdit::CleanType(typeName.c_str(), /*mode=*/1);
+   const std::string cleanedType = TClassEdit::CleanType(std::string(typeName).c_str(), /*mode=*/1);
 
    // Can happen when called from RFieldBase::Create() and is caught there
    if (cleanedType.empty())
@@ -529,12 +529,12 @@ std::string ROOT::Internal::GetRenormalizedTypeName(const std::type_info &ti)
    return GetRenormalizedDemangledTypeName(GetRawDemangledTypeName(ti), true /* renormalizeStdString */);
 }
 
-std::string ROOT::Internal::GetRenormalizedTypeName(const std::string &metaNormalizedName)
+std::string ROOT::Internal::GetRenormalizedTypeName(std::string_view metaNormalizedName)
 {
    return GetRenormalizedMetaTypeName(metaNormalizedName);
 }
 
-bool ROOT::Internal::NeedsMetaNameAsAlias(const std::string &metaNormalizedName, std::string &renormalizedAlias,
+bool ROOT::Internal::NeedsMetaNameAsAlias(std::string_view metaNormalizedName, std::string &renormalizedAlias,
                                           bool isArgInTemplatedUserClass)
 {
    const auto canonicalTypePrefix = ROOT::Internal::GetCanonicalTypePrefix(metaNormalizedName);
@@ -566,11 +566,11 @@ bool ROOT::Internal::NeedsMetaNameAsAlias(const std::string &metaNormalizedName,
    return result;
 }
 
-std::string ROOT::Internal::GetNormalizedUnresolvedTypeName(const std::string &origName)
+std::string ROOT::Internal::GetNormalizedUnresolvedTypeName(std::string_view origName)
 {
    const TClassEdit::EModType modType = static_cast<TClassEdit::EModType>(
       TClassEdit::kDropStlDefault | TClassEdit::kDropComparator | TClassEdit::kDropHash);
-   TClassEdit::TSplitType splitname(origName.c_str(), modType);
+   TClassEdit::TSplitType splitname(std::string(origName).c_str(), modType);
    std::string shortType;
    splitname.ShortType(shortType, modType);
    auto canonicalTypePrefix = GetCanonicalTypePrefix(shortType);
@@ -648,7 +648,7 @@ std::string ROOT::Internal::GetNormalizedInteger(unsigned long long val)
    return std::to_string(val);
 }
 
-std::string ROOT::Internal::GetNormalizedInteger(const std::string &intTemplateArg)
+std::string ROOT::Internal::GetNormalizedInteger(std::string_view intTemplateArg)
 {
    R__ASSERT(!intTemplateArg.empty());
    if (intTemplateArg[0] == '-')
@@ -656,46 +656,46 @@ std::string ROOT::Internal::GetNormalizedInteger(const std::string &intTemplateA
    return GetNormalizedInteger(ParseUIntTypeToken(intTemplateArg));
 }
 
-long long ROOT::Internal::ParseIntTypeToken(const std::string &intToken)
+long long ROOT::Internal::ParseIntTypeToken(std::string_view intToken)
 {
    std::size_t nChars = 0;
-   long long res = std::stoll(intToken, &nChars);
+   long long res = std::stoll(std::string(intToken), &nChars);
    if (nChars == intToken.size())
       return res;
 
    assert(nChars < intToken.size());
    if (nChars == 0) {
-      throw RException(R__FAIL("invalid integer type token: " + intToken));
+      throw RException(R__FAIL("invalid integer type token: " + std::string(intToken)));
    }
 
-   auto suffix = intToken.substr(nChars);
+   auto suffix = std::string(intToken.substr(nChars));
    std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::toupper);
    if (suffix == "L" || suffix == "LL")
       return res;
    if (res >= 0 && (suffix == "U" || suffix == "UL" || suffix == "ULL"))
       return res;
 
-   throw RException(R__FAIL("invalid integer type token: " + intToken));
+   throw RException(R__FAIL("invalid integer type token: " + std::string(intToken)));
 }
 
-unsigned long long ROOT::Internal::ParseUIntTypeToken(const std::string &uintToken)
+unsigned long long ROOT::Internal::ParseUIntTypeToken(std::string_view uintToken)
 {
    std::size_t nChars = 0;
-   unsigned long long res = std::stoull(uintToken, &nChars);
+   unsigned long long res = std::stoull(std::string(uintToken), &nChars);
    if (nChars == uintToken.size())
       return res;
 
    assert(nChars < uintToken.size());
    if (nChars == 0) {
-      throw RException(R__FAIL("invalid integer type token: " + uintToken));
+      throw RException(R__FAIL("invalid integer type token: " + std::string(uintToken)));
    }
 
-   auto suffix = uintToken.substr(nChars);
+   auto suffix = std::string(uintToken.substr(nChars));
    std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::toupper);
    if (suffix == "U" || suffix == "L" || suffix == "LL" || suffix == "UL" || suffix == "ULL")
       return res;
 
-   throw RException(R__FAIL("invalid integer type token: " + uintToken));
+   throw RException(R__FAIL("invalid integer type token: " + std::string(uintToken)));
 }
 
 ROOT::Internal::ERNTupleSerializationMode ROOT::Internal::GetRNTupleSerializationMode(const TClass *cl)

--- a/tree/ntuple/src/RFieldUtils.cxx
+++ b/tree/ntuple/src/RFieldUtils.cxx
@@ -463,7 +463,7 @@ std::string GetRenormalizedDemangledTypeName(std::string_view demangledName, boo
 std::string ROOT::Internal::GetCanonicalTypePrefix(std::string_view typeName)
 {
    // Remove outer cv qualifiers and extra white spaces
-   const std::string cleanedType = TClassEdit::CleanType(std::string(typeName).c_str(), /*mode=*/1);
+   const std::string cleanedType = TClassEdit::CleanType(typeName, /*mode=*/1);
 
    // Can happen when called from RFieldBase::Create() and is caught there
    if (cleanedType.empty())

--- a/tree/ntuple/src/RFieldVisitor.cxx
+++ b/tree/ntuple/src/RFieldVisitor.cxx
@@ -415,11 +415,11 @@ void ROOT::Internal::RPrintValueVisitor::VisitSoAField(const ROOT::Experimental:
 
 //---------------------------- RNTupleFormatter --------------------------------
 
-std::string ROOT::Internal::RNTupleFormatter::FitString(const std::string &str, int availableSpace)
+std::string ROOT::Internal::RNTupleFormatter::FitString(std::string_view str, int availableSpace)
 {
    int strSize{static_cast<int>(str.size())};
    if (strSize <= availableSpace)
-      return str + std::string(availableSpace - strSize, ' ');
+      return std::string(str) + std::string(availableSpace - strSize, ' ');
    else if (availableSpace < 3)
       return std::string(availableSpace, '.');
    return std::string(str, 0, availableSpace - 3) + "...";

--- a/tree/ntuple/src/RMiniFile.cxx
+++ b/tree/ntuple/src/RMiniFile.cxx
@@ -165,7 +165,7 @@ struct RTFString {
    unsigned char fLName{0};
    char fData[255];
    RTFString() = default;
-   RTFString(const std::string &str)
+   RTFString(std::string_view str)
    {
       // The length of strings with 255 characters and longer are encoded with a 32-bit integer following the first
       // byte. This is currently not handled.
@@ -1123,8 +1123,8 @@ void ROOT::Internal::RNTupleFileWriter::RImplSimple::Write(const void *buffer, s
 std::uint64_t
 ROOT::Internal::RNTupleFileWriter::RImplSimple::WriteKey(const void *buffer, std::size_t nbytes, std::size_t len,
                                                          std::int64_t offset, std::uint64_t directoryOffset,
-                                                         const std::string &className, const std::string &objectName,
-                                                         const std::string &title)
+                                                         std::string_view className, std::string_view objectName,
+                                                         std::string_view title)
 {
    auto &shared = *fShared;
 

--- a/tree/ntuple/src/RNTupleMetrics.cxx
+++ b/tree/ntuple/src/RNTupleMetrics.cxx
@@ -27,7 +27,7 @@ std::string ROOT::Experimental::Detail::RNTuplePerfCounter::ToString() const
    return fName + kFieldSeperator + fUnit + kFieldSeperator + fDescription + kFieldSeperator + GetValueAsString();
 }
 
-bool ROOT::Experimental::Detail::RNTupleMetrics::Contains(const std::string &name) const
+bool ROOT::Experimental::Detail::RNTupleMetrics::Contains(std::string_view name) const
 {
   return GetLocalCounter(name) != nullptr;
 }
@@ -62,7 +62,7 @@ ROOT::Experimental::Detail::RNTupleMetrics::GetCounter(std::string_view name) co
    return nullptr;
 }
 
-void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, const std::string &prefix) const
+void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, std::string_view prefix) const
 {
    if (!fIsEnabled) {
       output << fName << " metrics disabled!\n";
@@ -73,7 +73,7 @@ void ROOT::Experimental::Detail::RNTupleMetrics::Print(std::ostream &output, con
       output << prefix << fName << kNamespaceSeperator << c->ToString() << '\n';
    }
    for (const auto c : fObservedMetrics) {
-      c->Print(output, prefix + fName + ".");
+      c->Print(output, std::string(prefix) + fName + ".");
    }
 }
 

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -143,12 +143,12 @@ bool ROOT::Experimental::RNTupleSingleProcessor::CanReadFieldFromDisk(std::strin
 }
 
 std::unique_ptr<ROOT::RFieldBase>
-ROOT::Experimental::RNTupleSingleProcessor::CreateAndConnectField(const std::string &qualifiedFieldName,
-                                                                  const std::string &typeName)
+ROOT::Experimental::RNTupleSingleProcessor::CreateAndConnectField(std::string_view qualifiedFieldName,
+                                                                  std::string_view typeName)
 {
    assert(fPageSource);
 
-   std::string onDiskFieldName = qualifiedFieldName;
+   std::string_view onDiskFieldName = qualifiedFieldName;
 
    // Strip the "_join" prefix (for join fields) from the field name, if present.
    if (onDiskFieldName.find("_join.") == 0) {
@@ -171,7 +171,7 @@ ROOT::Experimental::RNTupleSingleProcessor::CreateAndConnectField(const std::str
       field = fieldDesc.CreateField(desc);
    } else {
       // Strip the parent field name prefix(es), if present.
-      std::string subfieldName = onDiskFieldName;
+      std::string_view subfieldName = onDiskFieldName;
       auto posDot = onDiskFieldName.find_last_of('.');
       if (posDot != std::string::npos)
          subfieldName = onDiskFieldName.substr(posDot + 1);
@@ -186,14 +186,14 @@ ROOT::Experimental::RNTupleSingleProcessor::CreateAndConnectField(const std::str
 }
 
 ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t
-ROOT::Experimental::RNTupleSingleProcessor::AddFieldToEntry(const std::string &fieldName, const std::string &typeName,
+ROOT::Experimental::RNTupleSingleProcessor::AddFieldToEntry(std::string_view fieldName, std::string_view typeName,
                                                             void *valuePtr,
                                                             const Internal::RNTupleProcessorProvenance &provenance)
 {
    auto fieldIdx = fEntry->FindFieldIndex(fieldName, typeName);
    if (!fieldIdx) {
       // Strip the processor name prefix(es), if present.
-      std::string qualifiedFieldName = fieldName;
+      std::string_view qualifiedFieldName = fieldName;
       if (provenance.IsPresentInFieldName(qualifiedFieldName)) {
          qualifiedFieldName = qualifiedFieldName.substr(provenance.Get().size() + 1);
       }
@@ -201,7 +201,7 @@ ROOT::Experimental::RNTupleSingleProcessor::AddFieldToEntry(const std::string &f
       auto field = CreateAndConnectField(qualifiedFieldName, typeName);
 
       if (!field) {
-         throw RException(R__FAIL("cannot register field with name \"" + qualifiedFieldName +
+         throw RException(R__FAIL("cannot register field with name \"" + std::string(qualifiedFieldName) +
                                   "\" because it is not present in the on-disk information of the RNTuple(s) this "
                                   "processor is created from"));
       }
@@ -338,7 +338,7 @@ void ROOT::Experimental::RNTupleChainProcessor::ConnectInnerProcessor(std::size_
 }
 
 ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t
-ROOT::Experimental::RNTupleChainProcessor::AddFieldToEntry(const std::string &fieldName, const std::string &typeName,
+ROOT::Experimental::RNTupleChainProcessor::AddFieldToEntry(std::string_view fieldName, std::string_view typeName,
                                                            void *valuePtr,
                                                            const Internal::RNTupleProcessorProvenance &provenance)
 {
@@ -479,7 +479,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::Connect(
 }
 
 ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t
-ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(const std::string &fieldName, const std::string &typeName,
+ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(std::string_view fieldName, std::string_view typeName,
                                                           void *valuePtr,
                                                           const Internal::RNTupleProcessorProvenance &provenance)
 {
@@ -489,7 +489,7 @@ ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(const std::string &fie
       // the primary processor itself is a join where its auxProcessor bears the same name as the current auxProcessor),
       // there will be name conflicts, so error out.
       if (fPrimaryProcessor->CanReadFieldFromDisk(fieldName)) {
-         throw RException(R__FAIL("ambiguous field name: \"" + fieldName +
+         throw RException(R__FAIL("ambiguous field name: \"" + std::string(fieldName) +
                                   "\" is present in the primary RNTupleProcessor \"" +
                                   fPrimaryProcessor->GetProcessorName() +
                                   "\", but may also refer to a field in the auxiliary RNTupleProcessor named \"" +

--- a/tree/ntuple/src/RNTupleProcessorEntry.cxx
+++ b/tree/ntuple/src/RNTupleProcessorEntry.cxx
@@ -52,13 +52,13 @@ ROOT::Experimental::Internal::RNTupleProcessorEntry::FindFieldIndex(std::string_
 }
 
 ROOT::Experimental::Internal::RNTupleProcessorEntry::FieldIndex_t
-ROOT::Experimental::Internal::RNTupleProcessorEntry::AddField(const std::string &qualifiedFieldName,
+ROOT::Experimental::Internal::RNTupleProcessorEntry::AddField(std::string_view qualifiedFieldName,
                                                               std::unique_ptr<ROOT::RFieldBase> field, void *valuePtr,
                                                               const RNTupleProcessorProvenance &provenance)
 {
-   auto fieldNameWithProcessorPrefix = qualifiedFieldName;
+   auto fieldNameWithProcessorPrefix = std::string(qualifiedFieldName);
    if (const auto &processorPrefix = provenance.Get(); !processorPrefix.empty())
-      fieldNameWithProcessorPrefix = processorPrefix + "." + qualifiedFieldName;
+      fieldNameWithProcessorPrefix = std::string(processorPrefix) + "." + std::string(qualifiedFieldName);
 
    if (FindFieldIndex(fieldNameWithProcessorPrefix, field->GetTypeName()))
       throw ROOT::RException(R__FAIL("field \"" + fieldNameWithProcessorPrefix + "\" is already present in the entry"));

--- a/tree/ntuple/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/src/RNTupleSerialize.cxx
@@ -741,7 +741,7 @@ std::uint32_t ROOT::Internal::RNTupleSerializer::DeserializeUInt64(const void *b
    return DeserializeInt64(buffer, *reinterpret_cast<std::int64_t *>(&val));
 }
 
-std::uint32_t ROOT::Internal::RNTupleSerializer::SerializeString(const std::string &val, void *buffer)
+std::uint32_t ROOT::Internal::RNTupleSerializer::SerializeString(std::string_view val, void *buffer)
 {
    if (buffer) {
       auto pos = reinterpret_cast<unsigned char *>(buffer);
@@ -2326,7 +2326,7 @@ std::string ROOT::Internal::RNTupleSerializer::SerializeStreamerInfos(const Stre
 }
 
 ROOT::RResult<ROOT::Internal::RNTupleSerializer::StreamerInfoMap_t>
-ROOT::Internal::RNTupleSerializer::DeserializeStreamerInfos(const std::string &extraTypeInfoContent)
+ROOT::Internal::RNTupleSerializer::DeserializeStreamerInfos(std::string_view extraTypeInfoContent)
 {
    StreamerInfoMap_t infoMap;
 

--- a/tree/ntuple/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/src/RPageStorageDaos.cxx
@@ -115,14 +115,14 @@ struct RDaosContainerNTupleLocator {
    static const ntuple_index_t kReservedIndex = 0;
 
    RDaosContainerNTupleLocator() = default;
-   explicit RDaosContainerNTupleLocator(const std::string &ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)) {}
+   explicit RDaosContainerNTupleLocator(std::string_view ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)) {}
 
    bool IsValid() { return fAnchor.has_value() && fAnchor->fNBytesHeader; }
    [[nodiscard]] ntuple_index_t GetIndex() const { return fIndex; };
-   static ntuple_index_t Hash(const std::string &ntupleName)
+   static ntuple_index_t Hash(std::string_view ntupleName)
    {
       // Convert string to numeric representation via `std::hash`.
-      uint64_t h = std::hash<std::string>{}(ntupleName);
+      uint64_t h = std::hash<std::string_view>{}(ntupleName);
       // Fold the hash into 32-bit using `boost::hash_combine()` algorithm and magic number.
       auto seed = static_cast<uint32_t>(h >> 32);
       seed ^= static_cast<uint32_t>(h & 0xffffffff) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
@@ -156,7 +156,7 @@ struct RDaosContainerNTupleLocator {
    }
 
    static std::pair<RDaosContainerNTupleLocator, ROOT::Internal::RNTupleDescriptorBuilder>
-   LocateNTuple(ROOT::Experimental::Internal::RDaosContainer &cont, const std::string &ntupleName)
+   LocateNTuple(ROOT::Experimental::Internal::RDaosContainer &cont, std::string_view ntupleName)
    {
       auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), ROOT::Internal::RNTupleDescriptorBuilder());
 

--- a/tree/ntuple/test/ntuple_merger.cxx
+++ b/tree/ntuple/test/ntuple_merger.cxx
@@ -1862,7 +1862,7 @@ TEST_P(RNTupleMergerCheckEncoding, CorrectEncoding)
       fileMerger.AddFile(nt2.get());
       // If `useDefaultComp` is true, it's as if we were calling hadd without a -f* flag
       if (useDefaultComp)
-         fileMerger.SetMergeOptions(TString("DefaultCompression"));
+         fileMerger.SetMergeOptions("DefaultCompression");
       fileMerger.Merge();
 
       EXPECT_TRUE(VerifyPageCompression(fileGuard3.GetPath(), expectedComp));
@@ -1948,7 +1948,7 @@ TEST(RNTupleMerger, MergeAsymmetric1TFileMerger)
          fileMerger.OutputFile(fileGuard3.GetPath().c_str(), "RECREATE");
          fileMerger.AddFile(nt1.get());
          fileMerger.AddFile(nt2.get());
-         fileMerger.SetMergeOptions(TString("rntuple.MergingMode=Filter"));
+         fileMerger.SetMergeOptions("rntuple.MergingMode=Filter");
          CheckDiagsRAII diags;
          diags.requiredDiag(kError, "TFileMerger::Merge", "error during merge", false);
          diags.requiredDiag(kError, "ROOT.NTuple.Merge", "missing the following field", false);
@@ -1964,7 +1964,7 @@ TEST(RNTupleMerger, MergeAsymmetric1TFileMerger)
          fileMerger.OutputFile(fileGuard3.GetPath().c_str(), "RECREATE");
          fileMerger.AddFile(nt1.get());
          fileMerger.AddFile(nt2.get());
-         fileMerger.SetMergeOptions(TString("rntuple.MergingMode=Strict"));
+         fileMerger.SetMergeOptions("rntuple.MergingMode=Strict");
          CheckDiagsRAII diags;
          diags.requiredDiag(kError, "TFileMerger::Merge", "error during merge", false);
          diags.requiredDiag(kError, "ROOT.NTuple.Merge", "missing the following field", false);
@@ -1980,7 +1980,7 @@ TEST(RNTupleMerger, MergeAsymmetric1TFileMerger)
          fileMerger.OutputFile(fileGuard3.GetPath().c_str(), "RECREATE");
          fileMerger.AddFile(nt1.get());
          fileMerger.AddFile(nt2.get());
-         fileMerger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+         fileMerger.SetMergeOptions("rntuple.MergingMode=Union");
          CheckDiagsRAII diags;
          diags.optionalDiag(kWarning, "TFileMerger::MergeRecursive", "Merging RNTuples is experimental", false);
          auto res = fileMerger.Merge();
@@ -2672,7 +2672,7 @@ TEST(RNTupleMerger, MergeIncrementalLMExt)
    {
       TFileMerger merger(kFALSE, kFALSE);
       merger.OutputFile(fileGuard.GetPath().c_str(), "RECREATE", compression);
-      merger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+      merger.SetMergeOptions("rntuple.MergingMode=Union");
 
       for (int i = 0; i < nInputs; ++i) {
          auto tfile = std::unique_ptr<TFile>(TFile::Open(inputFiles[i].GetPath().c_str(), "READ"));
@@ -2791,7 +2791,7 @@ TEST(RNTupleMerger, MergeIncrementalLMExtMemFile)
    {
       TFileMerger merger(kFALSE, kFALSE);
       merger.OutputFile(fileGuard.GetPath().c_str(), "RECREATE", compression);
-      merger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+      merger.SetMergeOptions("rntuple.MergingMode=Union");
 
       for (int i = 0; i < nInputs; ++i) {
          merger.AddFile(inputFiles[i].get());
@@ -3416,7 +3416,7 @@ TEST(RNTupleMerger, MergeStaggeredIncremental)
    // Merge the files
    TFileMerger merger(false, false);
    merger.OutputFile(fileGuardMerged.GetPath().c_str(), "RECREATE", 505);
-   merger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+   merger.SetMergeOptions("rntuple.MergingMode=Union");
    for (const auto &f : fileGuardsIn) {
       auto file = std::unique_ptr<TFile>(TFile::Open(f.GetPath().c_str(), "UPDATE"));
       merger.AddFile(file.get());
@@ -3673,7 +3673,7 @@ TEST(RNTupleMerger, GenerateZeroPagesIncremental)
 
    {
       TFileMerger merger(kFALSE, kTRUE);
-      merger.SetMergeOptions(TString("rntuple.MergingMode=Union"));
+      merger.SetMergeOptions("rntuple.MergingMode=Union");
       merger.OutputFile(fileGuardOut.GetPath().c_str(), "RECREATE",
                         ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
 


### PR DESCRIPTION
Experiment: change all viable `const std::string &` function parameters in the RNTuple library with `std::string_view`. Also contextually change a few core/io function signatures and see if anything breaks.

Rationale: consistent use of string_view is more optimal than `const char*`/`const string&` due to less useless copies / string size checks / type conversions.