### PR TITLE
[gh] Orchestrate MacOS test-wheels' build with cibuildwheel

### DIFF
--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -1,84 +1,158 @@
 name: 'ROOT Python wheels'
+
 on:
   workflow_dispatch:
     inputs:
-      major:
-        type: choice
-        description: Major
-        options: 
-        - 6
-        - 7
-        - 8
+      ref:
+        description: 'The git ref to build the wheel from (branch, tag, or commit SHA).'
+        type: string
         required: true
-        default: 6
-      minor:
-        type: choice
-        description: Minor
-        options: 
-        - 26
-        - 28
-        - 30
-        - 32
-        - 36
-        - 38
-        - 40
-        - 42
-        - 44
-        - 46
-        - 48
-        required: true
-        default: 40
-      patch:
-        type: choice
-        description: Patch
-        options: 
-        - "00"
-        - "02"
-        - "04"
-        - "06"
-        - "08"
-        - "10"
-        - "12"
-        - "14"
-        - "16"
-        - "18"
-        - "20"
-        - "22"
-        - "24"
-        - "26"
-        - "28"
-        - "30"
-        required: true
-        default: "00"
+        default: ''
+  schedule:
+    - cron: '01 1 * * *'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-  Build_Wheel:
-    runs-on: macos-26 
+  build-wheels:
+    if: |
+      (github.repository_owner == 'root-project' &&
+       (github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch')) ||
+      contains(github.event.pull_request.labels.*.name, 'build-python-wheels')
+    runs-on: ${{ contains(matrix.target, 'macosx') && 'macos-15' || 'ubuntu-latest' }} 
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 26.0
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - cp310-manylinux_x86_64
+          - cp311-manylinux_x86_64
+          - cp312-manylinux_x86_64
+          - cp313-manylinux_x86_64
+          - cp314-manylinux_x86_64
+          - cp310-macosx_arm64
+          - cp311-macosx_arm64
+          - cp312-macosx_arm64
+          - cp313-macosx_arm64
+          - cp314-macosx_arm64
+    name: ${{ matrix.target }}
     steps:
-      - name: Checkout the official ROOT repo
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          path: root
-#          ref: v${{ inputs.major }}-${{ inputs.minor }}-${{ inputs.patch }}
-      - name: Make wheel
-        env:
-            MACOSX_DEPLOYMENT_TARGET: 26.5
-        run: |
-            mkdir wheel_creation && cd wheel_creation
-            cp -r ../root .
-            python3 -m venv root_build_env 
-            source root_build_env/bin/activate
-            pip install --upgrade pip setuptools wheel build
-            cd root
-            pip install -r requirements.txt
-            python3 -m build --wheel
-            pip install delocate 
-            mkdir fixed_wheels
-            delocate-wheel -v -w fixed_wheels/ dist/*.whl
+          ref: ${{ github.event.inputs.ref }}
+      - uses: ./.github/workflows/cibuildwheel-impl
+        with:
+          build-tag: ${{ matrix.target }}
 
-      - name: Upload_wheel
-        uses: actions/upload-artifact@v6
+  test-wheels:
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    name: test-wheel-cp${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v6
         with:
-          name: Wheel upload
-          path: /Users/runner/work/root/root/wheel_creation/root/fixed_wheels/*.whl
-          if-no-files-found: error
+          ref: ${{ github.event.inputs.ref }}
+      - name: Download produced wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install produced wheel
+        run: |
+          ls -R wheels
+          PY_VER=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
+          WHEEL=$(ls wheels/*${PY_VER}*manylinux*.whl | head -n 1)
+          echo "Python version: ${PY_VER}, installing wheel: ${WHEEL}"
+          pip install "$WHEEL"
+
+      - name: Install tutorials dependencies
+        run: |
+          python -m pip install --no-cache-dir -r test/wheels/requirements-ci.txt
+
+      - name: Run tutorials
+        run: |
+          pytest -vv --verbosity="4" -rF test/wheels
+
+  create-and-upload-wheel-registry:
+      if: github.event_name != 'pull_request' # The secrets are not available in PR
+      needs: test-wheels
+      runs-on: ubuntu-latest
+      steps:
+
+      - name: Download produced wheels
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Install required system packages
+        run: sudo apt-get install -y krb5-user xrootd-client
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+
+      - name: Create PEP503-compliant wheel registry
+        run: |
+          mkdir -p wheelhouse
+          mv *.whl wheelhouse
+          python -m pip install --upgrade pip
+          python -m pip install --user simple503
+          simple503 wheelhouse
+
+      - name: Compute number of files to upload
+        id: nfiles
+        run: echo "NFILES=$(find wheelhouse -maxdepth 1 | wc -l)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload wheels to EOS
+        env:
+          RWEBEOS_KT: ${{ secrets.RWEBEOS_KT }}
+          KT_FILE_NAME: /tmp/decoded.keytab
+          EOS_PATH: /eos/project/r/root-eos/www/experimental-python-wheels
+          EOS_ENDPOINT: root://eosproject-r.cern.ch
+          KRB5CCNAME: /tmp/krb5cc
+          NFILES: ${{ steps.nfiles.outputs.NFILES }}
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo +++ Content
+          ls
+          echo +++ Retrieving the secret
+          echo ${RWEBEOS_KT} | base64 -d > ${KT_FILE_NAME}
+          echo +++ Creating the token
+          kinit  -p ${{ secrets.KRB5USER }}@${{ secrets.KRB5REALM }} -kt ${KT_FILE_NAME}
+          echo +++ Running the copy
+          xrdcp --parallel ${NFILES} -rf wheelhouse/* ${EOS_ENDPOINT}/${EOS_PATH}/
+
+  publish-to-pypi:
+      if: github.event_name == 'workflow_dispatch'
+      needs: test-wheels
+      runs-on: ubuntu-latest
+      name: >-
+        Publish Python distribution to PyPI
+      environment:
+        name: pypi
+        url: https://pypi.org/p/root
+      permissions:
+        id-token: write
+      steps:
+      - name: Download produced wheels
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,8 +604,7 @@ get_cmake_property(variables CACHE_VARIABLES)
 foreach(var ${variables})
   if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
      (NOT "${${var}}" STREQUAL "") AND
-     (NOT ${var} MATCHES "NOTFOUND") AND
-     (NOT ${var} MATCHES " "))
+     (NOT ${var} MATCHES "NOTFOUND"))
     if (var MATCHES "^QT_")
       # filter out the very long list of Qt libraries and include dirs
       if (var MATCHES "(QT_LIBRARY_DIR|QT_QTCORE_INCLUDE_DIR)")


### PR DESCRIPTION
# This Pull request:
Rolls-back the wheel-building workflow to the current production, `cibuildwheel`-based workflow modified to also build macos wheels. Currently only targets OSX 15 on arm.