### PR TITLE
[DF] Support for RHist with VariationsFor (on root master)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -541,6 +541,13 @@ public:
       }
    }
 
+   RHistFillHelper MakeNew(void *newResult, std::string_view /*variation*/ = "nominal")
+   {
+      auto &result = *static_cast<std::shared_ptr<Result_t> *>(newResult);
+      result->Clear();
+      return RHistFillHelper(result, fContexts.size());
+   }
+
    std::string GetActionName() { return "Hist"; }
 };
 
@@ -587,6 +594,13 @@ public:
    }
 
    void Finalize() {}
+
+   RHistEngineFillHelper MakeNew(void *newResult, std::string_view /*variation*/ = "nominal")
+   {
+      auto &result = *static_cast<std::shared_ptr<Result_t> *>(newResult);
+      result->Clear();
+      return RHistEngineFillHelper(result);
+   }
 
    std::string GetActionName() { return "Hist"; }
 };

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -65,6 +65,37 @@ auto PassAsVec(F &&f) -> PassAsVecHelper<std::make_index_sequence<N>, T, F>
    return PassAsVecHelper<std::make_index_sequence<N>, T, F>(std::forward<F>(f));
 }
 
+/**
+ * \brief Helper function to add a copy of an object to a vector of shared_ptrs, used in the implementation of
+ * VariationsFor.
+ * \tparam T An object that is used as result of a RDataFrame action, e.g. a histogram
+ * \param obj The object to be copied and wrapped by a new std::shared_ptr.
+ *
+ * The default implementation of this function template uses copy constructor, which should work for most objects types
+ * since they are copied for each slot.
+ */
+template <typename T>
+std::shared_ptr<T> CopyForVariations(const T &obj)
+{
+   return std::make_shared<T>(obj);
+}
+
+/// \brief Specialization of CopyForVariations for ROOT::Experimental::RHist objects, which are not copyable but
+/// clonable.
+template <typename B>
+std::shared_ptr<ROOT::Experimental::RHist<B>> CopyForVariations(const ROOT::Experimental::RHist<B> &obj)
+{
+   return std::make_shared<ROOT::Experimental::RHist<B>>(obj.Clone());
+}
+
+/// \brief Specialization of CopyForVariations for ROOT::Experimental::RHistEngine objects, which are not copyable but
+/// clonable.
+template <typename B>
+std::shared_ptr<ROOT::Experimental::RHistEngine<B>> CopyForVariations(const ROOT::Experimental::RHistEngine<B> &obj)
+{
+   return std::make_shared<ROOT::Experimental::RHistEngine<B>>(obj.Clone());
+}
+
 } // namespace RDF
 } // namespace Internal
 
