### PR TITLE
[Math] Fill in some gaps in custom derivative support for Clad

### DIFF
--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -203,412 +203,202 @@ ValueAndPushforward<T, T> TanH_pushforward(T x, T d_x)
 namespace ROOT {
 namespace Math {
 
+/// Evaluate the polynomial c[0] + c[1]*x + c[2]*x^2 + ... in Horner form,
+/// matching the evaluation order of the CERNLIB Landau routines below.
+template <unsigned N>
+double horner(const double (&c)[N], double x)
+{
+   double r = c[N - 1];
+   for (unsigned i = N - 1; i > 0; --i)
+      r = c[i - 1] + r * x;
+   return r;
+}
+
+/// Derivative of horner(c, x) with respect to x.
+template <unsigned N>
+double horner_deriv(const double (&c)[N], double x)
+{
+   double r = (N - 1) * c[N - 1];
+   for (unsigned i = N - 1; i > 1; --i)
+      r = (i - 1) * c[i - 1] + r * x;
+   return r;
+}
+
+/// Derivative of the rational function horner(p, x) / horner(q, x) with
+/// respect to x.
+template <unsigned N, unsigned M>
+double rational_deriv(const double (&p)[N], const double (&q)[M], double x)
+{
+   const double den = horner(q, x);
+   return (horner_deriv(p, x) - horner(p, x) / den * horner_deriv(q, x)) / den;
+}
+
+/// First derivative of the standardized Landau density
+/// p(v) = ROOT::Math::landau_pdf(v) with respect to v, obtained by
+/// differentiating each branch of the CERNLIB DENLAN rational approximation.
+/// The branch structure and the coefficient tables mirror landau_pdf() in
+/// PdfFuncMathCore.cxx. Used by landau_pdf_pullback() and by the
+/// second-derivative helpers further down.
+inline double landau_pdf_dv(double v)
+{
+   // clang-format off
+   static constexpr double p1[5] = {0.4259894875,-0.1249762550, 0.03984243700, -0.006298287635,   0.001511162253};
+   static constexpr double q1[5] = {1.0         ,-0.3388260629, 0.09594393323, -0.01608042283,    0.003778942063};
+
+   static constexpr double p2[5] = {0.1788541609, 0.1173957403, 0.01488850518, -0.001394989411,   0.0001283617211};
+   static constexpr double q2[5] = {1.0         , 0.7428795082, 0.3153932961,   0.06694219548,    0.008790609714};
+
+   static constexpr double p3[5] = {0.1788544503, 0.09359161662,0.006325387654, 0.00006611667319,-0.000002031049101};
+   static constexpr double q3[5] = {1.0         , 0.6097809921, 0.2560616665,   0.04746722384,    0.006957301675};
+
+   static constexpr double p4[5] = {0.9874054407, 118.6723273,  849.2794360,   -743.7792444,      427.0262186};
+   static constexpr double q4[5] = {1.0         , 106.8615961,  337.6496214,    2016.712389,      1597.063511};
+
+   static constexpr double p5[5] = {1.003675074,  167.5702434,  4789.711289,    21217.86767,     -22324.94910};
+   static constexpr double q5[5] = {1.0         , 156.9424537,  3745.310488,    9834.698876,      66924.28357};
+
+   static constexpr double p6[5] = {1.000827619,  664.9143136,  62972.92665,    475554.6998,     -5743609.109};
+   static constexpr double q6[5] = {1.0         , 651.4101098,  56974.73333,    165917.4725,     -2815759.939};
+
+   static constexpr double a1[3] = {0.04166666667,-0.01996527778, 0.02709538966};
+
+   static constexpr double a2[2] = {-1.845568670,-4.284640743};
+   // clang-format on
+   if (v < -5.5) {
+      const double u = ::std::exp(v + 1.);
+      if (u < 1e-10)
+         return 0.;
+      // p = C * exp(-1/u) / sqrt(u) * A(u) with u = exp(v + 1), so
+      // dp/dv = p * (1/u - 1/2) + C * exp(-1/u) * sqrt(u) * A'(u)
+      const double eu = 0.3989422803 * ::std::exp(-1. / u);
+      const double val = eu / ::std::sqrt(u) * (1 + (a1[0] + (a1[1] + a1[2] * u) * u) * u);
+      const double dA = a1[0] + (2 * a1[1] + 3 * a1[2] * u) * u;
+      return val * (1. / u - 0.5) + eu * ::std::sqrt(u) * dA;
+   } else if (v < -1) {
+      // p = exp(-u) * sqrt(u) * P(v)/Q(v) with u = exp(-v - 1); v acts both
+      // directly and through u, and d(exp(-u) * sqrt(u))/dv comes out as
+      // exp(-u) * sqrt(u) * (u - 1/2)
+      const double u = ::std::exp(-v - 1);
+      const double eu = ::std::exp(-u) * ::std::sqrt(u);
+      const double q = horner(q1, v);
+      const double r = horner(p1, v) / q;
+      return eu * ((u - 0.5) * r + (horner_deriv(p1, v) - r * horner_deriv(q1, v)) / q);
+   } else if (v < 1) {
+      return rational_deriv(p2, q2, v);
+   } else if (v < 5) {
+      return rational_deriv(p3, q3, v);
+   } else if (v < 12) {
+      // p = u^2 * P(u)/Q(u) with u = 1/v, du/dv = -u^2
+      const double u = 1 / v;
+      return -u * u * (2 * u * horner(p4, u) / horner(q4, u) + u * u * rational_deriv(p4, q4, u));
+   } else if (v < 50) {
+      const double u = 1 / v;
+      return -u * u * (2 * u * horner(p5, u) / horner(q5, u) + u * u * rational_deriv(p5, q5, u));
+   } else if (v < 300) {
+      const double u = 1 / v;
+      return -u * u * (2 * u * horner(p6, u) / horner(q6, u) + u * u * rational_deriv(p6, q6, u));
+   } else {
+      // p = u^2 * B(u) with u = 1/w, w = v - v*log(v)/(v + 1)
+      const double lv = ::std::log(v);
+      const double u = 1 / (v - v * lv / (v + 1));
+      const double dw = 1 - lv / (v + 1) - 1 / (v + 1) + v * lv / ((v + 1) * (v + 1));
+      const double dB = a2[0] + 2 * a2[1] * u;
+      return -u * u * dw * (2 * u * (1 + (a2[0] + a2[1] * u) * u) + u * u * dB);
+   }
+}
+
 inline void landau_pdf_pullback(double x, double xi, double x0, double d_out, double *d_x, double *d_xi, double *d_x0)
 {
    if (xi <= 0) {
       return;
    }
+   // The pdf is p(v) / xi with v = (x - x0) / xi.
+   const double v = (x - x0) / xi;
+   const double p = ::ROOT::Math::landau_pdf(v);
+   const double dp = landau_pdf_dv(v);
+   *d_x += d_out * dp / (xi * xi);
+   *d_x0 += -d_out * dp / (xi * xi);
+   *d_xi += -d_out * (v * dp + p) / (xi * xi);
+}
+
+/// Derivative with respect to v of the CERNLIB DISLAN rational approximation
+/// of the standardized Landau cumulative distribution, obtained by
+/// differentiating each branch of landau_cdf() in ProbFuncMathCore.cxx, whose
+/// branch structure and coefficient tables this function mirrors. Since
+/// DISLAN is an approximation of its own, this is not identical to
+/// landau_pdf() (they are consistent to about 1e-7 relative).
+inline double landau_cdf_dv(double v)
+{
    // clang-format off
-   static double p1[5] = {0.4259894875,-0.1249762550, 0.03984243700, -0.006298287635,   0.001511162253};
-   static double q1[5] = {1.0         ,-0.3388260629, 0.09594393323, -0.01608042283,    0.003778942063};
+   static constexpr double p1[5] = {0.2514091491e+0,-0.6250580444e-1, 0.1458381230e-1,-0.2108817737e-2, 0.7411247290e-3};
+   static constexpr double q1[5] = {1.0            ,-0.5571175625e-2, 0.6225310236e-1,-0.3137378427e-2, 0.1931496439e-2};
 
-   static double p2[5] = {0.1788541609, 0.1173957403, 0.01488850518, -0.001394989411,   0.0001283617211};
-   static double q2[5] = {1.0         , 0.7428795082, 0.3153932961,   0.06694219548,    0.008790609714};
+   static constexpr double p2[4] = {0.2868328584e+0, 0.3564363231e+0, 0.1523518695e+0, 0.2251304883e-1};
+   static constexpr double q2[4] = {1.0            , 0.6191136137e+0, 0.1720721448e+0, 0.2278594771e-1};
 
-   static double p3[5] = {0.1788544503, 0.09359161662,0.006325387654, 0.00006611667319,-0.000002031049101};
-   static double q3[5] = {1.0         , 0.6097809921, 0.2560616665,   0.04746722384,    0.006957301675};
+   static constexpr double p3[4] = {0.2868329066e+0, 0.3003828436e+0, 0.9950951941e-1, 0.8733827185e-2};
+   static constexpr double q3[4] = {1.0            , 0.4237190502e+0, 0.1095631512e+0, 0.8693851567e-2};
 
-   static double p4[5] = {0.9874054407, 118.6723273,  849.2794360,   -743.7792444,      427.0262186};
-   static double q4[5] = {1.0         , 106.8615961,  337.6496214,    2016.712389,      1597.063511};
+   static constexpr double p4[4] = {0.1000351630e+1, 0.4503592498e+1, 0.1085883880e+2, 0.7536052269e+1};
+   static constexpr double q4[4] = {1.0            , 0.5539969678e+1, 0.1933581111e+2, 0.2721321508e+2};
 
-   static double p5[5] = {1.003675074,  167.5702434,  4789.711289,    21217.86767,     -22324.94910};
-   static double q5[5] = {1.0         , 156.9424537,  3745.310488,    9834.698876,      66924.28357};
+   static constexpr double p5[4] = {0.1000006517e+1, 0.4909414111e+2, 0.8505544753e+2, 0.1532153455e+3};
+   static constexpr double q5[4] = {1.0            , 0.5009928881e+2, 0.1399819104e+3, 0.4200002909e+3};
 
-   static double p6[5] = {1.000827619,  664.9143136,  62972.92665,    475554.6998,     -5743609.109};
-   static double q6[5] = {1.0         , 651.4101098,  56974.73333,    165917.4725,     -2815759.939};
+   static constexpr double p6[4] = {0.1000000983e+1, 0.1329868456e+3, 0.9162149244e+3,-0.9605054274e+3};
+   static constexpr double q6[4] = {1.0            , 0.1339887843e+3, 0.1055990413e+4, 0.5532224619e+3};
 
-   static double a1[3] = {0.04166666667,-0.01996527778, 0.02709538966};
-
-   static double a2[2] = {-1.845568670,-4.284640743};
+   static constexpr double a1[4] = {0              ,-0.4583333333e+0, 0.6675347222e+0,-0.1641741416e+1};
+   static constexpr double a2[4] = {0              , 1.0            ,-0.4227843351e+0,-0.2043403138e+1};
    // clang-format on
-   const double _const0 = 0.3989422803;
-   double v = (x - x0) / xi;
-   double _d_v = 0;
-   double _d_denlan = 0;
    if (v < -5.5) {
-      double u = ::std::exp(v + 1.);
-      double _d_u = 0;
-      if (u >= 1.e-10) {
-         const double ue = ::std::exp(-1 / u);
-         const double us = ::std::sqrt(u);
-         double _t3;
-         double _d_ue = 0;
-         double _d_us = 0;
-         double denlan = _const0 * (ue / us) * (1 + (a1[0] + (a1[1] + a1[2] * u) * u) * u);
-         _d_denlan += d_out / xi;
-         *d_xi += d_out * -(denlan / (xi * xi));
-         denlan = _t3;
-         double _r_d3 = _d_denlan;
-         _d_denlan -= _r_d3;
-         _d_ue += _const0 * _r_d3 * (1 + (a1[0] + (a1[1] + a1[2] * u) * u) * u) / us;
-         double _r5 = _const0 * _r_d3 * (1 + (a1[0] + (a1[1] + a1[2] * u) * u) * u) * -(ue / (us * us));
-         _d_us += _r5;
-         _d_u += a1[2] * _const0 * (ue / us) * _r_d3 * u * u;
-         _d_u += (a1[1] + a1[2] * u) * _const0 * (ue / us) * _r_d3 * u;
-         _d_u += (a1[0] + (a1[1] + a1[2] * u) * u) * _const0 * (ue / us) * _r_d3;
-         double _r_d2 = _d_us;
-         _d_us -= _r_d2;
-         double _r4 = 0;
-         _r4 += _r_d2 * clad::custom_derivatives::sqrt_pushforward(u, 1.).pushforward;
-         _d_u += _r4;
-         double _r_d1 = _d_ue;
-         _d_ue -= _r_d1;
-         double _r2 = 0;
-         _r2 += _r_d1 * ::std::exp(-1 / u);
-         double _r3 = _r2 * -(-1 / (u * u));
-         _d_u += _r3;
-      }
-      double _r_d0 = _d_u;
-      _d_u -= _r_d0;
-      double _r1 = 0;
-      _r1 += _r_d0 * ::std::exp(v + 1.);
-      _d_v += _r1;
+      // F = C * exp(-1/u) * sqrt(u) * A(u) with u = exp(v + 1), so
+      // dF/dv = F * (1/u + 1/2) + C * exp(-1/u) * sqrt(u) * u * A'(u)
+      const double u = ::std::exp(v + 1);
+      const double eu = 0.3989422803 * ::std::exp(-1. / u) * ::std::sqrt(u);
+      const double val = eu * (1 + (a1[1] + (a1[2] + a1[3] * u) * u) * u);
+      const double dA = a1[1] + (2 * a1[2] + 3 * a1[3] * u) * u;
+      return val * (1. / u + 0.5) + eu * u * dA;
    } else if (v < -1) {
-      double _t4;
-      double u = ::std::exp(-v - 1);
-      double _d_u = 0;
-      double _t5;
-      double _t8 = ::std::exp(-u);
-      double _t7 = ::std::sqrt(u);
-      double _t6 = (q1[0] + (q1[1] + (q1[2] + (q1[3] + q1[4] * v) * v) * v) * v);
-      double denlan = _t8 * _t7 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) / _t6;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t5;
-      double _r_d5 = _d_denlan;
-      _d_denlan -= _r_d5;
-      double _r7 = 0;
-      _r7 += _r_d5 / _t6 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) * _t7 * ::std::exp(-u);
-      _d_u += -_r7;
-      double _r8 = 0;
-      _r8 += _t8 * _r_d5 / _t6 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) *
-             clad::custom_derivatives::sqrt_pushforward(u, 1.).pushforward;
-      _d_u += _r8;
-      _d_v += p1[4] * _t8 * _t7 * _r_d5 / _t6 * v * v * v;
-      _d_v += (p1[3] + p1[4] * v) * _t8 * _t7 * _r_d5 / _t6 * v * v;
-      _d_v += (p1[2] + (p1[3] + p1[4] * v) * v) * _t8 * _t7 * _r_d5 / _t6 * v;
-      _d_v += (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * _t8 * _t7 * _r_d5 / _t6;
-      double _r9 = _r_d5 * -(_t8 * _t7 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) / (_t6 * _t6));
-      _d_v += q1[4] * _r9 * v * v * v;
-      _d_v += (q1[3] + q1[4] * v) * _r9 * v * v;
-      _d_v += (q1[2] + (q1[3] + q1[4] * v) * v) * _r9 * v;
-      _d_v += (q1[1] + (q1[2] + (q1[3] + q1[4] * v) * v) * v) * _r9;
-      u = _t4;
-      double _r_d4 = _d_u;
-      _d_u -= _r_d4;
-      double _r6 = 0;
-      _r6 += _r_d4 * ::std::exp(-v - 1);
-      _d_v += -_r6;
+      // F = exp(-u) / sqrt(u) * P(v)/Q(v) with u = exp(-v - 1); v acts both
+      // directly and through u, and d(exp(-u) / sqrt(u))/dv comes out as
+      // exp(-u) / sqrt(u) * (u + 1/2)
+      const double u = ::std::exp(-v - 1);
+      const double eu = ::std::exp(-u) / ::std::sqrt(u);
+      const double q = horner(q1, v);
+      const double r = horner(p1, v) / q;
+      return eu * ((u + 0.5) * r + (horner_deriv(p1, v) - r * horner_deriv(q1, v)) / q);
    } else if (v < 1) {
-      double _t9;
-      double _t10 = (q2[0] + (q2[1] + (q2[2] + (q2[3] + q2[4] * v) * v) * v) * v);
-      double denlan = (p2[0] + (p2[1] + (p2[2] + (p2[3] + p2[4] * v) * v) * v) * v) / _t10;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t9;
-      double _r_d6 = _d_denlan;
-      _d_denlan -= _r_d6;
-      _d_v += p2[4] * _r_d6 / _t10 * v * v * v;
-      _d_v += (p2[3] + p2[4] * v) * _r_d6 / _t10 * v * v;
-      _d_v += (p2[2] + (p2[3] + p2[4] * v) * v) * _r_d6 / _t10 * v;
-      _d_v += (p2[1] + (p2[2] + (p2[3] + p2[4] * v) * v) * v) * _r_d6 / _t10;
-      double _r10 = _r_d6 * -((p2[0] + (p2[1] + (p2[2] + (p2[3] + p2[4] * v) * v) * v) * v) / (_t10 * _t10));
-      _d_v += q2[4] * _r10 * v * v * v;
-      _d_v += (q2[3] + q2[4] * v) * _r10 * v * v;
-      _d_v += (q2[2] + (q2[3] + q2[4] * v) * v) * _r10 * v;
-      _d_v += (q2[1] + (q2[2] + (q2[3] + q2[4] * v) * v) * v) * _r10;
-   } else if (v < 5) {
-      double _t11;
-      double _t12 = (q3[0] + (q3[1] + (q3[2] + (q3[3] + q3[4] * v) * v) * v) * v);
-      double denlan = (p3[0] + (p3[1] + (p3[2] + (p3[3] + p3[4] * v) * v) * v) * v) / _t12;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t11;
-      double _r_d7 = _d_denlan;
-      _d_denlan -= _r_d7;
-      _d_v += p3[4] * _r_d7 / _t12 * v * v * v;
-      _d_v += (p3[3] + p3[4] * v) * _r_d7 / _t12 * v * v;
-      _d_v += (p3[2] + (p3[3] + p3[4] * v) * v) * _r_d7 / _t12 * v;
-      _d_v += (p3[1] + (p3[2] + (p3[3] + p3[4] * v) * v) * v) * _r_d7 / _t12;
-      double _r11 = _r_d7 * -((p3[0] + (p3[1] + (p3[2] + (p3[3] + p3[4] * v) * v) * v) * v) / (_t12 * _t12));
-      _d_v += q3[4] * _r11 * v * v * v;
-      _d_v += (q3[3] + q3[4] * v) * _r11 * v * v;
-      _d_v += (q3[2] + (q3[3] + q3[4] * v) * v) * _r11 * v;
-      _d_v += (q3[1] + (q3[2] + (q3[3] + q3[4] * v) * v) * v) * _r11;
+      return rational_deriv(p2, q2, v);
+   } else if (v < 4) {
+      return rational_deriv(p3, q3, v);
    } else if (v < 12) {
-      double u = 1 / v;
-      double _d_u = 0;
-      double _t14;
-      double _t15 = (q4[0] + (q4[1] + (q4[2] + (q4[3] + q4[4] * u) * u) * u) * u);
-      double denlan = u * u * (p4[0] + (p4[1] + (p4[2] + (p4[3] + p4[4] * u) * u) * u) * u) / _t15;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t14;
-      double _r_d9 = _d_denlan;
-      _d_denlan -= _r_d9;
-      _d_u += _r_d9 / _t15 * (p4[0] + (p4[1] + (p4[2] + (p4[3] + p4[4] * u) * u) * u) * u) * u;
-      _d_u += u * _r_d9 / _t15 * (p4[0] + (p4[1] + (p4[2] + (p4[3] + p4[4] * u) * u) * u) * u);
-      _d_u += p4[4] * u * u * _r_d9 / _t15 * u * u * u;
-      _d_u += (p4[3] + p4[4] * u) * u * u * _r_d9 / _t15 * u * u;
-      _d_u += (p4[2] + (p4[3] + p4[4] * u) * u) * u * u * _r_d9 / _t15 * u;
-      _d_u += (p4[1] + (p4[2] + (p4[3] + p4[4] * u) * u) * u) * u * u * _r_d9 / _t15;
-      double _r13 = _r_d9 * -(u * u * (p4[0] + (p4[1] + (p4[2] + (p4[3] + p4[4] * u) * u) * u) * u) / (_t15 * _t15));
-      _d_u += q4[4] * _r13 * u * u * u;
-      _d_u += (q4[3] + q4[4] * u) * _r13 * u * u;
-      _d_u += (q4[2] + (q4[3] + q4[4] * u) * u) * _r13 * u;
-      _d_u += (q4[1] + (q4[2] + (q4[3] + q4[4] * u) * u) * u) * _r13;
-      double _r_d8 = _d_u;
-      _d_u -= _r_d8;
-      double _r12 = _r_d8 * -(1 / (v * v));
-      _d_v += _r12;
+      // F = P(u)/Q(u) with u = 1/v, du/dv = -u^2
+      const double u = 1. / v;
+      return -u * u * rational_deriv(p4, q4, u);
    } else if (v < 50) {
-      double u = 1 / v;
-      double _d_u = 0;
-      double _t17;
-      double _t18 = (q5[0] + (q5[1] + (q5[2] + (q5[3] + q5[4] * u) * u) * u) * u);
-      double denlan = u * u * (p5[0] + (p5[1] + (p5[2] + (p5[3] + p5[4] * u) * u) * u) * u) / _t18;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t17;
-      double _r_d11 = _d_denlan;
-      _d_denlan -= _r_d11;
-      _d_u += _r_d11 / _t18 * (p5[0] + (p5[1] + (p5[2] + (p5[3] + p5[4] * u) * u) * u) * u) * u;
-      _d_u += u * _r_d11 / _t18 * (p5[0] + (p5[1] + (p5[2] + (p5[3] + p5[4] * u) * u) * u) * u);
-      _d_u += p5[4] * u * u * _r_d11 / _t18 * u * u * u;
-      _d_u += (p5[3] + p5[4] * u) * u * u * _r_d11 / _t18 * u * u;
-      _d_u += (p5[2] + (p5[3] + p5[4] * u) * u) * u * u * _r_d11 / _t18 * u;
-      _d_u += (p5[1] + (p5[2] + (p5[3] + p5[4] * u) * u) * u) * u * u * _r_d11 / _t18;
-      double _r15 = _r_d11 * -(u * u * (p5[0] + (p5[1] + (p5[2] + (p5[3] + p5[4] * u) * u) * u) * u) / (_t18 * _t18));
-      _d_u += q5[4] * _r15 * u * u * u;
-      _d_u += (q5[3] + q5[4] * u) * _r15 * u * u;
-      _d_u += (q5[2] + (q5[3] + q5[4] * u) * u) * _r15 * u;
-      _d_u += (q5[1] + (q5[2] + (q5[3] + q5[4] * u) * u) * u) * _r15;
-      double _r_d10 = _d_u;
-      _d_u -= _r_d10;
-      double _r14 = _r_d10 * -(1 / (v * v));
-      _d_v += _r14;
+      const double u = 1. / v;
+      return -u * u * rational_deriv(p5, q5, u);
    } else if (v < 300) {
-      double _t19;
-      double u = 1 / v;
-      double _d_u = 0;
-      double _t20;
-      double _t21 = (q6[0] + (q6[1] + (q6[2] + (q6[3] + q6[4] * u) * u) * u) * u);
-      double denlan = u * u * (p6[0] + (p6[1] + (p6[2] + (p6[3] + p6[4] * u) * u) * u) * u) / _t21;
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t20;
-      double _r_d13 = _d_denlan;
-      _d_denlan -= _r_d13;
-      _d_u += _r_d13 / _t21 * (p6[0] + (p6[1] + (p6[2] + (p6[3] + p6[4] * u) * u) * u) * u) * u;
-      _d_u += u * _r_d13 / _t21 * (p6[0] + (p6[1] + (p6[2] + (p6[3] + p6[4] * u) * u) * u) * u);
-      _d_u += p6[4] * u * u * _r_d13 / _t21 * u * u * u;
-      _d_u += (p6[3] + p6[4] * u) * u * u * _r_d13 / _t21 * u * u;
-      _d_u += (p6[2] + (p6[3] + p6[4] * u) * u) * u * u * _r_d13 / _t21 * u;
-      _d_u += (p6[1] + (p6[2] + (p6[3] + p6[4] * u) * u) * u) * u * u * _r_d13 / _t21;
-      double _r17 = _r_d13 * -(u * u * (p6[0] + (p6[1] + (p6[2] + (p6[3] + p6[4] * u) * u) * u) * u) / (_t21 * _t21));
-      _d_u += q6[4] * _r17 * u * u * u;
-      _d_u += (q6[3] + q6[4] * u) * _r17 * u * u;
-      _d_u += (q6[2] + (q6[3] + q6[4] * u) * u) * _r17 * u;
-      _d_u += (q6[1] + (q6[2] + (q6[3] + q6[4] * u) * u) * u) * _r17;
-      u = _t19;
-      double _r_d12 = _d_u;
-      _d_u -= _r_d12;
-      double _r16 = _r_d12 * -(1 / (v * v));
-      _d_v += _r16;
+      const double u = 1. / v;
+      return -u * u * rational_deriv(p6, q6, u);
    } else {
-      double _t22;
-      double _t25 = ::std::log(v);
-      double _t24 = (v + 1);
-      double _t23 = (v - v * _t25 / _t24);
-      double u = 1 / _t23;
-      double _d_u = 0;
-      double _t26;
-      double denlan = u * u * (1 + (a2[0] + a2[1] * u) * u);
-      _d_denlan += d_out / xi;
-      *d_xi += d_out * -(denlan / (xi * xi));
-      denlan = _t26;
-      double _r_d15 = _d_denlan;
-      _d_denlan -= _r_d15;
-      _d_u += _r_d15 * (1 + (a2[0] + a2[1] * u) * u) * u;
-      _d_u += u * _r_d15 * (1 + (a2[0] + a2[1] * u) * u);
-      _d_u += a2[1] * u * u * _r_d15 * u;
-      _d_u += (a2[0] + a2[1] * u) * u * u * _r_d15;
-      u = _t22;
-      double _r_d14 = _d_u;
-      _d_u -= _r_d14;
-      double _r18 = _r_d14 * -(1 / (_t23 * _t23));
-      _d_v += _r18;
-      _d_v += -_r18 / _t24 * _t25;
-      double _r19 = 0;
-      _r19 += v * -_r18 / _t24 / v;
-      _d_v += _r19;
-      double _r20 = -_r18 * -(v * _t25 / (_t24 * _t24));
-      _d_v += _r20;
+      // F = 1 - G(u) with u = 1/w, w = v - v*log(v)/(v + 1)
+      const double lv = ::std::log(v);
+      const double u = 1. / (v - v * lv / (v + 1));
+      const double dw = 1 - lv / (v + 1) - 1 / (v + 1) + v * lv / ((v + 1) * (v + 1));
+      return horner_deriv(a2, u) * u * u * dw;
    }
