### PR TITLE
[RF] Delete fit objects before continuing in rs401d_FeldmanCousins.py

### DIFF
--- a/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
+++ b/tutorials/roofit/roostats/rs401d_FeldmanCousins.py
@@ -164,6 +164,12 @@ def rs401d_FeldmanCousins(doFeldmanCousins=False, doMCMC=True):
     dataCanvas.Draw()
     dataCanvas.SaveAs("3.png")
 
+    # The profile likelihood and the NLL are not needed anymore. Delete them
+    # already here, so that the NLL evaluation machinery is not torn down at
+    # interpreter shutdown, where the order of cleanups is less controlled.
+    del pll
+    del nll
+
     # --------------------------------------------------------------
     # show use of Feldman-Cousins utility in RooStats
     # set the distribution creator, which encodes the test statistic


### PR DESCRIPTION
Similar to 49fb353caf7.

The Python version of this tutorial sporadically crashes on CI with the upcoming cppyy upgrade. It is the same overlapping-heap-ownership problem that was worked around for `rf619_discrete_profiling.py` in 49fb353caf7.

The nll/pll pair used for the likelihood surface in pad 3 is not needed after that plot. Deleting it right there tears down the NLL evaluation machinery at a well-defined point instead of at interpreter shutdown, where the order of cleanups is less controlled. With this change the previously deterministic poisoned repro (4/4 crashing) passes 3/3, and plain and ctest invocations pass as well.