### PR TITLE
[cling] Always add primary NamespaceDecl to fNSSet

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -5872,6 +5872,16 @@ namespace {
 
          nsDecl->setHasExternalVisibleStorage();
          fNSSet.insert(nsDecl);
+
+         // When cling eventually queries fNSSet/fNSFromRootmaps, it always does so
+         // using the primary DeclContext. Therefore we need to store
+         // the namespace's primary, not just nsDecl which might just
+         // be a non-primary declaration context for the namespace.
+         auto *primaryNsDecl = dyn_cast_or_null<NamespaceDecl>(nsDecl->getPrimaryContext());
+         if (primaryNsDecl && primaryNsDecl != nsDecl) {
+            primaryNsDecl->setHasExternalVisibleStorage();
+            fNSSet.insert(primaryNsDecl);
+         }
          return true;
       }
       bool VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl* specDecl) {


### PR DESCRIPTION
# This Pull request:
Marks the primary `NamespaceDecl` as having external visible storage, ie. so that clang will query ROOT for any name it can't find in that namespace, and adds it into the `fNSFromRootmaps`/`fNSSet` alongside any potential non-primary redeclared context, so ROOT correctly reports any rootmap-redeclared namespace as an autoload candidate, even when the primary declaration comes from the PCH.

From the clang manual: [Clang Internals Manual](https://github.com/llvm/llvm-project/blob/20d5962141fd3f340840b86666f58c7f230f717c/clang/docs/InternalsManual.md?plain=1#L1926)

Example:
1. ROOT is built with gminimal=ON and without runtime modules. That build's PCH does not declare e.g. `ROOT::RDataFrame`, but it does declare the ROOT:: namespace. That `NamespaceDecl` in the PCH is designated the primary, and since it is sourced directly from the PCH it will never be inserted into `fNSFromRootmaps`.
2. Then, dataframe components are installed, e.g. via wheel. These components can be autoparsed and their .rootmap(s) redeclare the ROOT:: namespace, which contains e.g. `ROOT::RDataFrame`. The `NamespaceDecl` representing this redeclaration is added to `fNSFromRootmaps`.
3. The user tries to access `ROOT::RDataFrame`, clang's `lookupImpl` tries to find the external decl but does so by querying TCling with the primary `NamespaceDecl` for the ROOT:: namespace. TCling (through a chain of calls) checks for the primary in `fNSFromRootmaps`, but fails, because only dataframe's `NamespaceDecl` is in the set.
4. TCling reports failure, and the user sees `error: no member named 'RDataFrame' in namespace 'ROOT'` even though `RDataFrame` is present and could have been autoparsed.


## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

Bug discovered by LLM

