### PR TITLE
Prepare ROOT for a TEventList without auto registration

### DIFF
--- a/math/mlp/src/TMLPAnalyzer.cxx
+++ b/math/mlp/src/TMLPAnalyzer.cxx
@@ -350,6 +350,8 @@ void TMLPAnalyzer::DrawNetwork(Int_t neuron, const char* signal, const char* bg)
    // build event lists for signal and background
    TEventList* signal_list = new TEventList("__tmpSig_MLPA");
    TEventList* bg_list     = new TEventList("__tmpBkg_MLPA");
+   signal_list->SetDirectory(gDirectory);
+   bg_list->SetDirectory(gDirectory);
    data->Draw(">>__tmpSig_MLPA",signal,"goff");
    data->Draw(">>__tmpBkg_MLPA",bg,"goff");
 

--- a/math/mlp/src/TMultiLayerPerceptron.cxx
+++ b/math/mlp/src/TMultiLayerPerceptron.cxx
@@ -459,12 +459,12 @@ TMultiLayerPerceptron::TMultiLayerPerceptron(const char * layout, TTree * data,
    fCurrentTree = -1;
    fCurrentTreeWeight = 1;
    {
-      TDirectory::TContext ctxt;
+      TDirectory::TContext ctxt{nullptr};
       fTraining = new TEventList(Form("fTrainingList_%zu",(size_t)this));
    }
    fTrainingOwner = true;
    {
-      TDirectory::TContext ctxt;
+      TDirectory::TContext ctxt{nullptr};
       fTest = new TEventList(Form("fTestList_%zu",(size_t)this));
    }
    fTestOwner = true;
@@ -479,8 +479,12 @@ TMultiLayerPerceptron::TMultiLayerPerceptron(const char * layout, TTree * data,
    fManager = nullptr;
    if (data) {
       BuildNetwork();
+      fTraining->SetDirectory(gDirectory);
+      fTest->SetDirectory(gDirectory);
       data->Draw(Form(">>fTrainingList_%zu",(size_t)this),training,"goff");
       data->Draw(Form(">>fTestList_%zu",(size_t)this),(const char *)testcut,"goff");
+      fTraining->SetDirectory(nullptr);
+      fTest->SetDirectory(nullptr);
       AttachData();
    }
    else {
@@ -538,12 +542,12 @@ TMultiLayerPerceptron::TMultiLayerPerceptron(const char * layout,
    fCurrentTree = -1;
    fCurrentTreeWeight = 1;
    {
-      TDirectory::TContext ctxt;
+      TDirectory::TContext ctxt{nullptr};
       fTraining = new TEventList(Form("fTrainingList_%zu",(size_t)this));
    }
    fTrainingOwner = true;
    {
-      TDirectory::TContext ctxt;
+      TDirectory::TContext ctxt{nullptr};
       fTest = new TEventList(Form("fTestList_%zu",(size_t)this));
    }
    fTestOwner = true;
@@ -558,8 +562,12 @@ TMultiLayerPerceptron::TMultiLayerPerceptron(const char * layout,
    fManager = nullptr;
    if (data) {
       BuildNetwork();
+      fTraining->SetDirectory(gDirectory);
+      fTest->SetDirectory(gDirectory);
       data->Draw(Form(">>fTrainingList_%zu",(size_t)this),training,"goff");
       data->Draw(Form(">>fTestList_%zu",(size_t)this),(const char *)testcut,"goff");
+      fTraining->SetDirectory(nullptr);
+      fTest->SetDirectory(nullptr);
       AttachData();
    }
    else {
@@ -646,12 +654,14 @@ void TMultiLayerPerceptron::SetTrainingDataSet(const char * train)
 {
    if(fTraining && fTrainingOwner) delete fTraining;
    {
-      TDirectory::TContext ctxt;
+      TDirectory::TContext ctxt{nullptr};
       fTraining = new TEventList(Form("fTrainingList_%zu",(size_t)this));
    }
    fTrainingOwner = true;
    if (fData) {
+      fTraining->SetDirectory(gDirectory);
       fData->Draw(Form(">>fTrainingList_%zu",(size_t)this),train,"goff");
+      fTraining->SetDirectory(nullptr);
    }
    else {
       Warning("TMultiLayerPerceptron::TMultiLayerPerceptron","Data not set. Cannot define datasets");
@@ -673,7 +683,9 @@ void TMultiLayerPerceptron::SetTestDataSet(const char * test)
    }
    fTestOwner = true;
    if (fData) {
+      fTraining->SetDirectory(gDirectory);
       fData->Draw(Form(">>fTestList_%zu",(size_t)this),test,"goff");
+      fTraining->SetDirectory(nullptr);
    }
    else {
       Warning("TMultiLayerPerceptron::TMultiLayerPerceptron","Data not set. Cannot define datasets");

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -711,6 +711,7 @@ void stress7()
    char cutname[20];
    TEventList *el[10];
    TEventList *elistall = new TEventList("elistall","Sum of all cuts");
+   elistall->SetDirectory(gDirectory);
    for (i=0;i<10;i++) {
       snprintf(elistname,20,">>elist%d",i);
       snprintf(cutname,20,"i 10 == %d",i); cutname[1] ='%';

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -378,6 +378,12 @@ void TSelectorDraw::Begin(TTree *tree)
             Abort(abrt);
             return;
          }
+         if (!fOldHistogram && hnameplus) {
+            Warning("TSelectorDraw",
+                    "TTree::Draw was asked to fill the histogram '%s', but it was not found in the current directory."
+                    "Did you forget to call histogram->SetDirectory(gDirectory) or similar?",
+                    hname);
+         }
          if (fOldHistogram && !hnameplus) fOldHistogram->Reset();  // reset unless adding is wanted
 
          if (mustdelete) {

--- a/tree/treeplayer/src/TSelectorDraw.cxx
+++ b/tree/treeplayer/src/TSelectorDraw.cxx
@@ -401,11 +401,20 @@ void TSelectorDraw::Begin(TTree *tree)
                return;
             }
             if (!enlist) {
+               if (hnameplus) {
+                  Warning(
+                     "TSelectorDraw",
+                     "TTree::Draw was asked to append to TEntryList '%s', but it was not found in the current "
+                     "directory."
+                     "Did you forget to call entryList->SetDirectory(gDirectory) or similar? Creating a new list now.",
+                     hname);
+               }
                if (optEnlistArray) {
                   enlist = new TEntryListArray(hname, realSelection.GetTitle());
                } else {
                   enlist = new TEntryList(hname, realSelection.GetTitle());
                }
+               enlist->SetDirectory(gDirectory); // TTree::Draw documentation promises it shows up in gDirectory
             }
             if (enlist) {
                if (!hnameplus) {
@@ -417,6 +426,7 @@ void TSelectorDraw::Begin(TTree *tree)
                      } else {
                         inElist = new TEntryList(*enlist);
                      }
+                     inElist->SetDirectory(gDirectory); // TTree::Draw documentation promises it shows up in gDirectory
                      fCleanElist = true;
                      fTree->SetEntryList(inElist);
                   }
@@ -439,7 +449,16 @@ void TSelectorDraw::Begin(TTree *tree)
                return;
             }
             if (!evlist) {
+               if (hnameplus) {
+                  Warning(
+                     "TSelectorDraw",
+                     "TTree::Draw was asked to append to TEventList '%s', but it was not found in the current "
+                     "directory."
+                     "Did you forget to call eventList->SetDirectory(gDirectory) or similar? Creating a new list now.",
+                     hname);
+               }
                evlist = new TEventList(hname, realSelection.GetTitle(), 1000, 0);
+               evlist->SetDirectory(gDirectory); // TTree::Draw documentation promises it shows up in gDirectory
             }
             if (evlist) {
                if (!hnameplus) {

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -1,3 +1,4 @@
+#include "TEventList.h"
 #include "TEntryListArray.h"
 
 #include "TChain.h"
@@ -270,6 +271,7 @@ TEST(TTreeReaderBasic, EntryList) {
    auto tree = MakeTree();
    EXPECT_EQ(9, tree->Draw(">>negZ","three.z<0", "entrylistarray"));
    TEntryListArray* selected = (TEntryListArray*)gDirectory->Get("negZ");
+   ASSERT_NE(selected, nullptr);
    TTreeReader aReader(tree.get(), selected);
 
    EXPECT_EQ(9, aReader.GetEntries(false));
@@ -572,6 +574,43 @@ TEST(TTreeReaderBasic, ZeroEntriesTreeCheckValueStatus)
    }
 }
 
+template <typename T>
+void TTreeDrawTest()
+{
+   constexpr auto optionString = std::is_same_v<T, TEntryList>        ? "entrylist"
+                                 : std::is_same_v<T, TEntryListArray> ? "entrylistarray"
+                                                                      : "";
+   auto tree = MakeTree();
+   tree->Draw(">>elist", "z>2.", optionString);
+   auto eventList = gDirectory->Get<T>("elist");
+   ASSERT_NE(eventList, nullptr);
+   eventList->SetDirectory(nullptr);
+   delete eventList;
+
+   auto elistUnreg = std::make_unique<T>("elistUnreg", "Unregistered entry/event list");
+   elistUnreg->SetDirectory(nullptr);
+   ROOT_EXPECT_WARNING_PARTIAL(tree->Draw(">>+elistUnreg", "z>2.", optionString), "TSelectorDraw",
+                               "TTree::Draw was asked to append to");
+   auto elistPost = gDirectory->Get("elistUnreg");
+   EXPECT_NE(elistPost, nullptr);
+   EXPECT_NE(elistUnreg.get(), elistPost);
+   delete elistPost;
+}
+
+TEST(TTreeDraw, TEventList)
+{
+   TTreeDrawTest<TEventList>();
+}
+
+TEST(TTreeDraw, TEntryList)
+{
+   TTreeDrawTest<TEntryList>();
+}
+
+TEST(TTreeDraw, TEntryListArray)
+{
+   TTreeDrawTest<TEntryListArray>();
+}
 
 #ifdef R__USE_IMT
 // Check the warning emitted to address ROOT-10972


### PR DESCRIPTION
- Prepare a few tests for TEventList that don't auto-register themselves
- Explicitly register TEventList/TEntryList to gDirectory in TTree::Draw (that's what the documentation states)
- Add test
- Add warnings if `TTree::Draw(">>+entryList")` is asked to append to a list that's not registered