### PR TITLE
[hist] Fix TFormula Hessian result sizing

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -3419,7 +3419,7 @@ void TFormula::HessianPar(const Double_t *x, TFormula::CladStorage& result)
       return;
    }
 
-   if ((int)result.size() < fNpar) {
+   if ((int)result.size() < fNpar * fNpar) {
       Warning("HessianPar",
               "The size of hessian result is %zu but %d is required. Resizing.",
               result.size(), fNpar * fNpar);

--- a/hist/hist/test/TFormulaHessianTests.cxx
+++ b/hist/hist/test/TFormulaHessianTests.cxx
@@ -43,20 +43,19 @@ TEST(TFormulaHessianPar, ResultUpsize)
    TFormula f("f", "std::sin([1]) - std::cos([0])");
    double p[] = {60, 30};
    f.SetParameters(p);
-   TFormula::CladStorage result;
+   // Two elements passed the old check, but a 2x2 Hessian needs four.
+   TFormula::CladStorage result(2);
    double x[] = {2, 1};
 
-   ASSERT_TRUE(result.empty());
-   ROOT_EXPECT_WARNING(f.HessianPar(x, result),
-   "TFormula::HessianPar",
-   "The size of hessian result is 0 but 4 is required. Resizing."
-   );
+   ASSERT_TRUE(2 == result.size());
+   ROOT_EXPECT_WARNING(f.HessianPar(x, result), "TFormula::HessianPar",
+                       "The size of hessian result is 2 but 4 is required. Resizing.");
+   ASSERT_TRUE(4 == result.size());
 
    ASSERT_FLOAT_EQ(std::cos(p[0]), result[0]);
    ASSERT_FLOAT_EQ(0, result[1]);
    ASSERT_FLOAT_EQ(0, result[2]);
-   ASSERT_FLOAT_EQ(- std::sin(p[1]), result[3]);
-   ASSERT_TRUE(4 == result.size());
+   ASSERT_FLOAT_EQ(-std::sin(p[1]), result[3]);
 }
 
 TEST(TFormulaHessianPar, ResultDownsize)


### PR DESCRIPTION
`TFormula::HessianPar` returns a flattened matrix with `fNpar * fNpar`
elements, but the `CladStorage` overload only resized results smaller
than `fNpar`. With two parameters, a two-element result passed the old
check even though the Hessian needs four elements.

Use the full Hessian size for the check and update the existing
`ResultUpsize` test to cover this case.