### PR TITLE
[tutorials] adjust GL tutorials

### DIFF
--- a/tutorials/visualisation/gl/glViewerExercise.C
+++ b/tutorials/visualisation/gl/glViewerExercise.C
@@ -86,7 +86,7 @@ void AnimateCamera()
 
 void glViewerExercise()
 {
-   gROOT->ProcessLine(".x nucleus.C");
+   gROOT->ProcessLine(TString::Format(".x %s/visualisation/gl/nucleus.C", gROOT->GetTutorialsDir()));
    TGLViewer *v = gPad ? (TGLViewer *)gPad->GetViewer3D() : nullptr;
    if (!v) return;
 

--- a/tutorials/visualisation/gl/glbox.C
+++ b/tutorials/visualisation/gl/glbox.C
@@ -5,12 +5,17 @@
 /// \macro_image(nobatch)
 /// \macro_code
 ///
-/// \author  Timur Pocheptsov
+/// \author  Timur Pocheptsov, Sergey Linev
 
-void glbox()
+void glbox(bool gl = true)
 {
-   gStyle->SetCanvasPreferGL(kTRUE);
+   gStyle->SetCanvasPreferGL(gl);
    TCanvas *c = new TCanvas("glbox", "TH3 Drawing", 100, 10, 850, 400);
+
+   if (!c->UseGL() && !c->IsWeb())
+      ::Warning("glbox",
+                "To use glbox draw option, you need either OpenGL or Web rendering enabled");
+
    TPaveLabel *title = new TPaveLabel(0.04, 0.86, 0.96, 0.98, "\"glbox\" and \"glbox1\" options for TH3.");
    title->SetFillColor(32);
    title->Draw();

--- a/tutorials/visualisation/gl/gldemos.C
+++ b/tutorials/visualisation/gl/gldemos.C
@@ -8,13 +8,18 @@
 
 void gldemos()
 {
-   TControlBar *bar = new TControlBar("vertical", "GL painter demo", 20, 20);
+   auto bar = new TControlBar("vertical", "GL painter demo", 20, 20);
    bar->AddButton("Help on demos", "help()", "Description");
-   bar->AddButton("glsurfaces", ".x $ROOTSYS/tutorials/visualisation/gl/glsurfaces.C", "Surface painter example");
-   bar->AddButton("glrose", ".x $ROOTSYS/tutorials/visualisation/gl/glrose.C", "Surface in polar system");
-   bar->AddButton("gltf3", ".x $ROOTSYS/tutorials/visualisation/gl/gltf3.C", "TF3 painter");
-   bar->AddButton("glbox", ".x $ROOTSYS/tutorials/visualisation/gl/glbox.C", "BOX painter");
-   bar->AddButton("glparametric", ".x $ROOTSYS/tutorials/visualisation/gl/glparametric.C", "Parametric surface");
+   TString prefix = TString::Format(".x %s/visualisation/gl/", gROOT->GetTutorialsDir());
+   bar->AddButton("glsurfaces", prefix + "glsurfaces.C", "Surface painter example");
+   bar->AddButton("glrose", prefix + "glrose.C", "Surface in polar system");
+   bar->AddButton("gltf3", prefix + "gltf3.C", "TF3 painter");
+   bar->AddButton("glbox", prefix + "glbox.C", "BOX painter");
+   bar->AddButton("transp", prefix + "transp.C", "Use of transparent colors");
+   bar->AddButton("grad", prefix + "grad.C", "Use of gradient colors");
+   bar->AddButton("glparametric", prefix + "glparametric.C", "Parametric surface");
+   bar->AddButton("radialgradients", prefix + "radialgradients.C", "Radial gradients");
+   bar->AddButton("exit", ".q", "Exit demo");
    bar->Show();
 }
 

--- a/tutorials/visualisation/gl/glrose.C
+++ b/tutorials/visualisation/gl/glrose.C
@@ -9,7 +9,7 @@
 ///
 /// \author  Timur Pocheptsov
 
-void glrose()
+void glrose(bool gl = true)
 {
    const Int_t paletteSize = 10;
    Float_t rgb[paletteSize * 3] = {0.80f, 0.55f, 0.40f, 0.85f, 0.60f, 0.45f, 0.90f, 0.65f, 0.50f, 0.95f,
@@ -23,8 +23,12 @@ void glrose()
 
    gStyle->SetPalette(paletteSize, palette);
 
-   gStyle->SetCanvasPreferGL(1);
+   gStyle->SetCanvasPreferGL(gl);
    TCanvas *cnv = new TCanvas("glc", "Surface sample", 200, 10, 600, 550);
+
+   if (!cnv->UseGL() && !cnv->IsWeb())
+      ::Warning("glrose",
+                "To use glsurf draw option, you need either OpenGL or Web rendering enabled");
 
    TPaveLabel *title = new TPaveLabel(0.04, 0.86, 0.96, 0.98, "\"glsurf2pol\" option + user defined palette.");
    title->SetFillColor(32);

--- a/tutorials/visualisation/gl/gltf3.C
+++ b/tutorials/visualisation/gl/gltf3.C
@@ -12,12 +12,15 @@
 /// \macro_image(nobatch)
 /// \macro_code
 ///
-/// \author Timur Pocheptsov
+/// \author Timur Pocheptsov, Sergey Linev
 
-void gltf3()
+void gltf3(bool gl = true)
 {
-   gStyle->SetCanvasPreferGL(1);
+   gStyle->SetCanvasPreferGL(gl);
    TCanvas *cnv = new TCanvas("gltf3", "TF3: Klein bottle", 200, 10, 600, 600);
+   if (!cnv->UseGL() && !cnv->IsWeb())
+      ::Warning("gltf3",
+                "To use TF3 gl draw option, you need either OpenGL or Web rendering enabled");
 
    TPaveLabel *title =
       new TPaveLabel(0.04, 0.86, 0.96, 0.98, "\"gl\" option for TF3. Select plot and press 's' to change the color.");

--- a/tutorials/visualisation/gl/glvox1.C
+++ b/tutorials/visualisation/gl/glvox1.C
@@ -7,7 +7,7 @@
 ///
 /// \author  Timur Pocheptsov
 
-void glvox1()
+void glvox1(bool gl = true)
 {
    // Create and fill TH3.
    const UInt_t nX = 30;
@@ -37,7 +37,7 @@ void glvox1()
       }
    }
 
-   gStyle->SetCanvasPreferGL(1);
+   gStyle->SetCanvasPreferGL(gl);
 
    hist->Draw("glcol");
 }

--- a/tutorials/visualisation/gl/glvox2.C
+++ b/tutorials/visualisation/gl/glvox2.C
@@ -61,7 +61,7 @@ Double_t my_transfer_function(const Double_t *x, const Double_t * /*param*/)
 
 } // namespace
 
-void glvox2()
+void glvox2(bool gl = true)
 {
    // Create and fill TH3.
    const UInt_t nX = 30;
@@ -98,7 +98,7 @@ void glvox2()
       lf->Add(tf);
    }
 
-   gStyle->SetCanvasPreferGL(true);
+   gStyle->SetCanvasPreferGL(gl);
 
    hist->Draw("glcol");
 }

--- a/tutorials/visualisation/gl/grad.C
+++ b/tutorials/visualisation/gl/grad.C
@@ -8,7 +8,6 @@
 ///
 /// \authors  Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC (cling does not need them).
 #include "TColorGradient.h"
 #include "TCanvas.h"
 #include "TColor.h"

--- a/tutorials/visualisation/gl/grad2.C
+++ b/tutorials/visualisation/gl/grad2.C
@@ -10,7 +10,6 @@
 ///
 /// \authors  Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC (cling does not need them).
 #include "TColorGradient.h"
 #include "TCanvas.h"
 #include "TError.h"

--- a/tutorials/visualisation/gl/gradients.C
+++ b/tutorials/visualisation/gl/gradients.C
@@ -9,7 +9,6 @@
 ///
 /// \authors  Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC:
 #include "TColorGradient.h"
 #include "TCanvas.h"
 #include "TError.h"

--- a/tutorials/visualisation/gl/parallelcoordtrans.C
+++ b/tutorials/visualisation/gl/parallelcoordtrans.C
@@ -10,8 +10,6 @@
 ///
 /// \authors Timur Pocheptsov, Olivier Couet
 
-// All these includes are (only) to make the macro
-// ACLiCable.
 #include <cassert>
 
 #include "TParallelCoordVar.h"
@@ -49,7 +47,7 @@ void generate_random(Int_t i)
 } // namespace GLTutorials
 } // namespace ROOT
 
