### PR TITLE
[core] Restore check of `ROOT_USE_GMI`

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1271,10 +1271,19 @@ static void RegisterCxxModules(cling::Interpreter &clingInterp)
       LoadModules(FIXMEModules, clingInterp);
 
       GlobalModuleIndex *GlobalIndex = nullptr;
-      loadGlobalModuleIndex(clingInterp);
-      // FIXME: The ASTReader still calls loadGlobalIndex and loads the file
-      // We should investigate how to suppress it completely.
-      GlobalIndex = CI.getASTReader()->getGlobalIndex();
+
+      bool useGMI = true;
+      std::optional<std::string> envUseGMI = llvm::sys::Process::GetEnv("ROOT_USE_GMI");
+      if (envUseGMI.has_value())
+         if (!envUseGMI->empty() && !ROOT::FoundationUtils::ConvertEnvValueToBool(*envUseGMI))
+            useGMI = false;
+
+      if (useGMI) {
+         loadGlobalModuleIndex(clingInterp);
+         // FIXME: The ASTReader still calls loadGlobalIndex and loads the file
+         // We should investigate how to suppress it completely.
+         GlobalIndex = CI.getASTReader()->getGlobalIndex();
+      }
 
       llvm::StringSet<> KnownModuleFileNames;
       if (GlobalIndex)


### PR DESCRIPTION
Commit 3869282efb fixed `modules.idx` generation on Windows and turned it on by default. However, the environment variable `ROOT_USE_GMI` is still checked in `TClingCallbacks::findInGlobalModuleIndex`. So by setting it to 0 you get the benefit in `RegisterCxxModules` of not preloading modules, but then not loading modules on demand - resulting in a "broken" interpreter that cannot find some classes. Restore the check because it's convenient for testing of the `GlobalModuleIndex`.