### PR TITLE
[ci] Match event_file skip ci conditional with build_*

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -641,7 +641,11 @@ jobs:
     # can be skipped if the tag [skip-ci] or [skip ci] is written in the title.
     if: |
         (github.repository_owner == 'root-project' && github.event_name != 'pull_request') ||
-        (github.event_name == 'pull_request' && !(contains(github.event.pull_request.title, '[skip-ci]') || contains(github.event.pull_request.title, '[skip ci]')))
+        (github.event_name == 'pull_request' && !(
+          contains(github.event.pull_request.title, '[skip-ci]') ||
+          contains(github.event.pull_request.title, '[skip ci]') ||
+          contains(github.event.pull_request.labels.*.name, 'skip ci')
+        ))
 
     name: "Upload Github event context for the test summary step"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The discrepancy was spotted by MAI-Code-1.1-Flash:

Skip logic is inconsistent between jobs
The build jobs check both the PR title and the skip ci label, but the event_file job at root-ci.yml:692-708 only checks the title. That means a PR can be skipped in the build jobs but still produce an event artifact, which is inconsistent and makes debugging harder.


