### PR TITLE
[build] Do not strip away symbols from libraries and executables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 # Point backend to python packages and to explicitly use Ninja
 [tool.scikit-build]
+install.strip = false
 wheel.packages = [
 	"bindings/pyroot/pythonizations/python/ROOT",
 	"bindings/pyroot/cppyy/cppyy/python/cppyy",


### PR DESCRIPTION
By default, scikit-build triggers the stripping of debugging and other symbols, in order to optimize for space.
However, the stripping is too aggressive on macOS. This has undesired effects. For example, also the rootcling symbol `usedToIdentifyRootClingByDlSym` is stripped. Its presence changes the behaviour of some routines some ROOT libraries, e.g. when generating dictionaries.
