### PR TITLE
[cling][AST] Strip elaborated keyword exposed by partial desugaring

### DIFF
--- a/core/metacling/test/TClingDataMemberInfoTests.cxx
+++ b/core/metacling/test/TClingDataMemberInfoTests.cxx
@@ -252,3 +252,69 @@ TEST(TClingDataMemberInfo, Offset)
    EXPECT_EQ(-1L, (ptrdiff_t)GeoManagerInfo->GetAddress());
 #endif // R__USE_CXXMODULES and R__HAS_GEOM
 }
+
+// https://github.com/root-project/root/issues/23055
+// The elaborated type keyword ('typename', 'struct', 'class', 'enum') is part
+// of the spelling of a type, not of its identity: it must not end up in the
+// normalized type name, which is what the I/O uses to match a member against
+// the on-file description.
+TEST(TClingDataMemberInfo, ElaboratedTypeKeyword)
+{
+   gInterpreter->Declare(R"CODE(
+#include <vector>
+namespace ROOT23055 {
+struct Track {
+   int value = 0;
+};
+enum Color { kRed };
+namespace Inner {
+template <class T>
+struct Vec {
+   T *p;
+};
+}
+using Inner::Vec;
+
+template <class T>
+struct Container {
+   typedef typename std::vector<T *> seq_type;
+   typedef seq_type                  alias_of_alias;
+   typedef typename ROOT23055::Vec<T> using_type;
+   typedef struct ROOT23055::Track   record_type;
+   typedef enum ROOT23055::Color     enum_type;
+
+   seq_type                                          fSequential;
+   alias_of_alias                                    fThroughSecondAlias;
+   using_type                                        fUsing;
+   typename std::vector<T *>                         fWritten;
+   const typename std::vector<T *>                   fQualified{};
+   std::vector<typename std::vector<T *>::value_type> fNested;
+   record_type                                       fRecord;
+   enum_type                                         fEnum;
+};
+}
+)CODE");
+
+   TClass *cl = TClass::GetClass("ROOT23055::Container<ROOT23055::Track>");
+   ASSERT_NE(cl, nullptr);
+   auto *members = cl->GetListOfDataMembers();
+
+   auto trueTypeName = [members](const char *memberName) -> const char * {
+      auto *dm = (TDataMember *)members->FindObject(memberName);
+      EXPECT_NE(dm, nullptr) << " for member " << memberName;
+      return dm ? dm->GetTrueTypeName() : "";
+   };
+
+   EXPECT_STREQ(trueTypeName("fSequential"), "vector<ROOT23055::Track*>");
+   // Desugaring walks the whole alias chain before the keyword is looked at, so
+   // an alias of an alias behaves exactly like the direct case.
+   EXPECT_STREQ(trueTypeName("fThroughSecondAlias"), "vector<ROOT23055::Track*>");
+   // The using-declaration spelling is kept, as before; only the keyword goes.
+   EXPECT_STREQ(trueTypeName("fUsing"), "ROOT23055::Vec<ROOT23055::Track>");
+   EXPECT_STREQ(trueTypeName("fWritten"), "vector<ROOT23055::Track*>");
+   EXPECT_STREQ(trueTypeName("fQualified"), "const vector<ROOT23055::Track*>");
+   EXPECT_STREQ(trueTypeName("fNested"), "vector<ROOT23055::Track*>");
+   // Not only 'typename': the tag keywords leak the same way.
+   EXPECT_STREQ(trueTypeName("fRecord"), "ROOT23055::Track");
+   EXPECT_STREQ(trueTypeName("fEnum"), "ROOT23055::Color");
+}

--- a/interpreter/cling/lib/Utils/AST.cpp
+++ b/interpreter/cling/lib/Utils/AST.cpp
@@ -1337,6 +1337,67 @@ namespace utils {
     return nullptr;
   }
 
