### PR TITLE
[6.36][io] don't miss writing a histogram that is only in a last file with …

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -542,7 +542,8 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
             keyname, keytitle);
       return kTRUE;
    }
-   Bool_t canBeFound = (type & kIncremental) && (current_sourcedir->GetList()->FindObject(keyname) != nullptr);
+   Bool_t canBeFound = (type & kIncremental) && (current_sourcedir->GetList()->FindObject(keyname) != nullptr) &&
+                       (target->GetList()->FindObject(keyname) != nullptr);
 
    // if (cl->IsTObject())
    //    obj->ResetBit(kMustCleanup);


### PR DESCRIPTION
…option -n 2

Fixes https://github.com/root-project/root/issues/9022

(cherry picked from commit b0b489e7df7026e2dc0eb2bae86633024c537eb9)


Fix for https://root-forum.cern.ch/t/tbuffermerger-fails-to-write-histograms-to-output-file-for-alma-linux/64787
