### PR TITLE
[tmva][sofie] Avoid undefined behavior in Clean_name

### DIFF
--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -513,7 +513,7 @@ std::string UTILITY::Clean_name(std::string input_tensor_name){
    std::string s (input_tensor_name);
    std::replace( s.begin(), s.end(), '-', '_');
    // replace all non-alpohanumeric character except for "_"
-   s.erase(std::remove_if(s.begin(), s.end(), []( char const& c ) -> bool { return !std::isalnum(c) && c != '_'; } ), s.end());
+   s.erase(std::remove_if(s.begin(), s.end(), []( char const& c ) -> bool { return !std::isalnum(static_cast<unsigned char>(c)) && c != '_'; } ), s.end());
    return s;
 }
 


### PR DESCRIPTION
## Summary

Cast the character passed to `std::isalnum` to `unsigned char` in
`UTILITY::Clean_name`.

Passing a negative `char` directly to the `<cctype>` classification
functions can result in undefined behavior.