### PR TITLE
[tree] Restore a removed include

### DIFF
--- a/tree/tree/src/TEventList.cxx
+++ b/tree/tree/src/TEventList.cxx
@@ -46,6 +46,7 @@ the TEventList object created in the above commands:
 - A TEventList object can be saved on a file via the Write function.
 */
 
+#include "strlcpy.h"
 #include "TEventList.h"
 #include "TBuffer.h"
 #include "TCut.h"


### PR DESCRIPTION
Fix the following compiler error on Windows:
`TEventList.cxx(304,7): error C3861: 'strlcat': identifier not found`
