### PR TITLE
[df] Enable ROOT thread safety on the distributed client

### DIFF
--- a/bindings/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/distrdf/python/DistRDF/Backends/Base.py
@@ -187,6 +187,19 @@ class BaseBackend(ABC):
     shared_libraries = set()
     strings_to_declare = dict()
 
+    def __init__(self):
+        # Enable ROOT thread safety on the client side. Distributed backends
+        # drive ROOT from more than one thread in the user's process: besides
+        # the main thread, the scheduler client (e.g. the Dask IO loop thread)
+        # deserializes the ROOT result objects coming back from the workers.
+        # That deserialization goes through the cling interpreter (TClass,
+        # wrapper compilation, ...), so it can run concurrently with interpreter
+        # activity on the main thread. Without thread safety enabled the
+        # unsynchronized access corrupts the interpreter state and leads to
+        # sporadic crashes. This mirrors the ROOT.EnableThreadSafety() call done
+        # on the workers in setup_mapper().
+        ROOT.EnableThreadSafety()
+
     @classmethod
     def register_initialization(cls, fun, *args, **kwargs):
         """


### PR DESCRIPTION
Fixes a sporadic crash of the
`pyunittests-roottest-python-distrdf-backends-all` test (reported by CTest as "Subprocess aborted", i.e. the main pytest process dies from a fatal signal, most often surfacing at `TestInitialization::test_initialization_method[dask]`).

The problem was that the DistRDF client (the user's main process) drives ROOT from more than one thread without ROOT thread safety being enabled.
