### PR TITLE
[RF] Avoid redundant second clone in RooWorkspace::import()

### DIFF
--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -87,6 +87,7 @@ and try reading again.
 #include <iostream>
 #include <fstream>
 #include <cstring>
+#include <unordered_map>
 
 namespace {
 
@@ -428,7 +429,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
   const char* suffix = suffixA ? suffixA : suffixC ;
 
   // Process any change in variable names
-  std::map<string,string> varMap ;
+  std::unordered_map<string,string> varMap ;
   if (strlen(varChangeIn)>0) {
 
     // Parse comma separated lists into map<string,string>
@@ -524,6 +525,9 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
   }
 
   // Mark nodes that are to be renamed with special attribute
+  // Track whether any node in cloneSet actually gets renamed below: only then
+  // does the working copy have to be cloned a second time (see there).
+  bool nodesRenamed = false ;
   string topName2 = cloneTop->GetName() ;
   if (!renameConflictOrig) {
     // Mark all nodes to be imported for renaming following conflict resolution protocol
@@ -532,6 +536,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
       string origName = cnode2->GetName() ;
       cnode2->SetName(Form("%s_%s",cnode2->GetName(),suffix)) ;
       cnode2->SetTitle(Form("%s (%s)",cnode2->GetTitle(),suffix)) ;
+      nodesRenamed = true ;
       string tag = "ORIGNAME:" + origName;
       cnode2->setAttribute(tag.c_str()) ;
       if (!cnode2->getStringAttribute("origName")) {
@@ -598,6 +603,7 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
       if (varMap.find(cnode->GetName())!=varMap.end()) {
         string origName = cnode->GetName() ;
         cnode->SetName(varMap[cnode->GetName()].c_str()) ;
+        nodesRenamed = true ;
         string tag = "ORIGNAME:" + origName;
         cnode->setAttribute(tag.c_str()) ;
         if (!cnode->getStringAttribute("origName")) {
@@ -617,10 +623,18 @@ bool RooWorkspace::import(const RooAbsArg& inArg,
     }
   }
 
-  // Now clone again with renaming effective
-  RooArgSet cloneSet2;
-  cloneSet2.useHashMapForFind(true); // Faster finding
-  RooArgSet(*cloneTop).snapshot(cloneSet2, !noRecursion);
+  // Now clone again with renaming effective. Cloning re-resolves all server
+  // links by name, which is what makes the renaming above take effect. If
+  // nothing was renamed, the first working copy is already in its final state
+  // and cloning the whole computation graph a second time would only cost time
+  // and memory, so it is reused as-is. This is the common case: renaming only
+  // happens with an explicit Rename*() command argument or a name conflict.
+  RooArgSet renamedCloneSet;
+  if (nodesRenamed) {
+    renamedCloneSet.useHashMapForFind(true); // Faster finding
+    RooArgSet(*cloneTop).snapshot(renamedCloneSet, !noRecursion);
+  }
+  RooArgSet &cloneSet2 = nodesRenamed ? renamedCloneSet : cloneSet;
   RooAbsArg* cloneTop2 = cloneSet2.find(topName2.c_str()) ;
 
   // Perform any auxiliary imports at this point

--- a/roofit/roofitcore/test/testRooWorkspace.cxx
+++ b/roofit/roofitcore/test/testRooWorkspace.cxx
@@ -3,9 +3,11 @@
 //          Jonas Rembser, CERN 05/2025
 
 #include <RooAbsReal.h>
+#include <RooAddPdf.h>
 #include <RooArgList.h>
 #include <RooBreitWigner.h>
 #include <RooConstVar.h>
+#include <RooExponential.h>
 #include <RooFFTConvPdf.h>
 #include <RooFit/ModelConfig.h>
 #include <RooGaussian.h>
@@ -408,4 +410,140 @@ TEST(RooWorkspace, Issue_10577)
    const double afterPlot = doIntegral();
 
    EXPECT_DOUBLE_EQ(afterPlot, expected);
+}
+
+namespace {
+
+/// Small composition model used by the import tests below.
+struct ImportTestModel {
+   RooRealVar x{"x", "x", 0, 10};
+   RooRealVar mean{"mean", "mean", 5, 0, 10};
+   RooRealVar sigma{"sigma", "sigma", 1.0, 0.1, 5.0};
+   RooRealVar c{"c", "c", -0.1, -1.0, 0.0};
+   RooRealVar f{"f", "f", 0.4, 0.0, 1.0};
+   RooGaussian gauss{"gauss", "gaussian", x, mean, sigma};
+   RooExponential expo{"expo", "exponential", x, c};
+   RooAddPdf model{"model", "model", RooArgList{gauss, expo}, f};
+};
+
+bool hasServer(RooAbsArg const &node, RooAbsArg const &server)
+{
+   for (RooAbsArg *s : node.servers()) {
+      if (s == &server) {
+         return true;
+      }
+   }
+   return false;
+}
+
+/// The imported graph must be fully self-contained: every server of every node
+/// in the workspace has to be owned by that same workspace. If the renaming
+/// bookkeeping in import() is wrong, nodes end up still pointing at the
+/// original objects outside the workspace.
+void expectSelfContained(RooWorkspace &ws)
+{
+   for (RooAbsArg *node : ws.components()) {
+      EXPECT_EQ(node->workspace(), &ws) << "node " << node->GetName() << " is not owned by the workspace";
+      for (RooAbsArg *server : node->servers()) {
+         EXPECT_TRUE(ws.components().containsInstance(*server))
+            << "server " << server->GetName() << " of " << node->GetName() << " is not owned by the workspace";
+      }
+   }
+}
+
+} // namespace
+
+/// Importing a computation graph clones it, and clones it a second time to make
+/// any renaming effective. Check that each renaming mode results in a correctly
+/// named and correctly wired workspace, and that the values are preserved.
+TEST(RooWorkspace, ImportRenamingModes)
+{
+   // The pdfs are deliberately evaluated without a normalization set, which is
+   // fine here because only the imported and the original value are compared.
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::ERROR};
+
+   // No renaming at all
+   {
+      ImportTestModel m;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m.model, RooFit::Silence());
+
+      ASSERT_NE(ws.pdf("model"), nullptr);
+      EXPECT_DOUBLE_EQ(ws.pdf("model")->getVal(), m.model.getVal());
+      expectSelfContained(ws);
+   }
+
+   // Name conflict resolved by renaming the incoming nodes
+   {
+      ImportTestModel m1;
+      ImportTestModel m2;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m1.model, RooFit::Silence());
+      ws.import(m2.model, RooFit::RenameConflictNodes("v2"), RooFit::Silence());
+
+      ASSERT_NE(ws.pdf("model_v2"), nullptr);
+      EXPECT_NE(ws.pdf("gauss_v2"), nullptr);
+      EXPECT_NE(ws.pdf("expo_v2"), nullptr);
+      // The renamed top node must be wired to the renamed components
+      EXPECT_TRUE(hasServer(*ws.pdf("model_v2"), *ws.pdf("gauss_v2")));
+      EXPECT_TRUE(hasServer(*ws.pdf("model_v2"), *ws.pdf("expo_v2")));
+      EXPECT_STREQ(ws.pdf("model_v2")->getStringAttribute("origName"), "model");
+      EXPECT_DOUBLE_EQ(ws.pdf("model_v2")->getVal(), m2.model.getVal());
+      expectSelfContained(ws);
+   }
+
+   // Name conflict resolved by renaming the nodes already in the workspace
+   {
+      ImportTestModel m1;
+      ImportTestModel m2;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m1.model, RooFit::Silence());
+      ws.import(m2.model, RooFit::RenameConflictNodes("old", true), RooFit::Silence());
+
+      ASSERT_NE(ws.pdf("model"), nullptr);
+      EXPECT_NE(ws.pdf("model_old"), nullptr);
+      EXPECT_DOUBLE_EQ(ws.pdf("model")->getVal(), m2.model.getVal());
+      expectSelfContained(ws);
+   }
+
+   // Rename every node, not just the conflicting ones
+   {
+      ImportTestModel m1;
+      ImportTestModel m2;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m1.model, RooFit::Silence());
+      ws.import(m2.model, RooFit::RenameAllNodes("all"), RooFit::Silence());
+
+      ASSERT_NE(ws.pdf("model_all"), nullptr);
+      EXPECT_TRUE(hasServer(*ws.pdf("model_all"), *ws.pdf("gauss_all")));
+      EXPECT_DOUBLE_EQ(ws.pdf("model_all")->getVal(), m2.model.getVal());
+      expectSelfContained(ws);
+   }
+
+   // Rename a single variable
+   {
+      ImportTestModel m;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m.model, RooFit::RenameVariable("x", "obs"), RooFit::Silence());
+
+      ASSERT_NE(ws.var("obs"), nullptr);
+      EXPECT_EQ(ws.var("x"), nullptr);
+      EXPECT_TRUE(hasServer(*ws.pdf("gauss"), *ws.var("obs")));
+      EXPECT_DOUBLE_EQ(ws.pdf("model")->getVal(), m.model.getVal());
+      expectSelfContained(ws);
+   }
+
+   // Rename all variables at once
+   {
+      ImportTestModel m;
+      RooWorkspace ws{"ws", "ws"};
+      ws.import(m.model, RooFit::RenameAllVariables("sfx"), RooFit::Silence());
+
+      ASSERT_NE(ws.var("x_sfx"), nullptr);
+      EXPECT_EQ(ws.var("x"), nullptr);
+      EXPECT_NE(ws.var("mean_sfx"), nullptr);
+      EXPECT_TRUE(hasServer(*ws.pdf("gauss"), *ws.var("x_sfx")));
+      EXPECT_DOUBLE_EQ(ws.pdf("model")->getVal(), m.model.getVal());
+      expectSelfContained(ws);
+   }
 }


### PR DESCRIPTION
`RooWorkspace::import()` deep-clones the imported computation graph twice: once to create a working copy, and then again "with renaming effective".

The second clone is only needed because cloning re-resolves all server links by name, which is what makes the renaming take effect. If no node was actually renamed (no Rename*() command argument was given and there was no name conflict) the second clone is identical to the first one, which is then simply thrown away. This is the common case.

Keep track of whether any node was really renamed and reuse the first working copy if none was. On a RooSimultaneous with 3200 channels (22403 nodes), `import()` goes from 0.77 s to 0.35 s. It also halves the peak memory usage, because both clone sets used to be alive at the same time.

The varMap is changed from `std::map` to `std::unordered_map` as well, since it is only ever used for lookups and never iterated over.

Also add a test for the different renaming modes, which were almost uncovered so far. Verified that the imported workspace contents (names, titles, server links, attributes and values) are byte-identical to before for all renaming modes.

This change was motivated by reported performance bottlenecks in CMS Combine's `text2workspace` utility.