### PR TITLE
[gui] Let use `TGuiFactory` for alternative canvas implementations

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -250,37 +250,42 @@ void TApplication::InitializeGraphics(Bool_t only_web)
    if (fgGraphInit || !fgGraphNeeded)
       return;
 
+   Bool_t use_x11 = kFALSE;
+
    if (!only_web) {
       // Load the graphics related libraries
       LoadGraphicsLibs();
 
-      // Try to load TrueType font renderer. Only try to load if not in batch
-      // mode and Root.UseTTFonts is true and Root.TTFontPath exists. Abort silently
-      // if libttf or libGX11TTF are not found in $ROOTSYS/lib or $ROOTSYS/ttf/lib.
-      const char *ttpath = gEnv->GetValue("Root.TTFontPath",
-                                          TROOT::GetTTFFontDir());
-      char *ttfont = gSystem->Which(ttpath, "arialbd.ttf", kReadPermission);
-      // Check for use of DFSG - fonts
-      if (!ttfont)
-         ttfont = gSystem->Which(ttpath, "FreeSansBold.ttf", kReadPermission);
+      use_x11 = gGuiFactory->UseVirtualX();
 
-   #if !defined(R__WIN32)
-      if (!gROOT->IsBatch() && !strcmp(gVirtualX->GetName(), "X11") &&
-          ttfont && gEnv->GetValue("Root.UseTTFonts", 1)) {
-         if (gClassTable->GetDict("TGX11TTF")) {
-            // in principle we should not have linked anything against libGX11TTF
-            // but with ACLiC this can happen, initialize TGX11TTF by hand
-            // (normally this is done by the static library initializer)
-            ProcessLine("TGX11TTF::Activate();");
-         } else {
-            TPluginHandler *h;
-            if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualX", "x11ttf")))
-               if (h->LoadPlugin() == -1)
-                  Info("InitializeGraphics", "no TTF support");
+      if (use_x11) {
+         // Try to load TrueType font renderer. Only try to load if not in batch
+         // mode and Root.UseTTFonts is true and Root.TTFontPath exists. Abort silently
+         // if libttf or libGX11TTF are not found in $ROOTSYS/lib or $ROOTSYS/ttf/lib.
+         const char *ttpath = gEnv->GetValue("Root.TTFontPath",
+                                             TROOT::GetTTFFontDir());
+         char *ttfont = gSystem->Which(ttpath, "arialbd.ttf", kReadPermission);
+         // Check for use of DFSG - fonts
+         if (!ttfont)
+            ttfont = gSystem->Which(ttpath, "FreeSansBold.ttf", kReadPermission);
+
+      #if !defined(R__WIN32)
+         if (!gROOT->IsBatch() && !strcmp(gVirtualX->GetName(), "X11") &&
+            ttfont && gEnv->GetValue("Root.UseTTFonts", 1)) {
+            if (gClassTable->GetDict("TGX11TTF")) {
+               // in principle we should not have linked anything against libGX11TTF
+               // but with ACLiC this can happen, initialize TGX11TTF by hand
+               // (normally this is done by the static library initializer)
+               ProcessLine("TGX11TTF::Activate();");
+            } else {
+               if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualX", "x11ttf"))
+                  if (h->LoadPlugin() == -1)
+                     Info("InitializeGraphics", "no TTF support");
+            }
          }
+      #endif
+         delete [] ttfont;
       }
-   #endif
-      delete [] ttfont;
    }
 
    if (!only_web || !fAppImp) {
@@ -303,14 +308,12 @@ void TApplication::InitializeGraphics(Bool_t only_web)
    Init();
 
    // Set default screen factor (if not disabled in rc file)
-   if (!only_web && gEnv->GetValue("Canvas.UseScreenFactor", 1)) {
+   if (use_x11 && gVirtualX && gEnv->GetValue("Canvas.UseScreenFactor", 1)) {
       Int_t  x, y;
       UInt_t w, h;
-      if (gVirtualX) {
-         gVirtualX->GetGeometry(-1, x, y, w, h);
-         if (h > 0)
+      gVirtualX->GetGeometry(-1, x, y, w, h);
+      if (h > 0)
             gStyle->SetScreenFactor(0.001 * h);
-      }
    }
 }
 
@@ -465,7 +468,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
 
    const auto &positionalArgs = opts.GetArgs();
    const auto lastArgBeforeDashDash = opts.GetFirstPostDashDashArg().value_or(positionalArgs.size());
-   
+
    TString pwd;
 
    // Process all positional arguments before `--`
@@ -589,7 +592,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
                                "Everything after the -- will be ignored.");
       }
    }
