### PR TITLE
[v6.40][CMake] Produce an error when cuda=On and no CUDA compiler can be found.

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -347,6 +347,10 @@ if(testing)
   set(testsupport ON CACHE BOOL "" FORCE)
 endif()
 
+#---ensure that the cuda option is sound
+if(cuda AND NOT CMAKE_CUDA_COMPILER)
+  message(FATAL_ERROR "Option cuda=On, but CMAKE_CUDA_COMPILER='${CMAKE_CUDA_COMPILER}'")
+endif()
 
 if(unfold AND NOT xml)
   message(STATUS "Cannot enable unfold without enabling xml: unfold is disabled.")


### PR DESCRIPTION
When cuda=On, but no viable compiler can be found, CMake produces the hard-to-understand error:
  Cannot determine link language of RooBatchCompute_CUDA.

(cherry picked from commit 6fc16982cc82c33d92be37b708bc9a4275d9d582)