### PR TITLE
[tmva][sofie] Support Clad forward mode in generated inference code

### DIFF
--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1416,6 +1416,26 @@ void RModel::GenerateSessionCode()
       }
 
       fGC += "}\n\n";
+
+      // Used to build the tangent Session objects needed to differentiate the
+      // generated code with Clad: the derivatives of the (constant) weights
+      // are zero, but a default-constructed Session holds the actual values.
+      fGC += "// Set all weight and constant tensors to zero. This is useful to create\n"
+             "// the tangent Session objects needed to differentiate the generated code\n"
+             "// with Clad.\n"
+             "void SetWeightsToZero() {\n";
+      for (auto &i : fInitializedTensors) {
+         // IsNotWritable tensors have no emitted fTensor_ member, and integer
+         // tensors are structural (indices, shapes) that carry no tangent.
+         if (i.second.IsNotWritable() ||
+             (i.second.type() != ETensorType::FLOAT && i.second.type() != ETensorType::DOUBLE))
+            continue;
+         fGC += "   for (auto &v : fTensor_" + i.first + ") v = 0;\n";
+      }
+      for (auto &graph : fSubGraphs) {
+         fGC += "   fSession_" + graph->fName + ".SetWeightsToZero();\n";
+      }
+      fGC += "}\n\n";
    }
 
    // generate the inference overload that returns an output struct

--- a/tmva/sofie/src/SOFIE_common_helpers.cxx
+++ b/tmva/sofie/src/SOFIE_common_helpers.cxx
@@ -460,6 +460,88 @@ inline void Relu_pullback(float *output, const float *input, int size, float *_d
 }
 )SOFIE";
 
