### PR TITLE
[RF] Refactor RooAICRegistry and its usage

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -64,7 +64,6 @@
 #pragma link C++ class RooAddGenContext+ ;
 #pragma link C++ class RooAddition+ ;
 #pragma link C++ class RooAddModel+ ;
-#pragma link C++ class RooAICRegistry+ ;
 #pragma link C++ class RooArgList+ ;
 #pragma link C++ class RooArgProxy+ ;
 #pragma link C++ class RooArgSet+ ;

--- a/roofit/roofitcore/inc/RooAICRegistry.h
+++ b/roofit/roofitcore/inc/RooAICRegistry.h
@@ -16,44 +16,47 @@
 #ifndef ROO_AIC_REGISTRY
 #define ROO_AIC_REGISTRY
 
+#include <array>
+#include <memory>
 #include <vector>
-#include "Rtypes.h"
 
 class RooArgSet;
 
-typedef RooArgSet* pRooArgSet ;
-
+/// Registry for analytical integration codes.
 class RooAICRegistry {
 
 public:
-  RooAICRegistry(UInt_t size = 10) ;
-  RooAICRegistry(const RooAICRegistry &other);
-  RooAICRegistry &operator=(const RooAICRegistry &other);
-  RooAICRegistry(RooAICRegistry &&other) = default;
-  RooAICRegistry &operator=(RooAICRegistry &&other) = default;
-  virtual ~RooAICRegistry() ;
+   RooAICRegistry(std::size_t size = 10);
+   RooAICRegistry(const RooAICRegistry &other);
+   RooAICRegistry &operator=(const RooAICRegistry &other);
+   RooAICRegistry(RooAICRegistry &&other) = default;
+   RooAICRegistry &operator=(RooAICRegistry &&other) = default;
 
-  Int_t store(const std::vector<Int_t>& codeList, RooArgSet* set1 = nullptr, RooArgSet* set2 = nullptr,
-              RooArgSet* set3 = nullptr, RooArgSet* set4 = nullptr) ;
-  const std::vector<Int_t>& retrieve(Int_t masterCode) const ;
-  const std::vector<Int_t>&  retrieve(Int_t masterCode, pRooArgSet& set1) const ;
-  const std::vector<Int_t>&  retrieve(Int_t masterCode, pRooArgSet& set1, pRooArgSet& set2) const ;
-  const std::vector<Int_t>&  retrieve(Int_t masterCode, pRooArgSet& set1,
-                                      pRooArgSet& set2, pRooArgSet& set3, pRooArgSet& set4) const ;
-  size_t size() const;
+   int store(const std::vector<int> &codeList, RooArgSet *set1 = nullptr, RooArgSet *set2 = nullptr,
+             RooArgSet *set3 = nullptr, RooArgSet *set4 = nullptr);
 
-private:
-  void copyImpl(const RooAICRegistry &other);
+   struct Output {
+      std::vector<int> const &codes;
+      std::array<RooArgSet*, 4> sets;
+   };
+
+   /// Retrieve the array of integer codes associated with the given master code,
+   /// together with the (up to four) RooArgSets associated with this master code.
+   Output retrieve(int masterCode)
+   {
+      Output out{.codes = _clArr[masterCode], .sets = {}};
+      for (std::size_t iArr = 0; iArr < 4; ++iArr) {
+         out.sets[iArr] = _asArr[iArr][masterCode].get();
+      }
+      return out;
+   }
+
+   /// Number of stored code lists.
+   std::size_t size() const { return _clArr.size(); }
 
 protected:
-
-  std::vector<std::vector<Int_t> > _clArr; ///<! Array of array of code lists
-  std::vector<pRooArgSet> _asArr1;         ///<! Array of 1st RooArgSet pointers
-  std::vector<pRooArgSet> _asArr2;         ///<! Array of 2nd RooArgSet pointers
-  std::vector<pRooArgSet> _asArr3;         ///<! Array of 3rd RooArgSet pointers
-  std::vector<pRooArgSet> _asArr4;         ///<! Array of 4th RooArgSet pointers
-
-  ClassDef(RooAICRegistry,2) // Registry for analytical integration codes
-} ;
+   std::vector<std::vector<int>> _clArr;                          ///<! Array of array of code lists
+   std::array<std::vector<std::unique_ptr<RooArgSet>>, 4> _asArr; ///<! Array of RooArgSet pointers
+};
 
 #endif

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -19,7 +19,6 @@
 #include "RooResolutionModel.h"
 #include "RooListProxy.h"
 #include "RooSetProxy.h"
