### PR TITLE
[ntuple] Move `fProcessorName` into `RNTupleProcessorOptions` class

### DIFF
--- a/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
+++ b/tree/ntuple/inc/ROOT/RNTupleProcessor.hxx
@@ -64,6 +64,18 @@ public:
    std::unique_ptr<ROOT::Internal::RPageSource> CreatePageSource() const;
 };
 
+class RNTupleProcessorOptions {
+private:
+   /// By default, the processor name is the name of the underlying RNTuple for RNTupleSingleProcessor, the name of the
+   /// first processor for RNTupleChainProcessor, or the name of the primary RNTuple for RNTupleJoinProcessor.
+   std::string fProcessorName = "";
+
+public:
+   const std::string &GetProcessorName() const { return fProcessorName; }
+
+   void SetProcessorName(std::string_view name) { fProcessorName = name; }
+};
+
 // clang-format off
 /**
 \class ROOT::Experimental::RNTupleProcessorOptionalPtr<T>
@@ -252,7 +264,8 @@ class RNTupleProcessor {
    friend class RNTupleJoinProcessor;
 
 protected:
-   std::string fProcessorName;
+   RNTupleProcessorOptions fOptions;
+
    std::shared_ptr<Internal::RNTupleProcessorEntry> fEntry = nullptr;
    std::unordered_set<Internal::RNTupleProcessorEntry::FieldIndex_t> fFieldIdxs;
 
@@ -337,7 +350,7 @@ protected:
    /// \param[in] processorName Name of the processor. By default, this is the name of the underlying RNTuple for
    /// RNTupleSingleProcessor, the name of the first processor for RNTupleChainProcessor, or the name of the primary
    /// RNTuple for RNTupleJoinProcessor.
-   RNTupleProcessor(std::string_view processorName) : fProcessorName(processorName) {}
+   RNTupleProcessor(const RNTupleProcessorOptions &options) : fOptions(options) {}
 
 public:
    RNTupleProcessor(const RNTupleProcessor &) = delete;
@@ -345,6 +358,10 @@ public:
    RNTupleProcessor &operator=(const RNTupleProcessor &) = delete;
    RNTupleProcessor &operator=(RNTupleProcessor &&) = delete;
    virtual ~RNTupleProcessor() = default;
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Get the options used for this processor.
+   const RNTupleProcessorOptions &GetOptions() const { return fOptions; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Get the total number of entries processed so far.
@@ -359,14 +376,6 @@ public:
    ///
    /// This method is only relevant for the RNTupleChainProcessor. For the other processors, 0 is always returned.
    std::size_t GetCurrentProcessorNumber() const { return fCurrentProcessorNumber; }
-
-   /////////////////////////////////////////////////////////////////////////////
-   /// \brief Get the name of the processor.
-   ///
-   /// Unless this name was explicitly specified during creation of the processor, this is the name of the underlying
-   /// RNTuple for RNTupleSingleProcessor, the name of the first processor for RNTupleChainProcessor, or the name of the
-   /// primary processor for RNTupleJoinProcessor.
-   const std::string &GetProcessorName() const { return fProcessorName; }
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Request access to a field for reading during processing.
@@ -506,31 +515,32 @@ public:
    /// \brief Create an RNTupleProcessor for a single RNTuple.
    ///
    /// \param[in] ntuple The name and storage location of the RNTuple to process.
-   /// \param[in] processorName The name to give to the processor. If empty, the name of the input RNTuple is used.
+   /// \param[in] opts Options for the processor.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor> Create(RNTupleOpenSpec ntuple, std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor>
+   Create(RNTupleOpenSpec ntuple, const RNTupleProcessorOptions &opts = RNTupleProcessorOptions());
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of RNTuples.
    ///
    /// \param[in] ntuples A list specifying the names and locations of the RNTuples to process.
-   /// \param[in] processorName The name to give to the processor. If empty, the name of the first RNTuple is used.
+   /// \param[in] opts Options for the processor.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
-   CreateChain(std::vector<RNTupleOpenSpec> ntuples, std::string_view processorName = "");
+   CreateChain(std::vector<RNTupleOpenSpec> ntuples, const RNTupleProcessorOptions &opts = RNTupleProcessorOptions());
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *chain* (i.e., a vertical combination) of other RNTupleProcessors.
    ///
    /// \param[in] innerProcessors A list with the processors to chain.
-   /// \param[in] processorName The name to give to the processor. If empty, the name of the first inner processor is
-   /// used.
+   /// \param[in] opts Options for the processor.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor>
-   CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors, std::string_view processorName = "");
+   CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
+               const RNTupleProcessorOptions &opts = RNTupleProcessorOptions());
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -542,12 +552,12 @@ public:
    /// \param[in] joinFields The names of the fields on which to join, in case the specified RNTuples are unaligned.
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified RNTuple. If an empty list is provided, it is assumed that the specified ntuple are fully aligned.
-   /// \param[in] processorName The name to give to the processor. If empty, the name of the primary RNTuple is used.
+   /// \param[in] opts Options for the processor.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
    static std::unique_ptr<RNTupleProcessor> CreateJoin(RNTupleOpenSpec primaryNTuple, RNTupleOpenSpec auxNTuple,
                                                        const std::vector<std::string> &joinFields,
-                                                       std::string_view processorName = "");
+                                                       const RNTupleProcessorOptions &opts = RNTupleProcessorOptions());
 
    /////////////////////////////////////////////////////////////////////////////
    /// \brief Create an RNTupleProcessor for a *join* (i.e., a horizontal combination) of RNTuples.
@@ -559,12 +569,13 @@ public:
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified processors. If an empty list is provided, it is assumed that the specified processors are fully
    /// aligned.
-   /// \param[in] processorName The name to give to the processor. If empty, the name of the primary processor is used.
+   /// \param[in] opts Options for the processor.
    ///
    /// \return A pointer to the newly created RNTupleProcessor.
-   static std::unique_ptr<RNTupleProcessor>
-   CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor, std::unique_ptr<RNTupleProcessor> auxProcessor,
-              const std::vector<std::string> &joinFields, std::string_view processorName = "");
+   static std::unique_ptr<RNTupleProcessor> CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor,
+                                                       std::unique_ptr<RNTupleProcessor> auxProcessor,
+                                                       const std::vector<std::string> &joinFields,
+                                                       const RNTupleProcessorOptions &opts = RNTupleProcessorOptions());
 };
 
 // clang-format off
@@ -650,9 +661,8 @@ private:
    /// \brief Construct a new RNTupleProcessor for processing a single RNTuple.
    ///
    /// \param[in] ntuple The source specification (name and storage location) for the RNTuple to process.
-   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::Create, this is
-   /// the name of the underlying RNTuple.
-   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, std::string_view processorName);
+   /// \param[in] opts Options for the processor.
+   RNTupleSingleProcessor(RNTupleOpenSpec ntuple, const RNTupleProcessorOptions &opts);
 
 public:
    RNTupleSingleProcessor(const RNTupleSingleProcessor &) = delete;
@@ -745,11 +755,11 @@ private:
    /// \brief Construct a new RNTupleChainProcessor.
    ///
    /// \param[in] ntuples The source specification (name and storage location) for each RNTuple to process.
-   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateChain, this
-   /// is the name of the first inner processor.
+   /// \param[in] opts Options for the processor.
    ///
    /// RNTuples are processed in the order in which they are specified.
-   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName);
+   RNTupleChainProcessor(std::vector<std::unique_ptr<RNTupleProcessor>> processors,
+                         const RNTupleProcessorOptions &opts);
 
 public:
    RNTupleChainProcessor(const RNTupleChainProcessor &) = delete;
@@ -813,8 +823,8 @@ private:
    bool CanReadFieldFromDisk(std::string_view fieldName) final
    {
       if (!fPrimaryProcessor->CanReadFieldFromDisk(fieldName)) {
-         if (fieldName.find(fAuxiliaryProcessor->GetProcessorName()) == 0)
-            fieldName = fieldName.substr(fAuxiliaryProcessor->GetProcessorName().size() + 1);
+         if (fieldName.find(fAuxiliaryProcessor->fOptions.GetProcessorName()) == 0)
+            fieldName = fieldName.substr(fAuxiliaryProcessor->fOptions.GetProcessorName().size() + 1);
          return fAuxiliaryProcessor->CanReadFieldFromDisk(fieldName);
       }
 
@@ -849,11 +859,10 @@ private:
    /// \param[in] joinFields The names of the fields on which to join, in case the specified processors are unaligned.
    /// The join is made based on the combined join field values, and therefore each field has to be present in each
    /// specified processor. If an empty list is provided, it is assumed that the processors are fully aligned.
-   /// \param[in] processorName Name of the processor. Unless specified otherwise in RNTupleProcessor::CreateJoin, this
-   /// is the name of the primary processor.
+   /// \param[in] opts Options for the processor.
    RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                         std::unique_ptr<RNTupleProcessor> auxProcessor, const std::vector<std::string> &joinFields,
-                        std::string_view processorName);
+                        const RNTupleProcessorOptions &opts);
 
 public:
    RNTupleJoinProcessor(const RNTupleJoinProcessor &) = delete;

--- a/tree/ntuple/src/RNTupleProcessor.cxx
+++ b/tree/ntuple/src/RNTupleProcessor.cxx
@@ -34,13 +34,14 @@ std::unique_ptr<ROOT::Internal::RPageSource> ROOT::Experimental::RNTupleOpenSpec
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
-ROOT::Experimental::RNTupleProcessor::Create(RNTupleOpenSpec ntuple, std::string_view processorName)
+ROOT::Experimental::RNTupleProcessor::Create(RNTupleOpenSpec ntuple, const RNTupleProcessorOptions &options)
 {
-   return std::unique_ptr<RNTupleSingleProcessor>(new RNTupleSingleProcessor(std::move(ntuple), processorName));
+   return std::unique_ptr<RNTupleSingleProcessor>(new RNTupleSingleProcessor(std::move(ntuple), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
-ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> ntuples, std::string_view processorName)
+ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> ntuples,
+                                                  const RNTupleProcessorOptions &options)
 {
    if (ntuples.empty())
       throw RException(R__FAIL("at least one RNTuple must be provided"));
@@ -52,23 +53,23 @@ ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<RNTupleOpenSpec> n
       innerProcessors.emplace_back(Create(std::move(ntuple)));
    }
 
-   return CreateChain(std::move(innerProcessors), processorName);
+   return CreateChain(std::move(innerProcessors), options);
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateChain(std::vector<std::unique_ptr<RNTupleProcessor>> innerProcessors,
-                                                  std::string_view processorName)
+                                                  const RNTupleProcessorOptions &options)
 {
    if (innerProcessors.empty())
       throw RException(R__FAIL("at least one inner processor must be provided"));
 
-   return std::unique_ptr<RNTupleChainProcessor>(new RNTupleChainProcessor(std::move(innerProcessors), processorName));
+   return std::unique_ptr<RNTupleChainProcessor>(new RNTupleChainProcessor(std::move(innerProcessors), options));
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateJoin(RNTupleOpenSpec primaryNTuple, RNTupleOpenSpec auxNTuple,
                                                  const std::vector<std::string> &joinFields,
-                                                 std::string_view processorName)
+                                                 const RNTupleProcessorOptions &options)
 {
    if (joinFields.size() > 4) {
       throw RException(R__FAIL("a maximum of four join fields is allowed"));
@@ -78,18 +79,18 @@ ROOT::Experimental::RNTupleProcessor::CreateJoin(RNTupleOpenSpec primaryNTuple, 
       throw RException(R__FAIL("join fields must be unique"));
    }
 
-   std::unique_ptr<RNTupleProcessor> primaryProcessor = Create(std::move(primaryNTuple), processorName);
+   std::unique_ptr<RNTupleProcessor> primaryProcessor = Create(std::move(primaryNTuple), options);
 
    std::unique_ptr<RNTupleProcessor> auxProcessor = Create(std::move(auxNTuple));
 
-   return CreateJoin(std::move(primaryProcessor), std::move(auxProcessor), joinFields, processorName);
+   return CreateJoin(std::move(primaryProcessor), std::move(auxProcessor), joinFields, options);
 }
 
 std::unique_ptr<ROOT::Experimental::RNTupleProcessor>
 ROOT::Experimental::RNTupleProcessor::CreateJoin(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                                                  std::unique_ptr<RNTupleProcessor> auxProcessor,
                                                  const std::vector<std::string> &joinFields,
-                                                 std::string_view processorName)
+                                                 const RNTupleProcessorOptions &options)
 {
    if (joinFields.size() > 4) {
       throw RException(R__FAIL("a maximum of four join fields is allowed"));
@@ -100,17 +101,17 @@ ROOT::Experimental::RNTupleProcessor::CreateJoin(std::unique_ptr<RNTupleProcesso
    }
 
    return std::unique_ptr<RNTupleJoinProcessor>(
-      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessor), joinFields, processorName));
+      new RNTupleJoinProcessor(std::move(primaryProcessor), std::move(auxProcessor), joinFields, options));
 }
 
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleSingleProcessor::RNTupleSingleProcessor(RNTupleOpenSpec ntuple,
-                                                                   std::string_view processorName)
-   : RNTupleProcessor(processorName), fNTupleSpec(std::move(ntuple))
+                                                                   const RNTupleProcessorOptions &options)
+   : RNTupleProcessor(options), fNTupleSpec(std::move(ntuple))
 {
-   if (fProcessorName.empty()) {
-      fProcessorName = fNTupleSpec.fNTupleName;
+   if (fOptions.GetProcessorName().empty()) {
+      fOptions.SetProcessorName(fNTupleSpec.fNTupleName);
    }
 }
 
@@ -278,12 +279,12 @@ void ROOT::Experimental::RNTupleSingleProcessor::PrintStructureImpl(std::ostream
 //------------------------------------------------------------------------------
 
 ROOT::Experimental::RNTupleChainProcessor::RNTupleChainProcessor(
-   std::vector<std::unique_ptr<RNTupleProcessor>> processors, std::string_view processorName)
-   : RNTupleProcessor(processorName), fInnerProcessors(std::move(processors))
+   std::vector<std::unique_ptr<RNTupleProcessor>> processors, const RNTupleProcessorOptions &options)
+   : RNTupleProcessor(options), fInnerProcessors(std::move(processors))
 {
-   if (fProcessorName.empty()) {
+   if (fOptions.GetProcessorName().empty()) {
       // `CreateChain` ensures there is at least one inner processor.
-      fProcessorName = fInnerProcessors[0]->GetProcessorName();
+      fOptions.SetProcessorName(fInnerProcessors[0]->fOptions.GetProcessorName());
    }
 
    fInnerNEntries.assign(fInnerProcessors.size(), kInvalidNTupleIndex);
@@ -411,14 +412,14 @@ void ROOT::Experimental::RNTupleChainProcessor::PrintStructureImpl(std::ostream 
 ROOT::Experimental::RNTupleJoinProcessor::RNTupleJoinProcessor(std::unique_ptr<RNTupleProcessor> primaryProcessor,
                                                                std::unique_ptr<RNTupleProcessor> auxProcessor,
                                                                const std::vector<std::string> &joinFields,
-                                                               std::string_view processorName)
-   : RNTupleProcessor(processorName),
+                                                               const RNTupleProcessorOptions &options)
+   : RNTupleProcessor(options),
      fPrimaryProcessor(std::move(primaryProcessor)),
      fAuxiliaryProcessor(std::move(auxProcessor)),
      fJoinFieldNames(joinFields)
 {
-   if (fProcessorName.empty()) {
-      fProcessorName = fPrimaryProcessor->GetProcessorName();
+   if (fOptions.GetProcessorName().empty()) {
+      fOptions.SetProcessorName(fPrimaryProcessor->fOptions.GetProcessorName());
    }
 }
 
@@ -440,17 +441,17 @@ void ROOT::Experimental::RNTupleJoinProcessor::Initialize(
       for (const auto &joinField : fJoinFieldNames) {
          if (!fPrimaryProcessor->CanReadFieldFromDisk(joinField)) {
             throw RException(R__FAIL("could not find join field \"" + joinField + "\" in primary processor \"" +
-                                     fPrimaryProcessor->GetProcessorName() + "\""));
+                                     fPrimaryProcessor->fOptions.GetProcessorName() + "\""));
          }
          if (!fAuxiliaryProcessor->CanReadFieldFromDisk(joinField)) {
             throw RException(R__FAIL("could not find join field \"" + joinField + "\" in auxiliary processor \"" +
-                                     fAuxiliaryProcessor->GetProcessorName() + "\""));
+                                     fAuxiliaryProcessor->fOptions.GetProcessorName() + "\""));
          }
 
          // We prepend the name of the primary processor in this case to prevent reading from the wrong join field in
          // composed join operations.
-         auto fieldIdx = AddFieldToEntry(fProcessorName + "._join." + joinField, "std::uint64_t", nullptr,
-                                         Internal::RNTupleProcessorProvenance(fProcessorName));
+         auto fieldIdx = AddFieldToEntry(fOptions.GetProcessorName() + "._join." + joinField, "std::uint64_t", nullptr,
+                                         Internal::RNTupleProcessorProvenance(fOptions.GetProcessorName()));
          fJoinFieldIdxs.insert(fieldIdx);
       }
 
@@ -464,7 +465,7 @@ void ROOT::Experimental::RNTupleJoinProcessor::Connect(
 {
    Initialize();
 
-   auto auxProvenance = provenance.Evolve(fAuxiliaryProcessor->GetProcessorName());
+   auto auxProvenance = provenance.Evolve(fAuxiliaryProcessor->fOptions.GetProcessorName());
    for (const auto &fieldIdx : fieldIdxs) {
       const auto &fieldProvenance = fEntry->GetFieldProvenance(fieldIdx);
       if (fieldProvenance.Contains(auxProvenance))
@@ -482,7 +483,7 @@ ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(const std::string &fie
                                                           void *valuePtr,
                                                           const Internal::RNTupleProcessorProvenance &provenance)
 {
-   auto auxProvenance = provenance.Evolve(fAuxiliaryProcessor->GetProcessorName());
+   auto auxProvenance = provenance.Evolve(fAuxiliaryProcessor->fOptions.GetProcessorName());
    if (auxProvenance.IsPresentInFieldName(fieldName)) {
       // If the primaryProcessor has a field with the name of the auxProcessor (either as a "proper" field or because
       // the primary processor itself is a join where its auxProcessor bears the same name as the current auxProcessor),
@@ -490,9 +491,9 @@ ROOT::Experimental::RNTupleJoinProcessor::AddFieldToEntry(const std::string &fie
       if (fPrimaryProcessor->CanReadFieldFromDisk(fieldName)) {
          throw RException(R__FAIL("ambiguous field name: \"" + fieldName +
                                   "\" is present in the primary RNTupleProcessor \"" +
-                                  fPrimaryProcessor->GetProcessorName() +
+                                  fPrimaryProcessor->fOptions.GetProcessorName() +
                                   "\", but may also refer to a field in the auxiliary RNTupleProcessor named \"" +
-                                  fAuxiliaryProcessor->GetProcessorName() +
+                                  fAuxiliaryProcessor->fOptions.GetProcessorName() +
                                   "\". To avoid this ambiguity, rename the auxiliary RNTupleProcessor."));
       }
 

--- a/tree/ntuple/test/ntuple_processor.cxx
+++ b/tree/ntuple/test/ntuple_processor.cxx
@@ -646,9 +646,12 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedPrimary)
    auto primaryProc =
       RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {});
 
-   auto auxProc = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, "ntuple_aux2");
+   RNTupleProcessorOptions opts;
+   opts.SetProcessorName("ntuple_aux2");
+   auto auxProc = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, opts);
 
-   auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {"i"}, "joined_ntuple");
+   opts.SetProcessorName("joined_ntuple");
+   auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {"i"}, opts);
 
    auto i = proc->RequestField<int>("i");
    auto x = proc->RequestField<float>("x");
@@ -676,7 +679,9 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedPrimaryMissingEntries)
    auto primaryProc =
       RNTupleProcessor::CreateJoin({fNTupleNames[0], fFileNames[0]}, {fNTupleNames[1], fFileNames[1]}, {});
 
-   auto auxProc = RNTupleProcessor::Create({fNTupleNames[3], fFileNames[3]}, "ntuple_aux2");
+   RNTupleProcessorOptions opts;
+   opts.SetProcessorName("ntuple_aux2");
+   auto auxProc = RNTupleProcessor::Create({fNTupleNames[3], fFileNames[3]}, opts);
 
    auto proc = RNTupleProcessor::CreateJoin(std::move(primaryProc), std::move(auxProc), {"i"});
 
@@ -713,7 +718,9 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedAuxiliary)
 {
    auto primaryProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
 
-   auto auxProcIntermediate = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, "ntuple_aux2");
+   RNTupleProcessorOptions opts;
+   opts.SetProcessorName("ntuple_aux2");
+   auto auxProcIntermediate = RNTupleProcessor::Create({fNTupleNames[2], fFileNames[2]}, opts);
 
    auto auxProc = RNTupleProcessor::CreateJoin(RNTupleProcessor::Create({fNTupleNames[1], fFileNames[1]}),
                                                std::move(auxProcIntermediate), {"i"});
@@ -746,7 +753,9 @@ TEST_F(RNTupleProcessorTest, JoinedJoinComposedAuxiliaryMissingEntries)
 {
    auto primaryProc = RNTupleProcessor::Create({fNTupleNames[0], fFileNames[0]});
 
-   auto auxProcIntermediate = RNTupleProcessor::Create({fNTupleNames[3], fFileNames[3]}, "ntuple_aux2");
+   RNTupleProcessorOptions opts;
+   opts.SetProcessorName("ntuple_aux2");
+   auto auxProcIntermediate = RNTupleProcessor::Create({fNTupleNames[3], fFileNames[3]}, opts);
 
    auto auxProc = RNTupleProcessor::CreateJoin(RNTupleProcessor::Create({fNTupleNames[1], fFileNames[1]}),
                                                std::move(auxProcIntermediate), {"i"});
@@ -981,11 +990,11 @@ TEST_F(GH16805ProcessorTest, JoinReading)
    std::vector<RNTupleOpenSpec> joinSpecs{
       {"topLevelJoin", fJoinFiles[0]}, {"topLevelJoin", fJoinFiles[1]}, {"topLevelJoin", fJoinFiles[2]}};
 
-   auto stepOneProc = RNTupleProcessor::CreateChain(stepOneSpecs, "stepone");
+   auto stepOneProc = RNTupleProcessor::CreateChain(stepOneSpecs);
 
-   auto stepZeroProc = RNTupleProcessor::CreateChain(stepZeroSpecs, "stepzero");
+   auto stepZeroProc = RNTupleProcessor::CreateChain(stepZeroSpecs);
 
-   auto joinProc = RNTupleProcessor::CreateChain(joinSpecs, "topLevelJoin");
+   auto joinProc = RNTupleProcessor::CreateChain(joinSpecs);
 
    auto joinedWithJoin = RNTupleProcessor::CreateJoin(std::move(stepOneProc), std::move(joinProc), {});
 
@@ -1105,7 +1114,7 @@ protected:
    {
       std::vector<RNTupleOpenSpec> stepZeroSpecs{{"stepzero", fStepZeroFiles[0]}, {"stepzero", fStepZeroFiles[1]}};
 
-      auto stepZeroProc = RNTupleProcessor::CreateChain(stepZeroSpecs, "stepzero");
+      auto stepZeroProc = RNTupleProcessor::CreateChain(stepZeroSpecs);
 
       const auto &[chainStepOne, chainStepTwo, chainStepThree, chainStepFour] = GetParam();
 

--- a/tree/ntuple/test/ntuple_processor_chain.cxx
+++ b/tree/ntuple/test/ntuple_processor_chain.cxx
@@ -100,12 +100,14 @@ TEST_F(RNTupleChainProcessorTest, Basic)
 {
    auto proc = RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}});
 
-   EXPECT_STREQ("ntuple", proc->GetProcessorName().c_str());
+   EXPECT_STREQ("ntuple", proc->GetOptions().GetProcessorName().c_str());
 
    {
+      RNTupleProcessorOptions opts;
+      opts.SetProcessorName("my_ntuple");
       auto namedProc =
-         RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, "my_ntuple");
-      EXPECT_STREQ("my_ntuple", namedProc->GetProcessorName().c_str());
+         RNTupleProcessor::CreateChain({{fNTupleName, fFileNames[0]}, {fNTupleName, fFileNames[1]}}, opts);
+      EXPECT_STREQ("my_ntuple", namedProc->GetOptions().GetProcessorName().c_str());
    }
 
    auto x = proc->RequestField<float>("x");

--- a/tree/ntuple/test/ntuple_test.hxx
+++ b/tree/ntuple/test/ntuple_test.hxx
@@ -98,6 +98,7 @@ using RNTupleOpenSpec = ROOT::Experimental::RNTupleOpenSpec;
 using RNTuplePlainCounter = ROOT::Experimental::Detail::RNTuplePlainCounter;
 using RNTuplePlainTimer = ROOT::Experimental::Detail::RNTuplePlainTimer;
 using RNTupleProcessor = ROOT::Experimental::RNTupleProcessor;
+using RNTupleProcessorOptions = ROOT::Experimental::RNTupleProcessorOptions;
 using RNTupleSerializer = ROOT::Internal::RNTupleSerializer;
 using RPage = ROOT::Internal::RPage;
 using RPageAllocatorHeap = ROOT::Internal::RPageAllocatorHeap;


### PR DESCRIPTION
This is with the underlying motivation that the RNTupleProcessor will at some point require more options. This way, we can keep the creation methods fairly lean.

