### PR TITLE
[cmake][win] Prevent checking libgen-build dependencies

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -36,7 +36,7 @@ endif()
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set(GeneratorNeedsResourecLock False)
-  set(GeneratorNeedsBuildSerialization True)
+  set(GeneratorNeedsBuildSerialization False)
   if(winrtdebug)
     set(build_config "--config Debug")
   else()
@@ -2364,7 +2364,7 @@ if(CMAKE_GENERATOR MATCHES Makefiles)
   set(always-make --always-make)
 endif()
 if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
-  set(always-make -v:m)
+  set(always-make -v:m -clp:Summary -p:BuildProjectReferences=false)
 endif()
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Prevent checking and linking the `libgen-build` tests dependencies (like LLVM)
make the `libgen-build` tests take 10-15 seconds instead of 60-120 seconds
(or even more sometimes)
And `GeneratorNeedsBuildSerialization` is not needed anymore