### PR TITLE
[tmva][sofie] Handle out-of-range dynamic shape values

### DIFF
--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -43,6 +43,10 @@ std::vector<size_t> ConvertShapeToInt(const std::vector<Dim> & shape){
             ret_shape.clear();
             break;
          }
+         catch (const std::out_of_range& ) {
+            ret_shape.clear();
+            break;
+         }
       } else {
          ret_shape[i] = shape[i].dim;
       }


### PR DESCRIPTION
## Summary

Handle `std::out_of_range` when converting dynamic shape parameters
with `std::stoi` in `ConvertShapeToInt`.

Previously, a numeric parameter outside the range of `int` could propagate
an exception instead of following the existing conversion-failure path.

The function now clears the returned shape consistently for both
`std::invalid_argument` and `std::out_of_range`.