### PR TITLE
[test] Exclude test if TShape is not available

### DIFF
--- a/roottest/root/treeformula/casting/CMakeLists.txt
+++ b/roottest/root/treeformula/casting/CMakeLists.txt
@@ -3,10 +3,11 @@ ROOTTEST_ADD_TEST(write
                   FIXTURES_REQUIRED root-io-event-TestIoEvent-fixture
                   FIXTURES_SETUP root-treeformula-casting-write-fixture)
 
-ROOTTEST_COMPILE_MACRO(Simple.cxx
-                       FIXTURES_SETUP root-treeformula-casting-Simple-fixture)
-
 if(geom)
+  ROOTTEST_COMPILE_MACRO(Simple.cxx
+                         FIXTURES_SETUP root-treeformula-casting-Simple-fixture)
+
+
   ROOTTEST_ADD_TEST(run
                     MACRO Run.C
                     OUTREF Simple.ref


### PR DESCRIPTION
because geom=OFF, e.g. for minimal builds. Probably a remnant of https://github.com/root-project/root/pull/22845