### PR TITLE
[meta]  Ctor name lookup is not enough for the class info

### DIFF
--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -99,9 +99,14 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, b
                              &type, intantiateTemplate);
       }
    }
+   // The lookup finds the decl if the name corresponds to a namespace or a fully defined
+   // class; just a type in presence of a forward declaration of a class.
+   // This code identifies that case and prevents that a class type is found if the name
+   // of a constructor is passed (see ROOT-10311).
    if (!decl && type) {
-      if (const auto *TD = type->getAsTagDecl()) {
-         decl = TD;
+      const auto *CXXRD = type->getAsCXXRecordDecl();
+      if (CXXRD && !CXXRD->hasDefinition()) {
+         decl = CXXRD;
       }
    }
    SetDecl(decl);

--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -99,14 +99,9 @@ TClingClassInfo::TClingClassInfo(cling::Interpreter *interp, const char *name, b
                              &type, intantiateTemplate);
       }
    }
-   // The lookup finds the decl if the name corresponds to a namespace or a fully defined
-   // class; just a type in presence of a forward declaration of a class.
-   // This code identifies that case and prevents that a class type is found if the name
-   // of a constructor is passed (see ROOT-10311).
    if (!decl && type) {
-      const auto *CXXRD = type->getAsCXXRecordDecl();
-      if (CXXRD && !CXXRD->hasDefinition()) {
-         decl = CXXRD;
+      if (const auto *TD = type->getAsTagDecl()) {
+         decl = TD;
       }
    }
    SetDecl(decl);

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -468,3 +468,22 @@ using func0_ret_t = typename ROOT::TypeTraits::CallableTraits<decltype(func0)>::
    EXPECT_TRUE(res);
 }
 #endif
+
+// ROOT-10311
+TEST_F(TClingTests, TClassByCtorName)
+{
+   auto res = gInterpreter->Declare("namespace TClassByCtorName{class Foo;};");
+   EXPECT_TRUE(res);
+   {
+      ROOT::TestSupport::CheckDiagsRAII checkDiag;
+      checkDiag.requiredDiag(kWarning, "TClass::Init", "no dictionary for class TClassByCtorName::Foo is available", false);
+      EXPECT_TRUE(nullptr != TClass::GetClass("TClassByCtorName::Foo"));
+   }
+   const auto *wrongName = "TTree::TTree";
+   EXPECT_TRUE(nullptr == TClass::GetClass(wrongName));
+   EXPECT_TRUE(nullptr != TClass::GetClass("TTree"));
+
+   std::string classInterpreterName;
+   gInterpreter->GetInterpreterTypeName(wrongName, classInterpreterName);
+   EXPECT_STREQ(classInterpreterName.c_str(), "");
+}

--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -294,6 +294,14 @@ namespace cling {
         next = utils::Lookup::Named(&S, declName.substr(last, c + 1 - last), sofar);
         // If there is an ambiguity, we need to go the long route.
         if (next == (void *) -1) return false;
+        if (const auto *RD = dyn_cast_or_null<CXXRecordDecl>(next);
+            RD && RD->isInjectedClassName()) {
+          // We found an injected-class-name, which is not a scope.
+          // See [class.qual]p2.  Not skipping the injected-class-name, would
+          // lead to a wrong lookup result for "C::C" where C is a class name.
+          resultDecl = nullptr;
+          return true; // nothing found
+        }
         if (next) {
           resultDecl = next;
         }


### PR DESCRIPTION
The mechanism in place to allow the initialisation of TClingClassInfo based on names of forward declared classes was a bit too loose. It also allowed for finding a class by the name of its constructor.

The new mechanism is more explicit about the properties of the CXXRecordDecl identified by the lookup (if any).

Fixes ROOT-10311
