### PR TITLE
[CI] Export an OSX deployment target for mac beta.

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -112,6 +112,7 @@ jobs:
 
     env:
       VIRTUAL_ENV_DIR: ${{ github.workspace }}/ROOT_CI_VENV
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'mac-beta' && '27' || '' }} # Problems with gfortran falling back 18 (unsupported)
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
gfortran can't be used because by default, cmake tries to use it with SDK version 18. This is unsupported.
