### PR TITLE
[treeplayer] Support left-justified columns in TTree::Scan

### DIFF
--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -2433,6 +2433,8 @@ void TTreePlayer::RecursiveRemove(TObject *obj)
 ///       conversion specifier is given, will be suffixed by the letter g.
 ///       before being passed to fprintf.  If no format is specified for a
 ///       column, the default is used  (aka ${colsize}.${precision}g )
+///       As with printf, a leading minus sign left-justifies the column,
+///       e.g. `col=-20s` prints a 20-character-wide, left-justified column.
 ///
 /// For example:
 /// ~~~{.cpp}
@@ -2519,6 +2521,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
               || opt[numpos+numlen] == 'h'
               || opt[numpos+numlen] == 's'
               || opt[numpos+numlen] == '#'
+              || opt[numpos+numlen] == '-'
               || opt[numpos+numlen]=='.'
               || opt[numpos+numlen]==':')) numlen++;
       TString flist = opt(numpos,numlen);
@@ -2541,7 +2544,9 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
             colFormats.push_back(flist(i,next-i));
             i = next;
          }
-         UInt_t siz = atoi(colFormats[colFormats.size()-1].Data());
+         // A leading '-' requests left-justification (printf convention) and
+         // yields a negative size; a size of 0 means "use the default".
+         Int_t siz = atoi(colFormats[colFormats.size()-1].Data());
          colSizes.push_back( siz ? siz : colDefaultSize );
       }
    }
@@ -2679,7 +2684,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    if (hasArray) onerow += "***********";
 
    for (ui=0;ui<ncols;ui++) {
-      TString starFormat = Form("*%%%d.%ds",colSizes[ui]+2,colSizes[ui]+2);
+      TString starFormat = Form("*%%%d.%ds",std::abs(colSizes[ui])+2,std::abs(colSizes[ui])+2);
       onerow += Form(starFormat.Data(),var[ui]->PrintValue(-2));
    }
    if (fScanRedirect)
@@ -2689,7 +2694,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    onerow = "*    Row   ";
    if (hasArray) onerow += "* Instance ";
    for (ui=0;ui<ncols;ui++) {
-      TString numbFormat = Form("* %%%d.%ds ",colSizes[ui],colSizes[ui]);
+      TString numbFormat = Form("* %%%d.%ds ",colSizes[ui],std::abs(colSizes[ui]));
       onerow += Form(numbFormat.Data(),var[ui]->PrintValue(-1));
    }
    if (fScanRedirect)
@@ -2699,7 +2704,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    onerow = "***********";
    if (hasArray) onerow += "***********";
    for (ui=0;ui<ncols;ui++) {
-      TString starFormat = Form("*%%%d.%ds",colSizes[ui]+2,colSizes[ui]+2);
+      TString starFormat = Form("*%%%d.%ds",std::abs(colSizes[ui])+2,std::abs(colSizes[ui])+2);
       onerow += Form(starFormat.Data(),var[ui]->PrintValue(-2));
    }
    if (fScanRedirect)
