### PR TITLE
[interpreter] Update expected LLVM version number to 22

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT builtin_clang)
 endif()
 
 #--Set the LLVM version required for ROOT-----------------------------------------------------------
-set(ROOT_LLVM_VERSION_REQUIRED_MAJOR 20)
+set(ROOT_LLVM_VERSION_REQUIRED_MAJOR 22)
 
 #---Define the way we want to build and what of llvm/clang/cling------------------------------------
 set(LLVM_ENABLE_RTTI ON CACHE BOOL "")


### PR DESCRIPTION
Similar to: https://github.com/root-project/root/commit/18c930a

This needs to be kept in sync for building with `builtin_llvm=OFF`.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