-#include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
 
 class AddCacheElem;
@@ -112,8 +111,6 @@ protected:
   } ;
 
   mutable RooObjCacheManager _intCacheMgr ; ///<! Manager of cache with integrals
-
-  mutable RooAICRegistry _codeReg = 10; ///<! Registry of component analytical integration codes
 
   RooListProxy _pdfList ;   ///<  List of component PDFs
   RooListProxy _coefList ;  ///<  List of coefficients

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -19,7 +19,6 @@
 #include "RooAbsReal.h"
 #include "RooRealProxy.h"
 #include "RooSetProxy.h"
-#include "RooAICRegistry.h"
 #include "RooDataHist.h"
 
 #include <list>
@@ -115,7 +114,6 @@ protected:
   RooSetProxy _depList;                        ///< List of observables mapped onto histogram observables
   RooDataHist* _dataHist = nullptr;            ///< Unowned pointer to underlying histogram
   std::unique_ptr<RooDataHist> _ownedDataHist; ///<! Owned pointer to underlying histogram
-  mutable RooAICRegistry _codeReg;             ///<! Auxiliary class keeping tracking of analytical integration code
   Int_t _intOrder = 0;                         ///< Interpolation order
   bool _cdfBoundaries = false;                 ///< Use boundary conditions for CDFs.
   mutable double _totVolume = 0.0;             ///<! Total volume of space (product of ranges of observables)

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -19,7 +19,6 @@
 #include "RooAbsPdf.h"
 #include "RooRealProxy.h"
 #include "RooSetProxy.h"
-#include "RooAICRegistry.h"
 #include "RooDataHist.h"
 
 #include <list>
@@ -111,7 +110,6 @@ protected:
   RooSetProxy _pdfObsList;                     ///< List of observables mapped onto histogram observables
   RooDataHist* _dataHist = nullptr;            ///< Unowned pointer to underlying histogram
   std::unique_ptr<RooDataHist> _ownedDataHist; ///<! Owned pointer to underlying histogram
-  mutable RooAICRegistry _codeReg ;            ///<! Auxiliary class keeping tracking of analytical integration code
   Int_t _intOrder = 0;                         ///< Interpolation order
   bool _cdfBoundaries = false;                 ///< Use boundary conditions for CDFs.
   mutable double _totVolume = 0.0;             ///<! Total volume of space (product of ranges of observables)

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -19,7 +19,6 @@
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
 #include "RooLinkedList.h"
-#include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
 #include "RooCmdArg.h"
 
@@ -185,7 +184,7 @@ private:
                                   const RooArgSet *auxProto=nullptr, bool verbose= false) const override ;
 
 