+// Custom Clad forward-mode pushforwards for the same helpers, following
+// clad's convention for void functions: the original parameters followed by
+// same-type tangent clones of every parameter. Clad computes Hessians as
+// reverse-mode derivatives of forward-mode code, so the bodies below are
+// themselves reverse-differentiated and must consist of plain loops and of
+// calls with custom pullbacks only (for the namespace alias on the
+// Gemm_Call calls, see the comment at the emission site). Note that
+// Gemm_Call_pullback silently bails out for alpha != 1 (see the TODO there),
+// so Hessians inherit that restriction.
+constexpr const char *kGemmCallPushforward = R"SOFIE(
+inline void Gemm_Call_pushforward(float *output, bool transa, bool transb, int m, int n, int k, float alpha,
+                                  const float *A, const float *B, float beta, const float *C, float *_d_output, bool,
+                                  bool, int, int, int, float _d_alpha, const float *_d_A, const float *_d_B,
+                                  float _d_beta, const float *_d_C)
+{
+   // Primal: output = alpha * op(A) op(B) + beta * C, where a null C means
+   // "accumulate onto the existing output" (see Gemm_Call).
+   // Tangent:
+   //   d_output = alpha * (op(dA) op(B) + op(A) op(dB)) + beta * dC
+   //            + d_alpha * op(A) op(B) + d_beta * C
+   // with (C, dC) read as (output, d_output) in accumulate mode. The tangent
+   // is therefore computed first, while output and d_output still hold the
+   // values the primal call overwrites. The pointer null-checks are hoisted
+   // into bools: with a pointer-typed ternary condition, Clad's reverse pass
+   // (as of v2.4) hoists and tapes the condition with the const qualifier
+   // dropped, generating code that does not compile.
+   const bool hasC = C != nullptr;
+   const bool hasdC = _d_C != nullptr;
+   SOFIE_MODEL_NS::Gemm_Call(_d_output, transa, transb, m, n, k, alpha, _d_A, B, (hasC && !hasdC) ? 0.0f : beta, _d_C);
+   SOFIE_MODEL_NS::Gemm_Call(_d_output, transa, transb, m, n, k, alpha, A, _d_B, 1.0f, nullptr);
+   if (_d_alpha != 0.0f) {
+      SOFIE_MODEL_NS::Gemm_Call(_d_output, transa, transb, m, n, k, _d_alpha, A, B, 1.0f, nullptr);
+   }
+   if (_d_beta != 0.0f) {
+      if (hasC) {
+         for (int i = 0; i < m * n; ++i) {
+            _d_output[i] += _d_beta * C[i];
+         }
+      } else {
+         for (int i = 0; i < m * n; ++i) {
+            _d_output[i] += _d_beta * output[i];
+         }
+      }
+   }
+   SOFIE_MODEL_NS::Gemm_Call(output, transa, transb, m, n, k, alpha, A, B, beta, C);
+}
+)SOFIE";
+
+constexpr const char *kCopyPushforward = R"SOFIE(
+inline void Copy_pushforward(float *output, const float *input, int size, float *_d_output, const float *_d_input,
+                             int)
+{
+   for (int i = 0; i < size; i++) {
+      output[i] = input[i];
+      _d_output[i] = _d_input[i];
+   }
+}
+)SOFIE";
+
+constexpr const char *kFillPushforward = R"SOFIE(
+inline void Fill_pushforward(float *output, float value, int size, float *_d_output, float _d_value, int)
+{
+   for (int i = 0; i < size; i++) {
+      output[i] = value;
+      _d_output[i] = _d_value;
+   }
+}
+)SOFIE";
+
+constexpr const char *kReluPushforward = R"SOFIE(
+inline void Relu_pushforward(float *output, float const *input, int size, float *_d_output, float const *_d_input,
+                             int)
+{
+   // Tangent first: the generated code applies Relu in place, so input/output
+   // (and their tangents) may alias.
+   for (int i = 0; i < size; i++) {
+      _d_output[i] = (input[i] > 0.0f) ? _d_input[i] : 0.0f;
+      output[i] = (input[i] > 0.0f) ? input[i] : 0.0f;
+   }
+}
+)SOFIE";
+
 constexpr const char *kRelu = R"SOFIE(
 inline void Relu(float *output, float const *input, int size)
 {
@@ -797,29 +879,43 @@ HelperFunctionsCode GenerateHelperFunctionsCode(const std::set<std::string> &nee
 
    defs += "// --- End of SOFIE inference helper functions ---\n\n";
 
-   // ---- Clad custom derivatives (pullbacks) -------------------------------
+   // ---- Clad custom derivatives (pullbacks and pushforwards) --------------
    // Some helpers cannot be differentiated automatically by Clad (Gemm_Call
    // calls the bodyless BLAS routine sgemm_). For those we emit a hand-written
-   // pullback. Clad looks up custom derivatives in
-   // clad::custom_derivatives::<function-namespace>, so the pullback is placed
+   // pullback (reverse mode) and pushforward (forward mode). Clad looks up
+   // custom derivatives in
+   // clad::custom_derivatives::<function-namespace>, so they are placed
    // there (mirroring the generated model namespace) rather than next to the
    // function. The definitions reference the model's own helpers via a using
-   // declaration, so no Clad header is pulled in and a user who never
-   // differentiates the model simply carries an unused inline function.
+   // declaration / namespace alias, so no Clad header is pulled in and a user
+   // who never differentiates the model simply carries unused inline
+   // functions.
    std::string cladDefs;
    if (gemm || copy || fill || relu) {
       cladDefs += "\nnamespace clad {\nnamespace custom_derivatives {\nnamespace " + modelNamespace + " {\n";
       if (gemm) {
-         // Gemm_Call_pullback calls Gemm_Call, so bring it into scope.
+         // Gemm_Call_pullback calls Gemm_Call, so bring it into scope. The
+         // pushforward uses the SOFIE_MODEL_NS alias instead: its body gets
+         // reverse-differentiated by Clad for Hessians, and Clad resolves the
+         // custom Gemm_Call_pullback for the inner calls only when they do
+         // not go through a using-declaration.
          cladDefs += "using ::" + modelNamespace + "::Gemm_Call;\n";
+         cladDefs += "namespace SOFIE_MODEL_NS = ::" + modelNamespace + ";\n";
          cladDefs += kGemmCallPullback;
+         cladDefs += kGemmCallPushforward;
       }
-      if (copy)
+      if (copy) {
          cladDefs += kCopyPullback;
-      if (fill)
+         cladDefs += kCopyPushforward;
+      }
+      if (fill) {
          cladDefs += kFillPullback;
-      if (relu)
+         cladDefs += kFillPushforward;
+      }
+      if (relu) {
          cladDefs += kReluPullback;
+         cladDefs += kReluPushforward;
+      }
       cladDefs += "} // namespace " + modelNamespace + "\n} // namespace custom_derivatives\n} // namespace clad\n";
    }
 

--- a/tmva/sofie/test/TestCladAutodiff.cxx
+++ b/tmva/sofie/test/TestCladAutodiff.cxx
@@ -114,24 +114,210 @@ float Linear_16_wrapper_num_diff(TMVA_SOFIE_Linear_16::Session const &session, f
    auto grad_arr = reinterpret_cast<float *>(gInterpreter->ProcessLine("grad_output;"));
    auto numeric_arr = reinterpret_cast<float *>(gInterpreter->ProcessLine("numeric_output;"));
 
-   constexpr std::size_t kMaxPrint = 10;
-   std::size_t mismatchCount = 0;
-
-   for (std::size_t i = 0; i < arr_size; ++i) {
-      double diff = std::abs(grad_arr[i] - numeric_arr[i]);
-
-      if (diff > tol) {
-         if (mismatchCount < kMaxPrint) {
-            ADD_FAILURE() << "Mismatch at index " << i << " analytic=" << grad_arr[i] << " numeric=" << numeric_arr[i]
-                          << " diff=" << diff;
-         }
-         ++mismatchCount;
-      }
-   }
-
-   if (mismatchCount > kMaxPrint) {
-      ADD_FAILURE() << "Further mismatches suppressed (total mismatches: " << mismatchCount << ")";
-   }
+   expectNearCapped(grad_arr, numeric_arr, arr_size, tol);
 
    expectNear(output, ref.f32("output0"), TOLERANCE);
+}
+
+// Test forward-mode differentiation and Hessian-vector products of a
+// Gemm+Sigmoid network with Clad (a ReLU network like Linear_16 is
+// piecewise-linear in its inputs, so its input Hessian vanishes and would not
+// validate the second derivatives).
+//
+// The same inner/outer wrapper trick as in the gradient test above is used:
+// differentiating the outer wrapper generates the inner wrapper's
+// *pushforward*, which takes the session tangent as a function argument. The
+// top-level derivative functions that clad generates are not usable directly,
+// because they default-construct the Session tangent instead of zeroing its
+// weights (the weights are constants): hence Session::SetWeightsToZero.
+TEST(ONNXClad, LinearWithSigmoidForwardAndHessian)
+{
+   constexpr float TOLERANCE = DEFAULT_TOLERANCE;
+   constexpr int nInputs = 48; // input tensor shape { 2, 24 }; the output shape is { 2, 12 }
+
+   SofieReference ref = readReference("LinearWithSigmoid");
+   std::vector<float> input = ref.f32("input0");
+   ASSERT_EQ(input.size(), nInputs);
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "LinearWithSigmoid", input);
+   expectNear(output, ref.f32("output0"), TOLERANCE);
+
+   gInterpreter->Declare(R"(
+#include <Math/CladDerivator.h>
+
+float sig_w(TMVA_SOFIE_LinearWithSigmoid::Session const &session, float const *input)
+{
+   float out[24]{};
+   float output_sum = 0.0;
+
+   TMVA_SOFIE_LinearWithSigmoid::doInfer(session, input, out);
+
+   for (std::size_t i = 0; i < std::size(out); ++i) {
+      output_sum += out[i];
+   }
+   return output_sum;
+}
+
+float sig_outer(TMVA_SOFIE_LinearWithSigmoid::Session const &session, float const *input)
+{
+   return sig_w(session, input);
+}
+   )");
+
+   // Generate sig_w_pullback (reverse mode) and sig_w_pushforward (forward mode).
+   gInterpreter->ProcessLine("clad::gradient(sig_outer, \"input\");");
+   gInterpreter->ProcessLine("clad::differentiate(sig_outer, \"input[0]\");");
+
+   gInterpreter->Declare(R"(
+// Directional derivative of sig_w via the generated pushforward. Reverse
+// differentiation of this function gives the exact Hessian-vector product
+// H * dinput (in the input adjoint) and the gradient (in the dinput adjoint).
+// Both pointer arguments must be requested as active: for a non-varied
+// argument clad would look up the custom Gemm_Call pullback with a
+// reduced signature, not find it, and silently fall back to differentiating
+// the BLAS call, which yields zero.
+float sig_dir(TMVA_SOFIE_LinearWithSigmoid::Session const &session,
+              TMVA_SOFIE_LinearWithSigmoid::Session const &zeroSession, float const *input, float const *dinput)
+{
+   return sig_w_pushforward(session, input, zeroSession, dinput).pushforward;
+}
+
+float sig_dir_outer(TMVA_SOFIE_LinearWithSigmoid::Session const &session,
+                    TMVA_SOFIE_LinearWithSigmoid::Session const &zeroSession, float const *input, float const *dinput)
+{
+   return sig_dir(session, zeroSession, input, dinput);
+}
+   )");
+
+   gInterpreter->ProcessLine("clad::gradient(sig_dir_outer, \"input, dinput\");");
+
+   auto inputInterp = toInterpreter(input, "std::vector<float>", true);
+
+   // Sessions for the forward pass, the first-order reverse-pass adjoint
+   // (its weight values are irrelevant: adjoints are accumulated and
+   // discarded), and the zero-weight tangent session.
+   gInterpreter->Declare(R"(
+TMVA_SOFIE_LinearWithSigmoid::Session sig_session{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+TMVA_SOFIE_LinearWithSigmoid::Session sig_d_session{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+TMVA_SOFIE_LinearWithSigmoid::Session sig_zero_session{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+
+std::vector<float> sig_grad(48, 0.0f);
+std::vector<float> sig_fwd(48, 0.0f);
+std::vector<float> sig_dinput(48, 0.0f);
+std::vector<float> sig_hvp_grad(48, 0.0f);
+std::vector<float> sig_hess(48 * 48, 0.0f);
+std::vector<float> sig_hess_fd(48 * 48, 0.0f);
+float sig_hvp_dev = 0.0f;
+   )");
+   gInterpreter->ProcessLine("sig_zero_session.SetWeightsToZero();");
+
+   // Reverse-mode gradient (the reference for the forward mode below).
+   gInterpreter->ProcessLine(
+      ("sig_w_pullback(sig_session, " + inputInterp + ", 1, &sig_d_session, sig_grad.data());").c_str());
+
+   // Forward mode: directional derivatives along all unit directions.
+   gInterpreter->ProcessLine((R"(
+   for (int j = 0; j < 48; ++j) {
+      std::fill(sig_dinput.begin(), sig_dinput.end(), 0.0f);
+      sig_dinput[j] = 1.0f;
+      sig_fwd[j] = sig_w_pushforward(sig_session, )" +
+                              inputInterp + R"(, sig_zero_session, sig_dinput.data()).pushforward;
+   }
+   )")
+                                .c_str());
+
+   auto *gradArr = reinterpret_cast<float *>(gInterpreter->ProcessLine("sig_grad.data();"));
+   auto *fwdArr = reinterpret_cast<float *>(gInterpreter->ProcessLine("sig_fwd.data();"));
+   for (int i = 0; i < nInputs; ++i) {
+      EXPECT_NEAR(fwdArr[i], gradArr[i], 1e-5) << "forward vs reverse derivative at input index " << i;
+   }
+
+   // Hessian, column by column, as Hessian-vector products with unit
+   // directions. The adjoint sessions must be freshly constructed for every
+   // call: the clad-generated second-order pullback does not restore the
+   // intermediate adjoint state inside the adjoint sessions to zero (see the
+   // "clad referenced '_tracker...' before its declaration" warnings it
+   // prints during generation), so reusing them leaks state from one call
+   // into the next. They are constructed from the weight file each time
+   // because the generated Session is not copy-safe: the raw tensor_*
+   // pointer members of a copy would still point into the original's
+   // buffers.
+   //
+   // The adjoint of the tangent direction is the gradient again, for every
+   // direction, so the loop also tracks the largest deviation from the
+   // reverse-mode gradient as a cheap consistency check of the second-order
+   // code path.
+   gInterpreter->ProcessLine((R"(
+   for (int j = 0; j < 48; ++j) {
+      TMVA_SOFIE_LinearWithSigmoid::Session dSession{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+      TMVA_SOFIE_LinearWithSigmoid::Session dSession2{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+      std::fill(sig_dinput.begin(), sig_dinput.end(), 0.0f);
+      std::fill(sig_hvp_grad.begin(), sig_hvp_grad.end(), 0.0f);
+      sig_dinput[j] = 1.0f;
+      std::vector<float> hvp(48, 0.0f);
+      sig_dir_pullback(sig_session, sig_zero_session, )" +
+                              inputInterp + R"(, sig_dinput.data(), 1, &dSession, &dSession2, hvp.data(),
+                       sig_hvp_grad.data());
+      for (int i = 0; i < 48; ++i) {
+         sig_hess[i * 48 + j] = hvp[i];
+         sig_hvp_dev = std::max(sig_hvp_dev, std::abs(sig_hvp_grad[i] - sig_grad[i]));
+      }
+   }
+   )")
+                                .c_str());
+
+   auto *hvpDev = reinterpret_cast<float *>(gInterpreter->ProcessLine("&sig_hvp_dev;"));
+   EXPECT_LT(*hvpDev, 1e-5) << "dinput adjoint vs gradient";
+
+   // Reference Hessian: central finite differences of the exact reverse-mode
+   // gradient.
+   gInterpreter->Declare(R"(
+void sig_fd_hessian(float *input)
+{
+   const float eps = 1e-2f;
+   std::vector<float> gp(48);
+   std::vector<float> gm(48);
+   for (int j = 0; j < 48; ++j) {
+      // Fresh adjoint sessions, so the FD reference does not rely on the
+      // first-order pullback consuming-and-zeroing the adjoint state left
+      // behind by previous calls (see the Hessian loop above for why copies
+      // are not an option).
+      TMVA_SOFIE_LinearWithSigmoid::Session dp{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+      TMVA_SOFIE_LinearWithSigmoid::Session dm{"LinearWithSigmoid_FromONNX_unoptimized.dat"};
+      const float orig = input[j];
+      std::fill(gp.begin(), gp.end(), 0.0f);
+      std::fill(gm.begin(), gm.end(), 0.0f);
+      input[j] = orig + eps;
+      sig_w_pullback(sig_session, input, 1, &dp, gp.data());
+      input[j] = orig - eps;
+      sig_w_pullback(sig_session, input, 1, &dm, gm.data());
+      input[j] = orig;
+      for (int i = 0; i < 48; ++i) {
+         sig_hess_fd[i * 48 + j] = (gp[i] - gm[i]) / (2 * eps);
+      }
+   }
+}
+   )");
+   gInterpreter->ProcessLine(("sig_fd_hessian(" + inputInterp + ");").c_str());
+
+   auto *hessArr = reinterpret_cast<float *>(gInterpreter->ProcessLine("sig_hess.data();"));
+   auto *hessFdArr = reinterpret_cast<float *>(gInterpreter->ProcessLine("sig_hess_fd.data();"));
+
+   expectNearCapped(hessArr, hessFdArr, nInputs * nInputs, 1e-3);
+
+   // Guard against a trivially-zero Hessian, which would make the check above
+   // meaningless.
+   double maxAbsHess = 0.;
+   for (int i = 0; i < nInputs * nInputs; ++i) {
+      maxAbsHess = std::max(maxAbsHess, std::abs(static_cast<double>(hessArr[i])));
+   }
+   EXPECT_GT(maxAbsHess, 1e-4);
+
+   // The Hessian-vector products must assemble into a symmetric matrix.
+   for (int i = 0; i < nInputs; ++i) {
+      for (int j = 0; j < i; ++j) {
+         EXPECT_NEAR(hessArr[i * 48 + j], hessArr[j * 48 + i], 1e-5)
+            << "Hessian asymmetry at (" << i << ", " << j << ")";
+      }
+   }
 }

--- a/tmva/sofie/test/test_helpers.h
+++ b/tmva/sofie/test/test_helpers.h
@@ -107,6 +107,27 @@ void expectNear(std::vector<std::vector<T>> const &output, std::vector<std::vect
    }
 }
 
+/// Element-wise |actual - expected| <= tolerance over raw arrays, printing at
+/// most maxPrint failing elements followed by a count of the suppressed rest
+inline void
+expectNearCapped(const float *actual, const float *expected, std::size_t n, double tolerance, std::size_t maxPrint = 10)
+{
+   std::size_t mismatchCount = 0;
+   for (std::size_t i = 0; i < n; ++i) {
+      const double diff = std::abs(static_cast<double>(actual[i]) - static_cast<double>(expected[i]));
+      if (diff > tolerance) {
+         if (mismatchCount < maxPrint) {
+            ADD_FAILURE() << "Mismatch at index " << i << " actual=" << actual[i] << " expected=" << expected[i]
+                          << " diff=" << diff;
+         }
+         ++mismatchCount;
+      }
+   }
+   if (mismatchCount > maxPrint) {
+      ADD_FAILURE() << "Further mismatches suppressed (total mismatches: " << mismatchCount << ")";
+   }
+}
+
 /// Element-wise exact equality
 template <typename T, typename U>
 void expectEqual(std::vector<T> const &output, std::vector<U> const &expected)


### PR DESCRIPTION
Emit "_pushforward" custom derivatives for the standalone helper functions (Gemm_Call, Copy, Fill, Relu) next to the existing pullbacks, so that clad::differentiate() works on the generated code — and with it Hessians, which Clad computes by reverse differentiating the forward derivative code.

Also generate a Session::SetWeightsToZero() method for building the zero-weight tangent Sessions that forward-mode differentiation needs (the weights are constants, not inputs).

Add a TestCladAutodiff test on a Gemm+Sigmoid model that validates forward-mode directional derivatives against the reverse mode gradient, and a full Hessian, computed via exact Hessian-vector products (reverse-over-forward), against finite differences of the exact gradient. The Clad limitations and workarounds all this rests on are documented in the emitted code and in the test.

🤖 Done with the help of AI

This is needed for full analytic Hessian support of RooFit models that include ONNX functions.