### PR TITLE
[Python] Report exceptions from Jupyter cell code

### DIFF
--- a/bindings/pyroot/pythonizations/src/IOHandler.cxx
+++ b/bindings/pyroot/pythonizations/src/IOHandler.cxx
@@ -25,8 +25,11 @@
 #else
 #include <unistd.h>
 #endif
+#include <cstdlib>
 #include <string>
 #include <iostream>
+#include "TClassEdit.h"
+#include "TError.h"
 #include "TInterpreter.h"
 
 //////////////////////////
@@ -154,6 +157,18 @@ std::string &JupyROOTExecutorHandler::GetStderr()
 
 JupyROOTExecutorHandler *JupyROOTExecutorHandler_ptr = nullptr;
 
+// Report exceptions that escape the interpreted code like TRint does at the
+// ROOT prompt (see TRint::HandleTermInput), instead of swallowing them
+// silently (ROOT-10589).
+static void ReportCaughtException(const char *location, const std::exception &e)
+{
+   int err = 0;
+   char *demangledType_c = TClassEdit::DemangleTypeIdName(typeid(e), err);
+   const char *demangledType = err ? "<UNKNOWN>" : demangledType_c;
+   ::Error(location, "%s caught: %s", demangledType, e.what());
+   free(demangledType_c);
+}
+
 bool JupyROOTExecutorImpl(const char *code)
 {
    auto status = false;
@@ -167,8 +182,10 @@ bool JupyROOTExecutorImpl(const char *code)
          gInterpreter->ProcessLine(".@");
          gInterpreter->ProcessLine("cerr << \"Unbalanced braces. This cell was not processed.\" << endl;");
       }
+   } catch (std::exception &e) {
+      ReportCaughtException("JupyROOTExecutor", e);
    } catch (...) {
-      status = true;
+      ::Error("JupyROOTExecutor", "Exception caught!");
    }
 
    return status;
@@ -181,8 +198,10 @@ bool JupyROOTDeclarerImpl(const char *code)
       if (gInterpreter->Declare(code)) {
          status = true;
       }
+   } catch (std::exception &e) {
+      ReportCaughtException("JupyROOTDeclarer", e);
    } catch (...) {
-      status = true;
+      ::Error("JupyROOTDeclarer", "Exception caught!");
    }
    return status;
 }

--- a/roottest/python/JupyROOT/ROOT_kernel.ipynb
+++ b/roottest/python/JupyROOT/ROOT_kernel.ipynb
@@ -194,6 +194,26 @@
    "source": [
     "s->GetName()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error in <JupyROOTExecutor>: std::runtime_error caught: test error\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Exceptions must be reported, not silently swallowed (ROOT-10589)\n",
+    "throw std::runtime_error(\"test error\");"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
The ROOT C++ Jupyter kernel executed cells inside a bare `catch (...) { status = true; }`, so any exception thrown by the cell code - e.g. the std::runtime_error from `rd.Histo1D("foo")` with an unknown column - vanished without a trace, while the same code at the ROOT prompt prints:

```
  Error in <TRint::HandleTermInput()>: std::runtime_error caught: Unknown column: "foo"
```

Catch std::exception in JupyROOTExecutorImpl and JupyROOTDeclarerImpl and report it the same way TRint::HandleTermInput does (demangled type plus what()), with a catch-all fallback. The exception path now also returns false instead of pretending success; the return value is discarded in all kernel code paths.

Add a regression cell to the ROOT_kernel.ipynb roottest notebook that throws a std::runtime_error and expects the reported message.

Fixes [ROOT-10589](https://its.cern.ch/jira/browse/ROOT-10589).

🤖 Done with the help of AI