### PR TITLE
[gui] Native GUI draws canvas without defaulting to web

### DIFF
--- a/core/gui/inc/TGuiFactory.h
+++ b/core/gui/inc/TGuiFactory.h
@@ -50,6 +50,7 @@ public:
    virtual TApplicationImp *CreateApplicationImp(const char *classname, int *argc, char **argv);
 
    virtual TCanvasImp *CreateCanvasImp(TCanvas *c, const char *title, UInt_t width, UInt_t height);
+   virtual TCanvasImp *CreateCanvasImpNative(TCanvas *c, const char *title, UInt_t width, UInt_t height);
    virtual TCanvasImp *CreateCanvasImp(TCanvas *c, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height);
 
    virtual TBrowserImp *CreateBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt="");

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -82,6 +82,14 @@ TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, UInt_t w
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Create a batch version of TCanvasImpNative, skipping the IsWebDisplay check.
+
+TCanvasImp *TGuiFactory::CreateCanvasImpNative(TCanvas *c, const char *title, UInt_t width, UInt_t height)
+{
+   return new TCanvasImp(c, title, width, height);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Create a batch version of TCanvasImp.
 
 TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height)

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -255,7 +255,7 @@ TCanvas::TCanvas(const char *name, Int_t ww, Int_t wh, Int_t winid) : TPad(), fD
          fUseGL = kFALSE;
    }
 
-   fCanvasImp = gBatchGuiFactory->CreateCanvasImp(this, name, fCw, fCh);
+   fCanvasImp = gBatchGuiFactory->CreateCanvasImpNative(this, name, fCw, fCh);
    if (!fCanvasImp) return;
 
    CreatePainter();


### PR DESCRIPTION
When drawing a canvas in a native GUI (e.g. using
`tutorials/visualisation/gui/guitest.C` and Test->Dialog->Tab3), the canvas used to default to black. The workaround was `--web=off`, which is inconvenient.

Implements a new method `TGuiFactory::CreateCanvasImpNative` that bypasses the `gROOT->IsWebDisplay()` check and directly returns a `TCanvasImp` as required by the native GUI.

`TGuiFactory::CreateCanvasImp` receives `TCanvas *c` as a parameter. For a web canvas, the canvas ID is `111222333` (see `TWebCanvas.cxx:293`), this would be enough to determine that we do not want to create a web canvas element, but a native one instead. However, `TCanvas` is only forward declared within `TGuiFactory`, hence we cannot access its methods.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (not necessary)
- [ ] added tests (not sure how to write a test for this behaviour)
- [x] ran clang-format

## AI Disclaimer
I used AI in the debugging process, but I wrote the code myself. It is a very small edit anyway.
