### PR TITLE
[interpreter] fix cmake configuration with system-llvm on ubu26

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -404,6 +404,7 @@ else()
   set(LLVM_VERSION_MAJOR ${ROOT_LLVM_VERSION_REQUIRED_MAJOR} PARENT_SCOPE)
 
   # We are in the case of NOT builtin_llvm
+  set(CLANG_BUILT_STANDALONE TRUE)
   if (builtin_clang)
     # remove clang-cpp from CLANG_LINKS_TO_CREATE to avoid clashes with
     # install-clang-cpp target defined by LLVM's cmake module
@@ -422,8 +423,7 @@ else()
     set(CMAKE_CXX_STANDARD ${_cxx_standard})
   endif(builtin_clang)
 
-  set( CLANG_BUILT_STANDALONE 1 )
-  set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
+  set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}") # Used by cling
 endif(builtin_llvm)
 
 if (builtin_clang)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Without this fix, cmake configuration using -Dbuiltin_llvm=OFF fails: the builtin `interpreter/llvm-project/clang/cmake/modules/CMakeList.txt` thinks it's not a standalone build because `CLANG_BUILT_STANDALONE` was not yet defined, and tries to access reserved paths

`CMake Error: Could not open file for write in copy operation /usr/lib/llvm-22/lib/cmake/clang/ClangConfig.cmake.tmp CMake Error: : System Error: No such file or directory CMake Error at interpreter/llvm-project/clang/cmake/modules/CMakeLists.txt:37 (configure_file):`

Checked on local Ubuntu26 with `-Dbuiltin_llvm=OFF`

CI won't detect effects unless https://github.com/root-project/root/pull/22584 is merged first

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)