### PR TITLE
[tree] Fix bulk read inflating the reported branch size

### DIFF
--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -188,6 +188,7 @@ protected:
    virtual void SetAddressImpl(void *addr, bool /* implied */, Int_t /* offset */) { SetAddress(addr); }
 
 private:
+   void     DisassociateBulkBasket(Int_t basketnumber);
    Int_t    GetBasketAndFirst(TBasket*& basket, Long64_t& first, TBuffer* user_buffer);
    TBasket *GetBasketImpl(Int_t basket, TBuffer* user_buffer);
    Int_t    GetBulkEntries(Long64_t, TBuffer&);

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1296,6 +1296,33 @@ TBasket* TBranch::GetBasketImpl(Int_t basketnumber, TBuffer *user_buffer)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Drop the basket at index `basketnumber` from the list of baskets in memory.
+///
+/// Used by the bulk IO paths, which hand the basket buffer over to the user and
+/// park the basket in fExtraBasket. Clearing the slot is not enough, the
+/// bookkeeping has to follow: fNBaskets counts the baskets in memory, and
+/// TObjArray::fLast decides how many slots the array streams, so leaving fLast
+/// behind makes the branch stream one extra (empty) slot per basket read. See
+/// https://github.com/root-project/root/issues/8961.
+///
+/// Deliberately not TObjArray::RemoveAt: a bulk read leaves the array empty, so
+/// its backward scan for the new last element would run all the way down,
+/// making a full read quadratic in the number of baskets.
+
+void TBranch::DisassociateBulkBasket(Int_t basketnumber)
+{
+   if (fNBaskets <= 1) {
+      fBaskets.AddAt(nullptr, basketnumber);
+      fBaskets.SetLast(-1);
+      fNBaskets = 0;
+   } else if (fBaskets.RemoveAt(basketnumber)) {
+      // Other baskets are still in memory (e.g. with cluster prefetching), so
+      // the new last element has to be looked up.
+      --fNBaskets;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return address of basket in the file
 
 Long64_t TBranch::GetBasketSeek(Int_t basketnumber) const
@@ -1410,7 +1437,7 @@ Int_t TBranch::GetBasketAndFirst(TBasket *&basket, Long64_t &first,
             // When the user provides a memory buffer (i.e., for bulk IO), we should
             // make sure to drop all references to that buffer in the TTree afterward.
             fCurrentBasket = nullptr;
-            fBaskets[fReadBasket] = nullptr;
+            DisassociateBulkBasket(fReadBasket);
          } else {
             fCurrentBasket = basket;
          }
@@ -1515,7 +1542,7 @@ Int_t TBranch::GetBulkEntries(Long64_t entry, TBuffer &user_buf)
          user_buf.SetBuffer(buf->Buffer(), buf->BufferSize());
          buf->ResetBit(TBufferIO::kIsOwner);
          fCurrentBasket = nullptr;
-         fBaskets[fReadBasket] = nullptr;
+         DisassociateBulkBasket(fReadBasket);
       } else {
          // This is the only copy, we can't return it as is to the user, just make a copy.
          if (user_buf.BufferSize() < buf->BufferSize()) {
@@ -1633,7 +1660,7 @@ Int_t TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *
          user_buf.SetBuffer(buf->Buffer(), buf->BufferSize());
          buf->ResetBit(TBufferIO::kIsOwner);
          fCurrentBasket = nullptr;
-         fBaskets[fReadBasket] = nullptr;
+         DisassociateBulkBasket(fReadBasket);
       } else {
          // This is the only copy, we can't return it as is to the user, just make a copy.
          if (user_buf.BufferSize() < buf->BufferSize()) {

--- a/tree/tree/test/BulkApi.cxx
+++ b/tree/tree/test/BulkApi.cxx
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <memory>
 
 #include "Bytes.h"
 #include "TBranch.h"
@@ -254,4 +255,55 @@ TEST_F(BulkApiTest, BulkInMem)
       if (s < 0)
          break;
    }
+}
+
+// https://github.com/root-project/root/issues/8961
+// Reading a branch with the bulk API must not change its reported size: the bulk
+// path temporarily loads a basket into the fBaskets array and must remove it
+// cleanly afterwards, otherwise the branch streams an extra (empty) basket slot
+// and its total size grows by 4 bytes on every read.
+TEST_F(BulkApiTest, SizeInvariantAfterBulkRead)
+{
+   const std::string fileName = "BulkApiSizeInvariant.root";
+   {
+      // Heap-allocated to avoid the intermittent failures that stack-allocated
+      // TFile/TTree have caused in the past. The TTree is owned by the file.
+      std::unique_ptr<TFile> f(TFile::Open(fileName.c_str(), "recreate"));
+      f->SetCompressionLevel(0);
+      auto t = new TTree("T", "T");
+      int x = 0;
+      t->Branch("x", &x, 8000, 0); // small basket size -> many baskets
+      for (int i = 0; i < 100000; ++i) {
+         x = i;
+         t->Fill();
+      }
+      f->Write();
+   }
+
+   std::unique_ptr<TFile> f(TFile::Open(fileName.c_str()));
+   ASSERT_NE(nullptr, f);
+   auto t = f->Get<TTree>("T"); // owned by the file
+   ASSERT_NE(nullptr, t);
+   TBranch *b = t->GetBranch("x");
+   ASSERT_NE(nullptr, b);
+
+   const Long64_t sizeBefore = b->GetTotalSize();
+
+   // Read the whole branch: the size grew by 4 bytes on *every* call, so going
+   // through all the baskets also covers the accumulation over repeated reads.
+   TBufferFile buf(TBuffer::EMode::kWrite, 32 * 1024);
+   Long64_t entry = 0;
+   while (entry < t->GetEntries()) {
+      auto s = b->GetBulkRead().GetBulkEntries(entry, buf);
+      ASSERT_GT(s, 0) << "Did not read any entry with the bulk API at entry " << entry << ".";
+      entry += s;
+
+      EXPECT_EQ(sizeBefore, b->GetTotalSize())
+         << "The branch size must be invariant from the API used to read it (at entry " << entry << ").";
+      // The bulk read hands the basket buffer over to the user, so the branch
+      // must not be left holding on to the basket either.
+      EXPECT_EQ(0, b->GetListOfBaskets()->GetEntriesFast())
+         << "The bulk read left a basket behind (at entry " << entry << ").";
+   }
+   EXPECT_EQ(t->GetEntries(), entry);
 }


### PR DESCRIPTION
Calling `GetBulkRead().GetBulkEntries()/GetEntriesSerialized()` on a branch increased its reported Total Size by 4 bytes on every call, so the size was not invariant with respect to the API used to read the branch.

Root cause: a bulk read loads a basket into fBaskets via `TObjArray::AddAt` (`TBranch::GetBasketImpl`), which raises the array's fLast, then disassociates it again with a plain slot assignment, `fBaskets[fReadBasket] = nullptr`. That is not the inverse of `AddAt`: the non-const `TObjArray::operator[]` does `fLast = std::max(j, GetAbsLast())`, so writing the null actually pins fLast at fReadBasket rather than lowering it. The array is then streamed (by `GetTotalSize()`/`Print()`, and on a subsequent `TTree::Write()`) with one extra trailing slot, for which `TObjArray::Streamer` emits a 4-byte null marker.

Fix: route the three bulk-IO disassociation sites (GetBasketAndFirst, GetBulkEntries, GetEntriesSerialized) through a new private helper, `TBranch::DisassociateBulkBasket()`, which clears the slot and brings both pieces of bookkeeping back in sync: fLast, and fNBaskets (see below).

Adds a regression test (`BulkApiTest.SizeInvariantAfterBulkRead`) reading a branch to the end with the bulk API, asserting after every call that `GetTotalSize()` is unchanged and that no basket was left in the array. Without the fix it grows by exactly 4 bytes per call.

Notes for review:

- Performance, and why not `TObjArray::RemoveAt`. Dropping the basket with `fBaskets.RemoveAt(fReadBasket)` is the obvious way to keep fLast correct, but it is quadratic here: a bulk read holds exactly one basket, at an index that grows by one per call, so RemoveAt always hits its `i == fLast` case and its backward scan (`do { fLast--; } while (fLast >= 0 && !fCont[fLast]);`) finds every lower slot empty and walks all the way down to -1.

  Timing just that access pattern, a clean factor 4 per doubling (`root -b -q 'basketScanBench.C(100000)'`):

  ```C++
  /// Cost of the fLast bookkeeping in the access pattern a bulk read produces:
  /// the array holds a single basket at an index that grows by one per read.
  void basketScanBench(Int_t nbaskets = 100000)
  {
     TObjString basket("basket");
     TStopwatch sw;

     TObjArray withRemoveAt(nbaskets);
     sw.Start();
     for (Int_t i = 0; i < nbaskets; ++i) {
        withRemoveAt.AddAt(&basket, i);
        withRemoveAt.RemoveAt(i);
     }
     printf("%7d baskets  RemoveAt    %8.4f s\n", nbaskets, sw.RealTime());

     TObjArray withSetLast(nbaskets);
     sw.Start();
     for (Int_t i = 0; i < nbaskets; ++i) {
        withSetLast.AddAt(&basket, i);
        withSetLast.AddAt(nullptr, i);
        withSetLast.SetLast(-1);
     }
     printf("%7d baskets  SetLast(-1) %8.4f s\n", nbaskets, sw.RealTime());
  }
  ```
  ```
  baskets   RemoveAt   SetLast(-1)
  25000     0.0777 s     0.0005 s
  50000     0.3272 s     0.0009 s
  100000     1.2910 s     0.0018 s
  200000     5.0699 s     0.0035 s
  ```

  End to end on a branch with 107298 baskets (`root -b -q 'bulkReadBench.C(25000000, 1000)'`):

  ```C++
  /// Time a full bulk read of a branch with many baskets.
  void bulkReadBench(Long64_t nentries = 25000000, Int_t basketBytes = 1000)
  {
     const TString fname = TString::Format("bulkReadBench_%lld_%d.root", nentries, basketBytes);

     if (gSystem->AccessPathName(fname)) { // reuse the file across builds
        std::unique_ptr<TFile> f{TFile::Open(fname, "recreate")};
        f->SetCompressionLevel(0);
        auto t = new TTree("T", "T");
        t->SetAutoFlush(0); // keep the small baskets, OptimizeBaskets() would grow them
        int x = 0;
        t->Branch("x", &x, basketBytes, 0);
        for (Long64_t i = 0; i < nentries; ++i) {
           x = i;
           t->Fill();
        }
        f->Write();
     }

     std::unique_ptr<TFile> f{TFile::Open(fname)};
     auto b = f->Get<TTree>("T")->GetBranch("x");

     TBufferFile buf(TBuffer::kWrite, 32 * 1024);
     TStopwatch sw;
     sw.Start();
     for (Long64_t entry = 0; entry < nentries;) {
        const auto n = b->GetBulkRead().GetBulkEntries(entry, buf);
        if (n <= 0) {
           printf("bulk read failed at entry %lld\n", entry);
           return;
        }
        entry += n;
     }
     printf("%7d baskets  bulk read   %8.4f s\n", b->GetWriteBasket() + 1, sw.RealTime());
  }
  ```

  ```txt
  master (plain slot assignment)   0.15 s
  with TObjArray::RemoveAt         1.70 s   <- 11x slower
  this patch                       0.15 s
  ```

  The scan would be 80% of the whole bulk read, dwarfing the actual IO. DisassociateBulkBasket instead answers the question without searching: when the array is left empty, the new fLast is simply -1. That is the fast case DropBaskets already uses, guard included. RemoveAt is kept for when other baskets are still resident (cluster prefetching), where the lookup is real work.

- fNBaskets. The fast-path guard needs it accurate, and it was not: the bulk-IO paths increment it in GetBasketImpl but never decremented it when dropping the basket, so it drifted upwards on every bulk read, silently mis-steering GetFreshBasket's `fNBaskets == 1` basket reuse and DropBaskets's fast/slow choice. The helper now decrements it, a fix in its own right.

- Scope. Fixing the read path was preferred over making TObjArray::Streamer / GetTotalSize tolerant of trailing nulls, so that a bulk read leaves no observable state change at all. Other sites null a slot the same inflating way (the flush path, the basket-unload paths) and share the latent bug, but they are unrelated code paths not exercised by this issue and are better addressed separately.

- Only one of the two disassociation sites fires per bulk read: if the basket had to be loaded, GetBasketAndFirst clears it and GetBulkEntries then sees `&user_buf == buf`; otherwise only GetBulkEntries clears it. The helper is a no-op on an already-cleared slot anyway. The basket is not leaked, it is parked in fExtraBasket.

Closes https://github.com/root-project/root/issues/8961

🤖 Done with the help of AI.