### PR TITLE
[ci] strip pcms from wheels builds

### DIFF
--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -4,6 +4,10 @@ inputs:
   build-tag:
     description: 'The tag for this build'
     required: true
+  artifact-name:
+    description: 'The name of the artifact to upload'
+    required: false
+    default: ${{ inputs.build-tag }}
 
 runs:
   using: "composite"
@@ -16,5 +20,5 @@ runs:
     - name: Upload wheel
       uses: actions/upload-artifact@v6
       with:
-        name: ${{ inputs.build-tag }}
+        name: ${{ inputs.artifact-name }}
         path: wheelhouse/*

--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -16,6 +16,11 @@ runs:
       env:
         CIBW_BUILD: ${{ inputs.build-tag }}
 
+    - name: Setup Python for stripping pcms
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
     - name: Strip pre-built pcms
       shell: bash
       run: |

--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -6,8 +6,7 @@ inputs:
     required: true
   artifact-name:
     description: 'The name of the artifact to upload'
-    required: false
-    default: ${{ inputs.build-tag }}
+    required: true
 
 runs:
   using: "composite"

--- a/.github/workflows/cibuildwheel-impl/action.yml
+++ b/.github/workflows/cibuildwheel-impl/action.yml
@@ -16,6 +16,12 @@ runs:
       env:
         CIBW_BUILD: ${{ inputs.build-tag }}
 
+    - name: Strip pre-built pcms
+      shell: bash
+      run: |
+        python -m pip install --quiet wheel
+        python .github/workflows/utilities/strip_wheel_pcms.py wheelhouse
+
     - name: Upload wheel
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -54,31 +54,16 @@ on:
 jobs:
   Build_Wheel:
     runs-on: macos-26 
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [cp310-macosx_x86_64, cp311-macosx_x86_64, cp312-macosx_x86_64, cp313-macosx_x86_64, cp314-macosx_x86_64,
+                 cp310-macosx_arm64, cp311-macosx_arm64, cp312-macosx_arm64, cp313-macosx_arm64, cp314-macosx_arm64]
+    name: ${{ matrix.target }}
     steps:
-      - name: Checkout the official ROOT repo
-        uses: actions/checkout@v6
-        with:
-          path: root
-#          ref: v${{ inputs.major }}-${{ inputs.minor }}-${{ inputs.patch }}
-      - name: Make wheel
+      - uses: actions/checkout@v6
+      - uses: ./.github/workflows/cibuildwheel-impl
         env:
             MACOSX_DEPLOYMENT_TARGET: 26.5
-        run: |
-            mkdir wheel_creation && cd wheel_creation
-            cp -r ../root .
-            python3 -m venv root_build_env 
-            source root_build_env/bin/activate
-            pip install --upgrade pip setuptools wheel build
-            cd root
-            pip install -r requirements.txt
-            python3 -m build --wheel
-            pip install delocate 
-            mkdir fixed_wheels
-            delocate-wheel -v -w fixed_wheels/ dist/*.whl
-
-      - name: Upload_wheel
-        uses: actions/upload-artifact@v6
         with:
-          name: Wheel upload
-          path: /Users/runner/work/root/root/wheel_creation/root/fixed_wheels/*.whl
-          if-no-files-found: error
+          build-tag: ${{ matrix.target }}

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -50,6 +50,8 @@ on:
         - "30"
         required: true
         default: "00"
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   Build_Wheel:
@@ -57,8 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [cp310-macosx_x86_64, cp311-macosx_x86_64, cp312-macosx_x86_64, cp313-macosx_x86_64, cp314-macosx_x86_64,
-                 cp310-macosx_arm64, cp311-macosx_arm64, cp312-macosx_arm64, cp313-macosx_arm64, cp314-macosx_arm64]
+        target: [cp310-macosx_arm64, cp311-macosx_arm64, cp312-macosx_arm64, cp313-macosx_arm64, cp314-macosx_arm64]
     name: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           build-tag: ${{ matrix.target }}
 
-    Test_Wheels:
+  Test_Wheels:
     needs: Build_Wheel
     runs-on: macos-26
     strategy:

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -68,3 +68,40 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET: 26.5
         with:
           build-tag: ${{ matrix.target }}
+
+    Test_Wheels:
+    needs: Build_Wheel
+    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    name: test-wheel-cp${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download produced wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install produced wheel
+        run: |
+          ls -R wheels
+          PY_VER=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
+          WHEEL=$(ls wheels/*${PY_VER}*macosx*.whl | head -n 1)
+          echo "Python version: ${PY_VER}, installing wheel: ${WHEEL}"
+          pip install "$WHEEL"
+
+      - name: Install tutorials dependencies
+        run: |
+          python -m pip install --no-cache-dir -r test/wheels/requirements-ci.txt
+
+      - name: Run tutorials
+        run: |
+          pytest -vv --verbosity="4" -rF test/wheels

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -81,6 +81,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.config.deployment_target }}
         with:
           build-tag: ${{ matrix.python }}-${{ matrix.config.platform }}
+          artifact-name: ${{ matrix.python }}-${{ matrix.config.platform }}-${{ matrix.config.runner }}
 
   Test_Wheels:
     needs: Build_Wheel

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -84,12 +84,12 @@ jobs:
 
   Test_Wheels:
     needs: Build_Wheel
-    runs-on: ${{ matrix.config.runner }}
+    runs-on: ${{ matrix.test_config.runner }}
     strategy:
       fail-fast: false
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        config:
+        test_config:
           # native tests: each runner tests its own wheel
           - runner: macos-14
             wheel_pattern: "macosx_14"
@@ -104,13 +104,10 @@ jobs:
             wheel_pattern: "manylinux"
             label: "native"
           # portability tests: oldest wheel on newer runners
-          - runner: macos-15
-            wheel_pattern: "macosx_14"
-            label: "port"
           - runner: macos-26
-            wheel_pattern: "macosx_14"
+            wheel_pattern: "macosx_15"
             label: "port"
-    name: test-${{ matrix.python }}-${{ matrix.config.wheel_pattern }}-on-${{ matrix.config.runner }}-${{ matrix.config.label }}
+    name: test-${{ matrix.python }}-${{ matrix.test_config.wheel_pattern }}-on-${{ matrix.test_config.runner }}-${{ matrix.test_config.label }}
     steps:
       - uses: actions/checkout@v6
       - name: Download produced wheels
@@ -126,8 +123,8 @@ jobs:
         run: |
           ls -R wheels
           PY_VER=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
-          WHEEL=$(ls wheels/*${PY_VER}*${{ matrix.config.wheel_pattern }}*.whl | head -n 1)
-          echo "Testing wheel: ${WHEEL} on ${{ matrix.config.runner }} (${{ matrix.config.label }})"
+          WHEEL=$(ls wheels/*${PY_VER}*${{ matrix.test_config.wheel_pattern }}*.whl | head -n 1)
+          echo "Testing wheel: ${WHEEL} on ${{ matrix.test_config.runner }} (${{ matrix.test_config.label }})"
           pip install "$WHEEL"
       - name: Install tutorials dependencies
         run: |

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -55,29 +55,40 @@ on:
 
 jobs:
   Build_Wheel:
-    runs-on: macos-15
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
-        target: [cp310-macosx_arm64, cp311-macosx_arm64, cp312-macosx_arm64, cp313-macosx_arm64, cp314-macosx_arm64]
-    name: ${{ matrix.target }}
+        python: [cp310, cp311, cp312, cp313, cp314]
+        config:
+          - runner: macos-15
+            platform: macosx_arm64
+            deployment_target: "15.0"
+          - runner: macos-26
+            platform: macosx_arm64
+            deployment_target: "26.0"
+    name: ${{ matrix.python }}-${{ matrix.config.platform }}-${{ matrix.config.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/workflows/cibuildwheel-impl
         env:
-          MACOSX_DEPLOYMENT_TARGET: 15.0
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.config.deployment_target }}
         with:
-          build-tag: ${{ matrix.target }}
+          build-tag: ${{ matrix.python }}-${{ matrix.config.platform }}
 
   Test_Wheels:
     needs: Build_Wheel
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: [macos-15, macos-26]
-    name: test-wheel-cp${{ matrix.python-version }}-${{ matrix.os }}
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        config:
+          - runner: macos-15
+            wheel_pattern: "macosx_15"
+          - runner: macos-26
+            wheel_pattern: "macosx_26"
+    name: test-wheel-cp${{ matrix.python }}-${{ matrix.config.runner }}
     steps:
       - uses: actions/checkout@v6
       - name: Download produced wheels
@@ -85,20 +96,17 @@ jobs:
         with:
           path: wheels
           merge-multiple: true
-
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-
+          python-version: ${{ matrix.python }}
       - name: Install produced wheel
         run: |
           ls -R wheels
           PY_VER=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
-          WHEEL=$(ls wheels/*${PY_VER}*macosx*.whl | head -n 1)
+          WHEEL=$(ls wheels/*${PY_VER}*${{ matrix.config.wheel_pattern }}*.whl | head -n 1)
           echo "Python version: ${PY_VER}, installing wheel: ${WHEEL}"
           pip install "$WHEEL"
-
       - name: Install tutorials dependencies
         run: |
           python -m pip install --no-cache-dir -r test/wheels/requirements-ci.txt

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -61,9 +61,6 @@ jobs:
       matrix:
         python: [cp310, cp311, cp312, cp313, cp314]
         config:
-          - runner: macos-14
-            platform: macosx_arm64
-            deployment_target: "14.0"
           - runner: macos-15
             platform: macosx_arm64
             deployment_target: "15.0"
@@ -92,9 +89,6 @@ jobs:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         test_config:
           # native tests: each runner tests its own wheel
-          - runner: macos-14
-            wheel_pattern: "macosx_14"
-            label: "native"
           - runner: macos-15
             wheel_pattern: "macosx_15"
             label: "native"
@@ -105,12 +99,6 @@ jobs:
             wheel_pattern: "manylinux"
             label: "native"
           # portability tests: oldest wheel on newer runners
-          - runner: macos-15
-            wheel_pattern: "macosx_14"
-            label: "port"
-          - runner: macos-26
-            wheel_pattern: "macosx_14"
-            label: "port"
           - runner: macos-26
             wheel_pattern: "macosx_15"
             label: "port"

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -105,6 +105,12 @@ jobs:
             wheel_pattern: "manylinux"
             label: "native"
           # portability tests: oldest wheel on newer runners
+          - runner: macos-15
+            wheel_pattern: "macosx_14"
+            label: "port"
+          - runner: macos-26
+            wheel_pattern: "macosx_14"
+            label: "port"
           - runner: macos-26
             wheel_pattern: "macosx_15"
             label: "port"

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -55,7 +55,7 @@ on:
 
 jobs:
   Build_Wheel:
-    runs-on: macos-26 
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
@@ -65,18 +65,19 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/workflows/cibuildwheel-impl
         env:
-            MACOSX_DEPLOYMENT_TARGET: 26.5
+          MACOSX_DEPLOYMENT_TARGET: 15.0
         with:
           build-tag: ${{ matrix.target }}
 
   Test_Wheels:
     needs: Build_Wheel
-    runs-on: macos-26
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    name: test-wheel-cp${{ matrix.python-version }}
+        os: [macos-15, macos-26]
+    name: test-wheel-cp${{ matrix.python-version }}-${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Download produced wheels

--- a/.github/workflows/python_wheel_build.yml
+++ b/.github/workflows/python_wheel_build.yml
@@ -61,12 +61,18 @@ jobs:
       matrix:
         python: [cp310, cp311, cp312, cp313, cp314]
         config:
+          - runner: macos-14
+            platform: macosx_arm64
+            deployment_target: "14.0"
           - runner: macos-15
             platform: macosx_arm64
             deployment_target: "15.0"
           - runner: macos-26
             platform: macosx_arm64
             deployment_target: "26.0"
+          - runner: ubuntu-latest
+            platform: manylinux_x86_64
+            deployment_target: ""
     name: ${{ matrix.python }}-${{ matrix.config.platform }}-${{ matrix.config.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -84,11 +90,27 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         config:
+          # native tests: each runner tests its own wheel
+          - runner: macos-14
+            wheel_pattern: "macosx_14"
+            label: "native"
           - runner: macos-15
             wheel_pattern: "macosx_15"
+            label: "native"
           - runner: macos-26
             wheel_pattern: "macosx_26"
-    name: test-wheel-cp${{ matrix.python }}-${{ matrix.config.runner }}
+            label: "native"
+          - runner: ubuntu-latest
+            wheel_pattern: "manylinux"
+            label: "native"
+          # portability tests: oldest wheel on newer runners
+          - runner: macos-15
+            wheel_pattern: "macosx_14"
+            label: "port"
+          - runner: macos-26
+            wheel_pattern: "macosx_14"
+            label: "port"
+    name: test-${{ matrix.python }}-${{ matrix.config.wheel_pattern }}-on-${{ matrix.config.runner }}-${{ matrix.config.label }}
     steps:
       - uses: actions/checkout@v6
       - name: Download produced wheels
@@ -105,12 +127,11 @@ jobs:
           ls -R wheels
           PY_VER=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
           WHEEL=$(ls wheels/*${PY_VER}*${{ matrix.config.wheel_pattern }}*.whl | head -n 1)
-          echo "Python version: ${PY_VER}, installing wheel: ${WHEEL}"
+          echo "Testing wheel: ${WHEEL} on ${{ matrix.config.runner }} (${{ matrix.config.label }})"
           pip install "$WHEEL"
       - name: Install tutorials dependencies
         run: |
           python -m pip install --no-cache-dir -r test/wheels/requirements-ci.txt
-
       - name: Run tutorials
         run: |
           pytest -vv --verbosity="4" -rF test/wheels

--- a/.github/workflows/utilities/strip_wheel_pcms.py
+++ b/.github/workflows/utilities/strip_wheel_pcms.py
@@ -1,0 +1,60 @@
+import argparse
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+STRIP_PATTERNS = ("*.pcm", "modules.idx")
+
+
+def strip_one_wheel(wheel_path: pathlib.Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="strip-wheel-pcms-") as tmp:
+        tmp = pathlib.Path(tmp)
+        unpack_dir = tmp / "unpacked"
+        subprocess.run(
+            [sys.executable, "-m", "wheel", "unpack", str(wheel_path), "-d", str(unpack_dir)],
+            check=True,
+        )
+
+        # `wheel unpack` creates one <name>-<version> subdirectory
+        (extracted,) = list(unpack_dir.iterdir())
+
+        removed = []
+        for pattern in STRIP_PATTERNS:
+            for f in extracted.rglob(pattern):
+                f.unlink()
+                removed.append(str(f.relative_to(extracted)))
+
+        print(f"{wheel_path.name}: removed {len(removed)} file(s)")
+
+        repacked_dir = tmp / "repacked"
+        repacked_dir.mkdir()
+        subprocess.run(
+            [sys.executable, "-m", "wheel", "pack", str(extracted), "-d", str(repacked_dir)],
+            check=True,
+        )
+
+        (new_wheel,) = list(repacked_dir.glob("*.whl"))
+        wheel_path.unlink()
+        shutil.move(str(new_wheel), str(wheel_path))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=pathlib.Path, help="directory containing .whl files to strip")
+    args = parser.parse_args()
+
+    wheels = sorted(args.directory.glob("*.whl"))
+    if not wheels:
+        print(f"No .whl files found in {args.directory}", file=sys.stderr)
+        return 1
+
+    for wheel in wheels:
+        strip_one_wheel(wheel)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -213,6 +213,12 @@ try:
 except PackageNotFoundError:
     pass
 
+# Build every C++ module once per installation
+# needed for the wheels, in other cases this is done in the CMake build step, so we skip it here
+from . import _pcm_warmup
+
+_pcm_warmup.warmup(_root_facade)
+
 
 def _cleanup():
     # Delete TBrowser instances while the GUI event loop is still alive,

--- a/bindings/pyroot/pythonizations/python/ROOT/_pcm_warmup.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pcm_warmup.py
@@ -1,0 +1,86 @@
+# Author: Silia Taider, CERN 08/2026
+
+################################################################################
+# Copyright (C) 1995-2026, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+"""
+One-time warm-up that builds every ROOT C++ module ahead of use.
+What we do: explicitly import every module declared in ROOT.modulemap, 
+once, right after the interpreter is up.
+This only runs once per installation and is a no-op for builds that don't use C++
+modules at all.
+"""
+
+import os
+import re
+import sys
+
+_MODULE_LINE = re.compile(r'^module\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\{')
+
+
+def _module_names(modulemap_path):
+    """Extract the top-level module names declared in a Clang modulemap file"""
+    names = []
+    with open(modulemap_path) as f:
+        for line in f:
+            m = _MODULE_LINE.match(line)
+            if m:
+                names.append(m.group(1))
+    return names
+
+
+def _sentinel_path(lib_dir):
+    """Empty marker file to record that the module build run once"""
+    return os.path.join(lib_dir, ".pcm_warmup_complete")
+
+
+def _mark_warmup_complete(lib_dir, sentinel):
+    try:
+        os.makedirs(lib_dir, exist_ok=True)
+        with open(sentinel, "w") as f:
+            f.write("1")
+    except OSError:
+        pass
+
+
+def _print_progress(done, total, label):
+    width = 30
+    filled = width if total == 0 else int(width * done / total)
+    bar = "#" * filled + "-" * (width - filled)
+    sys.stderr.write(f"\r[{bar}] {done}/{total}  building {label:<28}")
+    sys.stderr.flush()
+
+
+def warmup(root_facade):
+    """Build every C++ module once"""
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    modulemap_path = os.path.join(this_dir, "include", "ROOT.modulemap")
+    if not os.path.exists(modulemap_path):
+        # runtime_cxxmodules is off in this build
+        return
+
+    lib_dir = os.path.join(this_dir, "lib")
+    sentinel = _sentinel_path(lib_dir)
+    if os.path.exists(sentinel):
+        return
+
+    names = _module_names(modulemap_path)
+    if not names:
+        return
+
+    sys.stderr.write(f"ROOT: preparing this installation for your machine, this may take some time: {len(names)} modules...\n")
+    declare = root_facade.gInterpreter.Declare
+    for i, name in enumerate(names, 1):
+        _print_progress(i, len(names), name)
+        try:
+            declare(f"#pragma clang module import {name}")
+        except Exception:
+            pass
+    sys.stderr.write("\n")
+
+    _mark_warmup_complete(lib_dir, sentinel)

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2276,6 +2276,11 @@ const char *TSystem::GetLibraries(const char *regexp, const char *options,
 
    static TRegexp separator("[^ \\t\\s]+");
    static TRegexp dynload("/lib-dynload/");
+   // Skip libffi, it is a private library used by the system. This is visible in the stub .tbd file:
+   // allowable-clients:
+   //     clients:         [ '!' ]
+   // See https://github.com/Homebrew/homebrew-core/issues/272324#issuecomment-5119880493 for more info
+   static TRegexp libffiMatch("/usr/lib/libffi");
 
    Ssiz_t start, index, end;
    start = index = end = 0;
@@ -2284,7 +2289,7 @@ const char *TSystem::GetLibraries(const char *regexp, const char *options,
       index = libs2.Index(separator, &end, start);
       if (index >= 0) {
          TString s = libs2(index, end);
-         if (s.Index(dynload) == kNPOS) {
+         if (s.Index(dynload) == kNPOS && s.Index(libffiMatch) == kNPOS) {
             if (!maclibs.IsNull()) maclibs.Append(" ");
             maclibs.Append(s);
          }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 # Point backend to python packages and to explicitly use Ninja
 [tool.scikit-build]
+install.strip = false
 wheel.packages = [
 	"bindings/pyroot/pythonizations/python/ROOT",
 	"bindings/pyroot/cppyy/cppyy/python/cppyy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ CMAKE_INSTALL_TUTDIR = "ROOT/tutorials"
 gminimal="ON"
 asimage="ON"
 opengl="OFF"
-runtime_cxxmodules="OFF"
+runtime_cxxmodules="ON"
 fail-on-missing="ON"
 
 # Prevent CMake from producing its own .dist-info metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ CMAKE_INSTALL_TUTDIR = "ROOT/tutorials"
 gminimal="ON"
 asimage="ON"
 opengl="OFF"
-runtime_cxxmodules="ON"
+runtime_cxxmodules="OFF"
 fail-on-missing="ON"
 
 # Prevent CMake from producing its own .dist-info metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ ssl="ON"
 imt="ON"
 roofit="ON"
 mathmore="ON"
+builtin_gif="ON"
 
 # Expose the ROOT cli as an executable command via _rootcli wrapper 
 [project.scripts]


### PR DESCRIPTION
Test a new strategy: ship ROOT wheels without pre-built C++ module `.pcm` files, and rebuild them once on the target machine instead.

`.pcm` files are frozen against the system headers of the build machine creating portability issues to other machines with different versions. This PR strips them out at CI build time and adds a one-time warm-up script that rebuilds them locally on first import ROOT against whatever headers actually exist on the user's machine.