### PR TITLE
[misc] Fix oob read in rmkdepend

### DIFF
--- a/misc/rmkdepend/main.c
+++ b/misc/rmkdepend/main.c
@@ -634,12 +634,11 @@ char *rgetline(register struct filepointer *filep)
          bol = p + 1;
       }
    }
-   if (*bol != '#')
-      bol = NULL;
+   bol = NULL;
 done:
    filep->f_p = p;
    filep->f_line = lineno;
-   return(bol);
+   return bol;
 }
 
 /*


### PR DESCRIPTION
The `for` loop immediately before the removed line can only exit if `bol >= eof`, therefore checking for `*bol` is guaranteed to perform an oob read (`eof` is the end of the allocation pointed by `bol`). The check is therefore useless and can be removed.

Found by asan.