### PR TITLE
[ntuple] Allow enabling RNTupleMetrics through env variable

### DIFF
--- a/roottest/root/ntuple/metrics/CMakeLists.txt
+++ b/roottest/root/ntuple/metrics/CMakeLists.txt
@@ -1,0 +1,8 @@
+ROOTTEST_ADD_TEST(metrics_env_enabled
+                  MACRO test_rntuple_metrics_env.C
+                  ENVIRONMENT ROOT_EXPORT_RNTUPLE_METRICS=metrics_env_enabled.root
+                  OUTREF metrics_env_enabled.ref)
+
+ROOTTEST_ADD_TEST(metrics_env_disabled
+                  MACRO test_rntuple_metrics_env.C
+                  OUTREF metrics_env_disabled.ref)

--- a/roottest/root/ntuple/metrics/metrics_env_disabled.ref
+++ b/roottest/root/ntuple/metrics/metrics_env_disabled.ref
@@ -1,0 +1,3 @@
+Processing test_rntuple_metrics_env.C...
+Metrics enabled: false
+nPageCommitted: 0

--- a/roottest/root/ntuple/metrics/metrics_env_enabled.ref
+++ b/roottest/root/ntuple/metrics/metrics_env_enabled.ref
@@ -1,0 +1,3 @@
+Processing test_rntuple_metrics_env.C...
+Metrics enabled: true
+nPageCommitted: 1

--- a/roottest/root/ntuple/metrics/test_rntuple_metrics_env.C
+++ b/roottest/root/ntuple/metrics/test_rntuple_metrics_env.C
@@ -1,0 +1,32 @@
+#include <ROOT/RNTupleModel.hxx>
+#include <ROOT/RNTupleWriter.hxx>
+
+#include <TSystem.h>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <utility>
+
+void test_rntuple_metrics_env()
+{
+   constexpr std::size_t kNEntries = 1000;
+   const std::string kFileName{"test_metrics_env.root"};
+
+   auto model = ROOT::RNTupleModel::Create();
+   auto pt = model->MakeField<float>("f");
+
+   auto writer = ROOT::RNTupleWriter::Recreate(std::move(model), "ntpl", kFileName);
+   for (std::size_t i = 0; i < kNEntries; ++i) {
+      *pt = static_cast<float>(i);
+      writer->Fill();
+   }
+   writer->CommitDataset();
+
+   const auto &metrics = writer->GetMetrics();
+   const auto *nPageCommitted = metrics.GetCounter("RNTupleWriter.RPageSinkBuf.RPageSinkFile.nPageCommitted");
+
+   std::cout << "Metrics enabled: " << std::boolalpha << metrics.IsEnabled() << std::endl;
+   std::cout << "nPageCommitted: " << (nPageCommitted ? std::to_string(nPageCommitted->GetValueAsInt()) : "?")
+             << std::endl;
+}

--- a/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
@@ -282,6 +282,9 @@ using RNTupleAtomicTimer = RNTupleTimer<RNTupleAtomicCounter, RNTupleTickCounter
 \brief A collection of Counter objects with a name, a unit, and a description.
 
 The class owns the counters.
+
+If the environment variable `ROOT_EXPORT_RNTUPLE_METRICS` is set, metrics are automatically enabled on
+construction, and any counter added afterwards through MakeCounter() is enabled as well.
 */
 // clang-format on
 class RNTupleMetrics {
@@ -297,7 +300,12 @@ private:
    bool Contains(const std::string &name) const;
 
 public:
-   explicit RNTupleMetrics(const std::string &name) : fName(name) {}
+   explicit RNTupleMetrics(const std::string &name) : fName(name)
+   {
+      // TODO: Use the value of `GetMetricsExportPath` to save the contents of the metrics in a `.root` file
+      if (!GetMetricsExportPath().empty())
+         Enable();
+   }
    RNTupleMetrics(const RNTupleMetrics &other) = delete;
    RNTupleMetrics & operator=(const RNTupleMetrics &other) = delete;
    RNTupleMetrics(RNTupleMetrics &&other) = default;
@@ -324,6 +332,7 @@ public:
    const RNTuplePerfCounter *GetCounter(std::string_view name) const;
 
    void ObserveMetrics(RNTupleMetrics &observee);
+   static const std::string &GetMetricsExportPath();
 
    void Print(std::ostream &output, const std::string &prefix = "") const;
    void Enable();

--- a/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleMetrics.hxx
@@ -312,6 +312,8 @@ public:
       auto counter = std::make_unique<std::remove_pointer_t<CounterPtrT>>(name, std::forward<Args>(args)...);
       auto ptrCounter = counter.get();
       fCounters.emplace_back(std::move(counter));
+      if (fIsEnabled)
+         ptrCounter->Enable();
       return ptrCounter;
    }
 

--- a/tree/ntuple/src/RNTupleMetrics.cxx
+++ b/tree/ntuple/src/RNTupleMetrics.cxx
@@ -14,6 +14,8 @@
 
 #include <ROOT/RNTupleMetrics.hxx>
 
+#include <TSystem.h>
+
 #include <ostream>
 
 #include <iostream>
@@ -89,4 +91,14 @@ void ROOT::Experimental::Detail::RNTupleMetrics::Enable()
 void ROOT::Experimental::Detail::RNTupleMetrics::ObserveMetrics(RNTupleMetrics &observee)
 {
    fObservedMetrics.push_back(&observee);
+}
+
+const std::string &ROOT::Experimental::Detail::RNTupleMetrics::GetMetricsExportPath()
+{
+   static const std::string path = []() -> std::string {
+      if (const char *env = gSystem->Getenv("ROOT_EXPORT_RNTUPLE_METRICS"); env && *env)
+         return env;
+      return "";
+   }();
+   return path;
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes: <- Changes

- Activate metrics automatically by setting environmental variable `ROOT_EXPORT_RNTUPLE_METRICS`.
- Auto-enable counters on creation if metrics are enabled.
- Added an integration test for `ROOT_EXPORT_RNTUPLE_METRICS` and updated the counters unit tests.

It's a first step towards improving the usability of the `RNTupleMetrics` class.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary) <- Documented env variable `ROOT_EXPORT_RNTUPLE_METRICS` in the header of the `RNTupleMetrics` class

This PR fixes # <- Nothing

