### PR TITLE
[cling] Consume the COFF getSymbolName error for ordinal-only exports

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -964,8 +964,10 @@ namespace cling {
         // All the symbols are already flagged as exported. 
         // We cannot really ignore symbols based on flags as we do on unix.
         StringRef Name;
-        if (I->getSymbolName(Name))
+        if (Error E = I->getSymbolName(Name)) {
+          consumeError(std::move(E));
           continue;
+        }
         if (Name.empty())
           continue;
 


### PR DESCRIPTION
`ExportDirectoryEntryRef::getSymbolName` returns `llvm::Error` which is checked but never consumed during the COFF export scan in `Dyld::BuildBloomFilter`. A DLL that exports only by ordinal (no name table) makes `getSymbolName` fail with "RVA 0x0 for export ordinal table not found", and the unconsumed Error aborts the program on destruction. Consume it and skip the entry. Fixes crashes on MSVC cling-llvm22 builds on CppInterOp CI.