+  // Return QT stripped of its elaborated type keyword ('typename', 'struct',
+  // 'class', 'enum'), leaving everything else - in particular the nested name
+  // specifier and the qualifiers - alone.  QT is returned unchanged if it
+  // carries no keyword.
+  //
+  // Up to LLVM 20 the keyword was not stored on the type itself: a type written
+  // with a keyword was wrapped in an ElaboratedType, and dropping the wrapper
+  // (QualType(etype->getNamedType().getTypePtr(), 0)) dropped the keyword along
+  // with it.  LLVM 22 removed ElaboratedType and moved the keyword onto the
+  // types that used to be wrapped, so the equivalent operation is to rebuild
+  // the type with ElaboratedTypeKeyword::None.  The list below is exactly the
+  // set of types that used to be wrapped; DependentNameType and
+  // DependentTemplateSpecializationType are deliberately absent, as they owned
+  // their keyword before LLVM 22 as well and it was never stripped: for a
+  // dependent name the 'typename' is not redundant spelling but the only thing
+  // that says the name denotes a type.
+  static QualType RemoveElaboratedKeyword(const ASTContext& Ctx, QualType QT) {
+    constexpr auto None = ElaboratedTypeKeyword::None;
+    const Type* Ty = QT.getTypePtr();
+
+    QualType stripped;
+    if (const auto* TT = dyn_cast<TagType>(Ty)) {
+      if (TT->getKeyword() == None)
+        return QT;
+      stripped = Ctx.getTagType(None, TT->getQualifier(), TT->getDecl(),
+                                TT->isTagOwned());
+    } else if (const auto* TT = dyn_cast<TypedefType>(Ty)) {
+      if (TT->getKeyword() == None)
+        return QT;
+      stripped = Ctx.getTypedefType(None, TT->getQualifier(), TT->getDecl(),
+                                    TT->desugar());
+    } else if (const auto* UT = dyn_cast<UsingType>(Ty)) {
+      if (UT->getKeyword() == None)
+        return QT;
+      stripped = Ctx.getUsingType(None, UT->getQualifier(), UT->getDecl(),
+                                  UT->desugar());
+    } else if (const auto* UT = dyn_cast<UnresolvedUsingType>(Ty)) {
+      if (UT->getKeyword() == None)
+        return QT;
+      stripped =
+          Ctx.getUnresolvedUsingType(None, UT->getQualifier(), UT->getDecl());
+    } else if (const auto* TST = dyn_cast<TemplateSpecializationType>(Ty)) {
+      if (TST->getKeyword() == None)
+        return QT;
+      stripped = Ctx.getTemplateSpecializationType(
+          None, TST->getTemplateName(), TST->template_arguments(),
+          /*CanonicalArgs=*/{}, TST->getCanonicalTypeInternal());
+    } else if (const auto* DTST =
+                   dyn_cast<DeducedTemplateSpecializationType>(Ty)) {
+      if (DTST->getKeyword() == None)
+        return QT;
+      stripped = Ctx.getDeducedTemplateSpecializationType(
+          None, DTST->getTemplateName(), DTST->getDeducedType(),
+          DTST->isDependentType());
+    } else {
+      return QT;
+    }
+
+    return Ctx.getQualifiedType(stripped, QT.getLocalQualifiers());
+  }
+
   static QualType GetPartiallyDesugaredTypeImpl(const ASTContext& Ctx,
     QualType QT, const Transform::Config& TypeConfig,
     bool fullyQualifyType, bool fullyQualifyTmpltArg)
@@ -1544,6 +1605,21 @@ namespace utils {
         break;
       }
     }
+
+    // Removing the elaborated type keyword is part of the normalization: it is
+    // spelling, not identity, so 'typename std::vector<Track*>' and
+    // 'std::vector<Track*>' have to normalize to the same name.  Before LLVM 22
+    // this happened right here as a side effect of unwrapping the
+    // ElaboratedType (see RemoveElaboratedKeyword); that unwrapping was lost
+    // when ElaboratedType was removed, so do it explicitly.
+    //
+    // Note that this cannot be folded into the prefix handling above: that one
+    // only looks at the type we were called with, whereas the keyword we have
+    // to remove here is the one of the type the desugaring loop ended on, e.g.
+    //    typedef typename std::vector<T*> seq_type;
+    // where 'seq_type' itself carries no keyword and the 'typename' only shows
+    // up once the typedef has been resolved.
+    QT = RemoveElaboratedKeyword(Ctx, QT);
 
     // If we have a reference, array or pointer we still need to
     // desugar what they point to.

--- a/interpreter/cling/test/Utils/Transform.C
+++ b/interpreter/cling/test/Utils/Transform.C
@@ -184,6 +184,19 @@ namespace NS4 {
 }
 typedef NS4::Inner::ConcreteTypedef GlobalAlias;
 
