### PR TITLE
[CMake] Produce an error when cuda=On and no CUDA compiler can be found.

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -342,6 +342,11 @@ if(testing)
   set(testsupport ON CACHE BOOL "" FORCE)
 endif()
 
+#---ensure that the cuda option is sound
+if(cuda AND NOT CMAKE_CUDA_COMPILER)
+  message(FATAL_ERROR "Option cuda=On, but CMAKE_CUDA_COMPILER='${CMAKE_CUDA_COMPILER}'")
+endif()
+
 #---running HS3 test suite requires both testing and pyroot, but testing globally disables tests
 if(testing AND test_roofit_hs3testsuite AND NOT pyroot)
   message(FATAL_ERROR "-Dtest_roofit_hs3testsuite=ON requires both -Dtesting=ON and -Dpyroot=ON)")


### PR DESCRIPTION
When cuda=On, but no viable compiler can be found, CMake produces the hard-to-understand error:
>  Cannot determine link language of RooBatchCompute_CUDA.