### PR TITLE
[ML] Update stale RDataLoader class name in LinkDef

### DIFF
--- a/tree/ml/LinkDef.h
+++ b/tree/ml/LinkDef.h
@@ -7,6 +7,6 @@
 //   corresponding dictionary source file, and apparently only the second one is necessary for cppyy.
 #pragma link C++ namespace ROOT::Experimental::ML;
 #pragma link C++ namespace ROOT::Experimental::Internal::ML;
-#pragma link C++ class ROOT::Experimental::Internal::ML::RDataLoader < int>;
+#pragma link C++ class ROOT::Experimental::Internal::ML::RDataLoaderEngine < int>;
 #endif
 #endif


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
`tree/ml/LinkDef.h` referenced `RDataLoader<int>`, but the class was renamed to `RDataLoaderEngine.`
