### PR TITLE
[ci] use system civetweb in fedora 44

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/fedora44.txt
+++ b/.github/workflows/root-ci-config/buildconfig/fedora44.txt
@@ -1,5 +1,4 @@
 CMAKE_CXX_STANDARD=23
-builtin_civetweb=ON
 experimental_adaptivecpp=OFF
 pythia8=ON
 roofit_multiprocess=ON


### PR DESCRIPTION
rather than builtin

DO NOT MERGE yet: needs awaiting https://bodhi.fedoraproject.org/updates/FEDORA-2026-781a24b2f2 to go from testing to stable, AND root-ci-image to be rebuilt then