### PR TITLE
[RVec] Inline `nodiscard` attribute and `std::uninitialized_value_construct`

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -523,18 +523,6 @@ public:
       elementsPerCacheLine >= 8 ? elementsPerCacheLine : (sizeof(T) * 8 > maxInlineByteSize ? 0 : 8);
 };
 
-// A C++14-compatible implementation of std::uninitialized_value_construct
-template <typename ForwardIt>
-void UninitializedValueConstruct(ForwardIt first, ForwardIt last)
-{
-#if __cplusplus < 201703L
-   for (; first != last; ++first)
-      new (static_cast<void *>(std::addressof(*first))) typename std::iterator_traits<ForwardIt>::value_type();
-#else
-   std::uninitialized_value_construct(first, last);
-#endif
-}
-
 /// An unsafe function to reset the buffer for which this RVec is acting as a view.
 ///
 /// \note This is a low-level method that _must_ be called on RVecs that are already non-owning:
@@ -1167,7 +1155,7 @@ public:
       if (Size > N)
          this->grow(Size);
       this->fSize = Size;
-      ROOT::Internal::VecOps::UninitializedValueConstruct(this->begin(), this->end());
+      std::uninitialized_value_construct(this->begin(), this->end());
    }
 
    template <typename ItTy,

--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -13,12 +13,6 @@
 #ifndef ROOT_RVEC
 #define ROOT_RVEC
 
-#if __cplusplus > 201402L
-#define R__RVEC_NODISCARD [[nodiscard]]
-#else
-#define R__RVEC_NODISCARD
-#endif
-
 #ifdef _WIN32
    #ifndef M_PI
       #ifndef _USE_MATH_DEFINES
@@ -178,7 +172,7 @@ public:
    size_t size() const { return fSize; }
    size_t capacity() const noexcept { return Owns() ? fCapacity : fSize; }
 
-   R__RVEC_NODISCARD bool empty() const { return !fSize; }
+   [[nodiscard]] bool empty() const { return !fSize; }
 
    /// Set the array size to \p N, which the current array must have enough
    /// capacity for.
@@ -643,7 +637,7 @@ public:
       this->SetSizeUnchecked(this->size() - NumItems);
    }
 
-   R__RVEC_NODISCARD T pop_back_val()
+   [[nodiscard]] T pop_back_val()
    {
       T Result = ::std::move(this->back());
       this->pop_back();


### PR DESCRIPTION
ROOT requires C++17 since a while already.