### PR TITLE
Cleanups across ROOT before disabling the auto registration of TEventList

### DIFF
--- a/math/mlp/inc/TMultiLayerPerceptron.h
+++ b/math/mlp/inc/TMultiLayerPerceptron.h
@@ -15,8 +15,8 @@
 #include "TObject.h"
 #include "TString.h"
 #include "TObjArray.h"
-#include "TMatrixD.h"
 #include "TNeuron.h"
+#include "TMatrixDfwd.h"
 
 class TTree;
 class TEventList;

--- a/math/mlp/src/TMultiLayerPerceptron.cxx
+++ b/math/mlp/src/TMultiLayerPerceptron.cxx
@@ -242,6 +242,7 @@ neurons, hidden layers and inputs/outputs that does not apply to TMultiLayerPerc
 #include "TH2.h"
 #include "TGraph.h"
 #include "TLegend.h"
+#include "TMatrixD.h"
 #include "TMultiGraph.h"
 #include "TDirectory.h"
 #include "TSystem.h"

--- a/roottest/root/tree/cache/variableCluster.C
+++ b/roottest/root/tree/cache/variableCluster.C
@@ -220,26 +220,13 @@ Long64_t checkBoundary(TTree *tree, Long64_t entry)
    TTree::TClusterIterator clusterIter = tree->GetClusterIterator(entry);
    fEntryCurrent = clusterIter();
    fEntryNext = clusterIter.GetNextEntry();
-   
+
 //   fprintf(stdout,"finds = %lld %lld\n",fEntryCurrent,fEntryNext);
-   
+
    if (fEntryCurrent < fEntryMin) fEntryCurrent = fEntryMin;
    if (fEntryMax <= 0) fEntryMax = tree->GetEntries();
    if (fEntryNext > fEntryMax) fEntryNext = fEntryMax;
-   
-   // Check if owner has a TEventList set. If yes we optimize for this
-   // Special case reading only the baskets containing entries in the
-   // list.
-//   TEventList *elist = fOwner->GetEventList();
-//   Long64_t chainOffset = 0;
-//   if (elist) {
-//      if (fOwner->IsA() ==TChain::Class()) {
-//         TChain *chain = (TChain*)fOwner;
-//         Int_t t = chain->GetTreeNumber();
-//         chainOffset = chain->GetTreeOffset()[t];
-//      }
-//   }
-   
+
    Int_t flushIntervals = 0;
    Long64_t minEntry = fEntryCurrent;
    Long64_t prevNtot;

--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -34,7 +34,6 @@
 #include <TKey.h>
 #include <TLeaf.h>
 #include <TBranch.h>
-#include <TEventList.h>
 #include <TGraph.h>
 #include <TMatrixF.h>
 #include <TMatrixDSym.h>

--- a/tmva/tmva/src/DataInputHandler.cxx
+++ b/tmva/tmva/src/DataInputHandler.cxx
@@ -36,11 +36,8 @@ Class that contains all the data information.
 #include "TMVA/DataLoader.h"
 #include "TMVA/MsgLogger.h"
 #include "TMVA/Types.h"
-#include "TEventList.h"
 #include "TCut.h"
 #include "TTree.h"
-
-#include "TMVA/Configurable.h"
 
 #include <vector>
 #include <fstream>

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -41,26 +41,17 @@ Class that contains all the data information
 #include <iostream>
 
 #include <algorithm>
-#include <functional>
-#include <numeric>
-#include <random>
 
 #include "TMVA/DataSetFactory.h"
 
-#include "TEventList.h"
 #include "TFile.h"
 #include "TRandom3.h"
-#include "TMatrixF.h"
-#include "TVectorF.h"
 #include "TMath.h"
 #include "TTree.h"
 #include "TBranch.h"
 
 #include "TMVA/MsgLogger.h"
 #include "TMVA/Configurable.h"
-#include "TMVA/VariableIdentityTransform.h"
-#include "TMVA/VariableDecorrTransform.h"
-#include "TMVA/VariablePCATransform.h"
 #include "TMVA/DataSet.h"
 #include "TMVA/DataSetInfo.h"
 #include "TMVA/DataInputHandler.h"

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -31,14 +31,8 @@ Class that contains all the data information.
 
 */
 
