### PR TITLE
Use dynamic allocation in `R__memcompress()`

### DIFF
--- a/core/zip/src/Bits.c
+++ b/core/zip/src/Bits.c
@@ -299,7 +299,7 @@ ulg R__memcompress(char *tgt, ulg tgtsize, const char *src, ulg srcsize)
     ush flags    = 0;
     ulg crc      = 0;
     int method   = Z_DEFLATED;
-    bits_internal_state state;
+    bits_internal_state *state = (bits_internal_state *) malloc(sizeof(bits_internal_state));
 
     if (tgtsize <= 6L) { R__error("target buffer too small"); /* errorflag = 1; */ }
 #if 0
@@ -307,27 +307,27 @@ ulg R__memcompress(char *tgt, ulg tgtsize, const char *src, ulg srcsize)
     crc = updcrc(src, (extent) srcsize);
 #endif
 #ifdef DYN_ALLOC
-    state.R__window = 0;
-    state.R__prev = 0;
+    state->R__window = 0;
+    state->R__prev = 0;
 #endif
 
     /* R__read_buf  = R__mem_read; */
     /* assert(R__read_buf == R__mem_read); */
-    state.in_buf    = src;
-    state.in_size   = (unsigned)srcsize;
-    state.in_offset = 0;
+    state->in_buf    = src;
+    state->in_size   = (unsigned)srcsize;
+    state->in_offset = 0;
 
-    state.out_buf    = tgt;
-    state.out_size   = (unsigned)tgtsize;
-    state.out_offset = 2 + 4;
-    state.R__window_size = 0L;
+    state->out_buf    = tgt;
+    state->out_size   = (unsigned)tgtsize;
+    state->out_offset = 2 + 4;
+    state->R__window_size = 0L;
 
-    R__bi_init(&state);
-    state.t_state = R__get_thread_tree_state();
-    R__ct_init(state.t_state, &att, &method);
-    R__lm_init(&state,(gCompressionLevel != 0 ? gCompressionLevel : 1), &flags);
-    R__Deflate(&state,&(state.error_flag));
-    state.R__window_size = 0L; /* was updated by lm_init() */
+    R__bi_init(state);
+    state->t_state = R__get_thread_tree_state();
+    R__ct_init(state->t_state, &att, &method);
+    R__lm_init(state,(gCompressionLevel != 0 ? gCompressionLevel : 1), &flags);
+    R__Deflate(state,&(state->error_flag));
+    state->R__window_size = 0L; /* was updated by lm_init() */
 
     /* For portability, force little-endian order on all machines: */
     tgt[0] = (char)(method & 0xff);
@@ -337,7 +337,12 @@ ulg R__memcompress(char *tgt, ulg tgtsize, const char *src, ulg srcsize)
     tgt[4] = (char)((crc >> 16) & 0xff);
     tgt[5] = (char)((crc >> 24) & 0xff);
 
-    return (ulg)state.out_offset;
+    ulg res = (ulg)state->out_offset;
+
+    R__lm_free(state);
+    free(state);
+
+    return res;
 }
 
 

--- a/core/zip/src/Bits.c
+++ b/core/zip/src/Bits.c
@@ -300,6 +300,10 @@ ulg R__memcompress(char *tgt, ulg tgtsize, const char *src, ulg srcsize)
     ulg crc      = 0;
     int method   = Z_DEFLATED;
     bits_internal_state *state = (bits_internal_state *) malloc(sizeof(bits_internal_state));
+    if (!state) {
+        R__error("fail to allocate bits_internal_state struct");
+        return 0L;
+    }
 
     if (tgtsize <= 6L) { R__error("target buffer too small"); /* errorflag = 1; */ }
 #if 0

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -167,6 +167,9 @@ static void R__zipOld(int cxlevel, int *srcsize, const char *src, int *tgtsize, 
     tgt[8] = (char)((state.in_size >> 16) & 0xff);
 
     *irep     = state.out_offset;
+
+    R__lm_free(&state);
+
     return;
 }
 

--- a/core/zip/src/ZDeflate.c
+++ b/core/zip/src/ZDeflate.c
@@ -301,7 +301,7 @@ int R__lm_init (bits_internal_state *state, int pack_level, ush *flags)
 /* ===========================================================================
  * Free the window and hash table
  */
-void R__lm_free()
+void R__lm_free(bits_internal_state *state)
 {
 #ifdef DYN_ALLOC
     if (state->R__window != NULL) {
@@ -313,6 +313,8 @@ void R__lm_free()
         fcfree(state->R__head);
         state->R__prev = state->R__head = NULL;
     }
+#else
+   (void) state;
 #endif /* DYN_ALLOC */
 }
 

--- a/core/zip/src/ZIP.h
+++ b/core/zip/src/ZIP.h
@@ -100,7 +100,7 @@ typedef struct tree_internal_state tree_internal_state;
 
         /* in deflate.c */
 int R__lm_init OF((bits_internal_state *state,int pack_level, ush *flags));
-void R__lm_free OF((void));
+void R__lm_free OF((bits_internal_state *state));
 ulg  R__Deflate OF((bits_internal_state *state,int *errorflag));
 
         /* in trees.c */


### PR DESCRIPTION
Allocate dynamically `bits_internal_state` struct which is about 128K

Probably one also can use dynamic allocation of same struct in `R__zipOld()` if by chance it will be used within THttpServer context.

Also correctly implement `R__lm_free()` function and call it.

Fix https://github.com/root-project/root/issues/22938