### PR TITLE
[CI] Streamline Mac config

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -186,34 +186,23 @@ jobs:
                     --binaries       ${{ inputs.binaries }}   \
                     --repository     ${{ github.server_url }}/${{ github.repository }}
 
-      - name: Nightly build
-        if:   github.event_name == 'schedule'
-        run: |
-          [ -d "${VIRTUAL_ENV_DIR}" ] && source ${VIRTUAL_ENV_DIR}/bin/activate
-          echo "Python is now $(which python3) $(python3 --version)"
-          src/.github/workflows/root-ci-config/build_root.py  \
-                    --buildtype      RelWithDebInfo           \
-                    --platform       ${{ matrix.platform }}   \
-                    --incremental    false                    \
-                    --binaries       true                     \
-                    --base_ref       ${{ inputs.ref_name }}   \
-                    --repository     ${{ github.server_url }}/${{ github.repository }}
-
-      - name: Update build cache after push to release branch
-        if:   github.event_name == 'push'
+      - name: Nightlies and push to branch
+        if:   github.event_name == 'schedule' || github.event_name == 'push'
         env:
-          OVERRIDES: ${{ join( matrix.overrides, ' ') }}
+          OVERRIDES: ${{ github.event_name == 'push' && format('{0} {1} {2}', '--overrides', env.GLOBAL_OVERRIDES, join( matrix.overrides, ' ')) || '' }}
+          BASE_REF:  ${{ github.event_name == 'push' && github.ref_name || inputs.ref_name }}
         run: |
           [ -d "${VIRTUAL_ENV_DIR}" ] && source ${VIRTUAL_ENV_DIR}/bin/activate
           echo "Python is now $(which python3) $(python3 --version)"
-          src/.github/workflows/root-ci-config/build_root.py  \
-                    --buildtype      RelWithDebInfo           \
-                    --platform       ${{ matrix.platform }}   \
-                    --incremental    false                    \
-                    --base_ref       ${{ github.ref_name }}   \
-                    --binaries       ${{ startsWith(github.ref, 'refs/tags/') }}  \
-                    --repository     ${{ github.server_url }}/${{ github.repository }}  \
-                    --overrides       ${GLOBAL_OVERRIDES} ${OVERRIDES}
+          src/.github/workflows/root-ci-config/build_root.py    \
+                    --buildtype        RelWithDebInfo           \
+                    --platform         ${{ matrix.platform }}   \
+                    --incremental      false                    \
+                    --upload_artifacts false                    \
+                    --binaries         ${{ github.event_name == 'schedule' }} \
+                    --base_ref         ${BASE_REF}              \
+                    --repository       ${{ github.server_url }}/${{ github.repository }} \
+                    ${OVERRIDES}
 
       - name: Upload test results
         if:   ${{ !cancelled() }}

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -155,7 +155,6 @@ jobs:
       - name: Pull Request Build
         if: github.event_name == 'pull_request'
         env:
-          INCREMENTAL: ${{ !contains(github.event.pull_request.labels.*.name, 'clean build') && !matrix.platform == 'mac15' && !matrix.platform == 'mac26'}}
           GITHUB_PR_ORIGIN: ${{ github.event.pull_request.head.repo.clone_url }}
           OVERRIDES: ${{ join( matrix.overrides, ' ') }}
         run: |
@@ -163,7 +162,7 @@ jobs:
           echo "Python is now $(which python3) $(python3 --version)"
           src/.github/workflows/root-ci-config/build_root.py  \
                     --buildtype       RelWithDebInfo          \
-                    --incremental     $INCREMENTAL            \
+                    --incremental     false                   \
                     --base_ref        ${{ github.base_ref }}  \
                     --sha             ${{ github.sha }}       \
                     --pull_repository ${{ github.event.pull_request.head.repo.clone_url }}  \


### PR DESCRIPTION
- Fix #23113, and clarify that Macs never build incrementals
- For "on: push" builds on Mac, stop uploading binaries to S3.
- Since the nightly and the "on: push" builds are now almost identical, join the two

For the merged build step, the intention is:
- The "on: push" build takes `github.ref_name` and uses the overrides.
- The nightly build takes `inputs.ref_name` and does not use overrides.