-   *d_x += _d_v / xi;
-   *d_x0 += -_d_v / xi;
-   double _r0 = _d_v * -((x - x0) / (xi * xi));
-   *d_xi += _r0;
 }
 
 inline void landau_cdf_pullback(double x, double xi, double x0, double d_out, double *d_x, double *d_xi, double *d_x0)
 {
-   // clang-format off
-   static double p1[5] = {0.2514091491e+0,-0.6250580444e-1, 0.1458381230e-1,-0.2108817737e-2, 0.7411247290e-3};
-   static double q1[5] = {1.0            ,-0.5571175625e-2, 0.6225310236e-1,-0.3137378427e-2, 0.1931496439e-2};
-
-   static double p2[4] = {0.2868328584e+0, 0.3564363231e+0, 0.1523518695e+0, 0.2251304883e-1};
-   static double q2[4] = {1.0            , 0.6191136137e+0, 0.1720721448e+0, 0.2278594771e-1};
-
-   static double p3[4] = {0.2868329066e+0, 0.3003828436e+0, 0.9950951941e-1, 0.8733827185e-2};
-   static double q3[4] = {1.0            , 0.4237190502e+0, 0.1095631512e+0, 0.8693851567e-2};
-
-   static double p4[4] = {0.1000351630e+1, 0.4503592498e+1, 0.1085883880e+2, 0.7536052269e+1};
-   static double q4[4] = {1.0            , 0.5539969678e+1, 0.1933581111e+2, 0.2721321508e+2};
-
-   static double p5[4] = {0.1000006517e+1, 0.4909414111e+2, 0.8505544753e+2, 0.1532153455e+3};
-   static double q5[4] = {1.0            , 0.5009928881e+2, 0.1399819104e+3, 0.4200002909e+3};
-
-   static double p6[4] = {0.1000000983e+1, 0.1329868456e+3, 0.9162149244e+3,-0.9605054274e+3};
-   static double q6[4] = {1.0            , 0.1339887843e+3, 0.1055990413e+4, 0.5532224619e+3};
-
-   static double a1[4] = {0              ,-0.4583333333e+0, 0.6675347222e+0,-0.1641741416e+1};
-   static double a2[4] = {0              , 1.0            ,-0.4227843351e+0,-0.2043403138e+1};
-   // clang-format on
-
+   // The cdf is a function of v = (x - x0) / xi alone.
    const double v = (x - x0) / xi;
-   double _d_v = 0;
-   if (v < -5.5) {
-      double _d_u = 0;
-      const double _const0 = 0.3989422803;
-      double u = ::std::exp(v + 1);
-      double _t3 = ::std::exp(-1. / u);
-      double _t2 = ::std::sqrt(u);
-      double _r2 = 0;
-      _r2 += _const0 * d_out * (1 + (a1[1] + (a1[2] + a1[3] * u) * u) * u) * _t2 * ::std::exp(-1. / u);
-      double _r3 = _r2 * -(-1. / (u * u));
-      _d_u += _r3;
-      double _r4 = 0;
-      _r4 += _const0 * _t3 * d_out * (1 + (a1[1] + (a1[2] + a1[3] * u) * u) * u) *
-             clad::custom_derivatives::sqrt_pushforward(u, 1.).pushforward;
-      _d_u += _r4;
-      _d_u += a1[3] * _const0 * _t3 * _t2 * d_out * u * u;
-      _d_u += (a1[2] + a1[3] * u) * _const0 * _t3 * _t2 * d_out * u;
-      _d_u += (a1[1] + (a1[2] + a1[3] * u) * u) * _const0 * _t3 * _t2 * d_out;
-      _d_v += _d_u * ::std::exp(v + 1);
-   } else if (v < -1) {
-      double _d_u = 0;
-      double u = ::std::exp(-v - 1);
-      double _t8 = ::std::exp(-u);
-      double _t7 = ::std::sqrt(u);
-      double _t6 = (q1[0] + (q1[1] + (q1[2] + (q1[3] + q1[4] * v) * v) * v) * v);
-      double _r6 = 0;
-      _r6 += d_out / _t6 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) / _t7 * ::std::exp(-u);
-      _d_u += -_r6;
-      double _r7 = d_out / _t6 * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) * -(_t8 / (_t7 * _t7));
-      double _r8 = 0;
-      _r8 += _r7 * clad::custom_derivatives::sqrt_pushforward(u, 1.).pushforward;
-      _d_u += _r8;
-      _d_v += p1[4] * (_t8 / _t7) * d_out / _t6 * v * v * v;
-      _d_v += (p1[3] + p1[4] * v) * (_t8 / _t7) * d_out / _t6 * v * v;
-      _d_v += (p1[2] + (p1[3] + p1[4] * v) * v) * (_t8 / _t7) * d_out / _t6 * v;
-      _d_v += (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * (_t8 / _t7) * d_out / _t6;
-      double _r9 = d_out * -((_t8 / _t7) * (p1[0] + (p1[1] + (p1[2] + (p1[3] + p1[4] * v) * v) * v) * v) / (_t6 * _t6));
-      _d_v += q1[4] * _r9 * v * v * v;
-      _d_v += (q1[3] + q1[4] * v) * _r9 * v * v;
-      _d_v += (q1[2] + (q1[3] + q1[4] * v) * v) * _r9 * v;
-      _d_v += (q1[1] + (q1[2] + (q1[3] + q1[4] * v) * v) * v) * _r9;
-      _d_v += -_d_u * ::std::exp(-v - 1);
-   } else if (v < 1) {
-      double _t10 = (q2[0] + (q2[1] + (q2[2] + q2[3] * v) * v) * v);
-      _d_v += p2[3] * d_out / _t10 * v * v;
-      _d_v += (p2[2] + p2[3] * v) * d_out / _t10 * v;
-      _d_v += (p2[1] + (p2[2] + p2[3] * v) * v) * d_out / _t10;
-      double _r10 = d_out * -((p2[0] + (p2[1] + (p2[2] + p2[3] * v) * v) * v) / (_t10 * _t10));
-      _d_v += q2[3] * _r10 * v * v;
-      _d_v += (q2[2] + q2[3] * v) * _r10 * v;
-      _d_v += (q2[1] + (q2[2] + q2[3] * v) * v) * _r10;
-   } else if (v < 4) {
-      double _t12 = (q3[0] + (q3[1] + (q3[2] + q3[3] * v) * v) * v);
-      _d_v += p3[3] * d_out / _t12 * v * v;
-      _d_v += (p3[2] + p3[3] * v) * d_out / _t12 * v;
-      _d_v += (p3[1] + (p3[2] + p3[3] * v) * v) * d_out / _t12;
-      double _r11 = d_out * -((p3[0] + (p3[1] + (p3[2] + p3[3] * v) * v) * v) / (_t12 * _t12));
-      _d_v += q3[3] * _r11 * v * v;
-      _d_v += (q3[2] + q3[3] * v) * _r11 * v;
-      _d_v += (q3[1] + (q3[2] + q3[3] * v) * v) * _r11;
-   } else if (v < 12) {
-      double _d_u = 0;
-      double u = 1. / v;
-      double _t15 = (q4[0] + (q4[1] + (q4[2] + q4[3] * u) * u) * u);
-      _d_u += p4[3] * d_out / _t15 * u * u;
-      _d_u += (p4[2] + p4[3] * u) * d_out / _t15 * u;
-      _d_u += (p4[1] + (p4[2] + p4[3] * u) * u) * d_out / _t15;
-      double _r13 = d_out * -((p4[0] + (p4[1] + (p4[2] + p4[3] * u) * u) * u) / (_t15 * _t15));
-      _d_u += q4[3] * _r13 * u * u;
-      _d_u += (q4[2] + q4[3] * u) * _r13 * u;
-      _d_u += (q4[1] + (q4[2] + q4[3] * u) * u) * _r13;
-      double _r12 = _d_u * -(1. / (v * v));
-      _d_v += _r12;
-   } else if (v < 50) {
-      double _d_u = 0;
-      double u = 1. / v;
-      double _t18 = (q5[0] + (q5[1] + (q5[2] + q5[3] * u) * u) * u);
-      _d_u += p5[3] * d_out / _t18 * u * u;
-      _d_u += (p5[2] + p5[3] * u) * d_out / _t18 * u;
-      _d_u += (p5[1] + (p5[2] + p5[3] * u) * u) * d_out / _t18;
-      double _r15 = d_out * -((p5[0] + (p5[1] + (p5[2] + p5[3] * u) * u) * u) / (_t18 * _t18));
-      _d_u += q5[3] * _r15 * u * u;
-      _d_u += (q5[2] + q5[3] * u) * _r15 * u;
-      _d_u += (q5[1] + (q5[2] + q5[3] * u) * u) * _r15;
-      double _r14 = _d_u * -(1. / (v * v));
-      _d_v += _r14;
-   } else if (v < 300) {
-      double _d_u = 0;
-      double u = 1. / v;
-      double _t21 = (q6[0] + (q6[1] + (q6[2] + q6[3] * u) * u) * u);
-      _d_u += p6[3] * d_out / _t21 * u * u;
-      _d_u += (p6[2] + p6[3] * u) * d_out / _t21 * u;
-      _d_u += (p6[1] + (p6[2] + p6[3] * u) * u) * d_out / _t21;
-      double _r17 = d_out * -((p6[0] + (p6[1] + (p6[2] + p6[3] * u) * u) * u) / (_t21 * _t21));
-      _d_u += q6[3] * _r17 * u * u;
-      _d_u += (q6[2] + q6[3] * u) * _r17 * u;
-      _d_u += (q6[1] + (q6[2] + q6[3] * u) * u) * _r17;
-      double _r16 = _d_u * -(1. / (v * v));
-      _d_v += _r16;
-   } else {
-      double _d_u = 0;
-      double _t25 = ::std::log(v);
-      double _t24 = (v + 1);
-      double _t23 = (v - v * _t25 / _t24);
-      double u = 1. / _t23;
-      double _t26;
-      _d_u += a2[3] * -d_out * u * u;
-      _d_u += (a2[2] + a2[3] * u) * -d_out * u;
-      _d_u += (a2[1] + (a2[2] + a2[3] * u) * u) * -d_out;
-      double _r18 = _d_u * -(1. / (_t23 * _t23));
-      _d_v += _r18;
-      _d_v += -_r18 / _t24 * _t25;
-      double _r19 = 0;
-      _r19 += v * -_r18 / _t24 / v;
-      _d_v += _r19;
-      double _r20 = -_r18 * -(v * _t25 / (_t24 * _t24));
-      _d_v += _r20;
-   }
-
-   *d_x += _d_v / xi;
-   *d_x0 += -_d_v / xi;
-   *d_xi += _d_v * -((x - x0) / (xi * xi));
+   const double dcdf = landau_cdf_dv(v);
+   *d_x += d_out * dcdf / xi;
+   *d_x0 += -d_out * dcdf / xi;
+   *d_xi += -d_out * dcdf * v / xi;
 }
 
 inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x);
