### PR TITLE
[RF] Make RooMultiPdf::generate() error out when the index is requested

### DIFF
--- a/roofit/roofitcore/inc/RooMultiPdf.h
+++ b/roofit/roofitcore/inc/RooMultiPdf.h
@@ -34,6 +34,9 @@ public:
 
    void getParametersHook(const RooArgSet *nset, RooArgSet *list, bool stripDisconnected) const override;
 
+   RooAbsGenContext *genContext(const RooArgSet &vars, const RooDataSet *prototype = nullptr,
+                                 const RooArgSet *auxProto = nullptr, bool verbose = false) const override;
+
 protected:
    RooListProxy c;
    RooListProxy corr;

--- a/roofit/roofitcore/src/RooMultiPdf.cxx
+++ b/roofit/roofitcore/src/RooMultiPdf.cxx
@@ -23,6 +23,9 @@
 #include <RooFit/Detail/MathFuncs.h>
 #include <RooConstVar.h>
 
+#include <sstream>
+#include <stdexcept>
+
 // Constructing a RooMultiPdf
 //  parameter name : The name of the RooMultiPdf object
 //  parameter title : Display title in plots
@@ -87,4 +90,34 @@ void RooMultiPdf::getParametersHook(const RooArgSet *nset, RooArgSet *list, bool
    list->removeAll();
    getCurrentPdf()->getParameters(nset, *list, stripDisconnected);
    list->add(*x);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// The index category of a RooMultiPdf selects between alternative hypotheses
+/// for the observables (as used in the discrete profiling method), it does not
+/// partition the data into subsamples like the index category of a
+/// RooSimultaneous. It therefore has no well-defined prior probability, and
+/// there is no meaningful way to sample it in generate(). Fix the index to a
+/// specific state (e.g. with RooCategory::setIndex()) and generate from the
+/// resulting single-component pdf instead.
+
+RooAbsGenContext *RooMultiPdf::genContext(const RooArgSet &vars, const RooDataSet *prototype,
+                                           const RooArgSet *auxProto, bool verbose) const
+{
+   RooArgSet allVars{vars};
+   if (prototype)
+      allVars.add(*prototype->get(), true);
+
+   if (allVars.find(x->GetName())) {
+      std::stringstream ss;
+      ss << "RooMultiPdf::genContext(" << GetName() << "): the index category \"" << x->GetName()
+         << "\" selects between alternative hypotheses for the observables and is not itself an observable "
+            "with a well-defined prior probability, unlike the index category of a RooSimultaneous. "
+            "Generating data with this index among the variables to generate is therefore not supported. "
+            "Fix the index to a specific state (e.g. with RooCategory::setIndex()) and generate from the "
+            "resulting single-component pdf instead.";
+      throw std::invalid_argument(ss.str());
+   }
+
+   return RooAbsPdf::genContext(vars, prototype, auxProto, verbose);
 }

--- a/roofit/roofitcore/test/testRooMulti.cxx
+++ b/roofit/roofitcore/test/testRooMulti.cxx
@@ -260,6 +260,38 @@ TEST(RooMultiPdfTest, Minimization)
    EXPECT_DOUBLE_EQ(multiNllVals[0], nllVal1);
    EXPECT_DOUBLE_EQ(multiNllVals[1], nllVal2);
 }
+
+// The index category of a RooMultiPdf selects between alternative hypotheses
+// for the observables and has no well-defined prior probability, unlike the
+// index category of a RooSimultaneous. Requesting it as a generation
+// observable should therefore fail loudly instead of silently sampling it
+// with some arbitrary, unspecified distribution.
+// Covers https://github.com/root-project/root/issues/22916
+TEST(RooMultiPdfTest, GeneratingIndexCategoryThrows)
+{
+   RooRealVar x("x", "x", -10, 10);
+
+   RooRealVar m1("mean1", "mean1", 0.);
+   RooRealVar s1("sigma1", "sigma1", 1.);
+   RooRealVar m2("mean2", "mean2", 3.);
+   RooRealVar s2("sigma2", "sigma2", 2.);
+
+   RooGaussian gaus1("gaus1", "gaus1", x, m1, s1);
+   RooGaussian gaus2("gaus2", "gaus2", x, m2, s2);
+
+   RooCategory indx("my_special_index", "my_index");
+   RooMultiPdf pdf("mult", "multi_pdf", indx, RooArgList{gaus1, gaus2});
+
+   // Generating the observable alone (index fixed) still works.
+   indx.setConstant();
+   EXPECT_NO_THROW({ std::unique_ptr<RooAbsData> data{pdf.generate(x, 100)}; });
+
+   // Requesting the index category itself among the generation variables is
+   // not supported and must throw rather than silently generate with an
+   // arbitrary implicit prior over the index.
+   EXPECT_THROW({ std::unique_ptr<RooAbsData> data{pdf.generate(RooArgSet{x, indx}, 100)}; }, std::invalid_argument);
+}
+
 TEST(RooMultiReal, SelectsCorrectModel)
 {
    RooRealVar x("x", "x", -10, 10);


### PR DESCRIPTION
The index category of a RooMultiPdf selects between alternative hypotheses for the observables (as used in the discrete profiling method), unlike the index category of a RooSimultaneous, which is a genuine observable that partitions the data. Component yields express "expected count if hypothesis k were true", not partition sizes, so there is no well-defined prior probability over the index that could be used to sample it, and the previous fallback to the generic accept-reject generator produced an arbitrary, unintended ~uniform split over hypotheses.

Add a RooMultiPdf::genContext() override that throws if the index category is among the requested generation variables, and points users at fixing the index (e.g. via RooCategory::setIndex()) and generating from the resulting single-component pdf instead, which is also how the discrete profiling method is actually used in practice.

Closes #22916.