@@ -2767,7 +2772,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
             onerow += Form("* %8d ",inst);
          }
          for (ui=0;ui<ncols;++ui) {
-            TString numbFormat = Form("* %%%d.%ds ",colSizes[ui],colSizes[ui]);
+            TString numbFormat = Form("* %%%d.%ds ",colSizes[ui],std::abs(colSizes[ui]));
             if (var[ui]->GetNdim()) onerow += Form(numbFormat.Data(),var[ui]->PrintValue(0,inst,colFormats[ui].Data()));
             else {
                TString emptyForm = Form("* %%%dc ",colSizes[ui]);
@@ -2797,7 +2802,7 @@ Long64_t TTreePlayer::Scan(const char *varexp, const char *selection,
    onerow = "***********";
    if (hasArray) onerow += "***********";
    for (ui=0;ui<ncols;ui++) {
-      TString starFormat = Form("*%%%d.%ds",colSizes[ui]+2,colSizes[ui]+2);
+      TString starFormat = Form("*%%%d.%ds",std::abs(colSizes[ui])+2,std::abs(colSizes[ui])+2);
       onerow += Form(starFormat.Data(),var[ui]->PrintValue(-2));
    }
    if (fScanRedirect)

--- a/tree/treeplayer/test/CMakeLists.txt
+++ b/tree/treeplayer/test/CMakeLists.txt
@@ -15,6 +15,8 @@ add_custom_command(TARGET treeplayer_branchobject POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/branchobject.root branchobject.root)
 endif()
 
+ROOT_ADD_GTEST(treeplayer_gh11786 gh11786.cxx LIBRARIES TreePlayer)
+
 ROOT_ADD_GTEST(treeplayer_gh16804 gh16804.cxx LIBRARIES TreePlayer)
 
 ROOT_ADD_GTEST(treeplayer_gh16805 gh16805.cxx LIBRARIES TreePlayer)

--- a/tree/treeplayer/test/gh11786.cxx
+++ b/tree/treeplayer/test/gh11786.cxx
@@ -1,0 +1,116 @@
+/// Regression test for https://github.com/root-project/root/issues/11786
+///
+/// TTreePlayer::Scan should honour the printf left-justification flag ('-')
+/// in the "col=" option. Before the fix, a '-' in the column specification
+/// would abort the parsing of the format list: all columns from the first '-'
+/// onwards reverted to the default width and stayed right-justified.
+
+#include <TTree.h>
+#include <TTreePlayer.h>
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct FileRAII {
+   const char *fPath;
+   FileRAII(const char *name) : fPath(name) {}
+   ~FileRAII() { std::remove(fPath); }
+};
+
+// Capture the (redirected) output of a TTree::Scan call.
+std::string
+ScanToString(TTree &tree, const char *varexp, const char *selection, const char *option, const char *redirectPath)
+{
+   auto *player = static_cast<TTreePlayer *>(tree.GetPlayer());
+   FileRAII redirectFile{redirectPath};
+   player->SetScanRedirect(true);
+   player->SetScanFileName(redirectFile.fPath);
+   tree.Scan(varexp, selection, option);
+   player->SetScanRedirect(false);
+
+   std::ifstream redirectStream(redirectFile.fPath);
+   std::stringstream redirectOutput;
+   redirectOutput << redirectStream.rdbuf();
+   return redirectOutput.str();
+}
+
+TTree *MakeTree()
+{
+   auto *tree = new TTree("t", "t");
+   static char name[32];
+   static int val;
+   tree->Branch("name", name, "name/C");
+   tree->Branch("val", &val, "val/I");
+   const char *names[] = {"alpha", "b", "gammalong", "de"};
+   const int vals[] = {1, 22, 333, 4};
+   for (int i = 0; i < 4; ++i) {
+      strcpy(name, names[i]);
+      val = vals[i];
+      tree->Fill();
+   }
+   return tree;
+}
+
+} // namespace
+
+TEST(TTreePlayerScan, LeftJustifiedColumns)
+{
+   std::unique_ptr<TTree> tree{MakeTree()};
+
+   const std::string out = ScanToString(*tree, "name:val", "", "col=-20s:-8d", "gh11786_left.txt");
+
+   const std::string expected = "**********************************************\n"
+                                "*    Row   * name                 * val      *\n"
+                                "**********************************************\n"
+                                "*        0 * alpha                * 1        *\n"
+                                "*        1 * b                    * 22       *\n"
+                                "*        2 * gammalong            * 333      *\n"
+                                "*        3 * de                   * 4        *\n"
+                                "**********************************************\n";
+
+   EXPECT_EQ(out, expected);
+}
+
+TEST(TTreePlayerScan, RightJustifiedColumnsStillWork)
+{
+   std::unique_ptr<TTree> tree{MakeTree()};
+
+   const std::string out = ScanToString(*tree, "name:val", "", "col=20s:8d", "gh11786_right.txt");
+
+   const std::string expected = "**********************************************\n"
+                                "*    Row   *                 name *      val *\n"
+                                "**********************************************\n"
+                                "*        0 *                alpha *        1 *\n"
+                                "*        1 *                    b *       22 *\n"
+                                "*        2 *            gammalong *      333 *\n"
+                                "*        3 *                   de *        4 *\n"
+                                "**********************************************\n";
+
+   EXPECT_EQ(out, expected);
+}
+
+// A default (right-justified) column sandwiched between left-justified ones:
+// this exercises the case where the '-' used to abort parsing mid-list.
+TEST(TTreePlayerScan, MixedJustification)
+{
+   std::unique_ptr<TTree> tree{MakeTree()};
+
+   const std::string out = ScanToString(*tree, "name:name:val", "", "col=-15s::-6d", "gh11786_mixed.txt");
+
+   const std::string expected = "***************************************************\n"
+                                "*    Row   * name            *      name * val    *\n"
+                                "***************************************************\n"
+                                "*        0 * alpha           *     alpha * 1      *\n"
+                                "*        1 * b               *         b * 22     *\n"
+                                "*        2 * gammalong       * gammalong * 333    *\n"
+                                "*        3 * de              *        de * 4      *\n"
+                                "***************************************************\n";
+
+   EXPECT_EQ(out, expected);
+}


### PR DESCRIPTION
TTreePlayer::Scan documents that the "col=" format strings follow the printf specification, but the parser did not accept the '-' left-justification flag: the scan of the "col=" value stopped at the first '-', so every column from there on silently reverted to the default (right-justified) width.

Accept '-' while scanning the "col=" value, read the per-column size as a signed integer (a negative size now marks a left-justified column), and build the field-width format strings so a negative width stays valid printf: the sign drives the justification while std::abs() is used for the precision and the '*' border widths.

Closes #11786.

🤖 Done with the help of AI.
