### PR TITLE
[http] remove workaround for `R__memcompress()` [6.40]

### DIFF
--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -107,8 +107,6 @@ else()
 
   target_include_directories(RHTTP SYSTEM PRIVATE ${civetweb_INCLUDE_DIR})
   target_link_libraries(RHTTP PRIVATE ${civetweb_LIBRARIES})
-  # workaround for R__memcompress failure with external civetweb
-  target_compile_definitions(RHTTP PRIVATE -D_EXTERNAL_CIVETWEB)
 
 endif(builtin_civetweb)
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -463,15 +463,8 @@ static int begin_request_handler(struct mg_connection *conn, void *)
       case THttpCallArg::kZipAlways: dozip = kTRUE; break;
       }
 
-      #ifdef _EXTERNAL_CIVETWEB
-      // with external civeweb one gets failure R__memcompress
-      // while it is not critical, try to avoid for now
-      // to be tested later
-      (void) dozip;
-      #else
       if (dozip)
          arg->CompressWithGzip();
-      #endif
 
       std::string hdr = arg->FillHttpHeader("HTTP/1.1");
       mg_printf(conn, "%s", hdr.c_str());


### PR DESCRIPTION
Now use of external civetweb does not lead to failure in R__memcompress. 
Therefore no need to disable compression with external civetweb 

Partial backport of #22988 