### PR TITLE
[6.40] Fix DrawImage in TGX11 and TGWin32

### DIFF
--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -1180,9 +1180,8 @@ void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
          bc = bcol;
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
+            for (x = 0; (x < (int) source->width) && (dotcnt < maxdots); x++, bc++, dotcnt++) {
                bc->pixel = GetPixelImage((Drawable_t)xim, bx + x, by + y);
-               if (++dotcnt >= maxdots) break;
             }
          }
          QueryColors(fColormap, bcol, dots);
@@ -1190,11 +1189,10 @@ void TGWin32::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
          bc = bcol;
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
+            for (x = 0; (x < (int) source->width) && (dotcnt < maxdots); x++, bc++, dotcnt++) {
                r += bc->red;
                g += bc->green;
                b += bc->blue;
-               if (++dotcnt >= maxdots) break;
             }
          }
          if (dots != 0) {

--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -268,11 +268,10 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
          bc = bcol;
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
+            for (x = 0; (x < (int) source->width) && (dotcnt < maxdots); x++, bc++, dotcnt++) {
 ///               bc->pixel = XGetPixel(xim, bx + x, by - c->TTF::fgAscent + y);
                bc->pixel = XGetPixel(xim, bx + x, by + y);
                bc->flags = DoRed | DoGreen | DoBlue;
-               if (++dotcnt >= maxdots) break;
             }
          }
          QueryColors(fColormap, bcol, dots);
@@ -280,11 +279,10 @@ void TGX11TTF::DrawImage(FT_Bitmap *source, ULong_t fore, ULong_t back,
          bc = bcol;
          dotcnt = 0;
          for (y = 0; y < (int) source->rows; y++) {
-            for (x = 0; x < (int) source->width; x++, bc++) {
+            for (x = 0; (x < (int) source->width) && (dotcnt < maxdots); x++, bc++, dotcnt++) {
                r += bc->red;
                g += bc->green;
                b += bc->blue;
-               if (++dotcnt >= maxdots) break;
             }
          }
          if (dots != 0) {


### PR DESCRIPTION
Loops allow to access memory outside of allocated array range

Two similar methods on TGX11 and TGWin32
In master this code will be completely changed by https://github.com/root-project/root/pull/23128 - where problem was recognized