@@ -618,11 +408,6 @@ inline void inc_gamma_pullback(double a, double x, double _d_y, double *_d_a, do
    // Synced with SpecFuncCephes.h
    constexpr double kMACHEP = 1.11022302462515654042363166809e-16;
    constexpr double kMAXLOG = 709.782712893383973096206318587;
-   constexpr double kMINLOG = -708.396418532264078748994506896;
-   constexpr double kMAXSTIR = 108.116855767857671821730036754;
-   constexpr double kMAXLGM = 2.556348e305;
-   constexpr double kBig = 4.503599627370496e15;
-   constexpr double kBiginv = 2.22044604925031308085e-16;
 
    double _d_ans = 0, _d_ax = 0, _d_c = 0, _d_r = 0;
    double _t1;
@@ -739,13 +524,10 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
    // Synced with SpecFuncCephes.h
    constexpr double kMACHEP = 1.11022302462515654042363166809e-16;
    constexpr double kMAXLOG = 709.782712893383973096206318587;
-   constexpr double kMINLOG = -708.396418532264078748994506896;
-   constexpr double kMAXSTIR = 108.116855767857671821730036754;
-   constexpr double kMAXLGM = 2.556348e305;
    constexpr double kBig = 4.503599627370496e15;
    constexpr double kBiginv = 2.22044604925031308085e-16;
 
-   double _d_ans = 0, _d_ax = 0, _d_c = 0, _d_yc = 0, _d_r = 0, _d_t = 0, _d_y0 = 0, _d_z = 0;
+   double _d_ans = 0, _d_ax = 0, _d_c = 0, _d_yc = 0, _d_r = 0, _d_y0 = 0, _d_z = 0;
    double _d_pk = 0, _d_pkm1 = 0, _d_pkm2 = 0, _d_qk = 0, _d_qkm1 = 0, _d_qkm2 = 0;
    double _t1;
    double _t2;
@@ -766,9 +548,7 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
    clad::tape<double> _t17 = {};
    clad::tape<double> _t19 = {};
    clad::tape<double> _t20 = {};
-   clad::tape<double> _t21 = {};
    clad::tape<double> _t22 = {};
-   clad::tape<double> _t23 = {};
    clad::tape<double> _t24 = {};
    clad::tape<double> _t25 = {};
    clad::tape<double> _t26 = {};
@@ -839,12 +619,10 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
          if (_t18) {
             clad::push(_t20, r);
             r = pk / qk;
-            clad::push(_t21, t);
             t = ::std::abs((ans - r) / r);
             clad::push(_t22, ans);
             ans = r;
          } else {
-            clad::push(_t23, t);
             t = 1.;
          }
          clad::push(_t19, _t18);
@@ -928,23 +706,14 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
             _d_pkm2 -= _r_d20;
             _d_pkm1 += _r_d20;
          }
