### PR TITLE
[test] Mix new and old IO through inheritance

### DIFF
--- a/roottest/root/io/newClassDef/new/CMakeLists.txt
+++ b/roottest/root/io/newClassDef/new/CMakeLists.txt
@@ -39,3 +39,7 @@ ROOTTEST_ADD_TEST(run
                                     root-io-newClassDef-new-namespace-fixture
                                     root-io-newClassDef-new-template-fixture
                                     root-io-newClassDef-new-nstemplate-fixture)
+
+# Issue 10240
+ROOTTEST_ADD_TEST(oldNewIOMix
+                  MACRO oldNewIOMix.C+)

--- a/roottest/root/io/newClassDef/new/oldNewIOMix.C
+++ b/roottest/root/io/newClassDef/new/oldNewIOMix.C
@@ -1,0 +1,24 @@
+#include <vector>
+#include "TTree.h"
+
+#ifdef __ROOTCLING__
+#pragma link C++ class A;
+#pragma link C++ class B+;
+#pragma link C++ class std::vector<B>+;
+#endif
+
+struct A {
+    int x;
+    ClassDef(A, 1);
+};
+
+struct B : A {
+    int y;
+    ClassDef(B, 1);
+};
+
+void oldNewIOMix() {
+   TTree* tree = new TTree("T", "T");
+   std::vector<B> bvec;
+   tree->Branch("B", &bvec);
+}


### PR DESCRIPTION
adding coverage for issue #10240, fixed since 6.28

Fixes #10240

