### PR TITLE
[6.38] [cmake] Quote list-valued cache variable in root-config generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,7 +622,7 @@ add_custom_target(dist COMMAND cpack --config CPackConfig.cmake)
 get_cmake_property(variables CACHE_VARIABLES)
 foreach(var ${variables})
   if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
-     (NOT ${${var}} STREQUAL "") AND
+     (NOT "${${var}}" STREQUAL "") AND
      (NOT ${var} MATCHES "NOTFOUND"))
     if (var MATCHES "^QT_")
       # filter out the very long list of Qt libraries and include dirs


### PR DESCRIPTION
Backport fix from master and 6.40 branches

The loop that builds the `root-config --config` argument list guards each cache variable with

    if((var MATCHES "_(LIBRARIES|LIBRARY|INCLUDE|VERSION)") AND
       (NOT ${${var}} STREQUAL "") AND
       (NOT ${var} MATCHES "NOTFOUND"))

When the variable holds a list (e.g.
CLING_LIBRARIES=clingInterpreter;clingMetaProcessor;clingUtils) the unquoted ${${var}} expands to several tokens, so the parenthesised sub-expression `(NOT a b c STREQUAL "")` is malformed. CMake silently accepted this until 4.4, which now propagates errors from parenthesised if() sub-expressions (kitware/cmake@240481490c, kitware/cmake#26424) and fails configuration with "Unknown arguments specified".

Quote the expansion so the value is compared as a single string. Besides fixing configuration with CMake >= 4.4, this restores the intended behaviour: list-valued variables were previously dropped from `root-config --config` (the malformed guard evaluated to false) and are now included.


(cherry picked from commit 227e0753f5c5ef9070b892d70848192fc16d06d5)

