### PR TITLE
[tmva][sofie] Improve const correctness in shape iteration

### DIFF
--- a/tmva/sofie/src/SOFIE_common.cxx
+++ b/tmva/sofie/src/SOFIE_common.cxx
@@ -54,7 +54,8 @@ std::vector<size_t> ConvertShapeToInt(const std::vector<Dim> & shape){
 std::size_t ConvertShapeToLength(const std::vector<size_t> & shape){
    // Empty shape represent scalar values, so we return a length=1
    std::size_t fLength = 1;
-   for (auto& dim: shape) fLength *= dim;
+   for (const auto &dim : shape)
+   fLength *= dim;
    return fLength;
 }
 


### PR DESCRIPTION
## Summary

Use a const reference when iterating over dimensions in
`ConvertShapeToLength`, since the shape dimensions are not modified.

This makes the read-only intent explicit without changing behavior.