-#include <vector>
-
-#include "TEventList.h"
 #include "TH2.h"
-#include "TRandom3.h"
 #include "TMatrixF.h"
-#include "TVectorF.h"
-#include "TROOT.h"
 
 #include "TMVA/MsgLogger.h"
 #include "TMVA/Tools.h"
@@ -49,6 +43,8 @@ Class that contains all the data information.
 
 #include "TMVA/Types.h"
 #include "TMVA/VariableInfo.h"
+
+#include <vector>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor

--- a/tmva/tmva/src/Factory.cxx
+++ b/tmva/tmva/src/Factory.cxx
@@ -71,26 +71,23 @@ evaluation phases.
 #include "TMVA/ResultsClassification.h"
 #include "TMVA/ResultsRegression.h"
 #include "TMVA/ResultsMulticlass.h"
-#include <list>
-#include <bitset>
-#include <set>
 
 #include "TMVA/Types.h"
 
 #include "TROOT.h"
 #include "TFile.h"
-#include "TLeaf.h"
-#include "TEventList.h"
 #include "TH2.h"
 #include "TGraph.h"
 #include "TStyle.h"
-#include "TMatrixF.h"
-#include "TMatrixDSym.h"
-#include "TMultiGraph.h"
 #include "TPrincipal.h"
 #include "TMath.h"
 #include "TSystem.h"
 #include "TCanvas.h"
+#include "TMultiGraph.h"
+
+#include <bitset>
+#include <list>
+#include <set>
 
 const Int_t MinNoTrainingEvents = 10;
 // const Int_t  MinNoTestEvents     = 1;

--- a/tmva/tmva/src/MethodTMlpANN.cxx
+++ b/tmva/tmva/src/MethodTMlpANN.cxx
@@ -46,7 +46,6 @@ for details on this ANN.
 #include "TMVA/MethodTMlpANN.h"
 
 #include "TMVA/Config.h"
-#include "TMVA/Configurable.h"
 #include "TMVA/DataSet.h"
 #include "TMVA/DataSetInfo.h"
 #include "TMVA/IMethod.h"
@@ -58,8 +57,6 @@ for details on this ANN.
 #include "TMVA/ClassifierFactory.h"
 #include "TMVA/Tools.h"
 
-#include "TLeaf.h"
-#include "TEventList.h"
 #include "TROOT.h"
 #include "TMultiLayerPerceptron.h"
 #include "ThreadLocalStorage.h"

