### PR TITLE
[tree] Prepare ROOT for a TEntryList without auto-registration

### DIFF
--- a/test/stressEntryList.cxx
+++ b/test/stressEntryList.cxx
@@ -35,7 +35,6 @@
 // *******************Deleting the data files****************************
 // **********************************************************************
 
-#include <map>
 #include <list>
 #include <array>
 #include <functional>
@@ -52,7 +51,6 @@
 #include "TFile.h"
 #include "TSystem.h"
 #include "TError.h"
-#include "snprintf.h"
 
 Int_t stressEntryList(Int_t nentries = 10000, Int_t nfiles = 10);
 void MakeTrees(Int_t nentries, Int_t nfiles);
@@ -219,8 +217,10 @@ Bool_t Test2()
    TCut cut1("cut1", "x>0");
    TCut cut2("cut2", "y<0.1 && y>-0.1");
    TEntryList *elist1 = new TEntryList("elist1", "elist1");
-   chain->Draw(">>elist1", cut1, "entrylist");
    TEntryList *elist2 = new TEntryList("elist2", "elist2");
+   elist1->SetDirectory(gDirectory);
+   elist2->SetDirectory(gDirectory);
+   chain->Draw(">>elist1", cut1, "entrylist");
    chain->Draw(">>elist2", cut2, "entrylist");
 
    //add those 2 lists (1+2)
@@ -229,6 +229,7 @@ Bool_t Test2()
    elistsum->Add(elist2);
 
    TEntryList *elistcheck = new TEntryList("elistcheck", "elistcheck");
+   elistcheck->SetDirectory(gDirectory);
    chain->Draw(">>elistcheck", cut1 || cut2, "entrylist");
 
    Int_t n=elistcheck->GetN();
@@ -264,6 +265,7 @@ Bool_t Test2()
 
    //add by using "+" in TTree::Draw
    TEntryList *elistsum3 = new TEntryList("elistsum3", "elistsum3");
+   elistsum3->SetDirectory(gDirectory);
    chain->Draw(">>elistsum3", cut1, "entrylist");
    chain->Draw(">>+elistsum3", cut2, "entrylist");
    wrongentries3 = 0;
@@ -282,6 +284,7 @@ Bool_t Test2()
    elistsum->Subtract(elist2);
    n = elistsum->GetN();
    TEntryList *elistcheck2 = new TEntryList("elistcheck2","elistcheck2");
+   elistcheck2->SetDirectory(gDirectory);
    chain->Draw(">>elistcheck2", cut1 && !cut2, "entrylist");
 
    wrongentries4 = 0;

--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -28,27 +28,27 @@ class TEntryList: public TNamed
    TEntryList& operator=(const TEntryList&); // Not implemented
 
  protected:
-   TList      *fLists;                  ///<  a list of underlying entry lists for each tree of a chain
-   TEntryList *fCurrent;                ///<! currently filled entry list
+   TList *fLists = nullptr;        ///<  a list of underlying entry lists for each tree of a chain
+   TEntryList *fCurrent = nullptr; ///<! currently filled entry list
 
-   Int_t            fNBlocks;           ///<  number of TEntryListBlocks
-   TObjArray       *fBlocks;            ///<  blocks with indices of passing events (TEntryListBlocks)
-   Long64_t         fN;                 ///<  number of entries in the list
-   Long64_t         fEntriesToProcess;  ///<  used on proof to set the number of entries to process in a packet
-   TString          fTreeName;          ///<  name of the tree
-   TString          fFileName;          ///<  name of the file, where the tree is
-   ULong_t          fStringHash;        ///<! Hash value of a string of treename and filename
-   Int_t            fTreeNumber;        ///<! the index of the tree in the chain (used when the entry
-                                        ///<  list is used as input (TTree::SetEntryList())
+   Int_t fNBlocks = 0;             ///<  number of TEntryListBlocks
+   TObjArray *fBlocks = nullptr;   ///<  blocks with indices of passing events (TEntryListBlocks)
+   Long64_t fN = 0;                ///<  number of entries in the list
+   Long64_t fEntriesToProcess = 0; ///<  used on proof to set the number of entries to process in a packet
+   TString fTreeName;              ///<  name of the tree
+   TString fFileName;              ///<  name of the file, where the tree is
+   ULong_t fStringHash = 0;        ///<! Hash value of a string of treename and filename
+   Int_t fTreeNumber = -1;         ///<! the index of the tree in the chain (used when the entry
+                                   ///<  list is used as input (TTree::SetEntryList())
 
-   Long64_t         fLastIndexQueried;  ///<! used to optimize GetEntry() function from a loop
-   Long64_t         fLastIndexReturned; ///<! used to optimize GetEntry() function from a loop
-   bool             fShift;             ///<! true when some sub-lists don't correspond to trees
-                                        ///<  (when the entry list is used as input in TChain)
-   TDirectory      *fDirectory;         ///<! Pointer to directory holding this tree
-   bool             fReapply;           ///<  If true, TTree::Draw will 'reapply' the original cut
+   Long64_t fLastIndexQueried = -1; ///<! used to optimize GetEntry() function from a loop
+   Long64_t fLastIndexReturned = 0; ///<! used to optimize GetEntry() function from a loop
+   bool fShift = false;             ///<! true when some sub-lists don't correspond to trees
+                                    ///<  (when the entry list is used as input in TChain)
+   TDirectory *fDirectory = nullptr; ///<! Pointer to directory holding this tree
+   bool fReapply = false;           ///<  If true, TTree::Draw will 'reapply' the original cut
 
