### PR TITLE
[RDF] Fix the events/s figure in the progress bar's final line

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -357,8 +357,8 @@ void ProgressHelper::PrintStatsFinal() const
 {
    auto &stream = std::cout;
    RestoreStreamState restore(stream);
-   const auto elapsedSeconds =
-      std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - fBeginTime);
+   const std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - fBeginTime;
+   const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed);
    const auto totalEvents = ComputeTotalEvents();
 
    // The next line resets the current line output in the terminal.
@@ -385,7 +385,9 @@ void ProgressHelper::PrintStatsFinal() const
    if (fUseShellColours)
       stream << "\033[0m";
 
-   stream << "  " << std::scientific << std::setprecision(2) << (double)totalEvents / elapsedSeconds.count()
+   // Divide by the full-precision duration rather than by `elapsedSeconds`: the latter is truncated
+   // to whole seconds, so it is zero for any event loop shorter than a second.
+   stream << "  " << std::scientific << std::setprecision(2) << (double)totalEvents / elapsed.count()
           << " evt/s";
 
    stream << "]\n";

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -1007,8 +1007,9 @@ TEST(RDFHelpers, ProgressBarFinalRateIsFinite)
    std::ostringstream strCout;
    std::cout.rdbuf(strCout.rdbuf());
    {
-      auto d_write = ROOT::RDataFrame(100).Define("x", ret42).Snapshot("tree", "fh_rate.root", {"x"});
-      ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh_rate.root"});
+      ROOT::TestSupport::FileRaii raii{"fh_rate.root"};
+      auto d_write = ROOT::RDataFrame(100).Define("x", ret42).Snapshot("tree", raii.GetPath(), {"x"});
+      ROOT::RDF::RNode d = ROOT::RDataFrame("tree", raii.GetPath());
       ROOT::RDF::Experimental::AddProgressBar(d);
       d.Count().GetValue();
    }

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -998,6 +998,28 @@ TEST(RDFHelpers, ProgressBarRestorePrecision)
    }
 }
 
+// Regression test for the final statistics line of the RDF progress bar. The events/s figure was
+// computed by dividing the event count by a duration that had already been truncated to whole
+// seconds, so an event loop shorter than one second divided by zero and printed `inf evt/s`.
+TEST(RDFHelpers, ProgressBarFinalRateIsFinite)
+{
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   {
+      auto d_write = ROOT::RDataFrame(100).Define("x", ret42).Snapshot("tree", "fh_rate.root", {"x"});
+      ROOT::RDF::RNode d = ROOT::RDataFrame("tree", {"fh_rate.root"});
+      ROOT::RDF::Experimental::AddProgressBar(d);
+      d.Count().GetValue();
+   }
+   std::cout.rdbuf(oldCoutStreamBuf);
+
+   const std::string out = strCout.str();
+   ASSERT_NE(out.find("evt/s"), std::string::npos) << "no final statistics line was printed";
+   EXPECT_EQ(out.find("inf"), std::string::npos) << "the events/s figure is not finite: " << out;
+   EXPECT_EQ(out.find("nan"), std::string::npos) << "the events/s figure is not a number: " << out;
+}
+
 // The code below is a unit test for a function called `ProgressHelper_Existence_MT` in the `RDFHelpers` class.
 
 #ifdef R__USE_IMT


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

`ProgressHelper::PrintStatsFinal` computes the events/s figure from a duration that has already been truncated to whole seconds:

```cpp
const auto elapsedSeconds =
   std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - fBeginTime);
...
stream << "  " << std::scientific << std::setprecision(2) << (double)totalEvents / elapsedSeconds.count()
       << " evt/s";
```

`duration_cast` truncates toward zero, so `elapsedSeconds.count()` is an integer. Two consequences:

- an event loop shorter than one second divides by **zero** and the line reads `inf evt/s`;
- any longer loop is divided by a value that is up to one second too small, so the reported rate is always **too high** — by 100% for a run of just under two seconds.

