### PR TITLE
[treeplayer] Fix array reading of typedef leaves via branch.leaf syntax

### DIFF
--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -843,8 +843,8 @@ bool ROOT::Internal::TTreeReaderArrayBase::GetBranchAndLeaf(TBranch *&branch, TL
       return false;
    }
 
-   if (tempDict->IsA() == TDataType::Class() &&
-       TDictionary::GetDictionary(((TDataType *)tempDict)->GetTypeName()) == fDict) {
+   if (tempDict->IsA() == TDataType::Class() && fDict->IsA() == TDataType::Class() &&
+       ((TDataType *)tempDict)->GetType() == ((TDataType *)fDict)->GetType()) {
       // fLeafOffset = myLeaf->GetOffset() / 4;
       branchActualType = fDict;
       fLeaf = myLeaf;

--- a/tree/treeplayer/test/leafs.cxx
+++ b/tree/treeplayer/test/leafs.cxx
@@ -254,3 +254,31 @@ TEST(TTreeReaderLeafs, BranchAndLeafWithDifferentNames)
    EXPECT_EQ(*rvwithdot, 42);
    EXPECT_FALSE(r.Next());
 }
+
+// Test for https://github.com/root-project/root/issues/9758
+// A TTreeReaderArray of a typedef'd fundamental type (e.g. ULong64_t) must be
+// readable through the extended "branch.leaf" syntax, not only through the plain
+// branch name. The leaf type name ("ULong64_t") and the reader's resolved type
+// name ("unsigned long long") differ, so the leaf/reader match must compare the
+// underlying data type, not the dictionary identity.
+TEST(TTreeReaderLeafs, ArrayLeafTypedefWithDots)
+{
+   TTree t("t", "t");
+   Int_t n = 3;
+   ULong64_t x[3] = {1, 2, 3};
+   t.Branch("n", &n, "n/I");
+   t.Branch("x", x, "x[n]/l");
+   t.Fill();
+
+   TTreeReader r(&t);
+   TTreeReaderArray<ULong64_t> arr(r, "x");
+   TTreeReaderArray<ULong64_t> arrWithDot(r, "x.x");
+   ASSERT_TRUE(r.Next());
+   ASSERT_EQ(arr.GetSize(), 3u);
+   ASSERT_EQ(arrWithDot.GetSize(), 3u);
+   for (std::size_t i = 0; i < arr.GetSize(); ++i) {
+      EXPECT_EQ(arr[i], x[i]);
+      EXPECT_EQ(arrWithDot[i], x[i]);
+   }
+   EXPECT_FALSE(r.Next());
+}


### PR DESCRIPTION
TTreeReaderArray<ULong64_t>(r, "x.x") failed with "Leaf of type ULong64_t cannot be read by TTreeReaderValue<unsigned long long>", while the plain branch name "x" worked.

TTreeReaderArrayBase::GetBranchAndLeaf() matched the leaf type against the reader type by comparing TDictionary object identity. For a typedef'd fundamental such as ULong64_t, the leaf's TDataType is the typedef itself (GetTypeName() returns "ULong64_t", not the resolved "unsigned long long"), so the looked-up dictionary differed from fDict (the "unsigned long long" TDataType) and the match failed even though both denote the same fundamental type.

Compare the underlying EDataType instead, mirroring what TTreeReaderValue already does. This fixes ULong64_t and every other typedef'd fundamental.

Closes #9758.

🤖 Done with the help of AI.