### PR TITLE
[CMake] Fix dictionary depfile target under CMP0116 OLD

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -728,6 +728,10 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif()
 
   #---call rootcling------------------------------------------
+  # use CMP0116 NEW locally so CMake normalises the depfile
+  # target for the active generator regardless of the global OLD setting.
+  cmake_policy(PUSH)
+  cmake_policy(SET CMP0116 NEW)
   add_custom_command(
     OUTPUT ${dictionary}.cxx ${pcm_name} ${rootmap_name} ${cpp_module_file}
     COMMAND ${command} -v2 -f  ${dictionary}.cxx ${newargs} ${excludepathsargs} ${rootmapargs}
@@ -750,6 +754,7 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
             ${cxx_std_stamp}
     COMMAND_EXPAND_LISTS
   )
+  cmake_policy(POP)
 
   # If we are adding to an existing target and it's not the dictionary itself,
   # we make an object library and add its output object file as source to the target.


### PR DESCRIPTION
Follows up on ae4d830f71e017, which switched ROOT_GENERATE_DICTIONARY() from IMPLICIT_DEPENDS to a proper DEPFILE, but rebuilt every dictionary on every incremental build with older Ninja (e.g. 1.8.2 on Alma 8):

```txt
  ninja: expected depfile '.../io/io/G__RIO.depfile' to mention
         'io/io/G__RIO.cxx', got 'G__RIO.cxx'
```

rootcling writes the depfile target as the plain dictionary name it is given (`"G__RIO.cxx"`) relative to CMAKE_CURRENT_BINARY_DIR. ROOT pins `CMP0116` to OLD globally (see 7392b023d10), and under OLD the Ninja generator consumes the depfile verbatim and expects the target relative to the top-level build directory (`"io/io/G__RIO.cxx"`). The mismatch makes older Ninja treat the dictionary as perpetually out of date; newer Ninja tolerates it, which is why the regression only showed up on some platforms.

This commit suggests to enable CMP0116 NEW locally around the dictionary `add_custom_command` so CMake transforms the depfile to whatever the active generator needs.