### PR TITLE
Implement ROOT::Experimental::Hist::ConvertToTH3 functions

### DIFF
--- a/hist/histv7util/CMakeLists.txt
+++ b/hist/histv7util/CMakeLists.txt
@@ -3,10 +3,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTHistUtil
     ROOT/Hist/ConversionUtils.hxx
     ROOT/Hist/ConvertToTH1.hxx
     ROOT/Hist/ConvertToTH2.hxx
+    ROOT/Hist/ConvertToTH3.hxx
   SOURCES
     ConversionUtils.cxx
     ConvertToTH1.cxx
     ConvertToTH2.cxx
+    ConvertToTH3.cxx
   DEPENDENCIES
     Core
     Hist

--- a/hist/histv7util/inc/ROOT/Hist/ConvertToTH3.hxx
+++ b/hist/histv7util/inc/ROOT/Hist/ConvertToTH3.hxx
@@ -1,0 +1,120 @@
+/// \file
+/// \warning This is part of the %ROOT 7 prototype! It will change without notice. It might trigger earthquakes.
+/// Feedback is welcome!
+
+#ifndef ROOT_Hist_ConvertToTH3
+#define ROOT_Hist_ConvertToTH3
+
+#include <ROOT/RBinWithError.hxx>
+#include <ROOT/RHist.hxx>
+#include <ROOT/RHistEngine.hxx>
+
+class TH3C;
+class TH3S;
+class TH3I;
+class TH3L;
+class TH3F;
+class TH3D;
+
+#include <memory>
+
+namespace ROOT {
+namespace Experimental {
+namespace Hist {
+
+/// Convert a three-dimensional histogram to TH3C.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3C> ConvertToTH3C(const RHistEngine<char> &engine);
+
+/// Convert a three-dimensional histogram to TH3S.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3S> ConvertToTH3S(const RHistEngine<short> &engine);
+
+/// Convert a three-dimensional histogram to TH3I.
+///
+/// As RHistEngine does not have global statistics, the number of entries and the total sum of weights will be unset.
+///
+/// Throws an exception if the histogram does not have three dimensions.
+///
+/// \param[in] engine the RHistEngine to convert
+/// \return the converted TH3
+std::unique_ptr<TH3I> ConvertToTH3I(const RHistEngine<int> &engine);
+
+/// Convert a three-dimensional histogram to TH3L.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3L> ConvertToTH3L(const RHistEngine<long> &engine);
+
+/// Convert a three-dimensional histogram to TH3L.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3L> ConvertToTH3L(const RHistEngine<long long> &engine);
+
+/// Convert a three-dimensional histogram to TH3F.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3F> ConvertToTH3F(const RHistEngine<float> &engine);
+
+/// Convert a three-dimensional histogram to TH3D.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3D> ConvertToTH3D(const RHistEngine<double> &engine);
+
+/// Convert a three-dimensional histogram to TH3D.
+///
+/// \copydetails ConvertToTH3I(const RHistEngine<int> &engine)
+std::unique_ptr<TH3D> ConvertToTH3D(const RHistEngine<RBinWithError> &engine);
+
+/// Convert a three-dimensional histogram to TH3C.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3C> ConvertToTH3C(const RHist<char> &hist);
+
+/// Convert a three-dimensional histogram to TH3S.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3S> ConvertToTH3S(const RHist<short> &hist);
+
+/// Convert a three-dimensional histogram to TH3I.
+///
+/// If the RHistStats are tainted, for example after setting bin contents, the number of entries and the total sum of
+/// weights will be unset.
+///
+/// Throws an exception if the histogram does not have three dimensions.
+///
+/// \param[in] hist the RHist to convert
+/// \return the converted TH3
+std::unique_ptr<TH3I> ConvertToTH3I(const RHist<int> &hist);
+
+/// Convert a three-dimensional histogram to TH3L.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3L> ConvertToTH3L(const RHist<long> &hist);
+
+/// Convert a three-dimensional histogram to TH3L.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3L> ConvertToTH3L(const RHist<long long> &hist);
+
+/// Convert a three-dimensional histogram to TH3F.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3F> ConvertToTH3F(const RHist<float> &hist);
+
+/// Convert a three-dimensional histogram to TH3D.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3D> ConvertToTH3D(const RHist<double> &hist);
+
+/// Convert a three-dimensional histogram to TH3D.
+///
+/// \copydetails ConvertToTH3I(const RHist<int> &hist)
+std::unique_ptr<TH3D> ConvertToTH3D(const RHist<RBinWithError> &hist);
+
+} // namespace Hist
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/hist/histv7util/src/ConvertToTH3.cxx
+++ b/hist/histv7util/src/ConvertToTH3.cxx
@@ -1,0 +1,242 @@
+/// \file
+/// \warning This is part of the %ROOT 7 prototype! It will change without notice. It might trigger earthquakes.
+/// Feedback is welcome!
+
+#include <ROOT/Hist/ConversionUtils.hxx>
+#include <ROOT/Hist/ConvertToTH3.hxx>
+#include <ROOT/RBinIndex.hxx>
+#include <ROOT/RHist.hxx>
+#include <ROOT/RHistEngine.hxx>
+
+#include <TH3.h>
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+using namespace ROOT::Experimental;
+
+namespace {
+template <typename Hist, typename T>
+std::unique_ptr<Hist> ConvertToTH3Impl(const RHistEngine<T> &engine)
+{
+   if (engine.GetNDimensions() != 3) {
+      throw std::invalid_argument("TH3 requires three dimensions");
+   }
+
+   auto ret = std::make_unique<Hist>();
+   ret->SetDirectory(nullptr);
+
+   const auto &axis0 = engine.GetAxes()[0];
+   ROOT::Experimental::Hist::Internal::ConvertAxis(*ret->GetXaxis(), axis0);
+   const auto &axis1 = engine.GetAxes()[1];
+   ROOT::Experimental::Hist::Internal::ConvertAxis(*ret->GetYaxis(), axis1);
+   const auto &axis2 = engine.GetAxes()[2];
+   ROOT::Experimental::Hist::Internal::ConvertAxis(*ret->GetZaxis(), axis2);
+   ret->SetBinsLength();
+
+   Double_t *sumw2 = nullptr;
+   auto copyBinContent = [&ret, &engine, &sumw2](Int_t i, RBinIndex index0, RBinIndex index1, RBinIndex index2) {
+      if constexpr (std::is_same_v<T, RBinWithError>) {
+         if (sumw2 == nullptr) {
+            ret->Sumw2();
+            sumw2 = ret->GetSumw2()->GetArray();
+         }
+         const RBinWithError &c = engine.GetBinContent(index0, index1, index2);
+         ret->GetArray()[i] = c.fSum;
+         sumw2[i] = c.fSum2;
+      } else {
+         (void)sumw2;
+         ret->GetArray()[i] = engine.GetBinContent(index0, index1, index2);
+      }
+   };
+
+   // Copy the bin contents, accounting for TH3 numbering conventions.
+   for (auto index0 : axis0.GetFullRange()) {
+      Int_t i0 = 0;
+      if (index0.IsUnderflow()) {
+         i0 = 0;
+      } else if (index0.IsOverflow()) {
+         i0 = axis0.GetNNormalBins() + 1;
+      } else {
+         assert(index0.IsNormal());
+         i0 = index0.GetIndex() + 1;
+      }
+      Int_t n0 = ret->GetXaxis()->GetNbins() + 2;
+
+      for (auto index1 : axis1.GetFullRange()) {
+         Int_t i1 = 0;
+         if (index1.IsUnderflow()) {
+            i1 = 0;
+         } else if (index1.IsOverflow()) {
+            i1 = axis1.GetNNormalBins() + 1;
+         } else {
+            assert(index1.IsNormal());
+            i1 = index1.GetIndex() + 1;
+         }
+
+         Int_t n1 = ret->GetYaxis()->GetNbins() + 2;
+         for (auto index2 : axis2.GetFullRange()) {
+            Int_t i2 = 0;
+            if (index2.IsUnderflow()) {
+               i2 = 0;
+            } else if (index2.IsOverflow()) {
+               i2 = axis2.GetNNormalBins() + 1;
+            } else {
+               assert(index2.IsNormal());
+               i2 = index2.GetIndex() + 1;
+            }
+            copyBinContent(i0 + n0 * (i1 + n1 * i2), index0, index1, index2);
+         }
+      }
+   }
+
+   return ret;
+}
+
+template <typename Hist>
+void ConvertGlobalStatistics(Hist &h, const RHistStats &stats)
+{
+   if (stats.IsTainted()) {
+      return;
+   }
+
+   h.SetEntries(stats.GetNEntries());
+
+   Double_t hStats[11] = {
+      stats.GetSumW(),
+      stats.GetSumW2(),
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+   };
+   if (stats.IsEnabled(0)) {
+      hStats[2] = stats.GetDimensionStats(0).fSumWX;
+      hStats[3] = stats.GetDimensionStats(0).fSumWX2;
+   }
+   if (stats.IsEnabled(1)) {
+      hStats[4] = stats.GetDimensionStats(1).fSumWX;
+      hStats[5] = stats.GetDimensionStats(1).fSumWX2;
+   }
+   // We do not have sumwxy for hStats[6]
+   if (stats.IsEnabled(2)) {
+      hStats[7] = stats.GetDimensionStats(2).fSumWX;
+      hStats[8] = stats.GetDimensionStats(2).fSumWX2;
+   }
+   // We do not have sumwxz or sumwyz for hStats[9] and hStats[10]
+   h.PutStats(hStats);
+}
+} // namespace
+
+namespace ROOT {
+namespace Experimental {
+namespace Hist {
+
+std::unique_ptr<TH3C> ConvertToTH3C(const RHistEngine<char> &engine)
+{
+   return ConvertToTH3Impl<TH3C>(engine);
+}
+
+std::unique_ptr<TH3S> ConvertToTH3S(const RHistEngine<short> &engine)
+{
+   return ConvertToTH3Impl<TH3S>(engine);
+}
+
+std::unique_ptr<TH3I> ConvertToTH3I(const RHistEngine<int> &engine)
+{
+   return ConvertToTH3Impl<TH3I>(engine);
+}
+
+std::unique_ptr<TH3L> ConvertToTH3L(const RHistEngine<long> &engine)
+{
+   return ConvertToTH3Impl<TH3L>(engine);
+}
+
+std::unique_ptr<TH3L> ConvertToTH3L(const RHistEngine<long long> &engine)
+{
+   return ConvertToTH3Impl<TH3L>(engine);
+}
+
+std::unique_ptr<TH3F> ConvertToTH3F(const RHistEngine<float> &engine)
+{
+   return ConvertToTH3Impl<TH3F>(engine);
+}
+
+std::unique_ptr<TH3D> ConvertToTH3D(const RHistEngine<double> &engine)
+{
+   return ConvertToTH3Impl<TH3D>(engine);
+}
+
+std::unique_ptr<TH3D> ConvertToTH3D(const RHistEngine<RBinWithError> &engine)
+{
+   return ConvertToTH3Impl<TH3D>(engine);
+}
+
+std::unique_ptr<TH3C> ConvertToTH3C(const RHist<char> &hist)
+{
+   auto ret = ConvertToTH3C(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3S> ConvertToTH3S(const RHist<short> &hist)
+{
+   auto ret = ConvertToTH3S(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3I> ConvertToTH3I(const RHist<int> &hist)
+{
+   auto ret = ConvertToTH3I(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3L> ConvertToTH3L(const RHist<long> &hist)
+{
+   auto ret = ConvertToTH3L(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3L> ConvertToTH3L(const RHist<long long> &hist)
+{
+   auto ret = ConvertToTH3L(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3F> ConvertToTH3F(const RHist<float> &hist)
+{
+   auto ret = ConvertToTH3F(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3D> ConvertToTH3D(const RHist<double> &hist)
+{
+   auto ret = ConvertToTH3D(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+std::unique_ptr<TH3D> ConvertToTH3D(const RHist<RBinWithError> &hist)
+{
+   auto ret = ConvertToTH3D(hist.GetEngine());
+   ConvertGlobalStatistics(*ret, hist.GetStats());
+   return ret;
+}
+
+} // namespace Hist
+} // namespace Experimental
+} // namespace ROOT

--- a/hist/histv7util/test/CMakeLists.txt
+++ b/hist/histv7util/test/CMakeLists.txt
@@ -1,3 +1,4 @@
 ROOT_ADD_GTEST(hist_conversion_utils hist_conversion_utils.cxx LIBRARIES ROOTHist ROOTHistUtil)
 ROOT_ADD_GTEST(hist_convert_TH1 hist_convert_TH1.cxx LIBRARIES ROOTHist ROOTHistUtil)
 ROOT_ADD_GTEST(hist_convert_TH2 hist_convert_TH2.cxx LIBRARIES ROOTHist ROOTHistUtil)
+ROOT_ADD_GTEST(hist_convert_TH3 hist_convert_TH3.cxx LIBRARIES ROOTHist ROOTHistUtil)

--- a/hist/histv7util/test/hist_convert_TH3.cxx
+++ b/hist/histv7util/test/hist_convert_TH3.cxx
@@ -1,0 +1,217 @@
+#include "histutil_test.hxx"
+
+#include <TH3.h>
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+
+TEST(ConvertToTH3I, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<int> engine(axis, axis, axis);
+
+   engine.SetBinContent(RBinIndex::Underflow(), 0, 0, 1000);
+   engine.SetBinContent(0, RBinIndex::Overflow(), 0, 2000);
+   engine.SetBinContent(0, 0, RBinIndex::Underflow(), 3000);
+   for (std::size_t i = 0; i < Bins; i++) {
+      for (std::size_t j = 0; j < Bins; j++) {
+         for (std::size_t k = 0; k < Bins; k++) {
+            engine.SetBinContent(i, j, k, 100 * i + 10 * j + k);
+         }
+      }
+   }
+   engine.SetBinContent(RBinIndex::Overflow(), 1, 2, 4000);
+
+   auto th3i = ConvertToTH3I(engine);
+   ASSERT_TRUE(th3i);
+   EXPECT_TRUE(th3i->GetDirectory() == nullptr);
+   ASSERT_EQ(th3i->GetDimension(), 3);
+   ASSERT_EQ(th3i->GetNbinsX(), Bins);
+   ASSERT_EQ(th3i->GetNbinsY(), Bins);
+   ASSERT_EQ(th3i->GetNbinsZ(), Bins);
+
+   EXPECT_EQ(th3i->GetBinContent(0, 1, 1), 1000);
+   EXPECT_EQ(th3i->GetBinContent(1, Bins + 1, 1), 2000);
+   EXPECT_EQ(th3i->GetBinContent(1, 1, 0), 3000);
+   for (std::size_t i = 0; i < Bins; i++) {
+      for (std::size_t j = 0; j < Bins; j++) {
+         for (std::size_t k = 0; k < Bins; k++) {
+            EXPECT_EQ(th3i->GetBinContent(i + 1, j + 1, k + 1), 100 * i + 10 * j + k);
+         }
+      }
+   }
+   EXPECT_EQ(th3i->GetBinContent(Bins + 1, 2, 3), 4000);
+
+   EXPECT_EQ(th3i->GetEntries(), 0);
+   Double_t stats[11];
+   th3i->GetStats(stats);
+   for (double stat : stats) {
+      EXPECT_EQ(stat, 0);
+   }
+}
+
+TEST(ConvertToTH3I, RHistEngineNoFlowBins)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins}, /*enableFlowBins=*/false);
+   RHistEngine<int> engine(axis, axis, axis);
+
+   engine.Fill(-100, 0.5, 0.5);
+   engine.Fill(0.5, -100, 0.5);
+   engine.Fill(0.5, 0.5, -100);
+   for (std::size_t i = 0; i < Bins; i++) {
+      for (std::size_t j = 0; j < Bins; j++) {
+         for (std::size_t k = 0; k < Bins; k++) {
+            engine.SetBinContent(i, j, k, 100 * i + 10 * j + k);
+         }
+      }
+   }
+
+   auto th3i = ConvertToTH3I(engine);
+   ASSERT_TRUE(th3i);
+   EXPECT_EQ(th3i->GetBinContent(0, 1, 1), 0);
+   EXPECT_EQ(th3i->GetBinContent(1, 0, 1), 0);
+   EXPECT_EQ(th3i->GetBinContent(1, 1, 0), 0);
+   for (std::size_t i = 0; i < Bins; i++) {
+      for (std::size_t j = 0; j < Bins; j++) {
+         for (std::size_t k = 0; k < Bins; k++) {
+            EXPECT_EQ(th3i->GetBinContent(i + 1, j + 1, k + 1), 100 * i + 10 * j + k);
+         }
+      }
+   }
+}
+
+TEST(ConvertToTH3I, RHistEngineInvalid)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RHistEngine<int> engine(axis, axis);
+
+   EXPECT_THROW(ConvertToTH3I(engine), std::invalid_argument);
+}
+
+TEST(ConvertToTH3I, RHist)
+{
+   static constexpr std::size_t Bins = 20;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHist<int> hist(axis, axis, axis);
+
+   for (std::size_t i = 0; i < Bins; i++) {
+      hist.Fill(i, 2 * i, 3 * i);
+   }
+
+   auto th3i = ConvertToTH3I(hist);
+   ASSERT_TRUE(th3i);
+
+   ASSERT_EQ(hist.GetNEntries(), Bins);
+   EXPECT_EQ(th3i->GetEntries(), Bins);
+   Double_t stats[11];
+   th3i->GetStats(stats);
+   EXPECT_EQ(stats[0], Bins);
+   EXPECT_EQ(stats[1], Bins);
+   EXPECT_EQ(stats[2], 190);
+   EXPECT_EQ(stats[3], 2470);
+   EXPECT_EQ(stats[4], 2 * 190);
+   EXPECT_EQ(stats[5], 4 * 2470);
+   EXPECT_EQ(stats[6], 0);
+   EXPECT_EQ(stats[7], 3 * 190);
+   EXPECT_EQ(stats[8], 9 * 2470);
+   EXPECT_EQ(stats[9], 0);
+   EXPECT_EQ(stats[10], 0);
+}
+
+TEST(ConvertToTH3I, RHistSetBinContentTainted)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHist<int> hist(axis, axis, axis);
+   const std::array<RBinIndex, 3> indices = {1, 2, 3};
+   hist.SetBinContent(indices, 42);
+   ASSERT_TRUE(hist.GetStats().IsTainted());
+
+   auto th3i = ConvertToTH3I(hist);
+   ASSERT_TRUE(th3i);
+
+   EXPECT_EQ(th3i->GetBinContent(2, 3, 4), 42);
+   EXPECT_EQ(th3i->GetEntries(), 0);
+   Double_t stats[11];
+   th3i->GetStats(stats);
+   for (double stat : stats) {
+      EXPECT_EQ(stat, 0);
+   }
+}
+
+TEST(ConvertToTH3I, RHistCategoricalAxis)
+{
+   const std::vector<std::string> categories = {"a", "b", "c"};
+   const RCategoricalAxis axis(categories);
+   RHist<int> hist(axis, axis, axis);
+   ASSERT_FALSE(hist.GetStats().IsEnabled(0));
+   ASSERT_FALSE(hist.GetStats().IsEnabled(1));
+   ASSERT_FALSE(hist.GetStats().IsEnabled(2));
+
+   hist.Fill("a", "b", "c");
+
+   auto th3i = ConvertToTH3I(hist);
+   ASSERT_TRUE(th3i);
+   EXPECT_EQ(th3i->GetBinContent(1, 2, 3), 1);
+   EXPECT_EQ(th3i->GetEntries(), 1);
+   Double_t stats[11];
+   th3i->GetStats(stats);
+   EXPECT_EQ(stats[0], 1);
+   EXPECT_EQ(stats[1], 1);
+   for (std::size_t i = 2; i < 11; i++) {
+      EXPECT_EQ(stats[i], 0);
+   }
+}
+
+TEST(ConvertToTH3D, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   RHistEngine<RBinWithError> engine(axis, axis, axis);
+
+   engine.Fill(0, 1, 2, RWeight(0.5));
+
+   auto th3d = ConvertToTH3D(engine);
+   ASSERT_TRUE(th3d);
+   const Double_t *sumw2 = th3d->GetSumw2()->GetArray();
+   ASSERT_TRUE(sumw2 != nullptr);
+   EXPECT_DOUBLE_EQ(th3d->GetBinContent(1, 2, 3), 0.5);
+   EXPECT_DOUBLE_EQ(sumw2[th3d->GetBin(1, 2, 3)], 0.25);
+}
+
+TEST(ConvertToTH3C, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RHistEngine<char> engine(axis, axis, axis);
+   EXPECT_TRUE(ConvertToTH3C(engine));
+}
+
+TEST(ConvertToTH3S, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RHistEngine<short> engine(axis, axis, axis);
+   EXPECT_TRUE(ConvertToTH3S(engine));
+}
+
+TEST(ConvertToTH3L, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RHistEngine<long> engine(axis, axis, axis);
+   EXPECT_TRUE(ConvertToTH3L(engine));
+}
+
+TEST(ConvertToTH3F, RHistEngine)
+{
+   static constexpr std::size_t Bins = 4;
+   const RRegularAxis axis(Bins, {0, Bins});
+   const RHistEngine<float> engine(axis, axis, axis);
+   EXPECT_TRUE(ConvertToTH3F(engine));
+}

--- a/hist/histv7util/test/histutil_test.hxx
+++ b/hist/histv7util/test/histutil_test.hxx
@@ -4,6 +4,7 @@
 #include <ROOT/Hist/ConversionUtils.hxx>
 #include <ROOT/Hist/ConvertToTH1.hxx>
 #include <ROOT/Hist/ConvertToTH2.hxx>
+#include <ROOT/Hist/ConvertToTH3.hxx>
 #include <ROOT/RAxisVariant.hxx>
 #include <ROOT/RBinWithError.hxx>
 #include <ROOT/RCategoricalAxis.hxx>


### PR DESCRIPTION
# Summary

This PR implements the conversion functions from RHist to TH3 just like the ones for TH1 and TH2.

The implementation is based on the TH2 one, mostly done just by search/replace and github copilot, but the end result looks reasonable to me.
 
 ## Testing
 * `ctest -V -R gtest-hist-histv7util-hist-convert-TH3`
 * Tested filling some 3D histograms of b-tagging efficiencies from a CMS MC sample using RDataframe, comparing filling with Histo3D vs filling with Hist and calling ConvertToHist3D and checked I get the same results.

