### PR TITLE
[TMVA][SOFIE] Fix Memory Bloat in ROperator_Pool by removing unused _xpad allocation

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -246,7 +246,6 @@ public:
       return out.str();
    }
 
-   // generate code for Session data members (e.g. internal vectors)
 
    std::string Generate(std::string OpName) override {
       OpName = "op_" + OpName;

--- a/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Pool.hxx
@@ -247,27 +247,6 @@ public:
    }
 
    // generate code for Session data members (e.g. internal vectors)
-   virtual std::string GenerateSessionMembersCode(std::string opName) override {
-      opName = "op_" + opName;
-      std::stringstream out;
-      // input matrix padded with zero
-      if(fDim == 1){
-          out << "std::vector<" << fType << "> fVec_" << opName << "_xpad = std::vector<" << fType << ">("
-          << fShapeX[1] * (fShapeX[2] + fAttrPads[0] + fAttrPads[2]) << ");\n";
-      }
-      else if(fDim == 2){
-          out << "std::vector<" << fType << "> fVec_" << opName << "_xpad = std::vector<" << fType << ">("
-          << fShapeX[1] * (fShapeX[2] + fAttrPads[0] + fAttrPads[2]) * (fShapeX[3] + fAttrPads[1] + fAttrPads[3])
-          << ");\n";
-      }
-      else{ //dim is 3D
-          out << "std::vector<" << fType << "> fVec_" << opName << "_xpad = std::vector<" << fType << ">("
-          << fShapeX[1] * (fShapeX[2] + fAttrPads[0] + fAttrPads[2]) * (fShapeX[3] + fAttrPads[1] + fAttrPads[3]) *
-          (fShapeX[4] + fAttrPads[2] + fAttrPads[4]) << ");\n";
-      }
-
-      return out.str();
-   }
 
    std::string Generate(std::string OpName) override {
       OpName = "op_" + OpName;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This PR eliminates a severe memory bloat issue in the SOFIE `ROperator_Pool` class. It
removes the `GenerateSessionMembersCode` virtual function override, which incorrectly
statically declared and allocated a massive unused padding vector (`std::vector<float>
fVec_op_name_xpad(SIZE)`). Because the actual pooling `Generate()` math handles padding
dynamically through loop index clamping, this vector was entirely dead code. Removing this
allocation reclaims hundreds of megabytes of heap memory per instantiation for large models
with zero effect on mathematical parity.

## Checklist:

* [ ] updated the docs (if necessary)
* [x] tested changes locally

This PR fixes #23081

---

Respected @lmoneta and @sanjibansg,

It's nice to work on the CERN codebase again. Could you please review this fix? I look
forward to your thoughts on this bug and PR soon.

Also, I have local bug reproduction scripts but they are currently not in ROOT standard
test layout. Kindly advise if you would like me to add the standardized tests in this PR?

With regards,
Samreedh Bhuyan


