### PR TITLE
[win] Disable a couple of failing tests (VS2026)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -197,7 +197,12 @@ endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/stressHistogram.5.18.00.root ${CMAKE_CURRENT_BINARY_DIR} COPYONLY)
 ROOT_EXECUTABLE(stressHistogram stressHistogram.cxx LIBRARIES Hist RIO)
 ROOT_ADD_TEST(test-stresshistogram COMMAND stressHistogram FAILREGEX "FAILED|Error in" LABELS longtest)
+# The stresshistogram-interpreted test fails on Windows due to unresolved symbols with Visual Studio 2026
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1951)
+  set(_willfail WILLFAIL)
+endif()
 ROOT_ADD_TEST(test-stresshistogram-interpreted COMMAND ${root_exe} -b -q ${CMAKE_CURRENT_SOURCE_DIR}/stressHistogram.cxx
+              ${_willfail}
               FAILREGEX "FAILED|Error in")
 
 #--stressGUI---------------------------------------------------------------------------------------

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -105,6 +105,11 @@ if(MSVC AND NOT win_broken_tests)
                           io/ntuple/ntpl017_shared_reader.C)
   # The RNTuple SoA tutorial fails on Windows if interpreted for unknown reasons
   list(APPEND ntuple_veto io/ntuple/ntpl020_soa.C)
+  # The SQliteDependencyOverVersion tutorial fails on Windows due to unresolved symbols
+  # with Visual Studio 2026
+  if(MSVC_VERSION GREATER_EQUAL 1951)
+    list(APPEND dataframe_veto analysis/dataframe/df027_SQliteDependencyOverVersion.C)
+  endif()
 endif()
 
 # TODO: fix the problem and re-enable the tutorial test. The rf615 tutorial


### PR DESCRIPTION
Disable tests failing due to unresolved symbols with Visual Studio 2026