### PR TITLE
[textinput] Keep the prompt on the terminal when stdout is redirected

### DIFF
--- a/core/textinput/src/textinput/TerminalConfigUnix.cpp
+++ b/core/textinput/src/textinput/TerminalConfigUnix.cpp
@@ -138,9 +138,13 @@ TerminalConfigUnix::Detach() {
 }
 
 bool TerminalConfigUnix::IsInteractive() const {
-  // Whether both stdin and stdout are attached to a tty.
-  return isatty(fileno(stdin)) && isatty(fileno(stdout))
-    && (getpgrp() == tcgetpgrp(STDOUT_FILENO));
+  // Whether we are driving an interactive terminal. This is decided by stdin,
+  // which is the terminal we read from and whose attributes we (re)configure
+  // through fFD: stdout may be redirected (e.g. to a file by the ".> file" meta
+  // command) while the command line is still driven interactively from the
+  // terminal. We must also be in the foreground process group of that terminal,
+  // otherwise reconfiguring it (raw mode) would disturb whoever controls it.
+  return isatty(fFD) && (getpgrp() == tcgetpgrp(fFD));
 }
 
 

--- a/core/textinput/src/textinput/TerminalDisplayUnix.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.cpp
@@ -103,8 +103,7 @@ namespace textinput {
   // If input is not a tty don't write in tty-mode either.
   TerminalDisplayUnix::TerminalDisplayUnix():
     TerminalDisplay(TerminalConfigUnix::Get().IsInteractive()),
-    fIsAttached(false), fNColors(16), fOutputID(STDOUT_FILENO),
-    fTTYOutputID(-1)
+    fIsAttached(false), fNColors(16), fTTYOutputID(-1)
   {
      if (::isatty(fileno(stdin))) {
         // As long as we read from a terminal, keep a handle on the controlling
@@ -122,7 +121,7 @@ namespace textinput {
            SetIsTTY(true);
      }
 
-    HandleResizeSignal(); // needs fOutputID
+    HandleResizeSignal(); // needs fTTYOutputID
     gTerminalDisplayUnix() = this;
     signal(SIGWINCH, TerminalDisplayUnix__handleResizeSignal);
 #ifdef TCSANOW
@@ -140,10 +139,6 @@ namespace textinput {
 
   TerminalDisplayUnix::~TerminalDisplayUnix() {
     Detach();
-    if (fOutputID != STDOUT_FILENO) {
-      SYNC_OUT(fOutputID);
-      ::close(fOutputID);
-    }
     if (fTTYOutputID != -1) {
       SYNC_OUT(fTTYOutputID);
       ::close(fTTYOutputID);
@@ -156,7 +151,7 @@ namespace textinput {
     struct winsize sz;
     // Query the terminal for its size: use the controlling terminal if we have
     // it, as stdout may be redirected to a file (which has no window size).
-    int sizeFD = (fTTYOutputID != -1) ? fTTYOutputID : fOutputID;
+    int sizeFD = (fTTYOutputID != -1) ? fTTYOutputID : STDOUT_FILENO;
     int ret = ioctl(sizeFD, TIOCGWINSZ, (char*)&sz);
     if (!ret && sz.ws_col) {
       SetWidth(sz.ws_col);
@@ -285,13 +280,13 @@ namespace textinput {
   /// \param[in] len length of the raw string
   void
   TerminalDisplayUnix::WriteRawString(const char *text, size_t len) {
-    int outputID = fOutputID;
     // The prompt and line-editing output normally go to stdout. But if stdout
     // is not (or no longer) connected to a terminal - most notably after the
     // ".> file" meta command redirects it to a file - write to the controlling
     // terminal instead, so the command line stays visible and usable while only
     // the executed code's output follows the redirection (issue 7626).
-    if (outputID == STDOUT_FILENO && fTTYOutputID != -1 && !::isatty(STDOUT_FILENO))
+    int outputID = STDOUT_FILENO;
+    if (fTTYOutputID != -1 && !::isatty(STDOUT_FILENO))
       outputID = fTTYOutputID;
     if (write(outputID, text, len) == -1) {
       // Silence Ubuntu's "unused result". We don't care if it fails.
@@ -312,7 +307,7 @@ namespace textinput {
   TerminalDisplayUnix::Attach() {
     // set to noecho
     if (fIsAttached) return;
-    SYNC_OUT(fOutputID);
+    SYNC_OUT(STDOUT_FILENO);
     TerminalConfigUnix::Get().Attach();
     fWritePos = Pos();
     fWriteLen = 0;
@@ -322,7 +317,7 @@ namespace textinput {
   void
   TerminalDisplayUnix::Detach() {
     if (!fIsAttached) return;
-    SYNC_OUT(fOutputID);
+    SYNC_OUT(STDOUT_FILENO);
     TerminalConfigUnix::Get().Detach();
     TerminalDisplay::Detach();
     fIsAttached = false;

--- a/core/textinput/src/textinput/TerminalDisplayUnix.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.cpp
@@ -103,13 +103,24 @@ namespace textinput {
   // If input is not a tty don't write in tty-mode either.
   TerminalDisplayUnix::TerminalDisplayUnix():
     TerminalDisplay(TerminalConfigUnix::Get().IsInteractive()),
-    fIsAttached(false), fNColors(16), fOutputID(STDOUT_FILENO)
+    fIsAttached(false), fNColors(16), fOutputID(STDOUT_FILENO),
+    fTTYOutputID(-1)
   {
-     if (::isatty(fileno(stdin)) && !::isatty(fOutputID)) {
-        // Display prompt, even if stdout is going somewhere else
-        fOutputID = ::open("/dev/tty", O_WRONLY);
-        SetIsTTY(true);
-    }
+     if (::isatty(fileno(stdin))) {
+        // As long as we read from a terminal, keep a handle on the controlling
+        // terminal so we can always display the prompt and the line-editing
+        // output there, even when stdout is not (or no longer) connected to it.
+        // In particular, the ".> file" meta command redirects stdout to a file;
+        // sending the prompt and the echo of typed characters into that file
+        // instead of to the terminal would leave the command line invisible and
+        // unusable, see https://github.com/root-project/root/issues/7626.
+        // WriteRawString() falls back to this descriptor whenever stdout is
+        // redirected, so only the output of the executed code follows the
+        // redirection, as expected.
+        fTTYOutputID = ::open("/dev/tty", O_WRONLY);
+        if (fTTYOutputID != -1)
+           SetIsTTY(true);
+     }
 
     HandleResizeSignal(); // needs fOutputID
     gTerminalDisplayUnix() = this;
@@ -133,13 +144,20 @@ namespace textinput {
       SYNC_OUT(fOutputID);
       ::close(fOutputID);
     }
+    if (fTTYOutputID != -1) {
+      SYNC_OUT(fTTYOutputID);
+      ::close(fTTYOutputID);
+    }
   }
 
   void
   TerminalDisplayUnix::HandleResizeSignal() {
 #ifdef TIOCGWINSZ
     struct winsize sz;
-    int ret = ioctl(fOutputID, TIOCGWINSZ, (char*)&sz);
+    // Query the terminal for its size: use the controlling terminal if we have
+    // it, as stdout may be redirected to a file (which has no window size).
+    int sizeFD = (fTTYOutputID != -1) ? fTTYOutputID : fOutputID;
+    int ret = ioctl(sizeFD, TIOCGWINSZ, (char*)&sz);
     if (!ret && sz.ws_col) {
       SetWidth(sz.ws_col);
 
@@ -267,7 +285,15 @@ namespace textinput {
   /// \param[in] len length of the raw string
   void
   TerminalDisplayUnix::WriteRawString(const char *text, size_t len) {
-    if (write(fOutputID, text, len) == -1) {
+    int outputID = fOutputID;
+    // The prompt and line-editing output normally go to stdout. But if stdout
+    // is not (or no longer) connected to a terminal - most notably after the
+    // ".> file" meta command redirects it to a file - write to the controlling
+    // terminal instead, so the command line stays visible and usable while only
+    // the executed code's output follows the redirection (issue 7626).
+    if (outputID == STDOUT_FILENO && fTTYOutputID != -1 && !::isatty(STDOUT_FILENO))
+      outputID = fTTYOutputID;
+    if (write(outputID, text, len) == -1) {
       // Silence Ubuntu's "unused result". We don't care if it fails.
     }
   }

--- a/core/textinput/src/textinput/TerminalDisplayUnix.h
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.h
@@ -52,6 +52,7 @@ namespace textinput {
     bool fIsAttached; // whether tty is configured
     size_t fNColors; // number of colors supported by output
     int fOutputID; // Prompt output file descriptor
+    int fTTYOutputID; // Controlling terminal, used when stdout is redirected
   };
 }
 #endif // TEXTINPUT_TERMINALDISPLAYUNIX_H

--- a/core/textinput/src/textinput/TerminalDisplayUnix.h
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.h
@@ -51,7 +51,6 @@ namespace textinput {
   private:
     bool fIsAttached; // whether tty is configured
     size_t fNColors; // number of colors supported by output
-    int fOutputID; // Prompt output file descriptor
     int fTTYOutputID; // Controlling terminal, used when stdout is redirected
   };
 }

--- a/roottest/root/rint/CMakeLists.txt
+++ b/roottest/root/rint/CMakeLists.txt
@@ -16,6 +16,15 @@ ROOTTEST_ADD_TEST(BackslashNewline
                   COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveTabCom.py
                   INPUT BackslashNewline_input.txt)
 
+# issue 7626: ".> file" must redirect the output of the executed code to the
+# file while keeping the prompt and the typed characters on the terminal (so
+# they never leak into the file). driveRedirect.py emits the content of the
+# redirected file; the reference contains only that output.
+ROOTTEST_ADD_TEST(Redirect
+                  COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/driveRedirect.py
+                  INPUT redirect_input.txt
+                  OUTREF redirect.oref)
+
 # issue 6439
 if(dataframe)
   ROOTTEST_ADD_TEST(failedCompilationBadState_1

--- a/roottest/root/rint/driveRedirect.py
+++ b/roottest/root/rint/driveRedirect.py
@@ -1,0 +1,133 @@
+# Test for issue 7626: the ".> file" meta command must redirect the output of
+# the executed code to the file, while the interactive prompt, the echo of the
+# typed characters and the line editing (e.g. recalling a previous command with
+# the up arrow) stay on the terminal and keep working - none of this must leak
+# into the file.
+#
+# ROOT is driven through a pseudo terminal (like driveTabCom.py) so that it
+# believes its stdin/stdout are a real, interactive terminal. Using pty.fork()
+# also makes that pty the controlling terminal of the ROOT process, so that
+# "/dev/tty" resolves to it even on headless machines (e.g. in the CI).
+#
+# The emulated input (read from our stdin) redirects to a file, runs two
+# commands, then recalls the first one with the up arrow and re-executes it, and
+# finally un-redirects and quits.
+#
+# We then print to our stdout, for comparison against the reference:
+#  * the content of the redirected file: it must contain only the output of the
+#    executed code, including the extra line produced by the command recalled
+#    from the history. Before the fix the prompt and the terminal escape
+#    sequences would leak into the file.
+#  * whether the terminal was left in "cooked" mode while stdout was redirected:
+#    in that case pressing the up arrow is echoed verbatim by the terminal as
+#    the raw escape sequence "\033[A" instead of being interpreted (and the line
+#    redrawn) by ROOT. We report whether that raw escape leaked to the terminal.
+#
+# Each emulated line is sent only once ROOT has displayed the next prompt, i.e.
+# once ROOT has switched the terminal to raw mode and is waiting for input. This
+# is essential: if we typed while ROOT is still starting up or busy executing a
+# command, the terminal is momentarily in cooked mode and the line discipline
+# would echo our keystrokes (including the up arrow) regardless of the bug,
+# yielding a false positive.
+
+import fcntl
+import os
+import pty
+import select
+import struct
+import sys
+import termios
+import time
+
+OUTFILE = "redirect_output.txt"
+PROMPT = b"root ["  # start of the interactive prompt "root [N] "
+
+try:
+    os.remove(OUTFILE)
+except OSError:
+    pass
+
+pid, master = pty.fork()
+if pid == 0:
+    # Child: turn into ROOT. Its stdin/stdout/stderr are the pty slave, which
+    # is now its controlling terminal.
+    os.execvp("root.exe", ["root.exe", "-b", "-l"])
+    os._exit(1)
+
+# Pin the terminal size so that the (short) recalled command is redrawn on a
+# single line, making the output deterministic across machines.
+fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+
+captured = bytearray()
+
+
+def pump(timeout):
+    # Read whatever ROOT rendered on the terminal (prompt, echo, line editing),
+    # if anything is available within `timeout`. Returns False on EOF/error.
+    if not select.select([master], [], [], timeout)[0]:
+        return True
+    try:
+        chunk = os.read(master, 4096)
+    except OSError:
+        return False
+    if not chunk:
+        return False
+    captured.extend(chunk)
+    return True
+
+
+def wait_for_prompts(count, overall_timeout=60.0):
+    # Read until at least `count` prompts have been shown (ROOT is idle, waiting
+    # for input, i.e. the terminal is in raw mode), or until the timeout.
+    deadline = time.time() + overall_timeout
+    while captured.count(PROMPT) < count and time.time() < deadline:
+        if not pump(1.0):
+            break
+
+
+# Read the whole emulated input from our stdin.
+emulated_input = b""
+while True:
+    chunk = os.read(0, 4096)
+    if not chunk:
+        break
+    emulated_input += chunk
+
+lines = emulated_input.splitlines(keepends=True)
+
+# Wait for the first prompt so ROOT is in raw mode before we type anything.
+seen = 1
+wait_for_prompts(seen)
+
+for index, line in enumerate(lines):
+    try:
+        os.write(master, line)
+    except OSError:
+        break
+    if index == len(lines) - 1:
+        break  # last line is ".q": ROOT quits, no further prompt
+    # Wait for the prompt that follows this command before typing the next line.
+    seen += 1
+    wait_for_prompts(seen)
+
+# Let ROOT finish and close the pty.
+while pump(1.0):
+    pass
+
+os.close(master)
+_, status = os.waitpid(pid, 0)
+
+# The content of the redirected file.
+with open(OUTFILE) as f:
+    sys.stdout.write(f.read())
+
+# Whether pressing the up arrow leaked the escape sequence to the terminal
+# (i.e. the terminal was stuck in cooked mode while stdout was redirected, so
+# the arrow was echoed by the terminal instead of being interpreted by ROOT).
+# A cooked terminal echoes the ESC either verbatim ("\033[A") or, more commonly,
+# in caret notation ("^[[A"); in raw mode neither is echoed.
+leaked = b"^[[A" in captured or b"\033[A" in captured
+sys.stdout.write("---\n")
+sys.stdout.write("up-arrow-leaked-raw-escape: {}\n".format("yes" if leaked else "no"))
+
+sys.exit(0 if os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0 else 1)

--- a/roottest/root/rint/redirect.oref
+++ b/roottest/root/rint/redirect.oref
@@ -1,0 +1,5 @@
+redirection-7626-line-one
+redirection-7626-line-two
+redirection-7626-line-one
+---
+up-arrow-leaked-raw-escape: no

--- a/roottest/root/rint/redirect_input.txt
+++ b/roottest/root/rint/redirect_input.txt
@@ -1,0 +1,6 @@
+.> redirect_output.txt
+printf("redirection-7626-line-one\n");
+printf("redirection-7626-line-two\n");
+[A[A
+.>
+.q


### PR DESCRIPTION
The `.> file` meta command redirects stdout to a file by dup2-ing fd 1, and the redirection persists across prompts. TerminalDisplayUnix, however, decided only once at construction where to write the prompt and line-editing output: it switched to /dev/tty only if stdout was already not a tty at startup. In an interactive session stdout is a tty at startup, so it kept writing to fd 1. Once `.> file` redirected fd 1 onto the file, the prompt, the echo of typed characters and the cursor movements all went into the file, leaving the command line invisible and unusable (arrow keys leaked raw escape sequences).

Keep a handle on the controlling terminal (/dev/tty) whenever stdin is a tty, and make WriteRawString() fall back to it when stdout is not (or no longer) connected to a terminal. As long as stdout is a terminal the prompt still goes to stdout exactly as before, so nothing changes for the common interactive case; only once stdout is redirected (e.g. by `.> file`) does the prompt go to the controlling terminal, keeping the command line usable while just the executed code's output follows the redirection.

This also guards the open("/dev/tty") result: on failure we keep writing to stdout instead of leaving the descriptor at -1.

Closes https://github.com/root-project/root/issues/7626

🤖 Done with the help of AI.

A regression test is added in a separate commit.