-   
+
    // go back to startup directory
    if (pwd != "")
       gSystem->ChangeDirectory(pwd);
@@ -681,7 +684,7 @@ void TApplication::OpenInBrowser(const TString &url)
       // The user will have a warning and the URL in the terminal.
       Warning("OpenInBrowser", "The $DISPLAY is not set! Please manually open (e.g. Ctrl-click) %s\n", url.Data());
       return;
-   }   
+   }
    // Command for opening a browser in Linux. Since the DISPLAY is set, it will open the browser.
    TString cLinux("xdg-open ");
    cLinux.Append(url);
@@ -1406,6 +1409,23 @@ void TApplication::LoadGraphicsLibs()
       if (h->LoadPlugin() == -1)
          return;
 
+   TString guiFactory = gEnv->GetValue("Gui.Factory", "native");
+   guiFactory.ToLower();
+   if (guiFactory == "native")
+      guiFactory = "root";
+
+   if (auto h = gROOT->GetPluginManager()->FindHandler("TGuiFactory", guiFactory)) {
+      if (h->LoadPlugin() == -1) {
+         gROOT->SetBatch(kTRUE);
+         return;
+      }
+      gGuiFactory = (TGuiFactory *) h->ExecPlugin(0);
+
+      if (!gGuiFactory || !gGuiFactory->UseVirtualX())
+         return;
+   }
+
+
    TString name;
    TString title1 = "ROOT interface to ";
    TString nativex, title;
@@ -1440,19 +1460,6 @@ void TApplication::LoadGraphicsLibs()
       }
       gVirtualX = (TVirtualX *) h->ExecPlugin(2, name.Data(), title.Data());
       fgGraphInit = kTRUE;
-   }
-
-   TString guiFactory = gEnv->GetValue("Gui.Factory", "native");
-   guiFactory.ToLower();
-   if (guiFactory == "native")
-      guiFactory = "root";
-
-   if (auto h = gROOT->GetPluginManager()->FindHandler("TGuiFactory", guiFactory)) {
-      if (h->LoadPlugin() == -1) {
-         gROOT->SetBatch(kTRUE);
-         return;
-      }
-      gGuiFactory = (TGuiFactory *) h->ExecPlugin(0);
    }
 }
 

--- a/core/gui/inc/TGuiFactory.h
+++ b/core/gui/inc/TGuiFactory.h
@@ -45,6 +45,8 @@ public:
    TGuiFactory(const char *name = "Batch", const char *title = "Batch GUI Factory");
    virtual ~TGuiFactory() { }
 
