### PR TITLE
[CI] Fix python wheel apt failure.

### DIFF
--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -18,3 +18,4 @@ runs:
       with:
         name: ${{ inputs.build-tag }}
         path: wheelhouse/*
+        retention-days: 1

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -89,7 +89,9 @@ jobs:
           merge-multiple: true
 
       - name: Install required system packages
-        run: sudo apt-get install -y krb5-user xrootd-client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y krb5-user xrootd-client
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
According to the docs, one should run an apt update before installing: https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/customize-runners

Moreover, the artifact retention was reduced to one day to not occupy more space than necessary.

Note: I had to hack the workflow file to ensure that the apt step runs also in the PR. This commit will be removed before merging.

TODO:
- [x] Remove last commit