### PR TITLE
[jsroot] 7.11.1 [6.40]

### DIFF
--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -10,11 +10,11 @@ var _documentCurrentScript = typeof document !== 'undefined' ? document.currentS
 
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = '7.11.x',
+const version_id = '7.11.1',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '24/07/2026',
+version_date = '27/07/2026',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -179855,9 +179855,9 @@ function decodeZigzag32(view) {
  * @private */
 function decodeZigzag64(view) {
    for (let o = 0; o < view.byteLength; o += 8) {
-      const x = view.getUint64(o, LITTLE_ENDIAN);
-      view.setInt64(o, (x >>> 1) ^ (-(x & 1)), LITTLE_ENDIAN);
-   }
+        const x = view.getBigUint64(o, LITTLE_ENDIAN);
+        view.setBigInt64(o, (x >> 1n) ^ (-(x & 1n)), LITTLE_ENDIAN);
+    }
 }
 
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -1,10 +1,11 @@
 # JSROOT changelog
 
-## Changes in 7.11.x
+## Changes in 7.11.1
 1. Fix - prevent very long header in context menu
 2. Fix - JSON production for TWebCanvas
 3. Fix - check evaluated value of TF1
 4. Fix - corrupted page layout in SWAN after calling %rootbrowse
+5. Fix - RNtuple decodeZigzag64 for SplitInt64 columns #410
 
 
 ## Changes in 7.11.0

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -2,11 +2,11 @@
 
 /** @summary version id
   * @desc For the JSROOT release the string in format 'major.minor.patch' like '7.0.0' */
-const version_id = '7.11.x',
+const version_id = '7.11.1',
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-version_date = '24/07/2026',
+version_date = '27/07/2026',
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/rntuple.mjs
+++ b/js/modules/rntuple.mjs
@@ -234,9 +234,9 @@ function decodeZigzag32(view) {
  * @private */
 function decodeZigzag64(view) {
    for (let o = 0; o < view.byteLength; o += 8) {
-      const x = view.getUint64(o, LITTLE_ENDIAN);
-      view.setInt64(o, (x >>> 1) ^ (-(x & 1)), LITTLE_ENDIAN);
-   }
+        const x = view.getBigUint64(o, LITTLE_ENDIAN);
+        view.setBigInt64(o, (x >> 1n) ^ (-(x & 1n)), LITTLE_ENDIAN);
+    }
 }
 
 


### PR DESCRIPTION
Fix - RNtuple decodeZigzag64 for SplitInt64 columns

Tagged jsroot version for 6.40 brancg