+         // t only controls the loop exit, so its adjoint is identically zero
+         // and it needs neither a tape nor a restore.
          if (clad::pop(_t19)) {
             {
                ans = clad::pop(_t22);
                double _r_d18 = _d_ans;
                _d_ans -= _r_d18;
                _d_r += _r_d18;
-            }
-            {
-               t = clad::pop(_t21);
-               double _r_d17 = _d_t;
-               _d_t -= _r_d17;
-               double _r7 = 0;
-               _r7 += _r_d17 * clad::custom_derivatives::std::abs_pushforward((ans - r) / r, 1.).pushforward;
-               _d_ans += _r7 / r;
-               _d_r += -_r7 / r;
-               double _r8 = _r7 * -((ans - r) / (r * r));
-               _d_r += _r8;
             }
             {
                r = clad::pop(_t20);
@@ -954,10 +723,6 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
                double _r6 = _r_d16 * -(pk / (qk * qk));
                _d_qk += _r6;
             }
-         } else {
-            t = clad::pop(_t23);
-            double _r_d19 = _d_t;
-            _d_t -= _r_d19;
          }
          {
             qk = clad::pop(_t17);
@@ -1135,19 +900,6 @@ inline clad::ValueAndPushforward<double, double> inc_gamma_pushforward(double a,
 inline clad::ValueAndPushforward<double, double> inc_gamma_c_pushforward(double a, double x, double d_a, double d_x)
 {
    return {::ROOT::Math::inc_gamma_c(a, x), -inc_gamma_da(a, x) * d_a - inc_gamma_dx(a, x) * d_x};
-}
-
-/// First derivative of the standardized Landau density (i.e.
-/// ROOT::Math::landau_pdf(v) with xi = 1 and x0 = 0) with respect to v. It
-/// has no closed form, but landau_pdf_pullback() computes it exactly by
-/// differentiating through the algorithm that evaluates the density.
-inline double landau_pdf_dv(double v)
-{
-   double dv = 0.;
-   double dxi = 0.;
-   double dx0 = 0.;
-   landau_pdf_pullback(v, 1., 0., 1., &dv, &dxi, &dx0);
-   return dv;
 }
 
 /// Pullback of landau_pdf_dv(). The second derivative of the standardized

--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -24,6 +24,9 @@
 
 #include <plugins/include/clad/Differentiator/Differentiator.h>
 #include "TMath.h"
+#include "Math/PdfFuncMathCore.h"
+#include "Math/ProbFuncMathCore.h"
+#include "Math/SpecFuncMathCore.h"
 
 #include <stdexcept>
 
@@ -1059,6 +1062,124 @@ inline void inc_gamma_c_pullback(double a, double x, double _d_y, double *_d_a, 
                                  a)); // numerical_diff::forward_central_difference(::std::lgamma, a, 0, 0, a);
       _d_ax = 0.;
    }
