### PR TITLE
[ci][wheels] Disable runtime C++ modules for wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ CMAKE_INSTALL_TUTDIR = "ROOT/tutorials"
 gminimal="ON"
 asimage="ON"
 opengl="OFF"
-runtime_cxxmodules="ON"
+runtime_cxxmodules="OFF"
 fail-on-missing="ON"
 
 # Prevent CMake from producing its own .dist-info metadata


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:


We're switching wheel builds from the per-library .pcm C++ modules to the aggregate PCH (`runtime_cxxmodules=OFF`).

This is needed for the macOS wheels to work _at the moment_: on Linux, manylinux wheels are built in containers pinned to a minimum glibc baseline that's explicitly designed to be a portable target across distros. macOS has no equivalent. cibuildwheel on macOS just builds against whatever Xcode/SDK happens to be on the runner, and Apple ships new SDK versions multiple times a year with real header/availability-annotation changes.
So on Linux, cxxmodules-mismatch is a rare edge case whereas on macOS given how the SDK is versioned and distributed, it's close to the default case for a wheel built on CI and installed elsewhere. PCH sidesteps needing to detect or fix that.

Next PR in the sequence adds macOS wheel support on top of this.

## Checklist:

- [x] tested changes locally



