### PR TITLE
[RF][HS3] Fix RooFormulaVar key export

### DIFF
--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -581,7 +581,7 @@ bool importExponential(RooJSONFactoryWSTool *tool, const JSONNode &p)
    //  },
    //  {
    //      "name": "c_exponential_inverted",    // transformation function created on-the-fly on export
-   //      "type": "generic_function",
+   //      "type": "generic",
    //      "expression": "-c"
    //  }
    //
@@ -1270,7 +1270,7 @@ STATIC_EXECUTE([]() {
    registerExporter<exportPolynomial<RooPolyVar>>(RooPolyVar::Class(), "polynomial", false);
    registerExporter<exportRealSumFunc>(RooRealSumFunc::Class(), "weighted_sum", false);
    registerExporter<exportRealSumPdf>(RooRealSumPdf::Class(), "weighted_sum_dist", false);
-   registerExporter<exportTFnBinding>(RooTFnBinding::Class(), "generic_function", false);
+   registerExporter<exportTFnBinding>(RooTFnBinding::Class(), "generic", false);
    registerExporter<exportRealIntegral>(RooRealIntegral::Class(), "integral", false);
    registerExporter<exportDerivative>(RooDerivative::Class(), "derivative", false);
    registerExporter<exportFFTConvPdf>(RooFFTConvPdf::Class(), "fft_convolution_dist", false);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -942,7 +942,7 @@ std::string RooJSONFactoryWSTool::exportTransformed(const RooAbsReal *original, 
 {
    std::string newname = std::string(original->GetName()) + suffix;
    RooFit::Detail::JSONNode &trafo_node = appendNamedChild((*_rootnodeOutput)["functions"], newname);
-   trafo_node["type"] << "generic_function";
+   trafo_node["type"] << "generic";
    trafo_node["expression"] << TString::Format(formula.c_str(), original->GetName()).Data();
    this->setAttribute(newname, "roofit_skip"); // this function should not be imported back in
    return newname;

--- a/roofit/hs3/test/testRooFitHS3.cxx
+++ b/roofit/hs3/test/testRooFitHS3.cxx
@@ -36,6 +36,7 @@
 #include <RooStats/HistFactory/ParamHistFunc.h>
 #include <RooStats/HistFactory/FlexibleInterpVar.h>
 #include <RooStats/HistFactory/PiecewiseInterpolation.h>
+#include <RooTFnBinding.h>
 #include <RooWorkspace.h>
 
 #include <cmath>
@@ -44,6 +45,7 @@
 #include <string_view>
 #include <vector>
 
+#include <TF3.h>
 #include <TROOT.h>
 
 #include <gtest/gtest.h>
@@ -2299,4 +2301,30 @@ TEST(RooFitHS3, SimultaneousFit)
    // todo: also check the modelconfig for equality
 
    EXPECT_TRUE(res2->isIdentical(*res1));
+}
+
+TEST(RooFitHS3, GenericTypeNames)
+{
+   RooRealVar x{"x", "x", 0.5, -1.0, 1.0};
+   RooRealVar y{"y", "y", 0.5, -1.0, 1.0};
+   RooRealVar z{"z", "z", 0.5, -1.0, 1.0};
+   RooRealVar c{"c", "c", -0.1};
+   RooFormulaVar formula{"formula", "x + y", RooArgList{x, y}};
+   RooGenericPdf genericPdf{"genericPdf", "x + 2.0", RooArgList{x}};
+   TF3 tf3{"tf3", "x + y + z", -1.0, 1.0, -1.0, 1.0, -1.0, 1.0};
+   RooTFnBinding binding{"binding", "binding", &tf3, RooArgList{x, y, z}};
+   RooExponential exponential{"exponential", "exponential", x, c};
+
+   RooWorkspace ws{"ws_generic_types"};
+   ws.import(formula, RooFit::Silence());
+   ws.import(genericPdf, RooFit::Silence(), RooFit::RecycleConflictNodes());
+   ws.import(binding, RooFit::Silence(), RooFit::RecycleConflictNodes());
+   ws.import(exponential, RooFit::Silence(), RooFit::RecycleConflictNodes());
+
+   const std::string json = RooJSONFactoryWSTool{ws}.exportJSONtoString();
+   EXPECT_NE(json.find("\"name\":\"formula\",\"type\":\"generic\""), std::string::npos) << json;
+   EXPECT_NE(json.find("\"name\":\"genericPdf\",\"type\":\"generic_dist\""), std::string::npos) << json;
+   EXPECT_NE(json.find("\"name\":\"binding\",\"type\":\"generic\""), std::string::npos) << json;
+   EXPECT_NE(json.find("\"name\":\"c_exponential_inverted\",\"type\":\"generic\""), std::string::npos) << json;
+   EXPECT_EQ(json.find("\"type\":\"generic_function\""), std::string::npos) << json;
 }


### PR DESCRIPTION
# This Pull request:

This PR handles some key changes to HS3 missed by https://github.com/root-project/root/pull/22735
Fix HS3 export type names for generic functions. `RooTFnBinding and generated transformation functions now export as `generic, while RooGenericPdf continues to use `generic_dist. Legacy `generic_function` files remain supported on import. 


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
