### PR TITLE
[XRF] Remove the silent change of the asimov null hypothesis

### DIFF
--- a/roofit/xroofit/src/xRooNLLVar.cxx
+++ b/roofit/xroofit/src/xRooNLLVar.cxx
@@ -1775,14 +1775,6 @@ std::shared_ptr<xRooNLLVar::xRooHypoPoint> xRooNLLVar::xRooHypoPoint::asimov(boo
          // dynamic_cast<RooRealVar *>(p)->removeRange("physical"); -- can't use this as will modify shared property
          if (auto v = dynamic_cast<RooRealVar *>(p)) {
             v->deleteSharedProperties(); // effectively removes all custom ranges
-            if (v->getVal() == 0) {
-               // for discovery tests, we generate asimov at mu!=0 and then evaluate the two sided
-               // at some value of mu. Normally we would use mu=0 but if we have a bin
-               // with only signal contribution (no bkg) will get asimov data in that bin
-               // and no prediction ... the cfit(mu=0) will never succeed on this
-               // so lets move to half the alt value instead (the value used to generate)
-               v->setVal(theFit->constPars().getRealValue(v->GetName()) * 0.5);
-            }
          }
       }
 


### PR DESCRIPTION
# This Pull request:
XRooFit changed the asimov null hypothesis, disallowing a value of 0.0. This is done because bins with signal but no background contributions result in infinities when the asimov data set is created at mu=1.0 and tested at mu=0.0.

I suggest we omit the change of this value, as this changes the result of the expected p-value without alerting the user behing the scenes. Furthermore, the issue lies with the workspaces, and not the calculation of the pvalue in xroofit. 

@will-cern Do you aggree with this change?
