### PR TITLE
[net] Restore TGrid* classes

### DIFF
--- a/net/net/CMakeLists.txt
+++ b/net/net/CMakeLists.txt
@@ -15,6 +15,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Net
     TApplicationRemote.h
     TApplicationServer.h
     TFileStager.h
+    TGrid.h
+    TGridCollection.h
+    TGridJDL.h
+    TGridJob.h
+    TGridJobStatus.h
+    TGridJobStatusList.h
+    TGridResult.h
     TMessage.h
     TMonitor.h
     TParallelMergingFile.h
@@ -34,6 +41,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Net
     src/NetErrors.cxx
     src/TApplicationRemote.cxx
     src/TApplicationServer.cxx
+    src/TGrid.cxx
+    src/TGridJDL.cxx
+    src/TGridJob.cxx
+    src/TGridJobStatus.cxx
+    src/TGridJobStatusList.cxx
+    src/TGridResult.cxx
     src/TFileStager.cxx
     src/TMessage.cxx
     src/TMonitor.cxx

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -34,7 +34,7 @@
 #pragma link C++ class TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
-#pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
+#pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TFileStager;
@@ -46,6 +46,5 @@
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
-#pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -33,7 +33,7 @@
 #pragma link C++ class ROOT::Deprecated::TGrid;
 #pragma link C++ class TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
-#pragma link C++ class ROOT::Deprecated::TGridJob+;
+#pragma link C++ class TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
@@ -45,6 +45,5 @@
 
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
-#pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -35,7 +35,7 @@
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
 #pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
-#pragma link C++ class ROOT::Deprecated::TGridJobStatusList+;
+#pragma link C++ class TGridJobStatusList+;
 #pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TFileStager;
 #pragma link C++ class TApplicationRemote;
@@ -47,6 +47,5 @@
 #pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 #pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
-#pragma read sourceClass="TGridJobStatusList" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatusList"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -14,7 +14,7 @@
 #pragma link C++ enum ESockOptions;
 #pragma link C++ enum ESendRecvOptions;
 
-#pragma link C++ global ROOT::Deprecated::gGrid;
+#pragma link C++ global gGrid;
 #pragma link C++ global gGridJobStatusList;
 
 #pragma link C++ class TServerSocket;
@@ -30,7 +30,7 @@
 #pragma link C++ class TSQLTableInfo;
 #pragma link C++ class TSQLColumnInfo;
 #pragma link C++ class TSQLMonitoringWriter;
-#pragma link C++ class ROOT::Deprecated::TGrid;
+#pragma link C++ class TGrid;
 #pragma link C++ class TGridResult+;
 #pragma link C++ class TGridJDL+;
 #pragma link C++ class TGridJob+;

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -31,7 +31,7 @@
 #pragma link C++ class TSQLColumnInfo;
 #pragma link C++ class TSQLMonitoringWriter;
 #pragma link C++ class ROOT::Deprecated::TGrid;
-#pragma link C++ class ROOT::Deprecated::TGridResult+;
+#pragma link C++ class TGridResult+;
 #pragma link C++ class ROOT::Deprecated::TGridJDL+;
 #pragma link C++ class ROOT::Deprecated::TGridJob+;
 #pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
@@ -48,6 +48,5 @@
 #pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
 #pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
 #pragma read sourceClass="TGridJobStatusList" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatusList"
-#pragma read sourceClass="TGridResult" version="[-1]" targetClass="ROOT::Deprecated::TGridResult"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -32,7 +32,7 @@
 #pragma link C++ class TSQLMonitoringWriter;
 #pragma link C++ class ROOT::Deprecated::TGrid;
 #pragma link C++ class TGridResult+;
-#pragma link C++ class ROOT::Deprecated::TGridJDL+;
+#pragma link C++ class TGridJDL+;
 #pragma link C++ class TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
@@ -44,6 +44,5 @@
 #pragma link C++ class TParallelMergingFile+;
 
 #pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
-#pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -36,13 +36,11 @@
 #pragma link C++ class TGridJob+;
 #pragma link C++ class TGridJobStatus+;
 #pragma link C++ class TGridJobStatusList+;
-#pragma link C++ class ROOT::Deprecated::TGridCollection+;
+#pragma link C++ class TGridCollection+;
 #pragma link C++ class TFileStager;
 #pragma link C++ class TApplicationRemote;
 #pragma link C++ class TApplicationServer;
 #pragma link C++ class TUDPSocket;
 #pragma link C++ class TParallelMergingFile+;
-
-#pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
 
 #endif

--- a/net/net/inc/LinkDef.h
+++ b/net/net/inc/LinkDef.h
@@ -14,6 +14,9 @@
 #pragma link C++ enum ESockOptions;
 #pragma link C++ enum ESendRecvOptions;
 
+#pragma link C++ global ROOT::Deprecated::gGrid;
+#pragma link C++ global gGridJobStatusList;
+
 #pragma link C++ class TServerSocket;
 #pragma link C++ class TSocket;
 #pragma link C++ class TPServerSocket;
@@ -27,10 +30,24 @@
 #pragma link C++ class TSQLTableInfo;
 #pragma link C++ class TSQLColumnInfo;
 #pragma link C++ class TSQLMonitoringWriter;
+#pragma link C++ class ROOT::Deprecated::TGrid;
+#pragma link C++ class ROOT::Deprecated::TGridResult+;
+#pragma link C++ class ROOT::Deprecated::TGridJDL+;
+#pragma link C++ class ROOT::Deprecated::TGridJob+;
+#pragma link C++ class ROOT::Deprecated::TGridJobStatus+;
+#pragma link C++ class ROOT::Deprecated::TGridJobStatusList+;
+#pragma link C++ class ROOT::Deprecated::TGridCollection+;
 #pragma link C++ class TFileStager;
 #pragma link C++ class TApplicationRemote;
 #pragma link C++ class TApplicationServer;
 #pragma link C++ class TUDPSocket;
 #pragma link C++ class TParallelMergingFile+;
+
+#pragma read sourceClass="TGridCollection" version="[-1]" targetClass="ROOT::Deprecated::TGridCollection"
+#pragma read sourceClass="TGridJDL" version="[-1]" targetClass="ROOT::Deprecated::TGridJDL"
+#pragma read sourceClass="TGridJob" version="[-1]" targetClass="ROOT::Deprecated::TGridJob"
+#pragma read sourceClass="TGridJobStatus" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatus"
+#pragma read sourceClass="TGridJobStatusList" version="[-1]" targetClass="ROOT::Deprecated::TGridJobStatusList"
+#pragma read sourceClass="TGridResult" version="[-1]" targetClass="ROOT::Deprecated::TGridResult"
 
 #endif

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
+class TGridJDL;
 class TGridJob;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