+// https://github.com/root-project/root/issues/23055: an elaborated type keyword
+// on the target of an alias.  Note that the alias must be reachable without a
+// nested name specifier of its own -- with one, the keyword is already dropped
+// when the prefix is rebuilt further up in GetPartiallyDesugaredTypeImpl().
+namespace NS5 {
+  class Track {};
+  enum Color { kRed };
+}
+typedef typename std::vector<NS5::Track> ElaboratedSeq;
+typedef ElaboratedSeq                    ElaboratedSeqAlias;
+typedef struct NS5::Track                ElaboratedRecord;
+typedef enum NS5::Color                  ElaboratedEnum;
+
 .rawInput 0
 
 const cling::LookupHelper& lookup = gCling->getLookupHelper();
@@ -537,4 +550,26 @@ if (const clang::RecordDecl *rdecl = llvm::dyn_cast_or_null<clang::RecordDecl>(d
 QT = lookup.findType("const GlobalAlias&", diags);
 std::cout << Transform::GetPartiallyDesugaredType(Ctx, QT, transConfig).getAsString().c_str() << std::endl;
 // CHECK: NS4::Inner::TemplateClass<double> &
+
+// The elaborated type keyword is part of the spelling of the typedef target and
+// must not survive the normalization.
+QT = lookup.findType("ElaboratedSeq", diags);
+std::cout << Transform::GetPartiallyDesugaredType(Ctx, QT, transConfig).getAsString().c_str() << std::endl;
+// CHECK: std::vector<NS5::Track>
+
+// The desugaring loop unwraps the whole alias chain, so an alias of an alias
+// ends up on the same type and is stripped just the same.
+QT = lookup.findType("ElaboratedSeqAlias", diags);
+std::cout << Transform::GetPartiallyDesugaredType(Ctx, QT, transConfig).getAsString().c_str() << std::endl;
+// CHECK: std::vector<NS5::Track>
+
+// It is not specific to 'typename': the tag keywords are stored on the type the
+// same way since LLVM 22.
+QT = lookup.findType("ElaboratedRecord", diags);
+std::cout << Transform::GetPartiallyDesugaredType(Ctx, QT, transConfig).getAsString().c_str() << std::endl;
+// CHECK: NS5::Track
+
+QT = lookup.findType("ElaboratedEnum", diags);
+std::cout << Transform::GetPartiallyDesugaredType(Ctx, QT, transConfig).getAsString().c_str() << std::endl;
+// CHECK: NS5::Color
 


### PR DESCRIPTION
Removing the elaborated type keyword ('typename', 'struct', 'class', 'enum') is part of what GetPartiallyDesugaredTypeImpl() does: the keyword is spelling, not identity, so 'typename std::vector<Track*>' and 'std::vector<Track*>' have to normalize to the same name.

Up to LLVM 20 that happened for free.  A type written with a keyword was wrapped in an ElaboratedType, and this function unwrapped it:

```c++
    const ElaboratedType* etype = dyn_cast<ElaboratedType>(QT.getTypePtr());
    if (etype) {
      prefix = SelectPrefix(Ctx, etype, original_prefix, TypeConfig);
      prefix_qualifiers.addQualifiers(QT.getLocalQualifiers());
      QT = QualType(etype->getNamedType().getTypePtr(), 0);
    }
```

getNamedType() dropped the keyword together with the wrapper.  LLVM 22 removed ElaboratedType and moved the keyword onto the types that used to be wrapped; the migration replaced the branch above with the prefix reconstruction below it, which never removes the keyword.  Restore that step explicitly.

With

```c++
    template <typename T> struct Container {
       typedef typename std::vector<T*> seq_type;
       seq_type m_sequential;
    };
```

the keyword sits on the TemplateSpecializationType that seq_type resolves to, so the normalized name of m_sequential came out as 'typename std::vector<Track*>'.  TStreamerInfo::BuildOld then fails to match it against the 'vector<Track*>' stored in the file, sets the new type to -2 and skips the element, i.e. the member is silently not read.

The keyword only survives when the type has no nested name specifier of its own; with one, it is already dropped where the prefix is rebuilt. It is not specific to 'typename' either -- 'typedef struct NS::Rec R;' and 'typedef enum NS::E E2;' leak 'struct'/'enum' the same way -- so this handles the whole set of types that used to be ElaboratedType-wrapped. DependentNameType and DependentTemplateSpecializationType are left alone: they owned their keyword before LLVM 22 as well and cling never stripped it, since for a dependent name the 'typename' is not redundant spelling but the only thing that says the name denotes a type.

Fixes https://github.com/root-project/root/issues/23055

🤖 Done with the help of AI