### PR TITLE
[cling] If sysroot not found, try to figure it out with xcrun

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -367,7 +367,39 @@ namespace {
       }
 
   #ifdef CLING_OSX_SYSROOT
-    sArguments.addArgument("-isysroot", CLING_OSX_SYSROOT);
+    std::string cling_osx_sysroot = CLING_OSX_SYSROOT;
+    if (!llvm::sys::fs::exists(cling_osx_sysroot)) {
+      // Fallback: try to find the correct SDK directory
+      std::array<char, 128> buffer;
+      std::string cling_osx_sysroot_str;
+      const std::string xcrun_cmd = "xcrun  --show-sdk-path";
+      std::unique_ptr<FILE, decltype(&pclose)> pipe(
+          ::popen(xcrun_cmd.c_str(), "r"), pclose);
+      if (!pipe) {
+        cling::errs() << "The sysroot directory set at build time, "
+                      << cling_osx_sysroot
+                      << ", could not be found. The command " << xcrun_cmd
+                      << " was tried to figure out the path of the SDK on "
+                         "the local system, however, the invocation through "
+                         "popen() failed.\n";
+      } else {
+        // Read the output block by block
+        while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+          cling_osx_sysroot_str += buffer.data();
+        }
+        if (!cling_osx_sysroot_str.empty()) {
+          cling_osx_sysroot_str.pop_back();
+          cling_osx_sysroot = cling_osx_sysroot_str;
+        } else {
+          cling::errs() << "The sysroot directory set at build time, "
+                        << cling_osx_sysroot
+                        << ", could not be found. The command " << xcrun_cmd
+                        << " was tried to figure out the path of the SDK on "
+                           "the local system, however, no valid path was returned.\n";
+        }
+      }
+    }
+    sArguments.addArgument("-isysroot", cling_osx_sysroot);
   #endif
 
 #endif // _MSC_VER

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -366,9 +366,49 @@ namespace {
           sArguments.addArgument("-nostdinc++");
       }
 
-  #ifdef CLING_OSX_SYSROOT
-    sArguments.addArgument("-isysroot", CLING_OSX_SYSROOT);
-  #endif
+  #ifdef __APPLE__
+  //
+  // On macOS, we try to find the SDK location through the following steps:
+  //   - We check if the -isysroot option is specified and the directory exists
+  //   - If not, we check for the directory specified by the SDKROOT env
+  //     variable, which is handled by the driver internally
+  //   - If also that is not there, we execute xcrun as a last resort
+  //
+  {
+    auto arvIt = std::find(args.begin(), args.end(), "-isysroot");
+    std::string cling_osx_sysroot_directory;
+    if(arvIt != args.end() && ++arvIt != args.end())
+      cling_osx_sysroot_directory = *arvIt;
+    if (!llvm::sys::fs::exists(cling_osx_sysroot_directory)) {
+      if (!::getenv("SDKROOT")) {
+        std::array<char, 128> buffer;
+        const auto xcrun_cmd = "xcrun  --show-sdk-path";
+        std::unique_ptr<FILE, decltype(&pclose)> pipe(
+            ::popen(xcrun_cmd, "r"), pclose);
+        if (!pipe) {
+          cling::errs() << "The option -isyroot was not passed to cling. "
+                        << "The command " << xcrun_cmd << " was tried to "
+                        << "find the SDK path on the  system, however, an "
+                        << "issue with the invocation occurred.\n";
+        } else {
+          cling_osx_sysroot_directory.clear();
+          // Read the output block by block
+          while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+            cling_osx_sysroot_directory += buffer.data();
+          }
+          if (!cling_osx_sysroot_directory.empty()) {
+            cling_osx_sysroot_directory.pop_back();
+            sArguments.addArgument("-isysroot", cling_osx_sysroot_directory);
+          } else {
+            cling::errs() << "The command " << xcrun_cmd << " was tried to "
+                          << "find the SDK path on the system, however, no "
+                            "valid path was returned.\n";
+          }
+        }
+      }
+    }
+  }
+  #endif // __APPLE__
 
 #endif // _MSC_VER
 

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -318,25 +318,6 @@ if (UNIX)
     #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
     #define CLING_INCLUDE_PATHS \"${CLING_INCLUDE_PATHS}\"
   ")
-  if (CMAKE_OSX_SYSROOT)
-    # CMAKE_OSX_SYSROOT hardcodes the concrete version of the sdk
-    # (eg .../MacOSX11.1.sdk) which changes after every update of XCode. We use
-    # the assumption that in the parent folder there is a symlink MacOSX.sdk
-    # which points to the current active sdk. This change allows releases
-    # to work when the users update their sdks.
-    # FIXME: That is a horrible hack and we should teach CIFactory to pick up
-    # the SDK directory at runtime, just as we do for the include paths to C++.
-    set (OSX_SYSROOT_DEFAULT_SDK ${CMAKE_OSX_SYSROOT})
-    if (${OSX_SYSROOT_DEFAULT_SDK} MATCHES "MacOSX[.0-9]+\.sdk")
-      get_filename_component(OSX_SYSROOT_DEFAULT_SDK ${OSX_SYSROOT_DEFAULT_SDK} DIRECTORY)
-      set (OSX_SYSROOT_DEFAULT_SDK ${OSX_SYSROOT_DEFAULT_SDK}/MacOSX.sdk/)
-    endif()
-
-    file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
-      "
-      #define CLING_OSX_SYSROOT \"${OSX_SYSROOT_DEFAULT_SDK}\"
-    ")
-  endif()
   if (CLING_CXX_PATH)
     MESSAGE(STATUS "And if not found, will invoke: '${CLING_CXX_PATH}' for them.")
     file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in


### PR DESCRIPTION
This is a necessary step to make macOS wheels work if the configuration of the target system differs, even slightly, from the one where the wheel was built. This is true also for other types of installation.
It's important to note that the system works as before, a fallback mechanism is added.