-  mutable RooAICRegistry _genCode ; ///<! Registry of composite direct generator codes
+  mutable std::vector<std::vector<int>> _genCode; ///<! Registry of composite direct generator codes
 
   double _cutOff = 0.0;       ///<  Cutoff parameter for running product
   RooListProxy _pdfList ;  ///<  List of PDF components

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -18,7 +18,6 @@
 
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
-#include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
 
 #include <list>

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -18,7 +18,6 @@
 
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
-#include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
 
 class RooRealSumPdf : public RooAbsPdf {

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -16,7 +16,6 @@
 #ifndef ROO_SIMULTANEOUS
 #define ROO_SIMULTANEOUS
 
-#include <RooAICRegistry.h>
 #include <RooAbsCacheElement.h>
 #include <RooAbsPdf.h>
 #include <RooArgList.h>

--- a/roofit/roofitcore/src/RooAICRegistry.cxx
+++ b/roofit/roofitcore/src/RooAICRegistry.cxx
@@ -24,116 +24,50 @@ classes that keeps track of analytical integration codes and
 associated normalization and integration sets.
 **/
 
-#include "RooAICRegistry.h"
-#include "RooMsgService.h"
-#include "RooArgSet.h"
-
-#include "Riostream.h"
-
+#include <RooAICRegistry.h>
+#include <RooArgSet.h>
 
 namespace {
 
-RooArgSet * makeSnapshot(RooArgSet const* set) {
-  if(!set) {
-    return nullptr;
-  }
-  auto out = new RooArgSet;
-  set->snapshot(*out, false);
-  return out;
-}
-
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-RooAICRegistry::RooAICRegistry(UInt_t size)
-  : _clArr(0), _asArr1(0), _asArr2(0), _asArr3(0), _asArr4(0)
+template<class RooArgSetPointer_t>
+std::unique_ptr<RooArgSet> makeSnapshot(RooArgSetPointer_t const &set)
 {
-  _clArr.reserve(size);
-  _asArr1.reserve(size);
-  _asArr2.reserve(size);
-  _asArr3.reserve(size);
-  _asArr4.reserve(size);
+   if (!set)
+      return nullptr;
+   auto out = std::make_unique<RooArgSet>();
+   set->snapshot(*out, false);
+   return out;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor
+} // namespace
 
-RooAICRegistry::RooAICRegistry(const RooAICRegistry &other)
+RooAICRegistry::RooAICRegistry(std::size_t size)
 {
-   copyImpl(other);
+   _clArr.reserve(size);
+   for (auto &a : _asArr) {
+      a.reserve(size);
+   }
+}
+
+RooAICRegistry::RooAICRegistry(const RooAICRegistry &other) : _clArr(other._clArr)
+{
+   // Copy code-list array if other PDF has one
+   for (std::size_t iArr = 0; iArr < _asArr.size(); ++iArr) {
+      _asArr[iArr].resize(_clArr.size());
+      for (std::size_t i = 0; i < _clArr.size(); ++i) {
+         _asArr[iArr][i] = makeSnapshot(other._asArr[iArr][i]);
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy assignment
+/// Copy assignment.
 
 RooAICRegistry &RooAICRegistry::operator=(const RooAICRegistry &other)
 {
-   // Delete code list array, if allocated
-   for (unsigned int i = 0; i < _clArr.size(); ++i) {
-      if (_asArr1[i]) {
-         delete _asArr1[i];
-         _asArr1[i] = nullptr;
-      }
-      if (_asArr2[i]) {
-         delete _asArr2[i];
-         _asArr2[i] = nullptr;
-      }
-      if (_asArr3[i]) {
-         delete _asArr3[i];
-         _asArr3[i] = nullptr;
-      }
-      if (_asArr4[i]) {
-         delete _asArr4[i];
-         _asArr4[i] = nullptr;
-      }
-   }
-   copyImpl(other);
+   RooAICRegistry tmp(other);
+   *this = std::move(tmp);
    return *this;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooAICRegistry::~RooAICRegistry()
-{
-  // Delete code list array, if allocated
-  for (unsigned int i = 0; i < _clArr.size(); ++i) {
-    if (_asArr1[i]) delete   _asArr1[i];
-    if (_asArr2[i]) delete   _asArr2[i];
-    if (_asArr3[i]) delete   _asArr3[i];
-    if (_asArr4[i]) delete   _asArr4[i];
-  }
-}
-
-
-void RooAICRegistry::copyImpl(const RooAICRegistry &other)
-{
-   _clArr = other._clArr;
-
-   // Copy code-list array if other PDF has one
-   UInt_t size = other._clArr.size();
-   if (size) {
-      _asArr1.resize(size, nullptr);
-      _asArr2.resize(size, nullptr);
-      _asArr3.resize(size, nullptr);
-      _asArr4.resize(size, nullptr);
-      for (UInt_t i = 0; i < size; ++i) {
-         _asArr1[i] = makeSnapshot(other._asArr1[i]);
-         _asArr2[i] = makeSnapshot(other._asArr2[i]);
-         _asArr3[i] = makeSnapshot(other._asArr3[i]);
-         _asArr4[i] = makeSnapshot(other._asArr4[i]);
-      }
-   }
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Get size of _clArr vector
-
-size_t RooAICRegistry::size() const
-{
-  return _clArr.size();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,98 +80,40 @@ size_t RooAICRegistry::size() const
 /// previously stored in the registry no objects are stored and the
 /// unique code of the existing entry is returned.
 
-Int_t RooAICRegistry::store(const std::vector<Int_t>& codeList, RooArgSet* set1,
-                            RooArgSet* set2, RooArgSet* set3, RooArgSet* set4)
+int RooAICRegistry::store(const std::vector<Int_t> &codeList, RooArgSet *set1, RooArgSet *set2, RooArgSet *set3,
+                            RooArgSet *set4)
 {
-  // Loop over code-list array
-  for (UInt_t i = 0; i < _clArr.size(); ++i) {
-    // Existing slot, compare with current list, if matched return index
-    bool match(true) ;
+   // Taking the ownership of the input sets
+   std::array<RooArgSet *, 4> sets{set1, set2, set3, set4};
 
-    // Check that array contents is identical
-    match &= _clArr[i] == codeList;
+   // Loop over code-list array
+   for (std::size_t i = 0; i < _clArr.size(); ++i) {
+      // Existing slot, compare with current list, if matched return index.
+      // First., check that array contents is identical.
+      bool match = _clArr[i] == codeList;
 
-    // Check that supplied configuration of lists is identical
-    if (_asArr1[i] && !set1) match=false ;
-    if (!_asArr1[i] && set1) match=false ;
-    if (_asArr2[i] && !set2) match=false ;
-    if (!_asArr2[i] && set2) match=false ;
-    if (_asArr3[i] && !set3) match=false ;
-    if (!_asArr3[i] && set3) match=false ;
-    if (_asArr4[i] && !set4) match=false ;
-    if (!_asArr4[i] && set4) match=false ;
+      // Check that supplied configuration of lists is identical
+      for (std::size_t iArr = 0; iArr < 4; ++iArr) {
+         if ((_asArr[iArr][i] && !sets[iArr]) || (!_asArr[iArr][i] && sets[iArr]))
+            match = false;
+      }
 
-    // Check that contents of arrays is identical
-    if (_asArr1[i] && set1 && !set1->equals(*_asArr1[i])) match=false ;
-    if (_asArr2[i] && set2 && !set2->equals(*_asArr2[i])) match=false ;
-    if (_asArr3[i] && set3 && !set3->equals(*_asArr3[i])) match=false ;
-    if (_asArr4[i] && set4 && !set4->equals(*_asArr4[i])) match=false ;
+      // Check that contents of arrays is identical
+      for (std::size_t iArr = 0; iArr < 4; ++iArr) {
+         if (_asArr[iArr][i] && sets[iArr] && !sets[iArr]->equals(*_asArr[iArr][i]))
+            match = false;
+      }
 
-    if (match) {
-      if (set1) delete set1 ;
-      if (set2) delete set2 ;
-      if (set3) delete set3 ;
-      if (set4) delete set4 ;
-      return i ;
-    }
-  }
+      if (match) {
+         return i;
+      }
+   }
 
-  // Store code list and return index
-  _clArr.push_back(codeList);
-  _asArr1.emplace_back(makeSnapshot(set1));
-  _asArr2.emplace_back(makeSnapshot(set2));
-  _asArr3.emplace_back(makeSnapshot(set3));
-  _asArr4.emplace_back(makeSnapshot(set4));
+   // Store code list and return index
+   _clArr.push_back(codeList);
+   for (std::size_t iArr = 0; iArr < 4; ++iArr) {
+      _asArr[iArr].emplace_back(makeSnapshot(sets[iArr]));
+   }
 
-  if (set1) delete set1 ;
-  if (set2) delete set2 ;
-  if (set3) delete set3 ;
-  if (set4) delete set4 ;
-  return _clArr.size() - 1;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Retrieve the array of integer codes associated with the given master code
-
-const std::vector<Int_t>& RooAICRegistry::retrieve(Int_t masterCode) const
-{
-  return _clArr[masterCode] ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Retrieve the array of integer codes associated with the given master code
-/// and set the passed set1 pointer to the first RooArgSet associated with this master code
-
-const std::vector<Int_t>& RooAICRegistry::retrieve(Int_t masterCode, pRooArgSet& set1) const
-{
-  set1 = _asArr1[masterCode] ;
-  return _clArr[masterCode] ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Retrieve the array of integer codes associated with the given master code
-/// and set the passed set1,set2 pointers to the first and second  RooArgSets associated with this
-/// master code respectively
-
-const std::vector<Int_t>& RooAICRegistry::retrieve
-(Int_t masterCode, pRooArgSet& set1, pRooArgSet& set2) const
-{
-  set1 = _asArr1[masterCode] ;
-  set2 = _asArr2[masterCode] ;
-  return _clArr[masterCode] ;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Retrieve the array of integer codes associated with the given master code
-/// and set the passed set1-4 pointers to the four  RooArgSets associated with this
-/// master code respectively
-
-const std::vector<Int_t>& RooAICRegistry::retrieve
-(Int_t masterCode, pRooArgSet& set1, pRooArgSet& set2, pRooArgSet& set3, pRooArgSet& set4) const
-{
-  set1 = _asArr1[masterCode] ;
-  set2 = _asArr2[masterCode] ;
-  set3 = _asArr3[masterCode] ;
-  set4 = _asArr4[masterCode] ;
-  return _clArr[masterCode] ;
+   return _clArr.size() - 1;
 }

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -506,10 +506,10 @@ Int_t RooAbsAnaConvPdf::getAnalyticalIntegralWN(RooArgSet& allVars,
 
   // takes ownership of all sets
   masterCode = _codeReg.store(tmp,
-                              intCoefSet.release(),
-                              intConvSet.release(),
-                              normCoefSet.release(),
-                              normConvSet.release()) + 1;
+                              intCoefSet.get(),
+                              intConvSet.get(),
+                              normCoefSet.get(),
+                              normConvSet.get()) + 1;
 
   analVars.add(allDeps) ;
 
@@ -556,11 +556,11 @@ double RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet *normS
       return getVal(normSet);
 
    // Unpack master code
-   RooArgSet *intCoefSet;
-   RooArgSet *intConvSet;
-   RooArgSet *normCoefSet;
-   RooArgSet *normConvSet;
-   _codeReg.retrieve(code - 1, intCoefSet, intConvSet, normCoefSet, normConvSet);
+   auto retrieved = _codeReg.retrieve(code - 1);
+   RooArgSet *intCoefSet = retrieved.sets[0];
+   RooArgSet *intConvSet = retrieved.sets[1];
+   RooArgSet *normCoefSet = retrieved.sets[2];
+   RooArgSet *normConvSet = retrieved.sets[3];
 
    Int_t index(0);
 

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -326,18 +326,18 @@ int RooAbsCachedPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& anal
     return 0 ;
   }
 
-  RooArgSet* all = new RooArgSet ;
-  RooArgSet* ana = new RooArgSet ;
-  RooArgSet* nrm = new RooArgSet ;
-  all->addClone(allVars) ;
-  ana->addClone(analVars) ;
+  RooArgSet all;
+  RooArgSet ana;
+  RooArgSet nrm;
+  all.addClone(allVars) ;
+  ana.addClone(analVars) ;
   if (normSet) {
-    nrm->addClone(*normSet) ;
+    nrm.addClone(*normSet) ;
   }
   std::vector<int> codeList(2);
   codeList[0] = code ;
   codeList[1] = cache->pdf()->haveUnitNorm() ? 1 : 0 ;
-  int masterCode = _anaReg.store(codeList,all,ana,nrm)+1 ; // takes ownership of all sets
+  int masterCode = _anaReg.store(codeList,&all,&ana,&nrm)+1 ;
 
 
   // Mark all observables as internally integrated
@@ -368,11 +368,11 @@ double RooAbsCachedPdf::analyticalIntegralWN(int code, const RooArgSet* normSet,
     return 0.;
   }
 
-  RooArgSet *allVars(nullptr);
-  RooArgSet *anaVars(nullptr);
-  RooArgSet *normSet2(nullptr);
-  RooArgSet *dummy(nullptr);
-  const std::vector<int> codeList = _anaReg.retrieve(code-1,allVars,anaVars,normSet2,dummy) ;
+  auto retrieved = _anaReg.retrieve(code-1);
+  std::vector<int> const &codeList = retrieved.codes;
+  RooArgSet *allVars = retrieved.sets[0];
+  RooArgSet *anaVars = retrieved.sets[1];
+  RooArgSet *normSet2 = retrieved.sets[2];
 
   // Mirror getAnalyticalIntegralWN's lookup key. If the caller passed a null
   // normSet to getAnalyticalIntegralWN, the stored normSet2 is non-null but

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -82,7 +82,6 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,false,false),
   _projCacheMgr(this,10),
   _intCacheMgr(this,10),
-  _codeReg(10),
   _pdfList("!pdfs","List of PDFs",this),
   _coefList("!coefficients","List of coefficients",this)
 {
@@ -160,7 +159,6 @@ RooAddModel::RooAddModel(const RooAddModel &other, const char *name)
      _refCoefRangeName((TNamed *)other._refCoefRangeName),
      _projCacheMgr(other._projCacheMgr, this),
      _intCacheMgr(other._intCacheMgr, this),
-     _codeReg(other._codeReg),
      _pdfList("!pdfs", this, other._pdfList),
      _coefList("!coefficients", this, other._coefList),
      _haveLastCoef(other._haveLastCoef),

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -683,8 +683,7 @@ Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars
   analVars.add(allAnalVars) ;
 
   // Store set of variables analytically integrated
-  RooArgSet* intSet = new RooArgSet(allAnalVars) ;
-  Int_t masterCode = _codeReg.store(subCode,intSet)+1 ;
+  Int_t masterCode = _codeReg.store(subCode,&allAnalVars)+1 ;
 
   return masterCode ;
 }
@@ -702,8 +701,9 @@ double RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, con
   }
 
   // Retrieve analytical integration subCodes and set of observabels integrated over
-  RooArgSet* intSet = nullptr;
-  const std::vector<Int_t>& subCode = _codeReg.retrieve(code-1,intSet) ;
+  auto retrieved = _codeReg.retrieve(code-1);
+  std::vector<int> const &subCode = retrieved.codes;
+  RooArgSet *intSet = retrieved.sets[0];
   if (subCode.empty()) {
     std::stringstream errorMsg;
     errorMsg << "RooAddPdf::analyticalIntegral(" << GetName() << "): ERROR unrecognized integration code, " << code;

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -53,7 +53,6 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgSet& v
   RooAbsReal(name,title),
   _depList("depList","List of dependents",this),
   _dataHist(const_cast<RooDataHist*>(&dhist)),
-  _codeReg(10),
   _intOrder(intOrder)
 {
   _histObsList.addClone(vars) ;
@@ -91,7 +90,6 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList& 
   RooAbsReal(name,title),
   _depList("depList","List of dependents",this),
   _dataHist(const_cast<RooDataHist*>(&dhist)),
-  _codeReg(10),
   _intOrder(intOrder)
 {
   _histObsList.addClone(histObs) ;
@@ -137,7 +135,6 @@ RooHistFunc::RooHistFunc(const RooHistFunc& other, const char* name) :
   RooAbsReal(other,name),
   _depList("depList",this,other._depList),
   _dataHist(other._dataHist),
-  _codeReg(other._codeReg),
   _intOrder(other._intOrder),
   _cdfBoundaries(other._cdfBoundaries),
   _totVolume(other._totVolume),

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -55,7 +55,6 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet& var
   RooAbsPdf(name,title),
   _pdfObsList("pdfObs","List of p.d.f. observables",this),
   _dataHist(const_cast<RooDataHist*>(&dhist)),
-  _codeReg(10),
   _intOrder(intOrder)
 {
   _histObsList.addClone(vars) ;
@@ -104,7 +103,6 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pd
   RooAbsPdf(name,title),
   _pdfObsList("pdfObs","List of p.d.f. observables",this),
   _dataHist(const_cast<RooDataHist*>(&dhist)),
-  _codeReg(10),
   _intOrder(intOrder)
 {
   _histObsList.addClone(histObs) ;
@@ -164,7 +162,6 @@ RooHistPdf::RooHistPdf(const RooHistPdf& other, const char* name) :
   RooAbsPdf(other,name),
   _pdfObsList("pdfObs",this,other._pdfObsList),
   _dataHist(other._dataHist),
-  _codeReg(other._codeReg),
   _intOrder(other._intOrder),
   _cdfBoundaries(other._cdfBoundaries),
   _totVolume(other._totVolume),

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1504,11 +1504,16 @@ Int_t RooProdPdf::getGenerator(const RooArgSet& directVars, RooArgSet &generateV
 
 
   if (!generateVars.empty()) {
-    Int_t masterCode = _genCode.store(code) ;
-    return masterCode+1 ;
-  } else {
-    return 0 ;
+    auto found = std::find(_genCode.begin(), _genCode.end(), code);
+    // If a generator for the codes was already cached, return the index to the
+    // corresponding caching index plus one.
+    if (found != _genCode.end()) {
+       return std::distance(_genCode.begin(), found) + 1;
+    }
+    _genCode.emplace_back(std::move(code));
+    return _genCode.size();
   }
+  return 0;
 }
 
 
@@ -1521,7 +1526,7 @@ void RooProdPdf::initGenerator(Int_t code)
 {
   if (!_useDefaultGen) return ;
 
-  const std::vector<Int_t>& codeList = _genCode.retrieve(code-1) ;
+  const std::vector<int>& codeList = _genCode[code-1];
   Int_t i(0) ;
   for (auto* pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
     if (codeList[i]!=0) {
@@ -1542,7 +1547,7 @@ void RooProdPdf::generateEvent(Int_t code)
 {
   if (!_useDefaultGen) return ;
 
-  const std::vector<Int_t>& codeList = _genCode.retrieve(code-1) ;
+  const std::vector<Int_t>& codeList = _genCode[code-1];
   Int_t i(0) ;
   for (auto* pdf : static_range_cast<RooAbsPdf*>(_pdfList)) {
     if (codeList[i]!=0) {


### PR DESCRIPTION
Modernize RooAICRegistry, the helper that operator p.d.f.s use to cache analytical integration codes and their associated RooArgSets, and clean up its usage across RooFitCore.

Storage and ownership:

  - Replace the four parallel `std::vector<RooArgSet*>` members and the hand-written copy/destroy bookkeeping with a single `std::array<std::vector<std::unique_ptr<RooArgSet>>, 4>`. The manual destructor and `copyImpl()` helper are gone; lifetime is now handled by the smart pointers.
  - `store()` no longer takes ownership of the RooArgSets passed to it; it only snapshots them. Callers are updated accordingly: they either keep their `unique_ptr`s (RooAbsAnaConvPdf) or pass stack objects instead of heap allocations (RooAbsCachedPdf), removing several `new`/`release()`/`delete` dances.

API:

  - Replace the four `retrieve()` out-parameter overloads with a single method returning a small `Output` struct (the code list plus the four set pointers), so call sites no longer declare and thread raw pointers by reference.
  - Drop the `ClassDef`/dictionary and the corresponding LinkDef entry: all data members were transient, so the registry was never persisted and does not need I/O support.

Cleanups in the consumers:

  - Remove the unused `_codeReg` registry members (and the now-redundant RooAICRegistry.h includes) from RooHistFunc, RooHistPdf and RooAddModel.
  - In RooProdPdf, `_genCode` only ever stored code lists without any RooArgSets, so demote it from a RooAICRegistry to a plain `std::vector<std::vector<int>>` and look codes up directly.

AI was only used to generate the commit message, and all the code changes were done by the human.