--- a/tree/tree/inc/TEventList.h
+++ b/tree/tree/inc/TEventList.h
@@ -31,15 +31,15 @@ class TCollection;
 class TEventList : public TNamed {
 
 protected:
-   Int_t            fN;           ///<  Number of elements in the list
-   Int_t            fSize;        ///<  Size of array
-   Int_t            fDelta;       ///<  Increment size
-   bool             fReapply;     ///<  If true, TTree::Draw will 'reapply' the original cut
-   Long64_t        *fList;        ///<[fN]Array of elements
-   TDirectory      *fDirectory;   ///<! Pointer to directory holding this tree
+   Int_t fN = 0;                     ///<  Number of elements in the list
+   Int_t fSize = 100;                ///<  Size of array
+   Int_t fDelta = 100;               ///<  Increment size
+   bool fReapply = false;            ///<  If true, TTree::Draw will 'reapply' the original cut
+   Long64_t *fList = nullptr;        ///<[fN]Array of elements
+   TDirectory *fDirectory = nullptr; ///<! Pointer to directory holding this tree
 
 public:
-   TEventList();
+   TEventList() = default;
    TEventList(const char *name, const char *title="",Int_t initsize=0, Int_t delta = 0);
    TEventList(const TEventList &list);
              ~TEventList() override;

--- a/tree/tree/src/TEventList.cxx
+++ b/tree/tree/src/TEventList.cxx
@@ -50,24 +50,10 @@ the TEventList object created in the above commands:
 #include "TBuffer.h"
 #include "TCut.h"
 #include "TDirectory.h"
-#include "TList.h"
-#include "TMath.h"
-#include "strlcpy.h"
-#include "snprintf.h"
+#include "TCollection.h"
+#include "TMathBase.h"
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor for a EventList.
-
-TEventList::TEventList(): TNamed()
-{
-   fN          = 0;
-   fSize       = 100;
-   fDelta      = 100;
-   fList       = nullptr;
-   fDirectory  = nullptr;
-   fReapply    = false;
-}
+#include <algorithm>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a EventList.
@@ -75,31 +61,25 @@ TEventList::TEventList(): TNamed()
 /// This Eventlist is added to the list of objects in current directory.
 
 TEventList::TEventList(const char *name, const char *title, Int_t initsize, Int_t delta)
-  :TNamed(name,title), fReapply(false)
+   : TNamed(name, title), fSize(std::max(100, initsize)), fDelta(std::max(100, delta))
 {
-   fN = 0;
-   if (initsize > 100) fSize  = initsize;
-   else                fSize  = 100;
-   if (delta > 100)    fDelta = delta;
-   else                fDelta = 100;
-   fList       = nullptr;
-   fDirectory  = gDirectory;
-   if (fDirectory) fDirectory->Append(this);
+   fDirectory = gDirectory;
+   if (fDirectory)
+      fDirectory->Append(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TEventList::TEventList(const TEventList &list) : TNamed(list)
+TEventList::TEventList(const TEventList &list)
+   : TNamed(list),
+     fN(list.fN),
+     fSize(list.fSize),
+     fDelta(list.fDelta),
+     fReapply(list.fReapply),
+     fList(new Long64_t[fSize])
 {
-   fN     = list.fN;
-   fSize  = list.fSize;
-   fDelta = list.fDelta;
-   fList  = new Long64_t[fSize];
-   for (Int_t i=0; i<fN; i++)
-      fList[i] = list.fList[i];
-   fReapply = list.fReapply;
-   fDirectory = nullptr;
+   std::copy(list.fList, list.fList + list.fN, fList);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -107,9 +87,9 @@ TEventList::TEventList(const TEventList &list) : TNamed(list)
 
 TEventList::~TEventList()
 {
-   delete [] fList;  fList = nullptr;
-   if (fDirectory) fDirectory->Remove(this);
-   fDirectory  = nullptr;
+   delete[] fList;
+   if (fDirectory)
+      fDirectory->Remove(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -622,8 +622,6 @@ Long64_t TTreePlayer::GetEntriesToProcess(Long64_t firstentry, Long64_t nentries
       lastentry  = fTree->GetEntriesFriend() - 1;
       nentries   = lastentry - firstentry + 1;
    }
-   //TEventList *elist = fTree->GetEventList();
-   //if (elist && elist->GetN() < nentries) nentries = elist->GetN();
    TEntryList *elist = fTree->GetEntryList();
    if (elist && elist->GetN() < nentries) nentries = elist->GetN();
    return nentries;

--- a/tree/treeviewer/src/TSpider.cxx
+++ b/tree/treeviewer/src/TSpider.cxx
@@ -730,8 +730,6 @@ Long64_t TSpider::GetEntriesToProcess(Long64_t firstentry, Long64_t nentries) co
       lastentry  = fTree->GetEntriesFriend() - 1;
       nentries   = lastentry - firstentry + 1;
    }
-   //TEventList *elist = fTree->GetEventList();
-   //if (elist && elist->GetN() < nentries) nentries = elist->GetN();
    TEntryList *elist = fTree->GetEntryList();
    if (elist && elist->GetN() < nentries) nentries = elist->GetN();
    return nentries;


### PR DESCRIPTION
As part of working on the auto-registration of TEventList (#22817), several cleanups were possible:
- Remove several unnecessary includes of TEventList across ROOT
- Remove commented-out code that mentioned TEventList
- Use member initialisers and clean up includes inside TEventList