### PR TITLE
[roottest] Disable benchmark test in asan builds

### DIFF
--- a/roottest/root/io/perf/slowreading/CMakeLists.txt
+++ b/roottest/root/io/perf/slowreading/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(asan)
+  # When address sanitizer is enabled tests may take longer than usual
+  set(COMPARE_TIME "kFALSE")
+else()
+  set(COMPARE_TIME "kTRUE")
+endif()
 
 ROOTTEST_ADD_TEST(files
                   COMMAND ${CMAKE_COMMAND} -E echo "copy files"
@@ -14,7 +20,7 @@ foreach(macro 60 61 62)
     # measure reading time and write file
     ROOTTEST_ADD_TEST(mark
                       MACRO Read.C
-                      MACROARG "\"NuEvent_60_cxx\", \"DST_60.root\", 1"
+                      MACROARG "\"NuEvent_60_cxx\", \"DST_60.root\", 1, ${COMPARE_TIME}"
                       FIXTURES_REQUIRED root-io-perf-slowreading-files-fixture
                                         root-io-perf-slowreading-60-fixture
                       FIXTURES_SETUP root-io-perf-slowreading-mark-fixture)
@@ -25,7 +31,7 @@ foreach(macro 60 61 62)
     # one could instead run performance code several times and choose best value
     ROOTTEST_ADD_TEST(check-macro${macro}-file${file}
                       MACRO Read.C
-                      MACROARG "\"NuEvent_${macro}_cxx\", \"DST_${file}.root\""
+                      MACROARG "\"NuEvent_${macro}_cxx\", \"DST_${file}.root\", 0, ${COMPARE_TIME}"
                       OUTREF Read.ref
                       FIXTURES_REQUIRED root-io-perf-slowreading-files-fixture
                                         root-io-perf-slowreading-${macro}-fixture

--- a/roottest/root/io/perf/slowreading/Read.C
+++ b/roottest/root/io/perf/slowreading/Read.C
@@ -8,7 +8,7 @@ using namespace std;
 #include "TBenchmark.h"
 #include "TChain.h"
 
-int Read(TString library, TString rootfilename, Bool_t ref = kFALSE)
+int Read(TString library, TString rootfilename, Bool_t ref = kFALSE, Bool_t compareTime = kTRUE)
 {
    std::string markfilename = "NuEvent_DST.mark";
    const int tolerance = 100;
@@ -67,7 +67,7 @@ int Read(TString library, TString rootfilename, Bool_t ref = kFALSE)
       ifstream markfile(markfilename.c_str());
       markfile >> refct;
 #endif
-      if ( TMath::Abs( (refct - ct) / refct ) > (tolerance/100.0)) {
+      if (compareTime && TMath::Abs((refct - ct) / refct) > (tolerance / 100.0)) {
          cout << "Reading time for " << rootfilename << " with " << library
               << " takes " << tolerance << "% more than the reference " << ct << " vs " << refct << "\n";
          return 1; // Failure


### PR DESCRIPTION
The address sanitizer may slow down test runs. Disable test with success condition based on runtime for asan builds.

Seen failing e.g. at https://github.com/root-project/root/actions/runs/30079949380/job/89439003185?pr=15588#step:8:9454

```
  Reading time for DST_61.root with NuEvent_61_cxx takes 100% more than the reference 0.24 vs 0.1
  (int) 1
```