### PR TITLE
[RF][HS3] Fix export of self_normalized flag

### DIFF
--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -1146,7 +1146,11 @@ bool importWrapperPdf(RooJSONFactoryWSTool *tool, const JSONNode &node)
 
    bool selfNormalized = false;
 
-   if (auto sn = node.find("selfNormalized"))
+   auto sn = node.find("self_normalized");
+   // ROOT previously exported this key without an underscore.
+   if (!sn)
+      sn = node.find("selfnormalized");
+   if (sn)
       selfNormalized = sn->val_bool();
 
    tool->wsEmplace<RooWrapperPdf>(name, *func, selfNormalized);
@@ -1169,7 +1173,7 @@ bool exportWrapperPdf(RooJSONFactoryWSTool *, const RooAbsArg *arg, JSONNode &no
 
    node["function"] << funcProxy->absArg()->GetName();
    if (pdf->selfNormalized())
-      node["selfnormalized"] << true;
+      node["self_normalized"] << true;
 
    return true;
 }


### PR DESCRIPTION
# This Pull request:
The `selfNormalized()` flag in the `RooWrapperPdf` importer and exporter keys didn't match.

## Changes or fixes:

Set the export key to `self_normalized` and retain the legacy import of the `selfnormalized` key

@guitargeek 