+}
+
+/// Derivative of the normalized lower incomplete gamma function P(a, x) with
+/// respect to x. This is the integrand of P(a, x), i.e. the gamma
+/// distribution density: x^(a-1) * exp(-x) / Gamma(a).
+inline double inc_gamma_dx(double a, double x)
+{
+   if (a <= 0 || x <= 0)
+      return 0.;
+   return ::std::exp((a - 1.) * ::std::log(x) - x - ::std::lgamma(a));
+}
+
+/// Pullback of inc_gamma_dx(), using the closed forms of the second
+/// derivatives of P(a, x):
+///
+///    d2P/dx2  = inc_gamma_dx(a, x) * ((a - 1) / x - 1)
+///    d2P/dxda = inc_gamma_dx(a, x) * (log(x) - digamma(a))
+inline void inc_gamma_dx_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   if (a <= 0 || x <= 0)
+      return;
+   const double g = inc_gamma_dx(a, x);
+   *_d_a += _d_y * g * (::std::log(x) - ::clad::custom_derivatives::std::clad_digamma(a));
+   *_d_x += _d_y * g * ((a - 1.) / x - 1.);
+}
+
+/// Derivative of the normalized lower incomplete gamma function P(a, x) with
+/// respect to a. It has no closed form, but inc_gamma_pullback() computes it
+/// exactly by differentiating through the algorithm that evaluates P(a, x).
+inline double inc_gamma_da(double a, double x)
+{
+   double da = 0.;
+   double dx = 0.;
+   inc_gamma_pullback(a, x, 1., &da, &dx);
+   return da;
+}
+
+/// Pullback of inc_gamma_da(). The mixed second derivative is known in
+/// closed form (it is the same as the a-derivative of inc_gamma_dx(), see
+/// inc_gamma_dx_pullback()). For d2P/da2 there is no closed form, so it is
+/// approximated by a central difference of the exact first derivative.
+inline void inc_gamma_da_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
+{
+   if (a <= 0 || x <= 0)
+      return;
+   *_d_x += _d_y * inc_gamma_dx(a, x) * (::std::log(x) - ::clad::custom_derivatives::std::clad_digamma(a));
+   // A first-order central difference of the exact derivative is much more
+   // accurate than a second-order finite difference of P(a, x) itself. The
+   // step size balances truncation and roundoff error (~ cbrt of the machine
+   // epsilon).
+   const double h = 6e-6 * ::std::max(1., ::std::abs(a));
+   *_d_a += _d_y * (inc_gamma_da(a + h, x) - inc_gamma_da(a - h, x)) / (2. * h);
+}
+
+/// Pushforward of ROOT::Math::inc_gamma. Besides forward-mode differentiation,
+/// this enables second derivatives (e.g. clad::hessian): clad differentiates
+/// this function in reverse mode, and all derivatives it needs for that are
+/// provided by custom pullbacks.
+inline clad::ValueAndPushforward<double, double> inc_gamma_pushforward(double a, double x, double d_a, double d_x)
+{
+   return {::ROOT::Math::inc_gamma(a, x), inc_gamma_da(a, x) * d_a + inc_gamma_dx(a, x) * d_x};
+}
+
+/// Pushforward of ROOT::Math::inc_gamma_c, which is 1 - inc_gamma. See
+/// inc_gamma_pushforward().
+inline clad::ValueAndPushforward<double, double> inc_gamma_c_pushforward(double a, double x, double d_a, double d_x)
+{
+   return {::ROOT::Math::inc_gamma_c(a, x), -inc_gamma_da(a, x) * d_a - inc_gamma_dx(a, x) * d_x};
+}
+
+/// First derivative of the standardized Landau density (i.e.
+/// ROOT::Math::landau_pdf(v) with xi = 1 and x0 = 0) with respect to v. It
+/// has no closed form, but landau_pdf_pullback() computes it exactly by
+/// differentiating through the algorithm that evaluates the density.
+inline double landau_pdf_dv(double v)
+{
+   double dv = 0.;
+   double dxi = 0.;
+   double dx0 = 0.;
+   landau_pdf_pullback(v, 1., 0., 1., &dv, &dxi, &dx0);
+   return dv;
+}
+
+/// Pullback of landau_pdf_dv(). The second derivative of the standardized
+/// Landau density has no closed form, so it is approximated by a central
+/// difference of the exact first derivative (see also inc_gamma_da_pullback()).
+inline void landau_pdf_dv_pullback(double v, double _d_y, double *_d_v)
+{
+   const double h = 6e-6 * ::std::max(1., ::std::abs(v));
+   *_d_v += _d_y * (landau_pdf_dv(v + h) - landau_pdf_dv(v - h)) / (2. * h);
+}
+
+/// Pushforward of ROOT::Math::landau_pdf, which is p((x - x0) / xi) / xi in
+/// terms of the standardized Landau density p. Like for
+/// inc_gamma_pushforward(), all derivatives that clad needs to differentiate
+/// this function in reverse mode (e.g. for clad::hessian) are provided by
+/// custom pullbacks.
+inline clad::ValueAndPushforward<double, double>
+landau_pdf_pushforward(double x, double xi, double x0, double d_x, double d_xi, double d_x0)
+{
+   if (xi <= 0.)
+      return {0., 0.};
+   const double v = (x - x0) / xi;
+   const double p = ::ROOT::Math::landau_pdf(v);
+   const double vDot = (d_x - d_x0 - v * d_xi) / xi;
+   return {p / xi, landau_pdf_dv(v) * vDot / xi - p / (xi * xi) * d_xi};
+}
+
+/// Pushforward of ROOT::Math::landau_cdf, which is the cumulative
+/// distribution function of the standardized Landau density evaluated at
+/// (x - x0) / xi. Its derivative in x is landau_pdf, so unlike for the
+/// density itself, all second derivatives are known in closed form.
+inline clad::ValueAndPushforward<double, double>
+landau_cdf_pushforward(double x, double xi, double x0, double d_x, double d_xi, double d_x0)
+{
+   const double v = (x - x0) / xi;
+   const double vDot = (d_x - d_x0 - v * d_xi) / xi;
+   return {::ROOT::Math::landau_cdf(x, xi, x0), ::ROOT::Math::landau_pdf(v) * vDot};
 }
 
 } // namespace Math

