### PR TITLE
[cling] remove outdated external LLVM header workaround

### DIFF
--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -373,32 +373,6 @@ set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
              APPEND PROPERTY OBJECT_DEPENDS
              ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
 
-# If LLVM is external, but Clang is builtin, we must use some files
-# from patched (builtin) version of LLVM
-if ((NOT builtin_llvm) AND builtin_clang)
-  set(FixInclude "${CMAKE_SOURCE_DIR}/interpreter/llvm-project/llvm/include")
-
-  get_property(P SOURCE IncrementalJIT.cpp PROPERTY INCLUDE_DIRECTORIES)
-  list(INSERT P 0 ${FixInclude})
-  set_property(SOURCE IncrementalJIT.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
-
-  get_property(P SOURCE IncrementalExecutor.cpp PROPERTY INCLUDE_DIRECTORIES)
-  list(INSERT P 0 ${FixInclude})
-  set_property(SOURCE IncrementalExecutor.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
-
-  get_property(P SOURCE Interpreter.cpp PROPERTY INCLUDE_DIRECTORIES)
-  list(INSERT P 0 ${FixInclude})
-  set_property(SOURCE Interpreter.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
-
-  get_property(P SOURCE Transaction.cpp PROPERTY INCLUDE_DIRECTORIES)
-  list(INSERT P 0 ${FixInclude})
-  set_property(SOURCE Transaction.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
-
-  get_property(P SOURCE TransactionUnloader.cpp PROPERTY INCLUDE_DIRECTORIES)
-  list(INSERT P 0 ${FixInclude})
-  set_property(SOURCE TransactionUnloader.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
-endif()
-
 # If both LLVM and Clang are external, we need to define LLVM_PATH in order for
 # cling to use the correct (external) LLVM/Clang directories.
 if ((NOT builtin_llvm) AND (NOT builtin_clang))


### PR DESCRIPTION
with LLVM22, maybe this hunk is no longer needed since patched headers have reached stable v22? At least that's what I understand from this comment: https://github.com/root-project/root/issues/19265#issuecomment-3032377397

Tested locally on Ubu26 and it seemed ok (getting an unrelated error though in a later place), with CI it will not show yet effects: To be confirmed once https://github.com/root-project/root/pull/22584 is inside