### PR TITLE
[RF] Exclude index category from RooSimultaneous plot coef. norm set

### DIFF
--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -976,7 +976,18 @@ RooSimultaneous::createAsymmetryComponent(const RooAbsCategoryLValue &asymCat, c
 void RooSimultaneous::selectNormalization(const RooArgSet* normSet, bool /*force*/)
 {
   _plotCoefNormSet.removeAll() ;
-  if (normSet) _plotCoefNormSet.add(*normSet) ;
+  if (normSet) {
+     // The index category must not be stored in the set: it is meaningless for
+     // the coefficient normalization, since it is never an observable of the
+     // component pdfs (RooAddPdf::selectNormalization() would filter it out
+     // again anyway). Worse, it is already registered as a value server via
+     // the index category proxy, and registering the same server a second
+     // time through this non-propagating set proxy corrupts the reference
+     // counts of the server's client lists when the set is cleared again.
+     RooArgSet filteredNormSet{*normSet};
+     filteredNormSet.remove(_indexCat.arg(), true, true);
+     _plotCoefNormSet.add(filteredNormSet);
+  }
 }
 
 

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -828,3 +828,33 @@ TEST(RooSimultaneous, AsymmetryPlot)
       EXPECT_NEAR(curve->interpolate(xv), analytic(xv), 1e-6) << "at x = " << xv;
    }
 }
+
+/// Regression test for a value-server link corruption: the index category is
+/// a value server of the RooSimultaneous via the index category proxy, and
+/// fixAddCoefNormalization() additionally stores it in the non-propagating
+/// "!plotCoefNormSet" set proxy. Clearing that set on the second call used to
+/// also remove the value-client entry owned by the index category proxy, so
+/// the index category silently disappeared from getObservables(). This
+/// happened in practice after two createChi2() calls with a non-legacy
+/// backend, which call fixAddCoefNormalization() on the original pdf.
+TEST(RooSimultaneous, RepeatedFixAddCoefNormalization)
+{
+   RooRealVar x("x", "x", 0, 1);
+   RooGenericPdf gaussA("gaussA", "1 + x", x);
+   RooGenericPdf gaussB("gaussB", "1 - x", x);
+
+   RooCategory sample("sample", "sample", {{"A", 0}, {"B", 1}});
+   RooSimultaneous simPdf("simPdf", "simPdf", {{"A", &gaussA}, {"B", &gaussB}}, sample);
+
+   RooArgSet normSet{x, sample};
+
+   for (int i = 0; i < 2; ++i) {
+      simPdf.fixAddCoefNormalization(normSet, false);
+
+      EXPECT_TRUE(sample.isValueServer(simPdf)) << "after fixAddCoefNormalization() call " << i + 1;
+
+      RooArgSet observables;
+      simPdf.getObservables(&normSet, observables);
+      EXPECT_TRUE(observables.find(sample)) << "after fixAddCoefNormalization() call " << i + 1;
+   }
+}


### PR DESCRIPTION
The index category is a value server of the RooSimultaneous via the index category proxy, and `selectNormalization()` additionally stored the full normalization set - index category included - in the non-propagating "!plotCoefNormSet" set proxy. Registering the same server twice with different value/shape propagation flags corrupts the reference counts of the server's client lists when one registration is removed: `RooAbsArg::removeServer()` unconditionally removes the client from the value and shape client lists.

Storing the index category in the coefficient normalization set has no meaning anyway: the set's only consumer is plotOn(), which forwards it to `RooAddPdf::selectNormalization()` on the component sum, and that filters the set through `getObservables()` before using it - and the index category is never an observable of the component pdfs. So exclude the index category (by name, to also catch clones of it inside cloned computation graphs) before filling the proxy, which avoids the double registration in the first place.