### PR TITLE
[RF] Fix RooProdPdf-wrapped RooAddPdf yield in ranged fits

### DIFF
--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2061,6 +2061,41 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
    std::unique_ptr<RooProdPdf> prodPdfClone{static_cast<RooProdPdf *>(this->Clone())};
    ctx.markAsCompiled(*prodPdfClone);
 
+   // If this RooProdPdf has a normalization range (e.g. the fit range in a
+   // ranged fit), propagate it to the component pdfs while they are compiled.
+   // This is required so that a RooAddPdf nested in a RooProdPdf reinterprets
+   // its coefficients with respect to the full range, exactly like a top-level
+   // RooAddPdf would. Without this, e.g. a RooProdPdf wrapping an extended
+   // RooAddPdf (a very common way to attach constraint terms) gives a different
+   // yield than the bare RooAddPdf in a ranged fit (GitHub issue #16673).
+   //
+   // The range must only be set on components for which it is actually defined:
+   // constraint pdfs of nuisance parameters are normalized over observables that
+   // don't know about the fit range, and forcing it on them would be wrong (and
+   // for a multi-range even throws because the undefined sub-ranges collapse to
+   // the full range and overlap).
+   std::vector<std::pair<RooAbsPdf *, std::string>> restoreNormRanges;
+   if (const char *prodNormRange = normRange()) {
+      std::vector<std::string> rangeTokens = ROOT::Split(prodNormRange, ",", /*skipEmpty=*/true);
+      for (auto *pdf : static_range_cast<RooAbsPdf *>(prodPdfClone->_pdfList)) {
+         RooArgSet pdfObs;
+         pdf->getObservables(&normSet, pdfObs);
+         bool rangeDefined = !pdfObs.empty();
+         for (RooAbsArg *obs : pdfObs) {
+            auto *lval = dynamic_cast<RooAbsRealLValue *>(obs);
+            for (auto const &token : rangeTokens) {
+               if (!lval || !lval->hasRange(token.c_str())) {
+                  rangeDefined = false;
+               }
+            }
+         }
+         if (rangeDefined && std::string(pdf->normRange() ? pdf->normRange() : "") != prodNormRange) {
+            restoreNormRanges.emplace_back(pdf, pdf->normRange() ? pdf->normRange() : "");
+            pdf->setNormRange(prodNormRange);
+         }
+      }
+   }
+
    for (const auto server : prodPdfClone->servers()) {
       auto nsetForServer = fillNormSetForServer(normSet, *server);
       RooArgSet const &nset = nsetForServer ? *nsetForServer : normSet;
@@ -2069,6 +2104,10 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
       server->getObservables(&nset, depList);
 
       ctx.compileServer(*server, *prodPdfClone, depList);
+   }
+
+   for (auto const &[pdf, oldRange] : restoreNormRanges) {
+      pdf->setNormRange(oldRange.empty() ? nullptr : oldRange.c_str());
    }
 
    auto fixedProdPdf = std::make_unique<RooFit::Detail::RooFixedProdPdf>(std::move(prodPdfClone), normSet);

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2066,6 +2066,43 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
    std::unique_ptr<RooProdPdf> prodPdfClone{static_cast<RooProdPdf *>(this->Clone())};
    ctx.markAsCompiled(*prodPdfClone);
 
