### PR TITLE
[zip] check return value of `R__memcompress`, adjust `R__zipOld`

### DIFF
--- a/core/zip/src/Bits.c
+++ b/core/zip/src/Bits.c
@@ -289,23 +289,27 @@ int R__seekable()
  * The values are stored in little-endian order on all machines.
  * This function returns the byte size of the compressed output, including
  * the first six bytes (method and crc).
+ * In case of error function returns 0.
  */
 
 ulg R__memcompress(char *tgt, ulg tgtsize, const char *src, ulg srcsize)
-/* char *tgt, *src;        target and source buffers */
-/* ulg tgtsize, srcsize;   target and source sizes */
 {
     ush att      = (ush)UNKNOWN;
     ush flags    = 0;
     ulg crc      = 0;
     int method   = Z_DEFLATED;
+
+    if (tgtsize <= 6L) {
+        R__error("target buffer too small");
+        return 0L;
+    }
+
     bits_internal_state *state = (bits_internal_state *) malloc(sizeof(bits_internal_state));
     if (!state) {
         R__error("fail to allocate bits_internal_state struct");
         return 0L;
     }
 
-    if (tgtsize <= 6L) { R__error("target buffer too small"); /* errorflag = 1; */ }
 #if 0
     crc = updcrc((char *)NULL, 0);
     crc = updcrc(src, (extent) srcsize);

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <cassert>
+#include <memory>
 
 // The size of the ROOT block framing headers for compression:
 // - 3 bytes to identify the compression algorithm and version.
@@ -115,7 +116,6 @@ void R__zipMultipleAlgorithm(int cxlevel, int *srcsize, const char *src, int *tg
 static void R__zipOld(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep)
 {
     int method   = Z_DEFLATED;
-    bits_internal_state state;
     ush att      = (ush)UNKNOWN;
     ush flags    = 0;
     if (cxlevel > 9) cxlevel = 9;
@@ -132,45 +132,49 @@ static void R__zipOld(int cxlevel, int *srcsize, const char *src, int *tgtsize, 
        return;
     }
 
+    auto state = std::make_unique<bits_internal_state>();
+    if (!state) {
+       R__error("fail to allocate bits_internal_state struct");
+       return;
+    }
+
 #ifdef DYN_ALLOC
-    state.R__window = 0;
-    state.R__prev = 0;
+    state->R__window = 0;
+    state->R__prev = 0;
 #endif
 
-    state.in_buf    = src;
-    state.in_size   = (unsigned) (*srcsize);
-    state.in_offset = 0;
+    state->in_buf    = src;
+    state->in_size   = (unsigned) (*srcsize);
+    state->in_offset = 0;
 
-    state.out_buf     = tgt;
-    state.out_size    = (unsigned) (*tgtsize);
-    state.out_offset  = HDRSIZE;
-    state.R__window_size = 0L;
+    state->out_buf     = tgt;
+    state->out_size    = (unsigned) (*tgtsize);
+    state->out_offset  = HDRSIZE;
+    state->R__window_size = 0L;
 
-    if (0 != R__bi_init(&state) ) return;       /* initialize bit routines */
-    state.t_state = R__get_thread_tree_state();
-    if (0 != R__ct_init(state.t_state,&att, &method)) return; /* initialize tree routines */
-    if (0 != R__lm_init(&state, gCompressionLevel, &flags)) return; /* initialize compression */
-    R__Deflate(&state,&state.error_flag);                  /* compress data */
-    if (state.error_flag != 0) return;
+    if (0 != R__bi_init(state.get())) return;       /* initialize bit routines */
+    state->t_state = R__get_thread_tree_state();
+    if (0 != R__ct_init(state->t_state,&att, &method)) return; /* initialize tree routines */
+    if (0 != R__lm_init(state.get(), gCompressionLevel, &flags)) return; /* initialize compression */
+    R__Deflate(state.get(), &(state->error_flag));                  /* compress data */
+    if (state->error_flag != 0) return;
 
     tgt[0] = 'C';               /* Signature 'C'-Chernyaev, 'S'-Smirnov */
     tgt[1] = 'S';
     tgt[2] = (char) method;
 
-    state.out_size  = state.out_offset - HDRSIZE;         /* compressed size */
-    tgt[3] = (char)(state.out_size & 0xff);
-    tgt[4] = (char)((state.out_size >> 8) & 0xff);
-    tgt[5] = (char)((state.out_size >> 16) & 0xff);
+    state->out_size  = state->out_offset - HDRSIZE;         /* compressed size */
+    tgt[3] = (char)(state->out_size & 0xff);
+    tgt[4] = (char)((state->out_size >> 8) & 0xff);
+    tgt[5] = (char)((state->out_size >> 16) & 0xff);
 
-    tgt[6] = (char)(state.in_size & 0xff);         /* decompressed size */
-    tgt[7] = (char)((state.in_size >> 8) & 0xff);
-    tgt[8] = (char)((state.in_size >> 16) & 0xff);
+    tgt[6] = (char)(state->in_size & 0xff);         /* decompressed size */
+    tgt[7] = (char)((state->in_size >> 8) & 0xff);
+    tgt[8] = (char)((state->in_size >> 16) & 0xff);
 
-    *irep     = state.out_offset;
+    *irep     = state->out_offset;
 
-    R__lm_free(&state);
-
-    return;
+    R__lm_free(state.get());
 }
 
 /**

--- a/graf3d/gl/src/TGLSdfFontMaker.cxx
+++ b/graf3d/gl/src/TGLSdfFontMaker.cxx
@@ -50,6 +50,11 @@ void gzip_compress_buffer(const char *objbuf, const size_t objlen, std::vector<c
 
    // R__memcompress fills first 6 bytes with own header, therefore just overwrite them
    unsigned long ziplen = R__memcompress(bufcur - 6, objlen + 6, (char *)objbuf, objlen);
+   if (!ziplen) {
+      // failure - return empty result
+      result.clear();
+      return;
+   }
 
    memcpy(bufcur - 6, dummy, 6);
 

--- a/io/io/src/TBufferJSON.cxx
+++ b/io/io/src/TBufferJSON.cxx
@@ -843,6 +843,10 @@ Int_t TBufferJSON::ExportToFile(const char *filename, const TObject *obj, const 
 
       // R__memcompress fills first 6 bytes with own header, therefore just overwrite them
       unsigned long ziplen = R__memcompress(bufcur - 6, objlen + 6, (char *)objbuf, objlen);
+      if (!ziplen) {
+         free(buffer);
+         return 0;
+      }
 
       memcpy(bufcur - 6, dummy, 6);
 

--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -107,8 +107,6 @@ else()
 
   target_include_directories(RHTTP SYSTEM PRIVATE ${civetweb_INCLUDE_DIR})
   target_link_libraries(RHTTP PRIVATE ${civetweb_LIBRARIES})
-  # workaround for R__memcompress failure with external civetweb
-  target_compile_definitions(RHTTP PRIVATE -D_EXTERNAL_CIVETWEB)
 
 endif(builtin_civetweb)
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -463,15 +463,8 @@ static int begin_request_handler(struct mg_connection *conn, void *)
       case THttpCallArg::kZipAlways: dozip = kTRUE; break;
       }
 
-      #ifdef _EXTERNAL_CIVETWEB
-      // with external civeweb one gets failure R__memcompress
-      // while it is not critical, try to avoid for now
-      // to be tested later
-      (void) dozip;
-      #else
       if (dozip)
          arg->CompressWithGzip();
-      #endif
 
       std::string hdr = arg->FillHttpHeader("HTTP/1.1");
       mg_printf(conn, "%s", hdr.c_str());

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -443,6 +443,10 @@ Bool_t THttpCallArg::CompressWithGzip()
 
    // R__memcompress fills first 6 bytes with own header, therefore just overwrite them
    unsigned long ziplen = R__memcompress(bufcur - 6, objlen + 6, objbuf, objlen);
+   if (!ziplen) {
+      Set404();
+      return kFALSE;
+   }
 
    memcpy(bufcur - 6, dummy, 6);
 


### PR DESCRIPTION
1. In `R__zipOld` allocate dynamically `bits_internal_state` struct, use `std::unique_ptr` to simplify cleanup
2. Return 0 in case of error from `R__memcompress`. 
3. Check return value of `R__memcompress` in all places where it used
4. In `THttpServer` remove special handling of external `civetweb`; now `R__memcompress` can be called also with smaller stack