-   void             GetFileName(const char *filename, TString &fn, bool * = nullptr);
+   void GetFileName(const char *filename, TString &fn, bool * = nullptr);
 
  public:
    enum {kBlockSize = 64000}; //number of entries in each block (not the physical size).

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -165,136 +165,71 @@ End_Macro
 ////////////////////////////////////////////////////////////////////////////////
 /// default c-tor
 
-TEntryList::TEntryList() : fEntriesToProcess(0)
-{
-   fLists = nullptr;
-   fCurrent = nullptr;
-   fBlocks = nullptr;
-   fN = 0;
-   fNBlocks = 0;
-   fTreeName = "";
-   fFileName = "";
-   fStringHash = 0;
-   fTreeNumber = -1;
-   fDirectory = nullptr;
-   fReapply = false;
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fShift = false;
-}
+TEntryList::TEntryList() = default;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor with name and title
 
-TEntryList::TEntryList(const char *name, const char *title) :
-   TNamed(name, title),
-   fEntriesToProcess(0)
+TEntryList::TEntryList(const char *name, const char *title) : TNamed(name, title)
 {
-   fLists = nullptr;
-   fCurrent = nullptr;
-   fBlocks = nullptr;
-   fN = 0;
-   fNBlocks = 0;
-   fTreeName = "";
-   fFileName = "";
-   fStringHash = 0;
-   fTreeNumber = -1;
-   fReapply = false;
 
    fDirectory  = gDirectory;
-   if (fDirectory) fDirectory->Append(this);
-
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fShift = false;
+   if (fDirectory)
+      fDirectory->Append(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor with name and title, which also sets the tree
 
-TEntryList::TEntryList(const char *name, const char *title, const TTree *tree):TNamed(name, title)
+TEntryList::TEntryList(const char *name, const char *title, const TTree *tree) : TNamed(name, title)
 {
-   fLists = nullptr;
-   fCurrent = nullptr;
-   fBlocks = nullptr;
-   fN = 0;
-   fNBlocks = 0;
-   fTreeNumber = -1;
    TEntryList::SetTree(tree);
-   fReapply = false;
 
    fDirectory  = gDirectory;
-   if (fDirectory) fDirectory->Append(this);
-
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fShift = false;
+   if (fDirectory)
+      fDirectory->Append(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor with name and title, which also sets the treename and the filename
 
-TEntryList::TEntryList(const char *name, const char *title, const char *treename, const char *filename) : TNamed(name, title),fEntriesToProcess(0)
+TEntryList::TEntryList(const char *name, const char *title, const char *treename, const char *filename)
+   : TNamed(name, title)
 {
-   fLists = nullptr;
-   fCurrent = nullptr;
-   fBlocks = nullptr;
-   fNBlocks = 0;
-   fN = 0;
    SetTree(treename, filename);
-   fTreeNumber = -1;
-   fReapply = false;
 
    fDirectory  = gDirectory;
-   if (fDirectory) fDirectory->Append(this);
-
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fShift = false;
+   if (fDirectory)
+      fDirectory->Append(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// c-tor, which sets the tree
 
-TEntryList::TEntryList(const TTree *tree) : fEntriesToProcess(0)
+TEntryList::TEntryList(const TTree *tree)
 {
-   fLists = nullptr;
-   fCurrent = nullptr;
-   fBlocks = nullptr;
-   fNBlocks = 0;
-   fN = 0;
-
    SetTree(tree);
-   fTreeNumber = -1;
 
-   fReapply = false;
    fDirectory  = gDirectory;
-   if (fDirectory) fDirectory->Append(this);
-
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fShift = false;
+   if (fDirectory)
+      fDirectory->Append(this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// copy c-tor
 
-TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
+TEntryList::TEntryList(const TEntryList &elist)
+   : TNamed(elist),
+     fNBlocks(elist.fNBlocks),
+     fN(elist.fN),
+     fEntriesToProcess(elist.fEntriesToProcess),
+     fTreeName(elist.fTreeName),
+     fFileName(elist.fFileName),
+     fStringHash(elist.fStringHash),
+     fTreeNumber(elist.fTreeNumber),
+     fShift(elist.fShift),
+     fReapply(elist.fReapply)
 {
-   fNBlocks = elist.fNBlocks;
-   fTreeName = elist.fTreeName;
-   fFileName = elist.fFileName;
-   fStringHash = elist.fStringHash;
-   fTreeNumber = elist.fTreeNumber;
-   fLastIndexQueried = -1;
-   fLastIndexReturned = 0;
-   fN = elist.fN;
-   fShift = elist.fShift;
-   fLists = nullptr;
-   fBlocks = nullptr;
-   fReapply = elist.fReapply;
-   fCurrent = nullptr;
-   fEntriesToProcess = elist.fEntriesToProcess;
    if (elist.fLists){
       fLists = new TList();
       TEntryList *el1 = nullptr;
@@ -320,8 +255,6 @@ TEntryList::TEntryList(const TEntryList &elist) : TNamed(elist)
       }
       fCurrent = this;
    }
-   fDirectory  = nullptr;
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/src/TTreeTableInterface.cxx
+++ b/tree/treeplayer/src/TTreeTableInterface.cxx
@@ -200,6 +200,7 @@ void TTreeTableInterface::SyncFormulas()
 void TTreeTableInterface::InitEntries()
 {
    TEntryList *entrylist = new TEntryList(fTree);
+   entrylist->SetDirectory(fTree->GetDirectory());
 
    UInt_t ui = 0;
    Int_t i = 0;


### PR DESCRIPTION
- Adapt tests such that they work with auto-registration on and off
- clang-tidy TEntryList in preparation for #22817