+   virtual Bool_t UseVirtualX() const { return kTRUE; }
+
    virtual TApplicationImp *CreateApplicationImp(const char *classname, int *argc, char **argv);
 
    virtual TCanvasImp *CreateCanvasImp(TCanvas *c, const char *title, UInt_t width, UInt_t height);

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -56,8 +56,18 @@ TApplicationImp *TGuiFactory::CreateApplicationImp(const char *classname, int *a
 
 TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, UInt_t width, UInt_t height)
 {
+   TString canvName;
    if (gROOT->IsWebDisplay()) {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+      canvName = "TWebCanvas";
+   } else {
+      canvName = gEnv->GetValue("Canvas.Name", "");
+      // in batch web display should be configured explicitely
+      if (canvName == "TWebCanvas")
+         canvName.Clear();
+   }
+
+   if (!canvName.IsNull() && (canvName != "TRootCanvas") && (canvName != "TCanvasImp")) {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", canvName);
 
       if (ph && ph->LoadPlugin() != -1) {
          auto imp = (TCanvasImp *)ph->ExecPlugin(6, c, title, 0, 0, width, height);
@@ -65,7 +75,7 @@ TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, UInt_t w
             return imp;
       }
 
-      Error("CreateCanvasImp", "Fail to create TWebCanvas, please provide missing libWebGui6 or run 'root --web=off'");
+      Error("CreateCanvasImp", "Fail to create %s canvas implementation", canvName.Data());
    }
 
    return new TCanvasImp(c, title, width, height);
@@ -76,8 +86,18 @@ TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, UInt_t w
 
 TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
+   TString canvName;
    if (gROOT->IsWebDisplay()) {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+      canvName = "TWebCanvas";
+   } else {
+      canvName = gEnv->GetValue("Canvas.Name", "");
+      // in batch web display should be configured explicitely
+      if (canvName == "TWebCanvas")
+         canvName.Clear();
+   }
+
+   if (!canvName.IsNull() && (canvName != "TRootCanvas") && (canvName != "TCanvasImp")) {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", canvName);
 
       if (ph && ph->LoadPlugin() != -1) {
          auto imp = (TCanvasImp *)ph->ExecPlugin(6, c, title, x, y, width, height);
@@ -85,7 +105,7 @@ TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, Int_t x,
             return imp;
       }
 
-      Error("CreateCanvasImp", "Fail to create TWebCanvas, please provide missing libWebGui6 or run 'root --web=off'");
+      Error("CreateCanvasImp", "Fail to create %s canvas implementation", canvName.Data());
    }
 
    return new TCanvasImp(c, title, x, y, width, height);

--- a/graf2d/cocoa/src/TGCocoa.mm
+++ b/graf2d/cocoa/src/TGCocoa.mm
@@ -579,8 +579,11 @@ void TGCocoa::Update(Int_t mode)
    R__LOCKGUARD(gROOTMutex);
 
    if (mode == 2) {
-      assert(gClient != 0 && "Update, gClient is null");
-      gClient->DoRedraw();//Call DoRedraw for all widgets, who need to be updated.
+      // with none-virtualX displays like qt6canv gClient not created at all
+      // while graphics libraries can be loaded by different ways prvent crash when client not present
+      // before not defined gClient was triggering assert here
+      if (gClient)
+         gClient->DoRedraw();//Call DoRedraw for all widgets, who need to be updated.
    } else if (mode > 0) {
       //Execute buffered commands.
       fPimpl->fX11CommandBuffer.Flush(fPimpl.get());

--- a/gui/gui/src/TRootGuiFactory.cxx
+++ b/gui/gui/src/TRootGuiFactory.cxx
@@ -78,11 +78,12 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                              UInt_t width, UInt_t height)
 {
    TString canvName = gEnv->GetValue("Canvas.Name", "TWebCanvas");
-   if (canvName == "TWebCanvas") {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+   if (!canvName.IsNull() && (canvName != "TRootCanvas"))  {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", canvName);
 
       if (ph && ph->LoadPlugin() != -1) {
-         ShowWebCanvasWarning();
+         if (canvName == "TWebCanvas")
+            ShowWebCanvasWarning();
          auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, 0, 0, width, height);
          if (imp) return imp;
       }
@@ -98,11 +99,12 @@ TCanvasImp *TRootGuiFactory::CreateCanvasImp(TCanvas *c, const char *title,
                                   Int_t x, Int_t y, UInt_t width, UInt_t height)
 {
    TString canvName = gEnv->GetValue("Canvas.Name", "TWebCanvas");
-   if (canvName == "TWebCanvas") {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", "TWebCanvas");
+   if (!canvName.IsNull() && (canvName != "TRootCanvas"))  {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TCanvasImp", canvName);
 
       if (ph && ph->LoadPlugin() != -1) {
-         ShowWebCanvasWarning();
+         if (canvName == "TWebCanvas")
+            ShowWebCanvasWarning();
          auto imp = (TCanvasImp *) ph->ExecPlugin(6, c, title, x, y, width, height);
          if (imp) return imp;
       }


### PR DESCRIPTION
1. Now only special `TWebCanvas` handled extra in `TGuiFactory`. Extend code to let load plugin for any alternative class. This allows to create alternative implementations for the TCanvas without need to implement complete `TGuiFactory` API. Useful during development phase or for simple implementations of the canvas. Used in qt6canvas PR https://github.com/root-project/root/pull/22736
2. Add `TGuiFactory::UseVirtualX()` virtual method indicating if GUI classes uses gVirtualX API. Return true by default
3. Add usage if `gGuiFactory->UseVirtualX()` in the graphics initialization in the `TApplication::InitializeGraphics()` method. If `gVirtualX` is not required - libraries loading will be skipped.
4. In TGocoa check if `gClient` exists. Before just `assert` was done, now one should be able load graphics lib without creating `gClient`