-class TGridJDL;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
+class TGridJob;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
-class TGridJob;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -1,0 +1,136 @@
+// @(#)root/net:$Id$
+// Author: Fons Rademakers   3/1/2002
+
+/*************************************************************************
+ * Copyright (C) 1995-2002, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGrid
+#define ROOT_TGrid
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGrid                                                                //
+//                                                                      //
+// Abstract base class defining interface to common GRID services.      //
+//                                                                      //
+// To open a connection to a GRID use the static method Connect().      //
+// The argument of Connect() is of the form:                            //
+//    <grid>://<host>[:<port>], e.g. alien://alice.cern.ch              //
+// Depending on the <grid> specified an appropriate plugin library      //
+// will be loaded which will provide the real interface.                //
+//                                                                      //
+// Related classes are TGridResult.                                     //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+
+#include "TString.h"
+
+#include "TGridJob.h"
+
+namespace ROOT::Deprecated {
+
+class TGridCollection;
+class TGridJDL;
+class TGridJob;
+class TGridJobStatusList;
+class TGridResult;
+
+class TGrid : public TObject {
+
+protected:
+   TString        fGridUrl; // the GRID url used to create the grid connection
+   TString        fGrid;    // type of GRID (AliEn, ...)
+   TString        fHost;    // GRID portal to which we are connected
+   TString        fUser;    // user name
+   TString        fPw;      // user passwd
+   TString        fOptions; // options specified
+   Int_t          fPort;    // port to which we are connected
+
+public:
+   TGrid() : fGridUrl(), fGrid(), fHost(), fUser(), fPw(), fOptions(), fPort(-1) {}
+   virtual ~TGrid() {}
+
+   const char    *GridUrl() const { return fGridUrl; }
+   const char    *GetGrid() const { return fGrid; }
+   const char    *GetHost() const { return fHost; }
+   const char    *GetUser() const { return fUser; }
+   const char    *GetPw() const { return fPw; }
+   const char    *GetOptions() const { return fOptions; }
+   Int_t          GetPort() const { return fPort; }
+   virtual Bool_t IsConnected() const { return fPort == -1 ? kFALSE : kTRUE; }
+
+   virtual void Shell() { MayNotUse("Shell"); }
+   virtual void Stdout() { MayNotUse("Stdout"); }
+   virtual void Stderr() { MayNotUse("Stderr"); }
+
+   virtual TGridResult *Command(const char * /*command*/,
+                                Bool_t /*interactive*/ = kFALSE,
+                                UInt_t /*stream*/ = 2)
+      { MayNotUse("Command"); return nullptr; }
+
+   virtual TGridResult *Query(const char * /*path*/, const char * /*pattern*/,
+                              const char * /*conditions*/ = "", const char * /*options*/ = "")
+      { MayNotUse("Query"); return nullptr; }
+
+   virtual TGridResult *LocateSites() { MayNotUse("LocalSites"); return nullptr; }
+
+   //--- Catalogue Interface
+   virtual TGridResult *Ls(const char* /*ldn*/ ="", Option_t* /*options*/ ="", Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Ls"); return nullptr; }
+   virtual const char  *Pwd(Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Pwd"); return nullptr; }
+   virtual const char  *GetHomeDirectory()
+      { MayNotUse("GetHomeDirectory"); return nullptr; }
+   virtual Bool_t Cd(const char* /*ldn*/ ="",Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Cd"); return kFALSE; }
+   virtual Int_t  Mkdir(const char* /*ldn*/ ="", Option_t* /*options*/ ="", Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Mkdir"); return kFALSE; }
+   virtual Bool_t Rmdir(const char* /*ldn*/ ="", Option_t* /*options*/ ="", Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Mkdir"); return kFALSE; }
+   virtual Bool_t Register(const char* /*lfn*/ , const char* /*turl*/ , Long_t /*size*/ =-1, const char* /*se*/ =nullptr, const char* /*guid*/ =nullptr, Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Mkdir"); return kFALSE; }
+   virtual Bool_t Rm(const char* /*lfn*/ , Option_t* /*option*/ ="", Bool_t /*verbose*/ =kFALSE)
+      { MayNotUse("Mkdir"); return kFALSE; }
+
+   //--- Job Submission Interface
+   virtual TGridJob *Submit(const char * /*jdl*/)
+      { MayNotUse("Submit"); return nullptr; }
+   virtual TGridJDL *GetJDLGenerator()
+      { MayNotUse("GetJDLGenerator"); return nullptr; }
+   virtual TGridCollection *OpenCollection(const char *, UInt_t /*maxentries*/ = 1000000)
+      { MayNotUse("OpenCollection"); return nullptr; }
+   virtual TGridCollection *OpenCollectionQuery(TGridResult * /*queryresult*/,Bool_t /*nogrouping*/ = kFALSE)
+      { MayNotUse("OpenCollection"); return nullptr; }
+   virtual TGridJobStatusList* Ps(const char* /*options*/, Bool_t /*verbose*/ = kTRUE)
+      { MayNotUse("Ps"); return nullptr; }
+   virtual Bool_t KillById(TString /*jobid*/)
+      { MayNotUse("KillById"); return kFALSE; }
+   virtual Bool_t ResubmitById(TString /*jobid*/)
+      { MayNotUse("ResubmitById"); return kFALSE; }
+   virtual Bool_t Kill(TGridJob *gridjob)
+      { return ((gridjob)?KillById(gridjob->GetJobID()):kFALSE); }
+   virtual Bool_t Resubmit(TGridJob* gridjob)
+      { return ((gridjob)?ResubmitById(gridjob->GetJobID()):kFALSE); }
+
+   //--- Load desired plugin and setup conection to GRID
+   static TGrid *Connect(const char *grid, const char *uid = nullptr,
+                         const char *pw = nullptr, const char *options = nullptr);
+
+   ClassDefOverride(TGrid,0)  // ABC defining interface to GRID services
+};
+
+R__EXTERN TGrid *gGrid;
+
+} // namespace ROOT::Deprecated
+
+using TGrid R__DEPRECATED(6, 42, "TGrid is expected to be unused and thus deprecated") = ROOT::Deprecated::TGrid;
+R__EXTERN ROOT::Deprecated::TGrid *&gGrid R__DEPRECATED(6, 42, "gGrid is expected to be unused and thus deprecated");
+
+#endif

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -12,22 +12,6 @@
 #ifndef ROOT_TGrid
 #define ROOT_TGrid
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGrid                                                                //
-//                                                                      //
-// Abstract base class defining interface to common GRID services.      //
-//                                                                      //
-// To open a connection to a GRID use the static method Connect().      //
-// The argument of Connect() is of the form:                            //
-//    <grid>://<host>[:<port>], e.g. alien://alice.cern.ch              //
-// Depending on the <grid> specified an appropriate plugin library      //
-// will be loaded which will provide the real interface.                //
-//                                                                      //
-// Related classes are TGridResult.                                     //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TObject.h"
 
 #include "TString.h"
@@ -41,6 +25,24 @@ class TGridCollection;
 class TGridJobStatusList;
 
 
+///////////////////////////////////////////////////////////////////////////
+///                                                                      
+/// Abstract base class defining interface to common GRID services.      
+///                                                                       
+/// \note This class is deprecated. It is kept for backward compatibility 
+/// but it should not be used in new code.                                
+///                                                                      
+/// To open a connection to a GRID use the static method Connect().      
+/// The argument of Connect() is of the form:                            
+/// ~~~
+///    <grid>://<host>[:<port>], e.g. alien://alice.cern.ch              
+/// ~~~
+/// Depending on the <grid> specified an appropriate plugin library      
+/// will be loaded which will provide the real interface.                
+///                                                                      
+/// Related classes are TGridResult.                                     
+///                                                                      
+///////////////////////////////////////////////////////////////////////////
 class TGrid : public TObject {
 
 protected:

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -35,13 +35,13 @@
 #include "TGridJob.h"
 
 class TGridResult;
+class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
 class TGridJob;
-class TGridJobStatusList;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -37,11 +37,10 @@
 class TGridResult;
 class TGridJDL;
 class TGridJob;
+class TGridCollection;
 class TGridJobStatusList;
 
 namespace ROOT::Deprecated {
-
-class TGridCollection;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -40,7 +40,6 @@ class TGridJob;
 class TGridCollection;
 class TGridJobStatusList;
 
-namespace ROOT::Deprecated {
 
 class TGrid : public TObject {
 
@@ -127,10 +126,5 @@ public:
 };
 
 R__EXTERN TGrid *gGrid;
-
-} // namespace ROOT::Deprecated
-
-using TGrid R__DEPRECATED(6, 42, "TGrid is expected to be unused and thus deprecated") = ROOT::Deprecated::TGrid;
-R__EXTERN ROOT::Deprecated::TGrid *&gGrid R__DEPRECATED(6, 42, "gGrid is expected to be unused and thus deprecated");
 
 #endif

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -34,13 +34,14 @@
 
 #include "TGridJob.h"
 
+class TGridResult;
+
 namespace ROOT::Deprecated {
 
 class TGridCollection;
 class TGridJDL;
 class TGridJob;
 class TGridJobStatusList;
-class TGridResult;
 
 class TGrid : public TObject {
 

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -1,0 +1,125 @@
+// @(#)root/net:$Id$
+// Author: Andreas-Joachim Peters 2005-05-09
+
+/*************************************************************************
+ * Copyright (C) 1995-2004, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridCollection
+#define ROOT_TGridCollection
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridCollection                                                      //
+//                                                                      //
+// Class which manages collection files on the Grid.                    //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+
+class TMap;
+class TFile;
+class TEntryList;
+class TList;
+class TDSet;
+class TFileCollection;
+
+namespace ROOT::Deprecated {
+
+class TGridResult;
+
+class TGridCollection : public TObject {
+public:
+   TGridCollection() { }
+   virtual ~TGridCollection() { }
+
+   virtual void         Reset()
+      { MayNotUse("Reset"); }
+   virtual TMap        *Next()
+      { MayNotUse("Next"); return nullptr;}
+   virtual Bool_t       Remove(TMap *)
+      { MayNotUse("Remove"); return 0;}
+   virtual const char  *GetTURL(const char * /*name*/ = "")
+      { MayNotUse("GetTURL"); return nullptr;}
+   virtual const char  *GetSURL(const char * /*name*/ = "")
+      { MayNotUse("GetSURL"); return nullptr;}
+   virtual const char  *GetLFN(const char * /*name*/ = "")
+      { MayNotUse("GetLFN"); return nullptr;}
+   virtual Long64_t    GetSize(const char * /*name*/ = "")
+      { MayNotUse("GetSize"); return -1;}
+   virtual Bool_t      IsOnline(const char * /*name*/ = "")
+      { MayNotUse("IsOnline"); return 0;}
+   virtual Bool_t      IsSelected(const char * /*name*/ = "")
+      { MayNotUse("IsSelected"); return 0;}
+   virtual void        Status()
+      { MayNotUse("Status"); }
+   virtual void        SetTag(const char * , const char * , TMap* )
+      { MayNotUse("SetTag"); }
+   virtual Bool_t      SelectFile(const char *, Int_t /*nstart*/ = -1 , Int_t /*nstop*/ = -1)
+      { MayNotUse("SelectFile"); return kFALSE;}
+   virtual Bool_t      DeselectFile(const char *, Int_t /*nstart*/ = -1, Int_t /*nstop*/ = -1)
+      { MayNotUse("DeselectFile"); return kFALSE;}
+   virtual Bool_t      InvertSelection()
+      { MayNotUse("InvertSelection"); return kFALSE;}
+   virtual Bool_t      DownscaleSelection(UInt_t /* scaler */ = 2)
+      { MayNotUse("DownscaleSelection"); return kFALSE;}
+   virtual Bool_t      ExportXML(const char *, Bool_t /*selected*/ = kTRUE, Bool_t /*online*/ = kTRUE,
+                                 const char * /*name*/ = "ROOT xml", const char * /*comment*/ = "Exported XML")
+      { MayNotUse("ExportXML"); return kFALSE;}
+   virtual const char* GetExportUrl()
+      { MayNotUse("GetExportUrl"); return nullptr;}
+   virtual Bool_t      SetExportUrl(const char * /*exporturl*/ = nullptr)
+      { MayNotUse("SetExportUrl"); return kFALSE;}
+   virtual void         Print(Option_t * = "") const override
+      { MayNotUse("Print"); }
+   virtual TFile       *OpenFile(const char *)
+      { MayNotUse("OpenFile"); return nullptr;}
+   virtual TList       *GetFileGroupList() const
+      { MayNotUse("GetFileGroupList"); return nullptr;}
+   virtual TEntryList  *GetEntryList(const char *)
+      { MayNotUse("GetEntryList"); return nullptr;}
+   virtual UInt_t       GetNofGroups() const
+      { MayNotUse("GetNofGroups"); return 0;}
+   virtual UInt_t       GetNofGroupfiles() const
+      { MayNotUse("GetNofGroupfiles"); return 0;}
+   virtual Bool_t       OverlapCollection(TGridCollection *)
+      { MayNotUse("OverlapCollection"); return 0;}
+   virtual void         Add(TGridCollection *)
+      { MayNotUse("Add");}
+   virtual Bool_t       Stage(Bool_t /*bulk*/ = kFALSE, Option_t * /*TFileStager option*/ = "")
+      { MayNotUse("Stage"); return kFALSE;}
+   virtual Bool_t       Prepare(Bool_t /*bulk*/ = kFALSE)
+      { MayNotUse("Prepare"); return kFALSE;}
+   virtual Bool_t       CheckIfOnline(Bool_t /*bulk*/ = kFALSE)
+      { MayNotUse("CheckIfOnline"); return kFALSE;}
+   virtual TDSet       *GetDataset(const char *, const char * , const char *)
+      { MayNotUse("GetDataset"); return nullptr;}
+   virtual TGridResult *GetGridResult(const char * /*filename*/ = "", Bool_t /*onlyonline*/ = kTRUE , Bool_t /*publicaccess*/ = kFALSE )
+      { MayNotUse("GetGridResult"); return nullptr;}
+   virtual Bool_t       LookupSUrls(Bool_t /*verbose*/ = kTRUE)
+      { MayNotUse("LookupSUrls"); return kFALSE;}
+   virtual TList       *GetTagFilterList() const
+      { MayNotUse("GetTagFilterList"); return nullptr;}
+   virtual void         SetTagFilterList(TList *)
+      { MayNotUse("SetTagFilterList");}
+   virtual const char* GetCollectionName() const
+      { MayNotUse("GetCollectionName"); return nullptr;}
+   virtual const char* GetInfoComment() const
+      { MayNotUse("GetInfoComment"); return nullptr;}
+   virtual TFileCollection* GetFileCollection(const char* /*name*/ = "", const char* /*title*/ = "") const
+      { MayNotUse("GetFileCollection"); return nullptr;}
+
+   ClassDefOverride(TGridCollection,1)  // ABC managing collection of files on the Grid
+};
+
+} // namespace ROOT::Deprecated
+
+using TGridCollection R__DEPRECATED(6, 42, "TGridCollection is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridCollection;
+
+#endif

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TGridCollection
 #define ROOT_TGridCollection
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridCollection                                                      //
-//                                                                      //
-// Class which manages collection files on the Grid.                    //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TObject.h"
 
 class TMap;
@@ -31,6 +23,14 @@ class TGridResult;
 class TFileCollection;
 
 
+//////////////////////////////////////////////////////////////////////////
+///                                                                      
+/// \note This class is deprecated. It is kept for backward compatibility 
+/// but it should not be used in new code.                                
+///                                                                      
+/// Class which manages collection files on the Grid.                    
+///                                                                      
+//////////////////////////////////////////////////////////////////////////
 class TGridCollection : public TObject {
 public:
    TGridCollection() { }

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -30,7 +30,6 @@ class TDSet;
 class TGridResult;
 class TFileCollection;
 
-namespace ROOT::Deprecated {
 
 class TGridCollection : public TObject {
 public:
@@ -115,10 +114,5 @@ public:
 
    ClassDefOverride(TGridCollection,1)  // ABC managing collection of files on the Grid
 };
-
-} // namespace ROOT::Deprecated
-
-using TGridCollection R__DEPRECATED(6, 42, "TGridCollection is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridCollection;
 
 #endif

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -27,11 +27,10 @@ class TFile;
 class TEntryList;
 class TList;
 class TDSet;
+class TGridResult;
 class TFileCollection;
 
 namespace ROOT::Deprecated {
-
-class TGridResult;
 
 class TGridCollection : public TObject {
 public:

--- a/net/net/inc/TGridJDL.h
+++ b/net/net/inc/TGridJDL.h
@@ -1,0 +1,84 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus   28/9/2004
+// Jancurova.lucia@cern.ch Slovakia  29/9/2008
+
+/*************************************************************************
+ * Copyright (C) 1995-2008, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridJDL
+#define ROOT_TGridJDL
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJDL                                                             //
+//                                                                      //
+// Abstract base class to generate JDL files for job submission to the  //
+// Grid.                                                                //
+//                                                                      //
+// Related classes are TGLiteJDL                                        //
+//                              .                                       //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+#include "TString.h"
+#include "TMap.h"
+
+namespace ROOT::Deprecated {
+
+class TGridJDL : public TObject {
+protected:
+   TMap    fMap;              // stores the key, value pairs of the JDL
+   TMap    fDescriptionMap;   // stores the key, value pairs of the JDL
+public:
+   TGridJDL() : fMap(), fDescriptionMap() { }
+   virtual ~TGridJDL();
+
+   void             SetValue(const char *key, const char *value);
+   const char      *GetValue(const char *key);
+   void             SetDescription(const char *key, const char *description);
+   const char      *GetDescription(const char *key);
+   TString          AddQuotes(const char *value);
+   void             AddToSet(const char *key, const char *value);
+   void             AddToSetDescription(const char *key, const char *description);
+   virtual TString  Generate();
+   void             Clear(const Option_t* = "") override;
+
+   virtual void SetExecutable(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void SetArguments(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void SetEMail(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void SetOutputDirectory(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void SetPrice(UInt_t price=1, const char *description=nullptr) = 0;
+   virtual void SetTTL(UInt_t ttl=72000, const char *description=nullptr) = 0;
+   virtual void SetJobTag(const char *jobtag=nullptr, const char *description=nullptr) = 0;
+   virtual void SetInputDataListFormat(const char *format="xml-single", const char *description=nullptr) = 0;
+   virtual void SetInputDataList(const char *list="collection.xml", const char *description=nullptr) = 0;
+
+   virtual void SetSplitMode(const char *value, UInt_t maxnumberofinputfiles=0,
+                             UInt_t maxinputfilesize=0, const char *d1=nullptr,
+                             const char *d2=nullptr, const char *d3=nullptr) = 0;
+   virtual void SetSplitArguments(const char *splitarguments=nullptr, const char *description=nullptr) = 0;
+   virtual void SetValidationCommand(const char *value, const char *description=nullptr) = 0;
+
+   virtual void AddToInputSandbox(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void AddToOutputSandbox(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void AddToInputData(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void AddToInputDataCollection(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void AddToRequirements(const char *value=nullptr, const char *description=nullptr) = 0;
+   virtual void AddToPackages(const char *name="AliRoot", const char *version="default",
+                              const char *type="VO_ALICE", const char *description=nullptr) = 0;
+   virtual void AddToOutputArchive(const char *value=nullptr, const char *description=nullptr) = 0;
+
+   ClassDefOverride(TGridJDL,1)  // ABC defining interface JDL generator
+};
+
+} // namespace ROOT::Deprecated
+
+using TGridJDL R__DEPRECATED(6, 42, "TGridJDL is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJDL;
+
+#endif

--- a/net/net/inc/TGridJDL.h
+++ b/net/net/inc/TGridJDL.h
@@ -14,14 +14,12 @@
 #define ROOT_TGridJDL
 
 //////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJDL                                                             //
-//                                                                      //
-// Abstract base class to generate JDL files for job submission to the  //
-// Grid.                                                                //
-//                                                                      //
-// Related classes are TGLiteJDL                                        //
-//                              .                                       //
+///                                                                     
+/// \note This class is deprecated. It is kept for backward compatibility
+/// but it should not be used in new code.                               
+///                                                                     
+/// Related classes are TGLiteJDL                                       
+///                              .                                      
 //////////////////////////////////////////////////////////////////////////
 
 #include "TObject.h"

--- a/net/net/inc/TGridJDL.h
+++ b/net/net/inc/TGridJDL.h
@@ -28,7 +28,6 @@
 #include "TString.h"
 #include "TMap.h"
 
-namespace ROOT::Deprecated {
 
 class TGridJDL : public TObject {
 protected:
@@ -75,10 +74,5 @@ public:
 
    ClassDefOverride(TGridJDL,1)  // ABC defining interface JDL generator
 };
-
-} // namespace ROOT::Deprecated
-
-using TGridJDL R__DEPRECATED(6, 42, "TGridJDL is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridJDL;
 
 #endif

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -28,8 +28,6 @@
 
 class TGridJobStatus;
 
-namespace ROOT::Deprecated {
-
 class TGridJob : public TObject {
 
 protected:
@@ -48,10 +46,5 @@ public:
    virtual Bool_t          Cancel () = 0;
    ClassDefOverride(TGridJob,1)  // ABC defining interface to a GRID job
 };
-
-} // namespace ROOT::Deprecated
-
-using TGridJob R__DEPRECATED(6, 42, "TGridJob is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridJob;
 
 #endif

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -12,22 +12,22 @@
 #ifndef ROOT_TGridJob
 #define ROOT_TGridJob
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJob                                                             //
-//                                                                      //
-// Abstract base class defining interface to a GRID job.                //
-//                                                                      //
-// Related classes are TGridJobStatus.                                  //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TObject.h"
 #include "TString.h"
 
 
 class TGridJobStatus;
 
+//////////////////////////////////////////////////////////////////////////
+///                                                                     
+/// Abstract base class defining interface to a GRID job.               
+///                                                                      
+/// \note This class is deprecated. It is kept for backward compatibility
+/// but it should not be used in new code.                               
+///                                                                     
+/// Related classes are TGridJobStatus.                                 
+///                                                                     
+//////////////////////////////////////////////////////////////////////////
 class TGridJob : public TObject {
 
 protected:

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -25,9 +25,10 @@
 #include "TObject.h"
 #include "TString.h"
 
-namespace ROOT::Deprecated {
 
 class TGridJobStatus;
+
+namespace ROOT::Deprecated {
 
 class TGridJob : public TObject {
 

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -1,0 +1,56 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus  06/10/2004
+
+/*************************************************************************
+ * Copyright (C) 1995-2004, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridJob
+#define ROOT_TGridJob
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJob                                                             //
+//                                                                      //
+// Abstract base class defining interface to a GRID job.                //
+//                                                                      //
+// Related classes are TGridJobStatus.                                  //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TObject.h"
+#include "TString.h"
+
+namespace ROOT::Deprecated {
+
+class TGridJobStatus;
+
+class TGridJob : public TObject {
+
+protected:
+   TString  fJobID;  // the job's ID
+
+public:
+   TGridJob(TString jobID) : fJobID(jobID) { }
+   virtual ~TGridJob() { }
+
+   virtual TString GetJobID() { return fJobID; }
+
+   virtual TGridJobStatus *GetJobStatus() const = 0;
+   virtual Int_t           GetOutputSandbox(const char *localpath, Option_t *opt = nullptr);
+
+   virtual Bool_t          Resubmit() = 0;
+   virtual Bool_t          Cancel () = 0;
+   ClassDefOverride(TGridJob,1)  // ABC defining interface to a GRID job
+};
+
+} // namespace ROOT::Deprecated
+
+using TGridJob R__DEPRECATED(6, 42, "TGridJob is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJob;
+
+#endif

--- a/net/net/inc/TGridJobStatus.h
+++ b/net/net/inc/TGridJobStatus.h
@@ -22,7 +22,6 @@
 
 #include "TNamed.h"
 
-namespace ROOT::Deprecated {
 
 class TGridJobStatus : public TNamed {
 
@@ -50,10 +49,5 @@ public:
 
   ClassDefOverride(TGridJobStatus,1)  // ABC defining status of a Grid job
 };
-
-} // namespace ROOT::Deprecated
-
-using TGridJobStatus R__DEPRECATED(6, 42, "TGridJobStatus is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridJobStatus;
 
 #endif

--- a/net/net/inc/TGridJobStatus.h
+++ b/net/net/inc/TGridJobStatus.h
@@ -12,17 +12,17 @@
 #ifndef ROOT_TGridJobStatus
 #define ROOT_TGridJobStatus
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJobStatus                                                       //
-//                                                                      //
-// Abstract base class containing the status of a Grid job.             //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TNamed.h"
 
 
+//////////////////////////////////////////////////////////////////////////
+///                                                                      
+/// \note This class is deprecated. It is kept for backward compatibility 
+/// but it should not be used in new code.                                
+///                                                                      
+/// Abstract base class containing the status of a Grid job.             
+///                                                                      
+//////////////////////////////////////////////////////////////////////////
 class TGridJobStatus : public TNamed {
 
 public:

--- a/net/net/inc/TGridJobStatus.h
+++ b/net/net/inc/TGridJobStatus.h
@@ -1,0 +1,59 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus   06/10/2004
+
+/*************************************************************************
+ * Copyright (C) 1995-2004, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridJobStatus
+#define ROOT_TGridJobStatus
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJobStatus                                                       //
+//                                                                      //
+// Abstract base class containing the status of a Grid job.             //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TNamed.h"
+
+namespace ROOT::Deprecated {
+
+class TGridJobStatus : public TNamed {
+
+public:
+   // Subset of Grid job states for common GetStatus function
+   enum EGridJobStatus {
+// clang++ <v20 (-Wshadow) complains about shadowing TQpSolverBase.h global enum ETerminationCode. Let's silence warning:
+#if defined(__clang__) && __clang_major__ < 20
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+         kUNKNOWN,
+#if defined(__clang__) && __clang_major__ < 20
+#pragma clang diagnostic pop
+#endif
+      kWAITING, kRUNNING, kABORTED, kFAIL, kDONE };
+
+  TGridJobStatus() { }
+  virtual ~TGridJobStatus() { }
+
+  // These functions reduces the possible job states to the subset given above
+  // in EGridJobStatus, for detailed status information query the specific
+  // implementation
+  virtual EGridJobStatus GetStatus() const = 0;
+
+  ClassDefOverride(TGridJobStatus,1)  // ABC defining status of a Grid job
+};
+
+} // namespace ROOT::Deprecated
+
+using TGridJobStatus R__DEPRECATED(6, 42, "TGridJobStatus is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJobStatus;
+
+#endif

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -22,8 +22,6 @@
 
 #include "TList.h"
 
-namespace ROOT::Deprecated {
-
 class TGridJobStatusList : public TList {
 
 protected:
@@ -37,12 +35,5 @@ public:
 };
 
 R__EXTERN TGridJobStatusList *gGridJobStatusList;
-
-} // namespace ROOT::Deprecated
-
-using TGridJobStatusList R__DEPRECATED(6, 42, "TGridJobStatusList is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridJobStatusList;
-R__EXTERN ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList
-   R__DEPRECATED(6, 42, "gGridJobStatusList is expected to be unused and thus deprecated");
 
 #endif

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -12,14 +12,6 @@
 #ifndef ROOT_TGridJobStatusList
 #define ROOT_TGridJobStatusList
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJobStatusList                                                   //
-//                                                                      //
-// Abstract base class defining a list of GRID job status               //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TList.h"
 
 #include "TGridJob.h"
@@ -27,6 +19,14 @@
 
 class TGridJob;
 
+//////////////////////////////////////////////////////////////////////////
+///                                                                      
+/// \note This class is deprecated. It is kept for backward compatibility 
+/// but it should not be used in new code.                                
+///                                                                      
+/// Abstract base class defining a list of GRID job status               
+///                                                                      
+//////////////////////////////////////////////////////////////////////////
 class TGridJobStatusList : public TList {
 
 protected:

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -22,6 +22,11 @@
 
 #include "TList.h"
 
+#include "TGridJob.h"
+
+
+class TGridJob;
+
 class TGridJobStatusList : public TList {
 
 protected:

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -1,0 +1,48 @@
+// @(#)root/net:$Id$
+// Author: Andreas-Joachim Peters  10/12/2006
+
+/*************************************************************************
+ * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridJobStatusList
+#define ROOT_TGridJobStatusList
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJobStatusList                                                   //
+//                                                                      //
+// Abstract base class defining a list of GRID job status               //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TList.h"
+
+namespace ROOT::Deprecated {
+
+class TGridJobStatusList : public TList {
+
+protected:
+   TString  fJobID;  // the job's ID
+
+public:
+   TGridJobStatusList() : fJobID("") { }
+   virtual ~TGridJobStatusList() { }
+
+   ClassDefOverride(TGridJobStatusList,1)  // ABC defining interface to a list of GRID jobs
+};
+
+R__EXTERN TGridJobStatusList *gGridJobStatusList;
+
+} // namespace ROOT::Deprecated
+
+using TGridJobStatusList R__DEPRECATED(6, 42, "TGridJobStatusList is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridJobStatusList;
+R__EXTERN ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList
+   R__DEPRECATED(6, 42, "gGridJobStatusList is expected to be unused and thus deprecated");
+
+#endif

--- a/net/net/inc/TGridResult.h
+++ b/net/net/inc/TGridResult.h
@@ -1,0 +1,61 @@
+// @(#)root/net:$Id$
+// Author: Fons Rademakers   3/1/2002
+
+/*************************************************************************
+ * Copyright (C) 1995-2002, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TGridResult
+#define ROOT_TGridResult
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridResult                                                          //
+//                                                                      //
+// Abstract base class defining interface to a GRID result.             //
+// Objects of this class are created by TGrid methods.                  //
+//                                                                      //
+// Related classes are TGrid.                                           //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TList.h"
+
+class TEntryList;
+
+namespace ROOT::Deprecated {
+
+class TGridResult : public TList {
+
+public:
+   TGridResult() : TList() { SetOwner(kTRUE); }
+   virtual ~TGridResult() { }
+
+   virtual const char *GetFileName(UInt_t) const
+      { MayNotUse("GetFileName"); return nullptr; }
+   virtual const char *GetFileNamePath(UInt_t) const
+      { MayNotUse("GetFileNamePath"); return nullptr; }
+   virtual const char *GetPath(UInt_t) const
+      { MayNotUse("GetPath"); return nullptr; }
+   virtual const TEntryList *GetEntryList(UInt_t) const
+      { MayNotUse("GetEntryList"); return nullptr; }
+   virtual const char *GetKey(UInt_t, const char*) const
+      { MayNotUse("GetKey"); return nullptr; }
+   virtual Bool_t      SetKey(UInt_t, const char*, const char*)
+      { MayNotUse("SetKey"); return kFALSE; }
+   virtual TList      *GetFileInfoList() const
+      { MayNotUse("GetFileInfoList"); return nullptr; }
+
+   ClassDefOverride(TGridResult,1)  // ABC defining interface to GRID result set
+};
+
+} // namespace ROOT::Deprecated
+
+using TGridResult R__DEPRECATED(6, 42, "TGridResult is expected to be unused and thus deprecated") =
+   ROOT::Deprecated::TGridResult;
+
+#endif

--- a/net/net/inc/TGridResult.h
+++ b/net/net/inc/TGridResult.h
@@ -27,7 +27,6 @@
 
 class TEntryList;
 
-namespace ROOT::Deprecated {
 
 class TGridResult : public TList {
 
@@ -52,10 +51,5 @@ public:
 
    ClassDefOverride(TGridResult,1)  // ABC defining interface to GRID result set
 };
-
-} // namespace ROOT::Deprecated
-
-using TGridResult R__DEPRECATED(6, 42, "TGridResult is expected to be unused and thus deprecated") =
-   ROOT::Deprecated::TGridResult;
 
 #endif

--- a/net/net/inc/TGridResult.h
+++ b/net/net/inc/TGridResult.h
@@ -12,22 +12,22 @@
 #ifndef ROOT_TGridResult
 #define ROOT_TGridResult
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridResult                                                          //
-//                                                                      //
-// Abstract base class defining interface to a GRID result.             //
-// Objects of this class are created by TGrid methods.                  //
-//                                                                      //
-// Related classes are TGrid.                                           //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TList.h"
 
 class TEntryList;
 
 
+//////////////////////////////////////////////////////////////////////////
+///                                                                     
+/// \note This class is deprecated. It is kept for backward compatibility
+/// but it should not be used in new code.                               
+///                                                                     
+/// Abstract base class defining interface to a GRID result.            
+/// Objects of this class are created by TGrid methods.                 
+///                                                                     
+/// Related classes are TGrid.                                          
+///                                                                     
+//////////////////////////////////////////////////////////////////////////
 class TGridResult : public TList {
 
 public:

--- a/net/net/src/TGrid.cxx
+++ b/net/net/src/TGrid.cxx
@@ -30,8 +30,7 @@
 #include "TPluginManager.h"
 #include "TError.h"
 
-ROOT::Deprecated::TGrid *ROOT::Deprecated::gGrid = 0;
-ROOT::Deprecated::TGrid *&gGrid = ROOT::Deprecated::gGrid;
+TGrid *gGrid = 0;
 
 
 
@@ -46,8 +45,8 @@ ROOT::Deprecated::TGrid *&gGrid = ROOT::Deprecated::gGrid;
 /// -debug=`<debug level from 1 to 10>`
 /// Example: "-domain=cern.ch -debug=5"
 
-ROOT::Deprecated::TGrid *
-ROOT::Deprecated::TGrid::Connect(const char *grid, const char *uid, const char *pw, const char *options)
+TGrid *TGrid::Connect(const char *grid, const char *uid, const char *pw,
+                      const char *options)
 {
    TPluginHandler *h;
    TGrid *g = 0;

--- a/net/net/src/TGrid.cxx
+++ b/net/net/src/TGrid.cxx
@@ -9,22 +9,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGrid                                                                //
-//                                                                      //
-// Abstract base class defining interface to common GRID services.      //
-//                                                                      //
-// To open a connection to a GRID use the static method Connect().      //
-// The argument of Connect() is of the form:                            //
-//    <grid>[://<host>][:<port>], e.g. alien://alice.cern.ch            //
-// Depending on the <grid> specified an appropriate plugin library      //
-// will be loaded which will provide the real interface.                //
-//                                                                      //
-// Related classes are TGridResult.                                     //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGrid.h"
 #include "TROOT.h"
 #include "TPluginManager.h"

--- a/net/net/src/TGrid.cxx
+++ b/net/net/src/TGrid.cxx
@@ -1,0 +1,77 @@
+// @(#)root/net:$Id$
+// Author: Fons Rademakers   3/1/2002
+
+/*************************************************************************
+ * Copyright (C) 1995-2002, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGrid                                                                //
+//                                                                      //
+// Abstract base class defining interface to common GRID services.      //
+//                                                                      //
+// To open a connection to a GRID use the static method Connect().      //
+// The argument of Connect() is of the form:                            //
+//    <grid>[://<host>][:<port>], e.g. alien://alice.cern.ch            //
+// Depending on the <grid> specified an appropriate plugin library      //
+// will be loaded which will provide the real interface.                //
+//                                                                      //
+// Related classes are TGridResult.                                     //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGrid.h"
+#include "TROOT.h"
+#include "TPluginManager.h"
+#include "TError.h"
+
+ROOT::Deprecated::TGrid *ROOT::Deprecated::gGrid = 0;
+ROOT::Deprecated::TGrid *&gGrid = ROOT::Deprecated::gGrid;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// The grid should be of the form:  `<grid>://<host>[:<port>]`,
+/// e.g.:  alien://alice.cern.ch
+/// The uid is the username and pw the password that should be used for
+/// the connection. Depending on the `<grid>` the shared library (plugin)
+/// for the selected system will be loaded. When the connection could not
+/// be opened 0 is returned. For AliEn the supported options are:
+/// -domain=`<domain name>`
+/// -debug=`<debug level from 1 to 10>`
+/// Example: "-domain=cern.ch -debug=5"
+
+ROOT::Deprecated::TGrid *
+ROOT::Deprecated::TGrid::Connect(const char *grid, const char *uid, const char *pw, const char *options)
+{
+   TPluginHandler *h;
+   TGrid *g = 0;
+
+   if (!grid) {
+      ::Error("TGrid::Connect", "no grid specified");
+      return 0;
+   }
+   if (!uid)
+      uid = "";
+   if (!pw)
+      pw = "";
+   if (!options)
+      options = "";
+
+   if ((h = gROOT->GetPluginManager()->FindHandler("TGrid", grid))) {
+      if (h->LoadPlugin() == -1) {
+         ::Error("TGrid::Connect", "Loading Plugin failed");
+         return 0;
+      }
+      g = (TGrid *) h->ExecPlugin(4, grid, uid, pw, options);
+   } else {
+      ::Error("TGrid::Connect", "Could not find plugin to handle TGrid");
+   }
+
+   return g;
+}

--- a/net/net/src/TGridJDL.cxx
+++ b/net/net/src/TGridJDL.cxx
@@ -30,7 +30,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// Cleanup.
 
-ROOT::Deprecated::TGridJDL::~TGridJDL()
+TGridJDL::~TGridJDL()
 {
    Clear();
 }
@@ -38,7 +38,7 @@ ROOT::Deprecated::TGridJDL::~TGridJDL()
 ////////////////////////////////////////////////////////////////////////////////
 /// Clears the JDL information.
 
-void ROOT::Deprecated::TGridJDL::Clear(const Option_t*)
+void TGridJDL::Clear(const Option_t*)
 {
    fMap.DeleteAll();
 }
@@ -46,7 +46,7 @@ void ROOT::Deprecated::TGridJDL::Clear(const Option_t*)
 ////////////////////////////////////////////////////////////////////////////////
 /// Sets a value. If the entry already exists the old one is replaced.
 
-void ROOT::Deprecated::TGridJDL::SetValue(const char *key, const char *value)
+void TGridJDL::SetValue(const char *key, const char *value)
 {
    TObject *object = fMap.FindObject(key);
    TPair *pair = dynamic_cast<TPair*>(object);
@@ -73,7 +73,7 @@ void ROOT::Deprecated::TGridJDL::SetValue(const char *key, const char *value)
 /// Returns the value corresponding to the provided key. Return 0 in case
 /// key is not found.
 
-const char *ROOT::Deprecated::TGridJDL::GetValue(const char *key)
+const char *TGridJDL::GetValue(const char *key)
 {
    if (!key)
       return 0;
@@ -100,7 +100,7 @@ const char *ROOT::Deprecated::TGridJDL::GetValue(const char *key)
 ////////////////////////////////////////////////////////////////////////////////
 /// Sets a value. If the entry already exists the old one is replaced.
 
-void ROOT::Deprecated::TGridJDL::SetDescription(const char *key, const char* description)
+void TGridJDL::SetDescription(const char *key, const char* description)
 {
    TObject *object = fDescriptionMap.FindObject(key);
    TPair *pair = dynamic_cast<TPair*>(object);
@@ -127,7 +127,7 @@ void ROOT::Deprecated::TGridJDL::SetDescription(const char *key, const char* des
 /// Returns the value corresponding to the provided key. Return 0 in case
 /// key is not found.
 
-const char *ROOT::Deprecated::TGridJDL::GetDescription(const char *key)
+const char *TGridJDL::GetDescription(const char *key)
 {
    if (!key)
       return 0;
@@ -155,7 +155,7 @@ const char *ROOT::Deprecated::TGridJDL::GetDescription(const char *key)
 /// Adds quotes to the provided string.
 ///  E.g. Value --> "Value"
 
-TString ROOT::Deprecated::TGridJDL::AddQuotes(const char *value)
+TString TGridJDL::AddQuotes(const char *value)
 {
    TString temp = TString("\"");
    temp += value;
@@ -168,7 +168,7 @@ TString ROOT::Deprecated::TGridJDL::AddQuotes(const char *value)
 /// Adds a value to a key value which hosts a set of values.
 /// E.g. InputSandbox: {"file1","file2"}
 
-void ROOT::Deprecated::TGridJDL::AddToSet(const char *key, const char *value)
+void TGridJDL::AddToSet(const char *key, const char *value)
 {
    const char *oldValue = GetValue(key);
    TString newString;
@@ -191,7 +191,7 @@ void ROOT::Deprecated::TGridJDL::AddToSet(const char *key, const char *value)
 /// Adds a value to a key value which hosts a set of values.
 /// E.g. InputSandbox: {"file1","file2"}
 
-void ROOT::Deprecated::TGridJDL::AddToSetDescription(const char *key, const char *description)
+void TGridJDL::AddToSetDescription(const char *key, const char *description)
 {
    const char *oldValue = GetDescription(key);
    TString newString;
@@ -204,7 +204,7 @@ void ROOT::Deprecated::TGridJDL::AddToSetDescription(const char *key, const char
 ////////////////////////////////////////////////////////////////////////////////
 /// Generates the JDL snippet.
 
-TString ROOT::Deprecated::TGridJDL::Generate()
+TString TGridJDL::Generate()
 {
    TString output("");
 

--- a/net/net/src/TGridJDL.cxx
+++ b/net/net/src/TGridJDL.cxx
@@ -1,0 +1,245 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus   28/9/2004
+//         Jancurova.lucia@cern.ch Slovakia  29/9/2008
+
+/*************************************************************************
+ * Copyright (C) 1995-2008, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJDL                                                             //
+//                                                                      //
+// Abstract base class to generate JDL files for job submission to the  //
+// Grid.                                                                //
+//                                                                      //
+// Related classes are TGLiteJDL.                                       //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGridJDL.h"
+#include "TObjString.h"
+#include "Riostream.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Cleanup.
+
+ROOT::Deprecated::TGridJDL::~TGridJDL()
+{
+   Clear();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Clears the JDL information.
+
+void ROOT::Deprecated::TGridJDL::Clear(const Option_t*)
+{
+   fMap.DeleteAll();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Sets a value. If the entry already exists the old one is replaced.
+
+void ROOT::Deprecated::TGridJDL::SetValue(const char *key, const char *value)
+{
+   TObject *object = fMap.FindObject(key);
+   TPair *pair = dynamic_cast<TPair*>(object);
+   if (pair) {
+      TObject *oldObject = pair->Key();
+      if (oldObject) {
+         TObject *oldValue = pair->Value();
+
+         fMap.Remove(oldObject);
+         delete oldObject;
+         oldObject = 0;
+
+         if (oldValue) {
+            delete oldValue;
+            oldValue = 0;
+         }
+      }
+   }
+
+   fMap.Add(new TObjString(key), new TObjString(value));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the value corresponding to the provided key. Return 0 in case
+/// key is not found.
+
+const char *ROOT::Deprecated::TGridJDL::GetValue(const char *key)
+{
+   if (!key)
+      return 0;
+
+   TObject *object = fMap.FindObject(key);
+   if (!object)
+      return 0;
+
+   TPair *pair = dynamic_cast<TPair*>(object);
+   if (!pair)
+      return 0;
+
+   TObject *value = pair->Value();
+   if (!value)
+      return 0;
+
+   TObjString *string = dynamic_cast<TObjString*>(value);
+   if (!string)
+      return 0;
+
+   return string->GetName();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Sets a value. If the entry already exists the old one is replaced.
+
+void ROOT::Deprecated::TGridJDL::SetDescription(const char *key, const char* description)
+{
+   TObject *object = fDescriptionMap.FindObject(key);
+   TPair *pair = dynamic_cast<TPair*>(object);
+   if (pair) {
+      TObject *oldObject = pair->Key();
+      if (oldObject) {
+         TObject *oldValue = pair->Value();
+
+         fDescriptionMap.Remove(oldObject);
+         delete oldObject;
+         oldObject = 0;
+
+         if (oldValue) {
+            delete oldValue;
+            oldValue = 0;
+         }
+      }
+   }
+
+   fDescriptionMap.Add(new TObjString(key), new TObjString(description));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Returns the value corresponding to the provided key. Return 0 in case
+/// key is not found.
+
+const char *ROOT::Deprecated::TGridJDL::GetDescription(const char *key)
+{
+   if (!key)
+      return 0;
+
+   TObject *object = fDescriptionMap.FindObject(key);
+   if (!object)
+      return 0;
+
+   TPair *pair = dynamic_cast<TPair*>(object);
+   if (!pair)
+      return 0;
+
+   TObject *value = pair->Value();
+   if (!value)
+      return 0;
+
+   TObjString *string = dynamic_cast<TObjString*>(value);
+   if (!string)
+      return 0;
+
+   return string->GetName();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Adds quotes to the provided string.
+///  E.g. Value --> "Value"
+
+TString ROOT::Deprecated::TGridJDL::AddQuotes(const char *value)
+{
+   TString temp = TString("\"");
+   temp += value;
+   temp += "\"";
+
+   return temp;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Adds a value to a key value which hosts a set of values.
+/// E.g. InputSandbox: {"file1","file2"}
+
+void ROOT::Deprecated::TGridJDL::AddToSet(const char *key, const char *value)
+{
+   const char *oldValue = GetValue(key);
+   TString newString;
+   if (oldValue)
+      newString = oldValue;
+   if (newString.IsNull()) {
+      newString = "{";
+   } else {
+      newString.Remove(newString.Length()-1);
+      newString += ",";
+   }
+
+   newString += AddQuotes(value);
+   newString += "}";
+
+   SetValue(key, newString);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Adds a value to a key value which hosts a set of values.
+/// E.g. InputSandbox: {"file1","file2"}
+
+void ROOT::Deprecated::TGridJDL::AddToSetDescription(const char *key, const char *description)
+{
+   const char *oldValue = GetDescription(key);
+   TString newString;
+   if (oldValue)
+      newString = oldValue;
+   newString += description;
+
+   SetDescription(key, newString);
+}
+////////////////////////////////////////////////////////////////////////////////
+/// Generates the JDL snippet.
+
+TString ROOT::Deprecated::TGridJDL::Generate()
+{
+   TString output("");
+
+   TIter next(&fMap);
+   TIter nextDescription(&fDescriptionMap);
+   TObject *object = 0;
+   TObject *objectD = 0;
+   while ((object = next())) {
+      TObjString *key = dynamic_cast<TObjString*>(object);
+      if (key) {
+         TObject *value = fMap.GetValue(object);
+         TObjString *valueobj = dynamic_cast<TObjString*>(value);
+
+         if (valueobj) {
+            nextDescription.Reset();
+            while ((objectD = nextDescription())) {
+               TObjString *keyD = dynamic_cast<TObjString*>(objectD);
+               if (keyD) {
+                  TObject *valueD = fDescriptionMap.GetValue(objectD);
+                  TObjString *valueobjD = dynamic_cast<TObjString*>(valueD);
+                  if (valueobjD && !strcmp(key->GetName(), keyD->GetName())){
+                     //Info("",Form("%s %s",key->GetString().Data(),keyD->GetString().Data()));
+                     output += "# ";
+                     output += valueobjD->GetName();
+                     output += "\n";
+                  }
+               }
+            }
+            output += key->GetName();
+            output += " = ";
+            output += valueobj->GetName();
+            output += ";\n\n";
+         }
+      }
+   }
+
+   return output;
+}

--- a/net/net/src/TGridJDL.cxx
+++ b/net/net/src/TGridJDL.cxx
@@ -10,17 +10,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJDL                                                             //
-//                                                                      //
-// Abstract base class to generate JDL files for job submission to the  //
-// Grid.                                                                //
-//                                                                      //
-// Related classes are TGLiteJDL.                                       //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGridJDL.h"
 #include "TObjString.h"
 #include "Riostream.h"

--- a/net/net/src/TGridJob.cxx
+++ b/net/net/src/TGridJob.cxx
@@ -27,7 +27,7 @@
 /// Must be implemented by actual GRID job implementation. Returns -1 in
 /// case of error, 0 otherwise.
 
-Int_t ROOT::Deprecated::TGridJob::GetOutputSandbox(const char *, Option_t *)
+Int_t TGridJob::GetOutputSandbox(const char *, Option_t *)
 {
    MayNotUse("GetOutputSandbox");
    return -1;

--- a/net/net/src/TGridJob.cxx
+++ b/net/net/src/TGridJob.cxx
@@ -9,16 +9,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJob                                                             //
-//                                                                      //
-// Abstract base class defining interface to a GRID job.                //
-//                                                                      //
-// Related classes are TGridJobStatus.                                  //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGridJob.h"
 
 

--- a/net/net/src/TGridJob.cxx
+++ b/net/net/src/TGridJob.cxx
@@ -1,0 +1,34 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus   06/10/2004
+
+/*************************************************************************
+ * Copyright (C) 1995-2004, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJob                                                             //
+//                                                                      //
+// Abstract base class defining interface to a GRID job.                //
+//                                                                      //
+// Related classes are TGridJobStatus.                                  //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGridJob.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Must be implemented by actual GRID job implementation. Returns -1 in
+/// case of error, 0 otherwise.
+
+Int_t ROOT::Deprecated::TGridJob::GetOutputSandbox(const char *, Option_t *)
+{
+   MayNotUse("GetOutputSandbox");
+   return -1;
+}

--- a/net/net/src/TGridJobStatus.cxx
+++ b/net/net/src/TGridJobStatus.cxx
@@ -9,14 +9,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJobStatus                                                       //
-//                                                                      //
-// Abstract base class containing the status of a Grid job.             //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGridJobStatus.h"
 
 

--- a/net/net/src/TGridJobStatus.cxx
+++ b/net/net/src/TGridJobStatus.cxx
@@ -1,0 +1,22 @@
+// @(#)root/net:$Id$
+// Author: Jan Fiete Grosse-Oetringhaus   06/10/2004
+
+/*************************************************************************
+ * Copyright (C) 1995-2004, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJobStatus                                                       //
+//                                                                      //
+// Abstract base class containing the status of a Grid job.             //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGridJobStatus.h"
+
+

--- a/net/net/src/TGridJobStatusList.cxx
+++ b/net/net/src/TGridJobStatusList.cxx
@@ -9,14 +9,6 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridJobStatusList                                                   //
-//                                                                      //
-// Abstract base class defining a list of GRID job status               //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGridJobStatusList.h"
 
 TGridJobStatusList *gGridJobStatusList = 0;

--- a/net/net/src/TGridJobStatusList.cxx
+++ b/net/net/src/TGridJobStatusList.cxx
@@ -1,0 +1,23 @@
+// @(#)root/net:$Id$
+// Author: Andreas-Joachim Peters  10/12/2006
+
+/*************************************************************************
+ * Copyright (C) 1995-2006, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridJobStatusList                                                   //
+//                                                                      //
+// Abstract base class defining a list of GRID job status               //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGridJobStatusList.h"
+
+ROOT::Deprecated::TGridJobStatusList *ROOT::Deprecated::gGridJobStatusList = 0;
+ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList = ROOT::Deprecated::gGridJobStatusList;

--- a/net/net/src/TGridJobStatusList.cxx
+++ b/net/net/src/TGridJobStatusList.cxx
@@ -19,5 +19,6 @@
 
 #include "TGridJobStatusList.h"
 
-ROOT::Deprecated::TGridJobStatusList *ROOT::Deprecated::gGridJobStatusList = 0;
-ROOT::Deprecated::TGridJobStatusList *&gGridJobStatusList = ROOT::Deprecated::gGridJobStatusList;
+TGridJobStatusList *gGridJobStatusList = 0;
+
+

--- a/net/net/src/TGridResult.cxx
+++ b/net/net/src/TGridResult.cxx
@@ -9,16 +9,5 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-//////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TGridResult                                                          //
-//                                                                      //
-// Abstract base class defining interface to a GRID result.             //
-// Objects of this class are created by TGrid methods.                  //
-//                                                                      //
-// Related classes are TGrid.                                           //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
-
 #include "TGridResult.h"
 

--- a/net/net/src/TGridResult.cxx
+++ b/net/net/src/TGridResult.cxx
@@ -1,0 +1,24 @@
+// @(#)root/net:$Id$
+// Author: Fons Rademakers   23/5/2002
+
+/*************************************************************************
+ * Copyright (C) 1995-2000, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+//                                                                      //
+// TGridResult                                                          //
+//                                                                      //
+// Abstract base class defining interface to a GRID result.             //
+// Objects of this class are created by TGrid methods.                  //
+//                                                                      //
+// Related classes are TGrid.                                           //
+//                                                                      //
+//////////////////////////////////////////////////////////////////////////
+
+#include "TGridResult.h"
+


### PR DESCRIPTION
The ALICE experiment depends critically on these classes so they cannot be removed for the time being.
This PR restores them to their non-deprecated status.

Likely needs backporting to 6.40.

cc @ktf 