--- a/math/mathcore/inc/Math/CladDerivator.h
+++ b/math/mathcore/inc/Math/CladDerivator.h
@@ -1103,6 +1103,11 @@ inline double inc_gamma_da(double a, double x)
 /// closed form (it is the same as the a-derivative of inc_gamma_dx(), see
 /// inc_gamma_dx_pullback()). For d2P/da2 there is no closed form, so it is
 /// approximated by a central difference of the exact first derivative.
+///
+/// For a <= h, the lower stencil point leaves the domain (inc_gamma_da()
+/// returns zero for non-positive a), so d2P/da2 is unreliable there. This is
+/// acceptable because RooFit never differentiates with respect to a, which is
+/// data there.
 inline void inc_gamma_da_pullback(double a, double x, double _d_y, double *_d_a, double *_d_x)
 {
    if (a <= 0 || x <= 0)
@@ -1148,10 +1153,34 @@ inline double landau_pdf_dv(double v)
 /// Pullback of landau_pdf_dv(). The second derivative of the standardized
 /// Landau density has no closed form, so it is approximated by a central
 /// difference of the exact first derivative (see also inc_gamma_da_pullback()).
+///
+/// The CERNLIB DENLAN approximation of the density is piecewise rational, and
+/// its first derivative has small jumps at the branch boundaries. Dividing
+/// such a jump by the step size would ruin the difference quotient (up to
+/// ~50 % error right at v = 1), so when the stencil would straddle a boundary
+/// it is shifted sideways to keep both points on the branch that contains v.
+/// The off-center evaluation costs one order in h, which is insignificant at
+/// this step size.
 inline void landau_pdf_dv_pullback(double v, double _d_y, double *_d_v)
 {
    const double h = 6e-6 * ::std::max(1., ::std::abs(v));
-   *_d_v += _d_y * (landau_pdf_dv(v + h) - landau_pdf_dv(v - h)) / (2. * h);
+   double lo = v - h;
+   double hi = v + h;
+   // Branch boundaries of landau_pdf(); each branch covers v < seam.
+   constexpr double seams[] = {-5.5, -1., 1., 5., 12., 50., 300.};
+   for (double seam : seams) {
+      if (lo < seam && seam <= hi) {
+         if (v < seam) {
+            lo -= h;
+            hi -= h;
+         } else {
+            lo += h;
+            hi += h;
+         }
+         break;
+      }
+   }
+   *_d_v += _d_y * (landau_pdf_dv(hi) - landau_pdf_dv(lo)) / (2. * h);
 }
 
 /// Pushforward of ROOT::Math::landau_pdf, which is p((x - x0) / xi) / xi in
@@ -1174,6 +1203,13 @@ landau_pdf_pushforward(double x, double xi, double x0, double d_x, double d_xi, 
 /// distribution function of the standardized Landau density evaluated at
 /// (x - x0) / xi. Its derivative in x is landau_pdf, so unlike for the
 /// density itself, all second derivatives are known in closed form.
+///
+/// That identity is exact only for the mathematical Landau distribution: ROOT
+/// implements the cdf (CERNLIB DISLAN) and the density (CERNLIB DENLAN) as
+/// independent rational approximations that are consistent with each other to
+/// about 1e-7 relative. The derivatives returned here therefore differ at
+/// that level both from the exact derivative of the implemented cdf and from
+/// landau_cdf_pullback(), which differentiates the DISLAN algorithm itself.
 inline clad::ValueAndPushforward<double, double>
 landau_cdf_pushforward(double x, double xi, double x0, double d_x, double d_xi, double d_x0)
 {


### PR DESCRIPTION
This is improving the code for existing custom pullbacks, and also adds missing pullbacks and pushforwards for the planned RooFit tests that cover Hessians generated with Clad.