Measured on this branch's parent, one 400-entry tree with a `Filter` that spins for a fixed time per entry, so the real rate is known:

| real event loop | measured rate | `master` prints | this PR prints |
|---|---|---|---|
| 0.447 s | 894 evt/s | `inf evt/s` | `8.94e+02 evt/s` |
| 2.408 s | 166 evt/s | `2.00e+02 evt/s` (+20%) | `1.66e+02 evt/s` |
| 5.607 s | 71.3 evt/s | `8.00e+01 evt/s` (+12%) | `7.13e+01 evt/s` |

The fix keeps the truncated value for the `h:mm` display, which wants whole seconds, and divides by the full-precision duration:

```cpp
const std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - fBeginTime;
const auto elapsedSeconds = std::chrono::duration_cast<std::chrono::seconds>(elapsed);
```

`prettyPrint(elapsedSeconds)` is unchanged, so the elapsed-time field prints exactly as before.

**The in-run line is not affected and is not touched.** `PrintProgressAndStats` takes its rate from `EvtPerSec()`, which averages the per-interval rates recorded in `RecordEvtCountAndTime` using a `duration<double>`. Only the final line had the integer division.

**This is independent of #15323.** That issue is about the *numerator* on the same line — `ComputeTotalEvents()` reports the size of the input dataset rather than what was processed. This PR deliberately does not touch the numerator; whichever way #15323 is decided, the denominator has to be a real duration.

<details>
<summary>Reproducer used for the table</summary>

The counts go to a file because the progress bar clears the terminal line with `\r` plus padding and swallows anything printed beside it.

```cpp
#include <fstream>
#include <chrono>
void rate_repro()
{
   {
      TFile f("rate.root", "RECREATE");
      TTree t("t", "t");
      int x = 0;
      t.Branch("x", &x);
      for (int i = 0; i < 400; ++i) { x = i; t.Fill(); }
      t.Write();
   }
   std::ofstream out("rate.txt");

   auto run = [&out](const char *label, int spinUs) {
      ROOT::RDataFrame df("t", "rate.root");
      ROOT::RDF::Experimental::AddProgressBar(df);
      auto slow = df.Filter([spinUs](int) {
         auto stop = std::chrono::steady_clock::now() + std::chrono::microseconds(spinUs);
         while (std::chrono::steady_clock::now() < stop) {}
         return true;
      }, {"x"});
      auto t0 = std::chrono::steady_clock::now();
      auto n = *slow.Count();
      std::chrono::duration<double> wall = std::chrono::steady_clock::now() - t0;
      out << label << " entries=" << n << " wall=" << wall.count()
          << " true_evt_per_s=" << n / wall.count() << std::endl;
   };

   run("SHORT", 1000);
   run("MID", 6000);
   run("LONG", 14000);
}
```

</details>

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary) — not necessary, no documented behaviour changes

Built from source at `6b57f8fc` (`ninja`, gcc 13, `-O3`) and exercised through `tree/dataframe/test/dataframe_helpers`:

- with only the test applied and the source unchanged, `RDFHelpers.ProgressBarFinalRateIsFinite` **fails**:
  ```
  the events/s figure is not finite: [Total elapsed time: 0:00m  processed files: 1  processed events: 100  inf evt/s]
  [  FAILED  ] RDFHelpers.ProgressBarFinalRateIsFinite
  ```
- with the source change, it passes, and the whole suite is green: `33 tests from 2 test suites ran. [ PASSED ] 33 tests.` — including `ProgressBarRestorePrecision`, which is the other test that inspects this stream.

This PR fixes # — no issue filed; happy to open one if you would rather track it that way.

## AI disclosure

AI-assisted (Claude Code). The tool found the truncation while I was reading `PrintStatsFinal` for #15323, wrote the reproducer and the regression test, and drafted this description. I built ROOT from source, ran the reproducer and the test suite myself, and checked the before/after numbers in the table against the measured wall-clock rates. I have reviewed and understood the change and take responsibility for it.
