### PR TITLE
Install libcppyy in the bin directory on Windows

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
+++ b/bindings/pyroot/cppyy/CPyCppyy/CMakeLists.txt
@@ -109,6 +109,9 @@ if(NOT MSVC)
   # Make sure that relative RUNPATH to main ROOT libraries is always correct.
   ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH(cppyy ${CMAKE_INSTALL_PYTHONDIR}/cppyy)
   ROOT_APPEND_LIBDIR_TO_INSTALL_RPATH(CPyCppyy ${CMAKE_INSTALL_LIBDIR})
+  set(CPPYY_INSTALL_DIR ${CMAKE_INSTALL_PYTHONDIR}/cppyy)
+else()
+  set(CPPYY_INSTALL_DIR ${CMAKE_INSTALL_PYTHONDIR})
 endif()
 
 # Install library
@@ -118,9 +121,9 @@ install(TARGETS CPyCppyy EXPORT ${CMAKE_PROJECT_NAME}Exports
                             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT libraries)
 
 install(TARGETS cppyy EXPORT ${CMAKE_PROJECT_NAME}Exports
-                            RUNTIME DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/cppyy COMPONENT libraries # Windows
-                            LIBRARY DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/cppyy COMPONENT libraries
-                            ARCHIVE DESTINATION ${CMAKE_INSTALL_PYTHONDIR}/cppyy COMPONENT libraries)
+                            RUNTIME DESTINATION ${CPPYY_INSTALL_DIR} COMPONENT libraries # Windows
+                            LIBRARY DESTINATION ${CPPYY_INSTALL_DIR} COMPONENT libraries
+                            ARCHIVE DESTINATION ${CPPYY_INSTALL_DIR} COMPONENT libraries)
 
 file(COPY ${headers} DESTINATION ${CMAKE_BINARY_DIR}/include/CPyCppyy)
 


### PR DESCRIPTION
On Windows, `libcppyy.pyd` cannot be found in the cppyy subdirectory
See the issue reported on the Forum:
https://root-forum.cern.ch/t/cern-root-on-windows/64947
