### PR TITLE
[RF] Fix dangling stack normSet after xRooNode::BuildHistogram

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -492,6 +492,7 @@ public:
 
    RooAbsProxy *getProxy(Int_t index) const;
    Int_t numProxies() const;
+   void setProxyNormSet(const RooArgSet *nset);
 
    /// De-duplicated pointer to this object's name.
    /// This can be used for fast name comparisons.
@@ -582,7 +583,6 @@ protected:
    void unRegisterProxy(RooArgProxy &proxy);
    void unRegisterProxy(RooSetProxy &proxy);
    void unRegisterProxy(RooListProxy &proxy);
-   void setProxyNormSet(const RooArgSet *nset);
 
    // Attribute list
    std::set<std::string> _boolAttrib;                // Boolean attributes

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1284,7 +1284,10 @@ Int_t RooAbsArg::numProxies() const
 }
 
 /// Forward a change in the cached normalization argset
-/// to all the registered proxies.
+/// to all the registered proxies. Passing `nullptr` makes this object forget
+/// any normalization set previously passed to `getVal()`, which is required if
+/// that set may not outlive this object (e.g. it lived on the caller's stack),
+/// as the proxies only keep a bare pointer to it.
 
 void RooAbsArg::setProxyNormSet(const RooArgSet *nset)
 {

--- a/roofit/xroofit/src/xRooNode.cxx
+++ b/roofit/xroofit/src/xRooNode.cxx
@@ -9355,6 +9355,25 @@ TH1 *xRooNode::BuildHistogram(RooAbsLValue *v, bool empty, bool errors, int binS
       }
    }
 
+   // We evaluated the above with `normSet`, which lives on this function's stack.
+   // RooFit proxies only cache a bare pointer to the last normSet and re-use it
+   // later (e.g. RooProduct::evaluate reads back _compRSet.nset()), so before it
+   // goes out of scope we must clear it everywhere it could have been cached,
+   // otherwise a later evaluation dereferences freed stack ("use of uninitialised
+   // value" in valgrind). sterilize() only walks clients, but getVal() propagates
+   // the normSet to the servers of the evaluated function, so reset those here.
+   {
+      RooArgSet evaluatedNodes;
+      for (RooAbsArg *treeRoot : {static_cast<RooAbsArg *>(rar), static_cast<RooAbsArg *>(p),
+                                  static_cast<RooAbsArg *>(oldrar), _coefs.get<RooAbsArg>()}) {
+         if (treeRoot)
+            treeRoot->treeNodeServerList(&evaluatedNodes);
+      }
+      for (RooAbsArg *node : evaluatedNodes) {
+         node->setProxyNormSet(nullptr);
+      }
+   }
+
    if (oldrar) {
       std::vector<RooAbsArg *> extra;
       if (auto s = dynamic_cast<RooSimultaneous *>(rar)) {


### PR DESCRIPTION
BuildHistogram evaluates the model with a stack-local `normSet`. RooFit proxies only cache a bare pointer to the last normalization set and re-use it later (e.g. RooProduct::evaluate reads back _compRSet.nset()), so once `normSet` goes out of scope those proxies dangle into freed stack memory. A subsequent evaluation then reads it, reported by valgrind as "use of uninitialised value" in RooAbsReal::getValV (nset->uniqueId()).

`sterilize()` was meant to forget the passed normSet, but in >=6.27 that code is disabled (the uniqueId invalidity check only guards `RooAbsPdf::_normSet`, not the proxy pointers) and it only walks clients, whereas getVal() propagates the normSet down to the servers of the evaluated function. Reset the proxy normSet on the whole server tree of every function we called getVal() on, before `normSet` is destroyed.

Thanks @TomasDado for reporting the problem!

FYI, @will-cern. If this works, I'll also submit it upstream to your xRooFit repo.