### PR TITLE
Avoid udpserver.c appears in a random place in the doc

### DIFF
--- a/tutorials/legacy/net/udpserver.c
+++ b/tutorials/legacy/net/udpserver.c
@@ -1,3 +1,6 @@
+/// \file udpserver.c
+/// \ingroup tutorial_net
+
 /* fpont 12/99 */
 /* pont.net    */
 /* udpserver.c */


### PR DESCRIPTION
Avoid udpserver.c appears in a random place in the doc: https://root.cern.ch/doc/master/udpserver_8c.html

