### PR TITLE
[tgx11] add missing kShapeDot to markers switch

### DIFF
--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -757,6 +757,9 @@ void TGX11::DrawPolyMarkerW(WinContext_t wctxt, Int_t n, TPoint *xy)
             pnt.fY += xyp[m].y;
          }
          switch(ctxt->markerType) {
+            case TAttMarker::kShapeDot:
+               // dot - handled before
+               break;
             case TAttMarker::kShapeCircle:
                // hollow circle
                XDrawArc((Display*)fDisplay, ctxt->fDrawing, ctxt->fGClist[kGCmark],


### PR DESCRIPTION
Dots handled before in more efficient way,
therefore not handled in this switch

Fix warning which harms CI