### PR TITLE
[clang] do not search again for LLVM if already found by parent project

### DIFF
--- a/interpreter/llvm-project/clang/CMakeLists.txt
+++ b/interpreter/llvm-project/clang/CMakeLists.txt
@@ -37,7 +37,9 @@ if(CLANG_BUILT_STANDALONE)
     mark_as_advanced(LLVM_ENABLE_ASSERTIONS)
   endif()
 
-  find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_DIR}")
+  if(NOT LLVM_FOUND)
+    find_package(LLVM REQUIRED HINTS "${LLVM_CMAKE_DIR}")
+  endif()
   list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
 
   # Turn into CACHE PATHs for overwritting


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

In ROOT, for builtin_llvm=OFF we have the sequence

```
find_package(LLVM) # searchs for system package, which sets DYLIB to ON
set(LLVM_LINK_LLVM_DYLIB OFF) # override DYLIB to OFF, we want static
add_subdirectory(clang) # this will call find_package LLVM again
```

See https://github.com/root-project/root/pull/13420

Since LLVM22 though, this fails:
Even if we call for a second time `set(LLVM_LINK_LLVM_DYLIB OFF)` after the `add_subdirectory` line, it's not enough, because that variable was ON all throughout the child `clang/CMakeLists.txt` and has already configured some stuff with the wrong flag.

Avoid the issue by preventing the double-search of LLVM and thus the double overwrite.

Fixes https://github.com/root-project/root/issues/18387
Fixes https://github.com/root-project/root/issues/23155

Upstream PR: https://github.com/llvm/llvm-project/pull/218965

## Reproducer

```
docker run -it registry.cern.ch/root-ci/ubuntu2604:buildready
apt update
apt install llvm-20 libedit-dev libpolly-20-dev
git clone https://github.com/root-project/root root_src && cd root_src
git checkout v6-40-00-patches
sed -i 's|LLVM REQUIRED|LLVM ${ROOT_LLVM_VERSION_REQUIRED_MAJOR}.1 REQUIRED|g' interpreter/CMakeLists.txt # Backport of a patch from master
mkdir build && cd build
cmake -Dbuiltin_llvm=OFF -Dminimal=ON ..
grep -r LLVM.so *
```

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)