+   // If this RooProdPdf has a normalization range (e.g. the fit range in a
+   // ranged fit), propagate it to the component pdfs while they are compiled,
+   // so that a nested RooAddPdf reinterprets its coefficients with respect to
+   // the full range exactly like a top-level RooAddPdf would. Otherwise, a
+   // RooProdPdf wrapping an extended RooAddPdf (the common way to attach
+   // constraint terms) gives a different yield than the bare RooAddPdf in a
+   // ranged fit (GitHub issue #16673).
+   //
+   // This must not change how constraint terms are normalized, so the range is
+   // only set on components whose normalization observables define it.
+   // Constraint pdfs are normalized over the nuisance parameters, which don't
+   // define the fit range, so they are skipped. Forcing the range on them would
+   // be wrong, and for a multi-range fit it even throws, because each undefined
+   // sub-range falls back to the parameter's full range and the sub-ranges then
+   // overlap.
+   std::vector<std::pair<RooAbsPdf *, std::string>> restoreNormRanges;
+   if (const char *prodNormRange = normRange()) {
+      std::vector<std::string> rangeTokens = ROOT::Split(prodNormRange, ",", /*skipEmpty=*/true);
+      for (auto *pdf : static_range_cast<RooAbsPdf *>(prodPdfClone->_pdfList)) {
+         RooArgSet pdfObs;
+         pdf->getObservables(&normSet, pdfObs);
+         bool rangeDefined = !pdfObs.empty();
+         for (RooAbsArg *obs : pdfObs) {
+            auto *lval = dynamic_cast<RooAbsRealLValue *>(obs);
+            for (auto const &token : rangeTokens) {
+               if (!lval || !lval->hasRange(token.c_str())) {
+                  rangeDefined = false;
+               }
+            }
+         }
+         if (rangeDefined && std::string(pdf->normRange() ? pdf->normRange() : "") != prodNormRange) {
+            restoreNormRanges.emplace_back(pdf, pdf->normRange() ? pdf->normRange() : "");
+            pdf->setNormRange(prodNormRange);
+         }
+      }
+   }
+
    for (const auto server : prodPdfClone->servers()) {
       auto nsetForServer = fillNormSetForServer(normSet, *server);
       RooArgSet const &nset = nsetForServer ? *nsetForServer : normSet;
@@ -2074,6 +2111,10 @@ RooProdPdf::compileForNormSet(RooArgSet const &normSet, RooFit::Detail::CompileC
       server->getObservables(&nset, depList);
 
       ctx.compileServer(*server, *prodPdfClone, depList);
+   }
+
+   for (auto const &[pdf, oldRange] : restoreNormRanges) {
+      pdf->setNormRange(oldRange.empty() ? nullptr : oldRange.c_str());
    }
 
    auto fixedProdPdf = std::make_unique<RooFit::Detail::RooFixedProdPdf>(std::move(prodPdfClone), normSet);

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -13,6 +13,7 @@
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
 #include <RooHelpers.h>
+#include <RooRandom.h>
 
 #include <Math/PdfFuncMathCore.h>
 
@@ -247,4 +248,66 @@ TEST(RooProdPdf, RooProdPdfWithExtendedTerm)
    double refVal = -std::log(ROOT::Math::gaussian_pdf(10, 0.2, 10)) + (10. - 5 * std::log(10.));
    double nll1Val = nll1->getVal();
    EXPECT_FLOAT_EQ(nll1Val, refVal);
+}
+
+// A RooProdPdf that just wraps a (extended) RooAddPdf must give the same result
+// in a ranged fit as the bare RooAddPdf. In particular, the RooAddPdf yield must
+// be reinterpreted with respect to the full range in both cases. This is the
+// common workspace pattern of attaching constraint terms to a model via a
+// RooProdPdf. Regression test for GitHub issue #16673.
+TEST(RooProdPdf, RangedFitWrappingRooAddPdf)
+{
+   using namespace RooFit;
+   RooHelpers::LocalChangeMsgLevel changeMsgLvl(RooFit::WARNING);
+
+   RooRandom::randomGenerator()->SetSeed(42);
+
+   RooRealVar x("x", "x", 0, 100);
+   x.setRange("LEFT", 0, 20);
+   x.setRange("RIGHT", 60, 100);
+
+   RooRealVar alphaGen("alpha", "alpha", -0.04, -0.1, -0.0);
+   RooGenericPdf modelGen("model", "exp(alpha*x)", {x, alphaGen});
+   std::unique_ptr<RooDataSet> data{modelGen.generate(x, 10000)};
+
+   // A nuisance parameter with a Gaussian constraint. Its observable does not
+   // know about the "LEFT"/"RIGHT" ranges, so the fit range must not be forced
+   // onto the constraint pdf (otherwise the ranged normalization throws).
+   RooRealVar theta("theta", "theta", 0, -5, 5);
+   RooRealVar thetaGlob("thetaGlob", "thetaGlob", 0);
+   RooRealVar thetaErr("thetaErr", "thetaErr", 1.0);
+   RooGenericPdf constraint("constraint", "exp(-0.5*(theta-thetaGlob)^2/thetaErr^2)", {theta, thetaGlob, thetaErr});
+
+   auto fitYield = [&](bool wrapInProd, bool withConstraint) {
+      RooRealVar alpha("alpha", "alpha", -0.04, -0.1, -0.0);
+      RooGenericPdf model("model", "exp(alpha*x)", {x, alpha});
+      RooRealVar nBkg("Nbkg", "Nbkg", 10000, 0, 20000);
+      RooAddPdf add("pdfadd", "", RooArgList{model}, RooArgList{nBkg});
+      std::unique_ptr<RooAbsPdf> owned;
+      RooAbsPdf *pdf = &add;
+      if (wrapInProd) {
+         RooArgList factors{add};
+         if (withConstraint) {
+            factors.add(constraint);
+         }
+         owned = std::make_unique<RooProdPdf>("pdfprod", "", factors);
+         pdf = owned.get();
+      }
+      pdf->fitTo(*data, Range("LEFT,RIGHT"), PrintLevel(-1));
+      return nBkg.getVal();
+   };
+
+   const double yieldAdd = fitYield(false, false);
+   const double yieldProd = fitYield(true, false);
+   const double yieldProdConstr = fitYield(true, true);
+
+   // The yield must refer to the full range, i.e. be clearly larger than the
+   // number of events actually inside the fit range.
+   const double nInFitRange = std::unique_ptr<RooAbsData>{data->reduce(CutRange("LEFT,RIGHT"))}->sumEntries();
+   EXPECT_GT(yieldAdd, 1.2 * nInFitRange);
+
+   // Wrapping in a RooProdPdf (with or without a constraint term) must not
+   // change the fitted yield.
+   EXPECT_NEAR(yieldProd, yieldAdd, 1e-3 * yieldAdd);
+   EXPECT_NEAR(yieldProdConstr, yieldAdd, 1e-3 * yieldAdd);
 }


### PR DESCRIPTION
In a ranged fit, a bare RooAddPdf reinterprets its coefficients with respect to the full range, but a RooAddPdf nested in a RooProdPdf (the common way to attach constraint terms, e.g. PROD::model(add, constraints)) did not: the normalization range set on the RooProdPdf was not propagated to its components, so the nested RooAddPdf never saw the fit range and its fitted yield collapsed to the number of events inside the fit range.

Fix this by propagating the normalization range to the component pdfs during compilation, mirroring what RooAddPdf already does for its own components.

This does not change how constraint terms are normalized: the range is only set on components whose normalization observables define it. Constraint pdfs are normalized over the nuisance parameters, which don't define the fit range, so they are skipped. Forcing the range on them would be wrong, and for a multi-range fit it even throws, because each undefined sub-range falls back to the parameter's full range and the sub-ranges then overlap.

Closes https://github.com/root-project/root/issues/16673.

🤖 Done with the help of AI.