-void parallelcoordtrans()
+void parallelcoordtrans(bool gl = true)
 {
    // This macro shows how to use parallel coords and semi-transparent lines
    //(the system color is updated with alpha == 0.01 (1% opaque).
@@ -60,8 +58,12 @@ void parallelcoordtrans()
    Double_t s2x = 0., s2y = 0., s2z = 0.;
    Double_t s3x = 0., s3y = 0., s3z = 0.;
 
-   gStyle->SetCanvasPreferGL(kTRUE);
+   gStyle->SetCanvasPreferGL(gl);
    TCanvas *c1 = new TCanvas("parallel coors", "parallel coords", 0, 0, 900, 1000);
+
+   if (!c1->UseGL() && !c1->IsWeb() && !gVirtualX->InheritsFrom("TGCocoa"))
+      ::Warning("parallelcoordtrans",
+                "To have real transparency in a canvas graphics, you need either OpenGL or Mac/Cocoa or Web rendering enabled");
 
    TNtuple *const nt = new TNtuple("nt", "Demo ntuple", "x:y:z:u:v:w:a:b:c");
 

--- a/tutorials/visualisation/gl/radialgradients.C
+++ b/tutorials/visualisation/gl/radialgradients.C
@@ -9,7 +9,6 @@
 ///
 /// \authors Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC:
 #include "TColorGradient.h"
 #include "TEllipse.h"
 #include "TRandom.h"

--- a/tutorials/visualisation/gl/transp.C
+++ b/tutorials/visualisation/gl/transp.C
@@ -7,7 +7,6 @@
 ///
 /// \authors Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC (cling does not need them).
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TError.h"
@@ -19,8 +18,11 @@ void transp(bool gl = true)
    auto redIndex = TColor::GetColor((Float_t)1., 0., 0., 0.85);
    auto greeIndex = TColor::GetColor((Float_t)0., 1., 0., 0.5);
 
-   gStyle->SetCanvasPreferGL(kTRUE);
+   gStyle->SetCanvasPreferGL(gl);
    auto cnv = new TCanvas("trasnparency", "transparency demo", 600, 400);
+   if (!cnv->UseGL() && !cnv->IsWeb() && !gVirtualX->InheritsFrom("TGCocoa"))
+      ::Warning("transp",
+                "To have real transparency in a canvas graphics, you need either OpenGL or Mac/Cocoa or Web rendering enabled");
 
    auto hist = new TH1F("a5", "b5", 10, -2., 3.);
    auto hist2 = new TH1F("c6", "d6", 10, -3., 3.);

--- a/tutorials/visualisation/gl/transp_text.C
+++ b/tutorials/visualisation/gl/transp_text.C
@@ -9,7 +9,6 @@
 ///
 /// \authors Timur Pocheptsov, Sergey Linev
 
-// Includes for ACLiC (cling does not need them).
 #include "TPaveText.h"
 #include "TCanvas.h"
 #include "TRandom.h"
@@ -28,8 +27,9 @@ void transp_text(bool gl = true)
    gStyle->SetCanvasPreferGL(gl);
 
    auto c1 = new TCanvas("transp_text", "transparent text demo", 10, 10, 900, 500);
-   if (!c1->UseGL() && !c1->IsWeb())
-      ::Warning("transp_text", "to use this macro you need either OpenGL or Web");
+   if (!c1->UseGL() && !c1->IsWeb() && !gVirtualX->InheritsFrom("TGCocoa"))
+      ::Warning("transp_text",
+                "To have real transparency in a canvas graphics, you need either OpenGL or Mac/Cocoa or Web rendering enabled");
 
    c1->SetGrid();
    c1->SetBottomMargin(0.15);


### PR DESCRIPTION
For most provide `(bool gl = true)` argument to let switch on/off usage of gl canvas, in many cases web canvas also can be used for display 

Extend `gldemos.C` macro adding new tutorials to list

Fix glViewerExercise.C to correctly run nucleus.C