@@ -243,9 +274,9 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
       // clone the result once for each variation
       variedResults.reserve(nVariations);
       for (auto i = 0u; i < nVariations; ++i){
-         // implicitly assuming that T is copiable: this should be the case
-         // for all result types in use, as they are copied for each slot
-         variedResults.emplace_back(new T{*resPtr.fObjPtr});
+
+         // Make a copy of the result object for this variation
+         variedResults.push_back(ROOT::Internal::RDF::CopyForVariations(*resPtr.fObjPtr));
 
          // Check if the result's type T inherits from TNamed
          if constexpr (std::is_base_of<TNamed, T>::value) {

--- a/tree/dataframe/test/dataframe_hist.cxx
+++ b/tree/dataframe/test/dataframe_hist.cxx
@@ -455,6 +455,78 @@ TEST_P(RDFHist, WeightInvalidNumberOfArgumentsJit)
    EXPECT_THROW(dfXW.Hist(engine, {"x", "x"}, "w"), std::invalid_argument);
 }
 
+TEST_P(RDFHist, Variations)
+{
+   RDataFrame df(10);
+   auto dfX = df.Define("x", [](ULong64_t e) -> Float_t { return e + 5.5f; }, {"rdfentry_"})
+                 .Vary("x", [](Float_t x) { return ROOT::RVecF{x - 1.0f, x + 1.0f}; }, {"x"}, 2);
+
+   const RRegularAxis axis(10, {5.0, 15.0});
+   auto hist = dfX.Hist</*BinContentType=*/double, Float_t>({axis}, {"x"});
+   auto vars = ROOT::RDF::Experimental::VariationsFor(hist);
+
+   // Check nominal
+   EXPECT_EQ(hist->GetNEntries(), 10);
+   for (auto index : axis.GetNormalRange()) {
+      EXPECT_EQ(hist->GetBinContent(index), 1.0);
+   }
+
+   // Check variations
+   EXPECT_EQ(vars.GetKeys().size(), 3); // nominal + 2 variations
+   for (const auto &key : vars.GetKeys()) {
+      auto &varHist = vars[key];
+      EXPECT_EQ(varHist.GetNEntries(), 10);
+      for (auto index : axis.GetNormalRange()) {
+         if (key == "nominal") {
+            EXPECT_EQ(varHist.GetBinContent(index), 1.0);
+         } else if (key == "x:0") {
+            EXPECT_EQ(varHist.GetBinContent(index), (index.GetIndex() == 9 ? 0.0 : 1.0));
+         } else if (key == "x:1") {
+            EXPECT_EQ(varHist.GetBinContent(index), (index.GetIndex() == 0 ? 0.0 : 1.0));
+         } else {
+            FAIL() << "Unexpected variation key: " << key;
+         }
+      }
+   }
+}
+
+TEST_P(RDFHist, VariationsEngine)
+{
+   RDataFrame df(10);
+   auto dfX = df.Define("x", [](ULong64_t e) -> Float_t { return e + 5.5f; }, {"rdfentry_"})
+                 .Vary("x", [](Float_t x) { return ROOT::RVecF{x - 1.0f, x + 1.0f}; }, {"x"}, 2);
+
+   const RRegularAxis axis(10, {5.0, 15.0});
+   auto hist = std::make_shared<RHistEngine<double>>(axis);
+   auto resPtr = dfX.Hist<Float_t>(hist, {"x"});
+   auto vars = ROOT::RDF::Experimental::VariationsFor(resPtr);
+
+   // Trigger the run
+   resPtr.GetValue();
+
+   // Check nominal
+   for (auto index : axis.GetNormalRange()) {
+      EXPECT_EQ(hist->GetBinContent(index), 1.0);
+   }
+
+   // Check variations
+   EXPECT_EQ(vars.GetKeys().size(), 3); // nominal + 2 variations
+   for (const auto &key : vars.GetKeys()) {
+      auto &varHist = vars[key];
+      for (auto index : axis.GetNormalRange()) {
+         if (key == "nominal") {
+            EXPECT_EQ(varHist.GetBinContent(index), 1.0);
+         } else if (key == "x:0") {
+            EXPECT_EQ(varHist.GetBinContent(index), (index.GetIndex() == 9 ? 0.0 : 1.0));
+         } else if (key == "x:1") {
+            EXPECT_EQ(varHist.GetBinContent(index), (index.GetIndex() == 0 ? 0.0 : 1.0));
+         } else {
+            FAIL() << "Unexpected variation key: " << key;
+         }
+      }
+   }
+}
+
 INSTANTIATE_TEST_SUITE_P(Seq, RDFHist, ::testing::Values(false));
 
 #ifdef R__USE_IMT


### PR DESCRIPTION
# Support for RHist with VariationsFor

## Changes or fixes:

In order to allow VariationsFor on RHist, this PR does two things:
 * change the plain copy of the object with a call to a template function that I can specialise to use `Clone()` on `RHist` and `RHistEngine` that are non-copiable.
 * implements the `MakeNew` method for `RHistFillHelper` and `RHistEngineFillHelper`

Both changes are trivial, all the existing logic for VariationsFor, copying and filling RHists is unchanged.

To check that the code compiles and run, two unit tests are added, for `RHistFillHelper` and `RHistEngineFillHelper`. 
No attempt is made of testing `VariationsFor` on all possible code paths (JIT vs compile time, 1D vs multi-D, weights vs no weights, etc.) because the code changes are agnostic to all that.

This PR is based on the current master, but I have also a branch on top of https://github.com/root-project/root/pull/22899 from @hahnjo : the two features are orthogonal, but some trivial merge conflicts are expected in the unit tests.

## Checklist:

- [x] tested changes locally
- [x] tested with `ctest -R gtest-tree-dataframe-dataframe-hist` 

This PR fixes #22954

