### PR TITLE
[tutorials] Remove dead test-dependency variables

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -595,7 +595,6 @@ set(returncode_1 math/fit/fit2a.C
 set(analysis-unfold-testUnfold5d-depends tutorial-analysis-unfold-testUnfold5c)
 set(analysis-unfold-testUnfold5c-depends tutorial-analysis-unfold-testUnfold5b)
 set(analysis-unfold-testUnfold5b-depends tutorial-analysis-unfold-testUnfold5a)
-set(analysis-unfold-testUnfold7d-depends tutorial-analysis-unfold-testUnfold7c)
 set(analysis-unfold-testUnfold7c-depends tutorial-analysis-unfold-testUnfold7b)
 set(analysis-unfold-testUnfold7b-depends tutorial-analysis-unfold-testUnfold7a)
 set(io-xml-xmlmodifyfile-depends tutorial-io-xml-xmlnewfile)
@@ -611,17 +610,6 @@ set(math-foam-foam_demopers-depends tutorial-math-foam-foam_demo)
 set(io-tree-tree502_staff-depends  tutorial-io-tree-tree500_cernbuild)
 set(io-tree-tree501_cernstaff-depends  tutorial-io-tree-tree500_cernbuild)
 set(hist-hist006_TH1_bar_charts-depends  tutorial-io-tree-tree500_cernbuild)
-set(benchmarks-depends tutorial-hsimple
-                       tutorial-math-fit-fit1
-                       tutorial-math-fit-myfit
-                       tutorial-hist-hist015_TH1_read_and_draw
-                       tutorial-hist-hist056_TPolyMarker_contour
-                       tutorial-legacy-g3d-na49view
-                       tutorial-io-tree-tree120_ntuple.C
-                       tutorial-io-tree-spider
-                       tutorial-io-hadd
-                       tutorial-io-loopdir
-                       tutorial-io-copyFiles)
 set(legacy-g3d-na49view-depends tutorial-legacy-g3d-geometry)
 set(io-tree-mt_readNtuplesFillHistosAndFit-depends tutorial-io-tree-mt_fillNtuples)
 set(io-tree-mp_readNtuplesFillHistosAndFit-depends tutorial-io-tree-mp_fillNtuples)
@@ -855,10 +843,6 @@ if(pyroot)
     list(APPEND pyveto ${tmva_veto_py})
   endif()
 
-  if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND)
-    set (machine_learning-TMVA_SOFIE_RDataFrame-py-depends tutorial-machine_learning-TMVA_SOFIE_PyTorch_HiggsModel)
-  endif()
-
   if(NOT tmva-pymva)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} machine_learning/pytorch/*.py)
     list(APPEND pyveto ${tmva_veto_py})
@@ -884,11 +868,6 @@ if(pyroot)
   #---Python tutorials dependencies--------------------------------------
   set(io-tree-ntuple1-depends tutorial-hsimple-py)
   set(hist-hist015_TH1_read_and_draw-depends tutorial-hsimple-py)
-  set(pyroot-benchmarks-depends tutorial-hsimple-py
-                                tutorial-math-fit-fit1-py
-                                tutorial-legacy-g3d-na49view-py
-                                tutorial-hist-hist015_TH1_read_and_draw-py
-                                tutorial-io-tree-ntuple1-py)
   set(hist-hist015_TH1_read_and_draw_uhi-depends tutorial-hsimple-py)
   set(math-fit-fit1-depends tutorial-hist-hist001_TH1_fillrandom-py)
   set(legacy-g3d-na49view-depends tutorial-legacy-g3d-geometry-py)

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -589,7 +589,6 @@ set(returncode_1 math/fit/fit2a.C
 set(analysis-unfold-testUnfold5d-depends tutorial-analysis-unfold-testUnfold5c)
 set(analysis-unfold-testUnfold5c-depends tutorial-analysis-unfold-testUnfold5b)
 set(analysis-unfold-testUnfold5b-depends tutorial-analysis-unfold-testUnfold5a)
-set(analysis-unfold-testUnfold7d-depends tutorial-analysis-unfold-testUnfold7c)
 set(analysis-unfold-testUnfold7c-depends tutorial-analysis-unfold-testUnfold7b)
 set(analysis-unfold-testUnfold7b-depends tutorial-analysis-unfold-testUnfold7a)
 set(io-xml-xmlmodifyfile-depends tutorial-io-xml-xmlnewfile)
@@ -605,17 +604,6 @@ set(math-foam-foam_demopers-depends tutorial-math-foam-foam_demo)
 set(io-tree-tree502_staff-depends  tutorial-io-tree-tree500_cernbuild)
 set(io-tree-tree501_cernstaff-depends  tutorial-io-tree-tree500_cernbuild)
 set(hist-hist006_TH1_bar_charts-depends  tutorial-io-tree-tree500_cernbuild)
-set(benchmarks-depends tutorial-hsimple
-                       tutorial-math-fit-fit1
-                       tutorial-math-fit-myfit
-                       tutorial-hist-hist015_TH1_read_and_draw
-                       tutorial-hist-hist056_TPolyMarker_contour
-                       tutorial-legacy-g3d-na49view
-                       tutorial-io-tree-tree120_ntuple.C
-                       tutorial-io-tree-spider
-                       tutorial-io-hadd
-                       tutorial-io-loopdir
-                       tutorial-io-copyFiles)
 set(legacy-g3d-na49view-depends tutorial-legacy-g3d-geometry)
 set(io-tree-mt_readNtuplesFillHistosAndFit-depends tutorial-io-tree-mt_fillNtuples)
 set(io-tree-mp_readNtuplesFillHistosAndFit-depends tutorial-io-tree-mp_fillNtuples)
@@ -849,10 +837,6 @@ if(pyroot)
     list(APPEND pyveto ${tmva_veto_py})
   endif()
 
-  if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND)
-    set (machine_learning-TMVA_SOFIE_RDataFrame-py-depends tutorial-machine_learning-TMVA_SOFIE_PyTorch_HiggsModel)
-  endif()
-
   if(NOT tmva-pymva)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} machine_learning/pytorch/*.py)
     list(APPEND pyveto ${tmva_veto_py})
@@ -878,11 +862,6 @@ if(pyroot)
   #---Python tutorials dependencies--------------------------------------
   set(io-tree-ntuple1-depends tutorial-hsimple-py)
   set(hist-hist015_TH1_read_and_draw-depends tutorial-hsimple-py)
-  set(pyroot-benchmarks-depends tutorial-hsimple-py
-                                tutorial-math-fit-fit1-py
-                                tutorial-legacy-g3d-na49view-py
-                                tutorial-hist-hist015_TH1_read_and_draw-py
-                                tutorial-io-tree-ntuple1-py)
   set(hist-hist015_TH1_read_and_draw_uhi-depends tutorial-hsimple-py)
   set(math-fit-fit1-depends tutorial-hist-hist001_TH1_fillrandom-py)
   set(legacy-g3d-na49view-depends tutorial-legacy-g3d-geometry-py)


### PR DESCRIPTION
Four `<tname>-depends` variables in `tutorials/CMakeLists.txt` are never read, so the test ordering they describe is not applied. This removes them.

## How the variables are consumed

They are read only as `${${tname}-depends}`, at four places (lines 758, 789, 1059, 1060). `tname` is the tutorial path with its extension stripped and `/` replaced by `-`:

```cmake
string(REPLACE ".py" "" tname ${t})
string(REPLACE "/" "-" tname ${tname})
set(tutorial_name tutorial-${tname}-py)
```

So a `<x>-depends` variable has an effect only if some tutorial file resolves to tname `<x>`.

## The four

**`benchmarks-depends`** (line 614) — the file is `legacy/benchmarks.C`, so its tname is `legacy-benchmarks`, not `benchmarks`. It is also listed in `extra_veto` ("These ones are disabled !!!"), so no test is generated for it under either name. Two of its entries are independently stale: `tutorial-io-tree-tree120_ntuple.C` carries a stray `.C` that no test name has, and `tutorial-io-tree-spider` names a tutorial that is no longer in the tree. Introduced in c43f3658f (2014), when the file was `tutorials/benchmarks.C`.

**`pyroot-benchmarks-depends`** (line 887) — `tutorials/pyroot/` no longer exists; the directory was dissolved in #17208 and there is no `pyroot/benchmarks.py`.

**`analysis-unfold-testUnfold7d-depends`** (line 598) — the unfold series stops at `testUnfold7c.C`; there is no `testUnfold7d.C`. Note the neighbouring `analysis-unfold-testUnfold5d-depends` is **kept**, because `testUnfold5d.C` does exist — the asymmetry is real, not a typo.

**`machine_learning-TMVA_SOFIE_RDataFrame-py-depends`** (line 859) — this is the only `-py-depends` in the file. `tname` never ends in `-py`: the suffix is appended to `tutorial_name`, not to `tname`, and no tutorial file is named `*-py.py`. The dependency it asks for is nevertheless already in effect, because the Python tutorial reads `machine_learning-TMVA_SOFIE_RDataFrame-depends`, set unconditionally at line 665 to `tutorial-machine_learning-TMVA_SOFIE_PyTorch_HiggsModel-py` — already correctly suffixed.

I checked that last one against CMake rather than trusting the reading, with a minimal project reproducing the idiom verbatim:

```
-- tname          = machine_learning-TMVA_SOFIE_RDataFrame
-- tutorial_name  = tutorial-machine_learning-TMVA_SOFIE_RDataFrame-py
-- lookup key     = machine_learning-TMVA_SOFIE_RDataFrame-depends
-- the -py-depends variable holds = 'tutorial-machine_learning-TMVA_SOFIE_PyTorch_HiggsModel'
-- RESULT: DEPENDS of tutorial-machine_learning-TMVA_SOFIE_RDataFrame-py
           = 'tutorial-machine_learning-TMVA_SOFIE_PyTorch_HiggsModel-py'
```

The ordering matters here — `TMVA_SOFIE_RDataFrame.py` raises `FileNotFoundError` if `HiggsModel.onnx` is missing — and it is retained by line 665 after this change.

One thing worth flagging separately, which I have **not** changed: that ordering survives only because `TMVA_SOFIE_RDataFrame.C` and `TMVA_SOFIE_RDataFrame.py` collapse to the same tname and therefore share one `-depends` variable. If the C++ tutorial is ever removed, line 665 would likely go with it and the Python test would lose its dependency silently. Happy to follow up on that if you think it is worth guarding.

## What I did not change

I resolved every `<tname>-depends` variable in the file against the tutorials on disk. The only other candidate the sweep produced was `tutorial-machine_learning-TMVA_SOFIE_GNN_Parser` inside `machine_learning-TMVA_SOFIE_GNN_Application-depends`, which is **correct**: that test does not come from the glob but is added explicitly at line 712 with exactly that name. It is left alone.

After the change the same sweep reports no `-depends` variable whose owner is missing, and no list entry naming a nonexistent test other than the explicitly-added one above.

## Checks

- `if`/`endif` counts drop by exactly one each (the removed `if (ROOT_TORCH_FOUND AND ROOT_ONNX_FOUND)` block) and parentheses stay balanced; `foreach`/`endforeach` are untouched.
- Deletions only: `+0/-21`, one file.
- Branched from current `master` so it applies fast-forward.

No test loses a dependency it was actually getting.

## AI disclosure

AI-assisted (Claude Code). The tool was used to run the sweep described above, to build the minimal CMake reproduction, and to draft this description. The findings were checked before opening: the consumption sites and tname derivation were read in the file, each missing tutorial was confirmed absent from the tree, the blame commits were looked up, and the one false positive was identified and excluded. I have reviewed and understood the change and take responsibility for it.
