### PR TITLE
[math] Remove unused aggregate LinkDef headers

### DIFF
--- a/math/genvector/inc/Math/LinkDef_GenVectorAll.h
+++ b/math/genvector/inc/Math/LinkDef_GenVectorAll.h
@@ -1,3 +1,0 @@
-#include "LinkDef_GenVector32.h"
-#include "LinkDef_GenVector.h"
-

--- a/math/smatrix/inc/LinkDefAll.h
+++ b/math/smatrix/inc/LinkDefAll.h
@@ -1,2 +1,0 @@
-#include "LinkDefD32.h"
-#include "LinkDef.h"


### PR DESCRIPTION
## What

Removes two aggregate `LinkDef` headers that are no longer part of any dictionary:

- `math/smatrix/inc/LinkDefAll.h`
- `math/genvector/inc/Math/LinkDef_GenVectorAll.h`

One commit per module, since the two are independently revertable.

## Why

Both were added in 880fe6d64 (2014-01-30, "Fix the CMake build"), when each package built a
single combined dictionary. Each file exists only to pull its two real LinkDefs together:

```cpp
// math/smatrix/inc/LinkDefAll.h
#include "LinkDefD32.h"
#include "LinkDef.h"
```

The build has since returned to two separate dictionaries per package, each with its own LinkDef:

| package | dictionary | `LINKDEF` |
|---|---|---|
| Smatrix | `G__Smatrix` | `LinkDef.h` |
| Smatrix | `G__Smatrix32` (`MULTIDICT`) | `LinkDefD32.h` |
| GenVector | `G__GenVector` | `Math/LinkDef_GenVector.h` |
| GenVector | `G__GenVector32` (`MULTIDICT`) | `Math/LinkDef_GenVector32.h` |

That leaves the aggregate headers unreferenced. Neither name appears in any `CMakeLists.txt` or
`.cmake` file in the repository, and no other `LinkDef` includes them. They are also not reachable
from outside the repository: `ROOT_INSTALL_HEADERS` excludes LinkDef headers from installation
(`cmake/modules/RootMacros.cmake:1237`, `set(options REGEX "LinkDef" EXCLUDE)`).

## Verification

Configured a build with both files removed (Ninja, `-DCMAKE_BUILD_TYPE=Release -Dtesting=ON
-Droottest=OFF`, GCC 13.3 on Ubuntu 24.04). Configuration completes with no errors, and the
generated `build.ninja` contains:

| reference | occurrences |
|---|---|
| `LinkDefAll` | 0 |
| `LinkDef_GenVectorAll` | 0 |
| `math/smatrix/inc/LinkDef.h` | 2 |
| `LinkDefD32.h` | 2 |
| `LinkDef_GenVector.h` | 2 |
| `LinkDef_GenVector32.h` | 2 |

All four dictionaries are still generated: `G__Smatrix.cxx`, `G__Smatrix32.cxx`,
`G__GenVector.cxx`, `G__GenVector32.cxx`.

## Related

Same class of leftover as #23002 (`[tmva] Remove unused LinkDef5.h`), found by the same sweep.
The two are independent; this one can be taken or dropped on its own.

For completeness, the sweep flagged two further candidates that I am **not** proposing here:
`test/guiviewerLinkDef.h`, because `guiviewer.cxx`/`guiviewer.h` are still present and documented
in `test/Readme.md`, so the LinkDef is only as orphaned as the example itself; and the LinkDefs
under `math/experimental/genvectorx/`, because that package builds no dictionary at all today and
is only configured with `sycl AND experimental_genvectorx`. Both look like questions for the
owners rather than obvious removals — happy to open an issue on either if useful.

## AI-assisted coding disclosure

This contribution was AI-assisted (Claude Code). The tool was used to build a reachability graph
over every `LinkDef` file in the repository (CMake references, `#include` edges between LinkDefs,
and the default `LinkDef.h` convention), and to draft this description.

The results were verified before opening the PR rather than taken on trust: both files were
confirmed unreferenced repository-wide, the 2014 commit that introduced them was read, the current
`CMakeLists.txt` dictionary definitions were checked by hand, the installation exclusion was
located in `RootMacros.cmake`, and the configuration check above was run against the branch with
both files already deleted. Two of the four candidates the sweep produced were set aside as
described above rather than bundled in.

I have reviewed and understood the change and take responsibility for it.
