### PR TITLE
[CI] Trigger the python wheel workflow only when a PR is labelled.

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     - cron: '01 1 * * *'
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
This is an attempt to reduce unnessecary triggers of the workflow. In most PRs, the wheels won't be built, so the PR "opened" trigger is a bit too much.
Instead, trigger only when a PR is labelled, rebased, or reopened.
