### PR TITLE
[ntuple] fix type check in REntry::BindRawPtr()

### DIFF
--- a/tree/ntuple/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/inc/ROOT/REntry.hxx
@@ -215,7 +215,7 @@ public:
    template <typename T>
    void BindRawPtr(std::string_view fieldName, T *rawPtr)
    {
-      BindRawPtr<void>(GetToken(fieldName), rawPtr);
+      BindRawPtr<T>(GetToken(fieldName), rawPtr);
    }
 
    /// Get the (typed) pointer to the value for the field referenced by `token`.

--- a/tree/ntuple/test/ntuple_basics.cxx
+++ b/tree/ntuple/test/ntuple_basics.cxx
@@ -817,6 +817,12 @@ TEST(REntry, Basics)
    EXPECT_EQ("float", e->GetTypeName("pt"));
    EXPECT_EQ("float", e->GetTypeName(model->GetToken("pt")));
 
+   float rawPt;
+   double wrongType;
+   e->BindRawPtr("pt", &rawPt);
+   EXPECT_EQ(&rawPt, e->GetPtr<float>("pt").get());
+   EXPECT_THROW(e->BindRawPtr("pt", &wrongType), ROOT::RException);
+
    auto ptrPt = std::make_shared<float>();
    e->BindValue("pt", ptrPt);
    EXPECT_EQ(ptrPt.get(), e->GetPtr<float>("pt").get());


### PR DESCRIPTION
The BindRawPtr() overload receiving a field name mistakenly disabled the type check.

Requires backport to 6.40 and 6.36

Fixes #22856 