### PR TITLE
[RF] Fix numerical precision of RooIntegralMorph

### DIFF
--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -25,89 +25,85 @@ class TH1D;
 
 class RooIntegralMorph : public RooAbsCachedPdf {
 public:
-  RooIntegralMorph() = default;
-  RooIntegralMorph(const char *name, const char *title,
-         RooAbsReal& _pdf1,
-         RooAbsReal& _pdf2,
-           RooAbsReal& _x,
-         RooAbsReal& _alpha, bool cacheAlpha=false);
-  RooIntegralMorph(const RooIntegralMorph& other, const char* name=nullptr) ;
-  TObject* clone(const char* newname=nullptr) const override { return new RooIntegralMorph(*this,newname); }
+   RooIntegralMorph() = default;
+   RooIntegralMorph(const char *name, const char *title, RooAbsReal &_pdf1, RooAbsReal &_pdf2, RooAbsReal &_x,
+                    RooAbsReal &_alpha, bool cacheAlpha = false);
+   RooIntegralMorph(const RooIntegralMorph &other, const char *name = nullptr);
+   TObject *clone(const char *newname = nullptr) const override { return new RooIntegralMorph(*this, newname); }
 
-  bool selfNormalized() const override {
-    // P.d.f is self normalized
-    return true ;
-  }
-  void setCacheAlpha(bool flag) {
-    // Activate caching of p.d.f. shape for all values of alpha as well
-    _cacheMgr.sterilize() ; _cacheAlpha = flag ;
-  }
-  bool cacheAlpha() const {
-    // If true caching of p.d.f for all alpha values is active
-    return _cacheAlpha ;
-  }
+   bool selfNormalized() const override
+   {
+      // P.d.f is self normalized
+      return true;
+   }
+   void setCacheAlpha(bool flag)
+   {
+      // Activate caching of p.d.f. shape for all values of alpha as well
+      _cacheMgr.sterilize();
+      _cacheAlpha = flag;
+   }
+   bool cacheAlpha() const
+   {
+      // If true caching of p.d.f for all alpha values is active
+      return _cacheAlpha;
+   }
 
-  void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const override ;
+   void preferredObservableScanOrder(const RooArgSet &obs, RooArgSet &orderedObs) const override;
 
-  class MorphCacheElem : public RooAbsCachedPdf::PdfCacheElem {
-  public:
-    MorphCacheElem(RooIntegralMorph& self, const RooArgSet* nset) ;
-    ~MorphCacheElem() override ;
-    void calculate(TIterator* iter) ;
-    RooArgList containedArgs(Action) override ;
+   class MorphCacheElem : public RooAbsCachedPdf::PdfCacheElem {
+   public:
+      MorphCacheElem(RooIntegralMorph &self, const RooArgSet *nset);
+      ~MorphCacheElem() override;
+      void calculate(TIterator *iter);
+      RooArgList containedArgs(Action) override;
 
-  protected:
+   protected:
+      void findRange();
+      double calcX(double y, bool &ok);
+      Int_t binX(double x);
+      void fillGap(Int_t ixlo, Int_t ixhi, double splitPoint = 0.5);
+      void interpolateGap(Int_t ixlo, Int_t ixhi);
 
-    void findRange() ;
-    double calcX(double y, bool& ok) ;
-    Int_t binX(double x) ;
-    void fillGap(Int_t ixlo, Int_t ixhi,double splitPoint=0.5) ;
-    void interpolateGap(Int_t ixlo, Int_t ixhi) ;
+      RooIntegralMorph *_self; //
+      std::unique_ptr<RooArgSet> _nset;
+      RooAbsPdf *_pdf1;                         // PDF1
+      RooAbsPdf *_pdf2;                         // PDF2
+      RooRealVar *_x;                           // X
+      RooAbsReal *_alpha;                       // ALPHA
+      std::unique_ptr<RooAbsReal> _c1;          // CDF of PDF 1
+      std::unique_ptr<RooAbsReal> _c2;          // CDF of PDF 2
+      std::unique_ptr<RooAbsFunc> _cb1;         // Binding of CDF1
+      std::unique_ptr<RooAbsFunc> _cb2;         // Binding of CDF2
+      std::unique_ptr<RooBrentRootFinder> _rf1; // ROOT finder on CDF1
+      std::unique_ptr<RooBrentRootFinder> _rf2; // ROOT finder of CDF2 ;
 
-    RooIntegralMorph* _self ; //
-    std::unique_ptr<RooArgSet> _nset ;
-    RooAbsPdf* _pdf1 ; // PDF1
-    RooAbsPdf* _pdf2 ; // PDF2
-    RooRealVar* _x   ; // X
-    RooAbsReal* _alpha ; // ALPHA
-    std::unique_ptr<RooAbsReal> _c1 ; // CDF of PDF 1
-    std::unique_ptr<RooAbsReal> _c2 ; // CDF of PDF 2
-    std::unique_ptr<RooAbsFunc> _cb1 ; // Binding of CDF1
-    std::unique_ptr<RooAbsFunc> _cb2 ; // Binding of CDF2
-    std::unique_ptr<RooBrentRootFinder> _rf1; // ROOT finder on CDF1
-    std::unique_ptr<RooBrentRootFinder> _rf2; // ROOT finder of CDF2 ;
+      std::vector<double> _yatX;  //
+      std::vector<double> _calcX; //
+      Int_t _yatXmin, _yatXmax;
+      Int_t _ccounter;
 
-    std::vector<double> _yatX ; //
-    std::vector<double> _calcX; //
-    Int_t _yatXmin, _yatXmax ;
-    Int_t _ccounter ;
-
-    double _ycutoff ;
-
-  } ;
+      double _ycutoff;
+   };
 
 protected:
+   friend class MorphCacheElem;
+   PdfCacheElem *createCache(const RooArgSet *nset) const override;
+   const char *inputBaseName() const override;
+   RooFit::OwningPtr<RooArgSet> actualObservables(const RooArgSet &nset) const override;
+   RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet &nset) const override;
+   void fillCacheObject(PdfCacheElem &cache) const override;
 
-  friend class MorphCacheElem ;
-  PdfCacheElem* createCache(const RooArgSet* nset) const override ;
-  const char* inputBaseName() const override ;
-  RooFit::OwningPtr<RooArgSet> actualObservables(const RooArgSet& nset) const override ;
-  RooFit::OwningPtr<RooArgSet> actualParameters(const RooArgSet& nset) const override ;
-  void fillCacheObject(PdfCacheElem& cache) const override ;
+   RooRealProxy pdf1;                        // First input shape
+   RooRealProxy pdf2;                        // Second input shape
+   RooRealProxy x;                           // Observable
+   RooRealProxy alpha;                       // Interpolation parameter
+   bool _cacheAlpha;                         // If true, both (x,alpha) are cached
+   mutable MorphCacheElem *_cache = nullptr; // Current morph cache element in use
 
-  RooRealProxy pdf1 ; // First input shape
-  RooRealProxy pdf2 ; // Second input shape
-  RooRealProxy x ;    // Observable
-  RooRealProxy alpha ; // Interpolation parameter
-  bool _cacheAlpha ; // If true, both (x,alpha) are cached
-  mutable MorphCacheElem* _cache = nullptr; // Current morph cache element in use
-
-
-  double evaluate() const override ;
+   double evaluate() const override;
 
 private:
-
-  ClassDefOverride(RooIntegralMorph,1) // Linear shape interpolation operator p.d.f
+   ClassDefOverride(RooIntegralMorph, 1) // Linear shape interpolation operator p.d.f
 };
 
 #endif

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -1,13 +1,13 @@
- /*****************************************************************************
-  * Project: RooFit                                                           *
-  *                                                                           *
-  * Copyright (c) 2000-2005, Regents of the University of California          *
-  *                          and Stanford University. All rights reserved.    *
-  *                                                                           *
-  * Redistribution and use in source and binary forms,                        *
-  * with or without modification, are permitted according to the terms        *
-  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
-  *****************************************************************************/
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ *                                                                           *
+ * Copyright (c) 2000-2005, Regents of the University of California          *
+ *                          and Stanford University. All rights reserved.    *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
 
 /** \class RooIntegralMorph
     \ingroup Roofit
@@ -89,8 +89,7 @@ in calculation speed.
 #include "RooDataHist.h"
 #include "TH1.h"
 
- using std::flush, std::endl;
-
+using std::flush, std::endl;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with observables x, pdf shapes pdf1 and pdf2 which represent
@@ -98,31 +97,27 @@ in calculation speed.
 /// If doCacheAlpha is true, a two-dimensional cache is constructed in
 /// both alpha and x
 
-RooIntegralMorph::RooIntegralMorph(const char *name, const char *title,
-                RooAbsReal& _pdf1,
-                RooAbsReal& _pdf2,
-                RooAbsReal& _x,
-                RooAbsReal& _alpha,
-                bool doCacheAlpha) :
-  RooAbsCachedPdf(name,title,2),
-  pdf1("pdf1","pdf1",this,_pdf1),
-  pdf2("pdf2","pdf2",this,_pdf2),
-  x("x","x",this,_x),
-  alpha("alpha","alpha",this,_alpha),
-  _cacheAlpha(doCacheAlpha)
+RooIntegralMorph::RooIntegralMorph(const char *name, const char *title, RooAbsReal &_pdf1, RooAbsReal &_pdf2,
+                                   RooAbsReal &_x, RooAbsReal &_alpha, bool doCacheAlpha)
+   : RooAbsCachedPdf(name, title, 2),
+     pdf1("pdf1", "pdf1", this, _pdf1),
+     pdf2("pdf2", "pdf2", this, _pdf2),
+     x("x", "x", this, _x),
+     alpha("alpha", "alpha", this, _alpha),
+     _cacheAlpha(doCacheAlpha)
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
-RooIntegralMorph::RooIntegralMorph(const RooIntegralMorph& other, const char* name) :
-  RooAbsCachedPdf(other,name),
-  pdf1("pdf1",this,other.pdf1),
-  pdf2("pdf2",this,other.pdf2),
-  x("x",this,other.x),
-  alpha("alpha",this,other.alpha),
-  _cacheAlpha(other._cacheAlpha)
+RooIntegralMorph::RooIntegralMorph(const RooIntegralMorph &other, const char *name)
+   : RooAbsCachedPdf(other, name),
+     pdf1("pdf1", this, other.pdf1),
+     pdf2("pdf2", this, other.pdf2),
+     x("x", this, other.x),
+     alpha("alpha", this, other.alpha),
+     _cacheAlpha(other._cacheAlpha)
 {
 }
 
@@ -131,85 +126,87 @@ RooIntegralMorph::RooIntegralMorph(const RooIntegralMorph& other, const char* na
 /// Returns the 'x' observable unless doCacheAlpha is set in which
 /// case a set with both x and alpha
 
-RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualObservables(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualObservables(const RooArgSet & /*nset*/) const
 {
-  RooArgSet* obs = new RooArgSet ;
-  if (_cacheAlpha) {
-    obs->add(alpha.arg()) ;
-  }
-  obs->add(x.arg()) ;
-  return RooFit::OwningPtr<RooArgSet>{obs};
+   RooArgSet *obs = new RooArgSet;
+   if (_cacheAlpha) {
+      obs->add(alpha.arg());
+   }
+   obs->add(x.arg());
+   return RooFit::OwningPtr<RooArgSet>{obs};
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Parameters of the cache. Returns parameters of both pdf1 and pdf2
 /// and parameter cache, in case doCacheAlpha is not set.
 
-RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualParameters(const RooArgSet& /*nset*/) const
+RooFit::OwningPtr<RooArgSet> RooIntegralMorph::actualParameters(const RooArgSet & /*nset*/) const
 {
-  std::unique_ptr<RooArgSet> par1{pdf1->getParameters(static_cast<RooArgSet*>(nullptr))};
-  RooArgSet par2;
-  pdf2->getParameters(nullptr, par2);
-  par1->add(par2,true) ;
-  par1->remove(x.arg(),true,true) ;
-  if (!_cacheAlpha) {
-    par1->add(alpha.arg()) ;
-  }
-  return RooFit::makeOwningPtr(std::move(par1));
+   std::unique_ptr<RooArgSet> par1{pdf1->getParameters(static_cast<RooArgSet *>(nullptr))};
+   RooArgSet par2;
+   pdf2->getParameters(nullptr, par2);
+   par1->add(par2, true);
+   par1->remove(x.arg(), true, true);
+   if (!_cacheAlpha) {
+      par1->add(alpha.arg());
+   }
+   return RooFit::makeOwningPtr(std::move(par1));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return base name component for cache components in this case
 /// a string encoding the names of both end point p.d.f.s
 
-const char* RooIntegralMorph::inputBaseName() const
+const char *RooIntegralMorph::inputBaseName() const
 {
-  static TString name ;
+   static TString name;
 
-  name = pdf1.arg().GetName() ;
-  name.Append("_MORPH_") ;
-  name.Append(pdf2.arg().GetName()) ;
-  return name.Data() ;
+   name = pdf1.arg().GetName();
+   name.Append("_MORPH_");
+   name.Append(pdf2.arg().GetName());
+   return name.Data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill the cache with the interpolated shape.
 
-void RooIntegralMorph::fillCacheObject(PdfCacheElem& cache) const
+void RooIntegralMorph::fillCacheObject(PdfCacheElem &cache) const
 {
-  MorphCacheElem& mcache = static_cast<MorphCacheElem&>(cache) ;
+   MorphCacheElem &mcache = static_cast<MorphCacheElem &>(cache);
 
-  // If cacheAlpha is true employ slice iterator here to fill all slices
+   // If cacheAlpha is true employ slice iterator here to fill all slices
 
-  if (!_cacheAlpha) {
+   if (!_cacheAlpha) {
 
-    std::unique_ptr<TIterator> dIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(x.arg()),RooArgSet())};
-    mcache.calculate(dIter.get());
-
-  } else {
-    std::unique_ptr<TIterator> slIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(alpha.arg()),RooArgSet())};
-
-    double alphaSave = alpha ;
-    RooArgSet alphaSet(alpha.arg()) ;
-    coutP(Eval) << "RooIntegralMorph::fillCacheObject(" << GetName() << ") filling multi-dimensional cache" ;
-    while(slIter->Next()) {
-      alphaSet.assign(*cache.hist()->get()) ;
-      std::unique_ptr<TIterator> dIter{cache.hist()->sliceIterator(const_cast<RooAbsReal&>(x.arg()),RooArgSet(alpha.arg()))};
+      std::unique_ptr<TIterator> dIter{cache.hist()->sliceIterator(const_cast<RooAbsReal &>(x.arg()), RooArgSet())};
       mcache.calculate(dIter.get());
-      ccoutP(Eval) << "." << flush;
-    }
-    ccoutP(Eval) << std::endl;
 
-    const_cast<RooIntegralMorph*>(this)->alpha = alphaSave ;
-  }
+   } else {
+      std::unique_ptr<TIterator> slIter{
+         cache.hist()->sliceIterator(const_cast<RooAbsReal &>(alpha.arg()), RooArgSet())};
+
+      double alphaSave = alpha;
+      RooArgSet alphaSet(alpha.arg());
+      coutP(Eval) << "RooIntegralMorph::fillCacheObject(" << GetName() << ") filling multi-dimensional cache";
+      while (slIter->Next()) {
+         alphaSet.assign(*cache.hist()->get());
+         std::unique_ptr<TIterator> dIter{
+            cache.hist()->sliceIterator(const_cast<RooAbsReal &>(x.arg()), RooArgSet(alpha.arg()))};
+         mcache.calculate(dIter.get());
+         ccoutP(Eval) << "." << flush;
+      }
+      ccoutP(Eval) << std::endl;
+
+      const_cast<RooIntegralMorph *>(this)->alpha = alphaSave;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create and return a derived MorphCacheElem.
 
-RooAbsCachedPdf::PdfCacheElem* RooIntegralMorph::createCache(const RooArgSet* nset) const
+RooAbsCachedPdf::PdfCacheElem *RooIntegralMorph::createCache(const RooArgSet *nset) const
 {
-  return new MorphCacheElem(const_cast<RooIntegralMorph&>(*this),nset) ;
+   return new MorphCacheElem(const_cast<RooIntegralMorph &>(*this), nset);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -217,17 +214,17 @@ RooAbsCachedPdf::PdfCacheElem* RooIntegralMorph::createCache(const RooArgSet* ns
 
 RooArgList RooIntegralMorph::MorphCacheElem::containedArgs(Action action)
 {
-  RooArgList ret ;
-  ret.add(PdfCacheElem::containedArgs(action)) ;
-  ret.add(*_self) ;
-  ret.add(*_pdf1) ;
-  ret.add(*_pdf2) ;
-  ret.add(*_x  ) ;
-  ret.add(*_alpha) ;
-  ret.add(*_c1) ;
-  ret.add(*_c2) ;
+   RooArgList ret;
+   ret.add(PdfCacheElem::containedArgs(action));
+   ret.add(*_self);
+   ret.add(*_pdf1);
+   ret.add(*_pdf2);
+   ret.add(*_x);
+   ret.add(*_alpha);
+   ret.add(*_c1);
+   ret.add(*_c2);
 
-  return ret ;
+   return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -247,57 +244,58 @@ RooIntegralMorph::MorphCacheElem::MorphCacheElem(RooIntegralMorph &self, const R
      _ccounter(0),
      _ycutoff(1e-12)
 {
-  // Mark in base class that normalization of cached pdf is invariant under pdf parameters
+   // Mark in base class that normalization of cached pdf is invariant under pdf parameters
 
-  _nset = std::make_unique<RooArgSet>(*_x);
+   _nset = std::make_unique<RooArgSet>(*_x);
 
-  _c1 = std::unique_ptr<RooAbsReal>{_pdf1->createCdf(*_x)};
-  _c2 = std::unique_ptr<RooAbsReal>{_pdf2->createCdf(*_x)};
-  _cb1 = std::unique_ptr<RooAbsFunc>{_c1->bindVars(*_x,_nset.get())};
-  _cb2 = std::unique_ptr<RooAbsFunc>{_c2->bindVars(*_x,_nset.get())};
+   _c1 = std::unique_ptr<RooAbsReal>{_pdf1->createCdf(*_x)};
+   _c2 = std::unique_ptr<RooAbsReal>{_pdf2->createCdf(*_x)};
+   _cb1 = std::unique_ptr<RooAbsFunc>{_c1->bindVars(*_x, _nset.get())};
+   _cb2 = std::unique_ptr<RooAbsFunc>{_c2->bindVars(*_x, _nset.get())};
 
-  _rf1 = std::make_unique<RooBrentRootFinder>(*_cb1);
-  _rf2 = std::make_unique<RooBrentRootFinder>(*_cb2);
+   _rf1 = std::make_unique<RooBrentRootFinder>(*_cb1);
+   _rf2 = std::make_unique<RooBrentRootFinder>(*_cb2);
 
-  _rf1->setTol(1e-12) ;
-  _rf2->setTol(1e-12) ;
+   _rf1->setTol(1e-12);
+   _rf2->setTol(1e-12);
 
-  // _yatX = 0 ;
-  // _calcX = 0 ;
+   // _yatX = 0 ;
+   // _calcX = 0 ;
 
-  // Must do this here too: fillCache() may not be called if cache contents is retrieved from EOcache
-  pdf()->setUnitNorm(true) ;
+   // Must do this here too: fillCache() may not be called if cache contents is retrieved from EOcache
+   pdf()->setUnitNorm(true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
-RooIntegralMorph::MorphCacheElem::~MorphCacheElem()
-{
-}
+RooIntegralMorph::MorphCacheElem::~MorphCacheElem() {}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate the x value of the output p.d.f at the given cdf value y.
 /// The ok boolean is filled with the success status of the operation.
 
-double RooIntegralMorph::MorphCacheElem::calcX(double y, bool& ok)
+double RooIntegralMorph::MorphCacheElem::calcX(double y, bool &ok)
 {
-  if (y<0 || y>1) {
-    oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calcX() WARNING: requested root finding for unphysical CDF value " << y << std::endl ;
-  }
-  double x1;
-  double x2;
+   if (y < 0 || y > 1) {
+      oocoutW(_self, Eval)
+         << "RooIntegralMorph::MorphCacheElem::calcX() WARNING: requested root finding for unphysical CDF value " << y
+         << std::endl;
+   }
+   double x1;
+   double x2;
 
-  double xmax = _x->getMax("cache") ;
-  double xmin = _x->getMin("cache") ;
+   double xmax = _x->getMax("cache");
+   double xmin = _x->getMin("cache");
 
-  ok=true ;
-  ok &= _rf1->findRoot(x1,xmin,xmax,y) ;
-  ok &= _rf2->findRoot(x2,xmin,xmax,y) ;
-  if (!ok) return 0 ;
-  _ccounter++ ;
+   ok = true;
+   ok &= _rf1->findRoot(x1, xmin, xmax, y);
+   ok &= _rf2->findRoot(x2, xmin, xmax, y);
+   if (!ok)
+      return 0;
+   _ccounter++;
 
-  return _alpha->getVal()*x1 + (1-_alpha->getVal())*x2 ;
+   return _alpha->getVal() * x1 + (1 - _alpha->getVal()) * x2;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -305,169 +303,177 @@ double RooIntegralMorph::MorphCacheElem::calcX(double y, bool& ok)
 
 Int_t RooIntegralMorph::MorphCacheElem::binX(double X)
 {
-  double xmax = _x->getMax("cache") ;
-  double xmin = _x->getMin("cache") ;
-  return (Int_t)(_x->numBins("cache")*(X-xmin)/(xmax-xmin)) ;
+   double xmax = _x->getMax("cache");
+   double xmin = _x->getMin("cache");
+   return (Int_t)(_x->numBins("cache") * (X - xmin) / (xmax - xmin));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate shape of p.d.f for x,alpha values
 /// defined by dIter iterator over cache histogram
 
-void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
+void RooIntegralMorph::MorphCacheElem::calculate(TIterator *dIter)
 {
-  double xsave = _self->x ;
+   double xsave = _self->x;
 
-  // if (!_yatX) {
-  //   _yatX = new double[_x->numBins("cache")+1] ;
-  //   _calcX = new double[_x->numBins("cache")+1] ;
-  // }
+   // if (!_yatX) {
+   //   _yatX = new double[_x->numBins("cache")+1] ;
+   //   _calcX = new double[_x->numBins("cache")+1] ;
+   // }
 
- _yatX.resize(_x->numBins("cache")+1);
- _calcX.resize(_x->numBins("cache")+1);
+   _yatX.resize(_x->numBins("cache") + 1);
+   _calcX.resize(_x->numBins("cache") + 1);
 
-  _ccounter = 0 ;
+   _ccounter = 0;
 
-  // Get number of bins from PdfCacheElem histogram
-  Int_t nbins = _x->numBins("cache") ;
-  if (nbins < 2) {
-    oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName()
-         << ") ERROR: observable " << _x->GetName() << " has an empty binning for the cache histogram."
-         << " Define one with RooRealVar::setBins(nbins, \"cache\")." << std::endl ;
-    return ;
-  }
+   // Get number of bins from PdfCacheElem histogram
+   Int_t nbins = _x->numBins("cache");
+   if (nbins < 2) {
+      oocoutE(_self, Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName()
+                           << ") ERROR: observable " << _x->GetName()
+                           << " has an empty binning for the cache histogram."
+                           << " Define one with RooRealVar::setBins(nbins, \"cache\")." << std::endl;
+      return;
+   }
 
-  // Initialize yatX array to 'un-calculated values (-1)'
-  for (int i=0 ; i<nbins ; i++) {
-    _yatX[i] = -1 ;
-    _calcX[i] = 0 ;
-  }
+   // Initialize yatX array to 'un-calculated values (-1)'
+   for (int i = 0; i < nbins; i++) {
+      _yatX[i] = -1;
+      _calcX[i] = 0;
+   }
 
-  // Find low and high point
-  findRange() ;
+   // Find low and high point
+   findRange();
 
-  // Perform initial scan of 100 points
-  for (int i=0 ; i<10 ; i++) {
+   // Perform initial scan of 100 points
+   for (int i = 0; i < 10; i++) {
 
-    // Take a point in y
-    double offset = _yatX[_yatXmin] ;
-    double delta = (_yatX[_yatXmax] - _yatX[_yatXmin])/10 ;
-    double y = offset + i*delta ;
+      // Take a point in y
+      double offset = _yatX[_yatXmin];
+      double delta = (_yatX[_yatXmax] - _yatX[_yatXmin]) / 10;
+      double y = offset + i * delta;
 
-    // Calculate corresponding X
-    bool ok ;
-    double X = calcX(y,ok) ;
-    if (ok) {
-      Int_t iX = binX(X) ;
-      _yatX[iX] = y ;
-      _calcX[iX] =  X ;
-    }
-  }
+      // Calculate corresponding X
+      bool ok;
+      double X = calcX(y, ok);
+      if (ok) {
+         Int_t iX = binX(X);
+         _yatX[iX] = y;
+         _calcX[iX] = X;
+      }
+   }
 
-  // Now take an iteration filling the 'gaps'
-  Int_t igapLow = _yatXmin+1 ;
-  while(true) {
-    // Find next gap
-    Int_t igapHigh = igapLow+1 ;
-    while(igapHigh<(_yatXmax) && _yatX[igapHigh]<0) igapHigh++ ;
+   // Now take an iteration filling the 'gaps'
+   Int_t igapLow = _yatXmin + 1;
+   while (true) {
+      // Find next gap
+      Int_t igapHigh = igapLow + 1;
+      while (igapHigh < (_yatXmax) && _yatX[igapHigh] < 0)
+         igapHigh++;
 
-    // Fill the gap (iteratively and/or using interpolation)
-    fillGap(igapLow-1,igapHigh) ;
+      // Fill the gap (iteratively and/or using interpolation)
+      fillGap(igapLow - 1, igapHigh);
 
-    // Terminate after processing of last gap
-    if (igapHigh>=_yatXmax-1) break ;
-    igapLow = igapHigh+1 ;
-  }
+      // Terminate after processing of last gap
+      if (igapHigh >= _yatXmax - 1)
+         break;
+      igapLow = igapHigh + 1;
+   }
 
-  // Make one more iteration to recalculate Y value at bin centers
-  double xmax = _x->getMax("cache") ;
-  double xmin = _x->getMin("cache") ;
-  double binw = (xmax-xmin)/_x->numBins("cache") ;
-  for (int i=_yatXmin+1 ; i<_yatXmax-1 ; i++) {
+   // Make one more iteration to recalculate Y value at bin centers
+   double xmax = _x->getMax("cache");
+   double xmin = _x->getMin("cache");
+   double binw = (xmax - xmin) / _x->numBins("cache");
+   for (int i = _yatXmin + 1; i < _yatXmax - 1; i++) {
 
-    // Calculate additional offset to apply if bin ixlo does not have X value calculated at bin center
-    double xBinC = xmin + (i+0.5)*binw ;
-    double xOffset = xBinC-_calcX[i] ;
-    if (std::abs(xOffset/binw)>1e-3) {
-      double slope = (_yatX[i+1]-_yatX[i-1])/(_calcX[i+1]-_calcX[i-1]) ;
-      double newY = _yatX[i] + slope*xOffset ;
-      //cout << "bin " << i << " needs to be re-centered " << xOffset/binw << " slope = " << slope << " origY = " << _yatX[i] << " newY = " << newY << std::endl ;
-      _yatX[i] = newY ;
-    }
-  }
+      // Calculate additional offset to apply if bin ixlo does not have X value calculated at bin center
+      double xBinC = xmin + (i + 0.5) * binw;
+      double xOffset = xBinC - _calcX[i];
+      if (std::abs(xOffset / binw) > 1e-3) {
+         double slope = (_yatX[i + 1] - _yatX[i - 1]) / (_calcX[i + 1] - _calcX[i - 1]);
+         double newY = _yatX[i] + slope * xOffset;
+         // cout << "bin " << i << " needs to be re-centered " << xOffset/binw << " slope = " << slope << " origY = " <<
+         // _yatX[i] << " newY = " << newY << std::endl ;
+         _yatX[i] = newY;
+      }
+   }
 
-  // Zero output histogram below lowest calculable X value
-  for (int i=0; i<_yatXmin ; i++) {
-    dIter->Next() ;
-    const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
-    hist()->set(binIdx, 0, -1) ;
-  }
-
-  double xMax = _x->getMax("cache");
-  const double aval = _alpha->getVal() ;
-
-  // Lower bounds for the root finding in the loop below, exploiting the fact
-  // that the cumulative distribution functions increase monotonically: as y
-  // increases from bin to bin, the x values found in the previous bin are
-  // valid lower bounds for the current bin.
-  double x1lo = _x->getMin("cache");
-  double x2lo = _x->getMin("cache");
-
-  // Transfer calculated values to histogram
-  for (int i=_yatXmin ; i<=_yatXmax ; i++) {
-
-    double y = _yatX[i] ;
-    const double xBinC = xmin + (i+0.5)*binw ;
-
-    double x1 = x1lo ;
-    double x2 = x2lo ;
-    double f1x1 = 0 ;
-    double f2x2 = 0 ;
-
-    // The y values obtained from the recursive gap filling are only
-    // approximate solutions of X(y) == xBinC. Polish them with Newton
-    // iterations on the monotone map X(y) = alpha*x1(y) + (1-alpha)*x2(y),
-    // whose derivative is dX/dy = alpha/f1(x1) + (1-alpha)/f2(x2), so that
-    // the stored p.d.f. value corresponds to the bin center to full precision.
-    for (int iter=0 ; iter<10 ; iter++) {
-      bool ok = _rf1->findRoot(x1,x1lo,xMax,y) ;
-      ok &= _rf2->findRoot(x2,x2lo,xMax,y) ;
-      _x->setVal(x1);
-      f1x1 = _pdf1->getVal(_nset.get());
-      _x->setVal(x2);
-      f2x2 = _pdf2->getVal(_nset.get());
-      if (!ok || f1x1<=0 || f2x2<=0) break ;
-      const double X = aval*x1 + (1-aval)*x2 ;
-      if (std::abs(X-xBinC) < 1e-12*(xMax-xmin)) break ;
-      const double dXdy = aval/f1x1 + (1-aval)/f2x2 ;
-      const double yNew = y + (xBinC-X)/dXdy ;
-      if (!(yNew>0.) || !(yNew<1.) || yNew==y) break ;
-      y = yNew ;
-    }
-    _yatX[i] = y ;
-
-    double fbarX = f1x1*f2x2 / ( aval*f2x2 + (1-aval)*f1x1 ) ;
-
-    dIter->Next() ;
-    {
+   // Zero output histogram below lowest calculable X value
+   for (int i = 0; i < _yatXmin; i++) {
+      dIter->Next();
       const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
-      hist()->set(binIdx, fbarX, -1) ;
-    }
+      hist()->set(binIdx, 0, -1);
+   }
 
-    x1lo = x1 ;
-    x2lo = x2 ;
-  }
-  // Zero output histogram above highest calculable X value
-  for (int i=_yatXmax+1 ; i<nbins ; i++) {
-    dIter->Next() ;
-    const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
-    hist()->set(binIdx, 0, -1) ;
-  }
+   double xMax = _x->getMax("cache");
+   const double aval = _alpha->getVal();
 
-  pdf()->setUnitNorm(true) ;
-  _self->x = xsave ;
+   // Lower bounds for the root finding in the loop below, exploiting the fact
+   // that the cumulative distribution functions increase monotonically: as y
+   // increases from bin to bin, the x values found in the previous bin are
+   // valid lower bounds for the current bin.
+   double x1lo = _x->getMin("cache");
+   double x2lo = _x->getMin("cache");
 
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName() << ") calculation required " << _ccounter << " samplings of cdfs" << std::endl ;
+   // Transfer calculated values to histogram
+   for (int i = _yatXmin; i <= _yatXmax; i++) {
+
+      double y = _yatX[i];
+      const double xBinC = xmin + (i + 0.5) * binw;
+
+      double x1 = x1lo;
+      double x2 = x2lo;
+      double f1x1 = 0;
+      double f2x2 = 0;
+
+      // The y values obtained from the recursive gap filling are only
+      // approximate solutions of X(y) == xBinC. Polish them with Newton
+      // iterations on the monotone map X(y) = alpha*x1(y) + (1-alpha)*x2(y),
+      // whose derivative is dX/dy = alpha/f1(x1) + (1-alpha)/f2(x2), so that
+      // the stored p.d.f. value corresponds to the bin center to full precision.
+      for (int iter = 0; iter < 10; iter++) {
+         bool ok = _rf1->findRoot(x1, x1lo, xMax, y);
+         ok &= _rf2->findRoot(x2, x2lo, xMax, y);
+         _x->setVal(x1);
+         f1x1 = _pdf1->getVal(_nset.get());
+         _x->setVal(x2);
+         f2x2 = _pdf2->getVal(_nset.get());
+         if (!ok || f1x1 <= 0 || f2x2 <= 0)
+            break;
+         const double X = aval * x1 + (1 - aval) * x2;
+         if (std::abs(X - xBinC) < 1e-12 * (xMax - xmin))
+            break;
+         const double dXdy = aval / f1x1 + (1 - aval) / f2x2;
+         const double yNew = y + (xBinC - X) / dXdy;
+         if (!(yNew > 0.) || !(yNew < 1.) || yNew == y)
+            break;
+         y = yNew;
+      }
+      _yatX[i] = y;
+
+      double fbarX = f1x1 * f2x2 / (aval * f2x2 + (1 - aval) * f1x1);
+
+      dIter->Next();
+      {
+         const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
+         hist()->set(binIdx, fbarX, -1);
+      }
+
+      x1lo = x1;
+      x2lo = x2;
+   }
+   // Zero output histogram above highest calculable X value
+   for (int i = _yatXmax + 1; i < nbins; i++) {
+      dIter->Next();
+      const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
+      hist()->set(binIdx, 0, -1);
+   }
+
+   pdf()->setUnitNorm(true);
+   _self->x = xsave;
+
+   oocxcoutD(_self, Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName()
+                          << ") calculation required " << _ccounter << " samplings of cdfs" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -478,82 +484,86 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
 
 void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double splitPoint)
 {
-  // CONVENTION: _yatX[ixlo] is filled, _yatX[ixhi] is filled, elements in between are empty
-  //   std::cout << "fillGap: gap from _yatX[" << ixlo << "]=" << _yatX[ixlo] << " to _yatX[" << ixhi << "]=" << _yatX[ixhi] << ", size = " << ixhi-ixlo << std::endl ;
+   // CONVENTION: _yatX[ixlo] is filled, _yatX[ixhi] is filled, elements in between are empty
+   //   std::cout << "fillGap: gap from _yatX[" << ixlo << "]=" << _yatX[ixlo] << " to _yatX[" << ixhi << "]=" <<
+   //   _yatX[ixhi] << ", size = " << ixhi-ixlo << std::endl ;
 
-  if (_yatX[ixlo]<0) {
-    oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap " << ixlo << " = " << ixhi
-         << " splitPoint= " << splitPoint << " _yatX[ixlo] = " << _yatX[ixlo] << std::endl ;
-  }
-  if (_yatX[ixhi]<0) {
-    oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap " << ixlo << " = " << ixhi
-         << " splitPoint " << splitPoint << " _yatX[ixhi] = " << _yatX[ixhi] << std::endl ;
-  }
+   if (_yatX[ixlo] < 0) {
+      oocoutE(_self, Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap "
+                           << ixlo << " = " << ixhi << " splitPoint= " << splitPoint << " _yatX[ixlo] = " << _yatX[ixlo]
+                           << std::endl;
+   }
+   if (_yatX[ixhi] < 0) {
+      oocoutE(_self, Eval) << "RooIntegralMorph::MorphCacheElme::fillGap(" << _self->GetName() << "): ERROR in fillgap "
+                           << ixlo << " = " << ixhi << " splitPoint " << splitPoint << " _yatX[ixhi] = " << _yatX[ixhi]
+                           << std::endl;
+   }
 
-  // Determine where half-way Y value lands
-  double ymid = _yatX[ixlo]*splitPoint + _yatX[ixhi]*(1-splitPoint) ;
-  bool ok ;
-  double Xmid = calcX(ymid,ok) ;
-  if (!ok) {
-    oocoutW(_self,Eval) << "RooIntegralMorph::MorphCacheElem::fillGap(" << _self->GetName() << ") unable to calculate midpoint in gap ["
-         << ixlo << "," << ixhi << "], resorting to interpolation" << std::endl ;
-    interpolateGap(ixlo,ixhi) ;
-  }
+   // Determine where half-way Y value lands
+   double ymid = _yatX[ixlo] * splitPoint + _yatX[ixhi] * (1 - splitPoint);
+   bool ok;
+   double Xmid = calcX(ymid, ok);
+   if (!ok) {
+      oocoutW(_self, Eval) << "RooIntegralMorph::MorphCacheElem::fillGap(" << _self->GetName()
+                           << ") unable to calculate midpoint in gap [" << ixlo << "," << ixhi
+                           << "], resorting to interpolation" << std::endl;
+      interpolateGap(ixlo, ixhi);
+   }
 
-  Int_t iX = binX(Xmid) ;
-  double cq = (Xmid-_calcX[ixlo])/(_calcX[ixhi]-_calcX[ixlo])-0.5 ;
+   Int_t iX = binX(Xmid);
+   double cq = (Xmid - _calcX[ixlo]) / (_calcX[ixhi] - _calcX[ixlo]) - 0.5;
 
-  // Store midway point
-  _yatX[iX] = ymid ;
-  _calcX[iX] = Xmid ;
+   // Store midway point
+   _yatX[iX] = ymid;
+   _calcX[iX] = Xmid;
 
+   // Policy: If centration quality is better than 1% OR better than 1/10 of a bin, fill interval with linear
+   // interpolation
+   if (std::abs(cq) < 0.01 || std::abs(cq * (ixhi - ixlo)) < 0.1 || ymid < _ycutoff) {
 
-  // Policy: If centration quality is better than 1% OR better than 1/10 of a bin, fill interval with linear interpolation
-  if (std::abs(cq)<0.01 || std::abs(cq*(ixhi-ixlo))<0.1 || ymid<_ycutoff ) {
+      // Fill remaining gaps on either side with linear interpolation
+      if (iX - ixlo > 1) {
+         interpolateGap(ixlo, iX);
+      }
+      if (ixhi - iX > 1) {
+         interpolateGap(iX, ixhi);
+      }
 
-    // Fill remaining gaps on either side with linear interpolation
-    if (iX-ixlo>1) {
-      interpolateGap(ixlo,iX) ;
-    }
-    if (ixhi-iX>1) {
-      interpolateGap(iX,ixhi) ;
-    }
+   } else {
 
-  } else {
+      if (iX == ixlo) {
 
-    if (iX==ixlo) {
+         if (splitPoint < 0.95) {
+            // Midway value lands on lowest bin, retry split with higher split point
+            double newSplit = splitPoint + 0.5 * (1 - splitPoint);
+            fillGap(ixlo, ixhi, newSplit);
+         } else {
+            // Give up and resort to interpolation
+            interpolateGap(ixlo, ixhi);
+         }
 
-      if (splitPoint<0.95) {
-   // Midway value lands on lowest bin, retry split with higher split point
-   double newSplit = splitPoint + 0.5*(1-splitPoint) ;
-   fillGap(ixlo,ixhi,newSplit) ;
+      } else if (iX == ixhi) {
+
+         // Midway value lands on highest bin, retry split with lower split point
+         if (splitPoint > 0.05) {
+            double newSplit = splitPoint / 2;
+            fillGap(ixlo, ixhi, newSplit);
+         } else {
+            // Give up and resort to interpolation
+            interpolateGap(ixlo, ixhi);
+         }
+
       } else {
-   // Give up and resort to interpolation
-   interpolateGap(ixlo,ixhi) ;
-      }
 
-    } else if (iX==ixhi) {
-
-      // Midway value lands on highest bin, retry split with lower split point
-      if (splitPoint>0.05) {
-   double newSplit = splitPoint/2 ;
-   fillGap(ixlo,ixhi,newSplit) ;
-      } else {
-   // Give up and resort to interpolation
-   interpolateGap(ixlo,ixhi) ;
+         // Midway point reasonable, iterate on interval on both sides
+         if (iX - ixlo > 1) {
+            fillGap(ixlo, iX);
+         }
+         if (ixhi - iX > 1) {
+            fillGap(iX, ixhi);
+         }
       }
-
-    } else {
-
-      // Midway point reasonable, iterate on interval on both sides
-      if (iX-ixlo>1) {
-   fillGap(ixlo,iX) ;
-      }
-      if (ixhi-iX>1) {
-   fillGap(iX,ixhi) ;
-      }
-    }
-  }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -562,24 +572,23 @@ void RooIntegralMorph::MorphCacheElem::fillGap(Int_t ixlo, Int_t ixhi, double sp
 
 void RooIntegralMorph::MorphCacheElem::interpolateGap(Int_t ixlo, Int_t ixhi)
 {
-  //cout << "filling gap with linear interpolation ixlo=" << ixlo << " ixhi=" << ixhi << std::endl ;
+   // cout << "filling gap with linear interpolation ixlo=" << ixlo << " ixhi=" << ixhi << std::endl ;
 
-  double xmax = _x->getMax("cache") ;
-  double xmin = _x->getMin("cache") ;
-  double binw = (xmax-xmin)/_x->numBins("cache") ;
+   double xmax = _x->getMax("cache");
+   double xmin = _x->getMin("cache");
+   double binw = (xmax - xmin) / _x->numBins("cache");
 
-  // Calculate deltaY in terms of actual X difference calculate, not based on nominal bin width
-  double deltaY = (_yatX[ixhi]-_yatX[ixlo])/((_calcX[ixhi]-_calcX[ixlo])/binw) ;
+   // Calculate deltaY in terms of actual X difference calculate, not based on nominal bin width
+   double deltaY = (_yatX[ixhi] - _yatX[ixlo]) / ((_calcX[ixhi] - _calcX[ixlo]) / binw);
 
-  // Calculate additional offset to apply if bin ixlo does not have X value calculated at bin center
-  double xBinC = xmin + (ixlo+0.5)*binw ;
-  double xOffset = xBinC-_calcX[ixlo] ;
+   // Calculate additional offset to apply if bin ixlo does not have X value calculated at bin center
+   double xBinC = xmin + (ixlo + 0.5) * binw;
+   double xOffset = xBinC - _calcX[ixlo];
 
-  for (int j=ixlo+1 ; j<ixhi ; j++) {
-    _yatX[j] = _yatX[ixlo]+(xOffset/binw+(j-ixlo))*deltaY ;
-    _calcX[j] = xmin + (j+0.5)*binw ;
-  }
-
+   for (int j = ixlo + 1; j < ixhi; j++) {
+      _yatX[j] = _yatX[ixlo] + (xOffset / binw + (j - ixlo)) * deltaY;
+      _calcX[j] = xmin + (j + 0.5) * binw;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -591,96 +600,105 @@ void RooIntegralMorph::MorphCacheElem::interpolateGap(Int_t ixlo, Int_t ixhi)
 
 void RooIntegralMorph::MorphCacheElem::findRange()
 {
-  double xmin = _x->getMin("cache") ;
-  double xmax = _x->getMax("cache") ;
-  Int_t nbins = _x->numBins("cache") ;
+   double xmin = _x->getMin("cache");
+   double xmax = _x->getMax("cache");
+   Int_t nbins = _x->numBins("cache");
 
-  double x1;
-  double x2;
-  bool ok = true ;
-  double ymin = 0.1;
-  double yminSave(-1);
-  double Xsave(-1);
-  double Xlast = xmax;
+   double x1;
+   double x2;
+   bool ok = true;
+   double ymin = 0.1;
+   double yminSave(-1);
+   double Xsave(-1);
+   double Xlast = xmax;
 
-  // Find lowest Y value that can be measured
-  // Start at 0.1 and iteratively lower limit by sqrt(10)
-  while(true) {
-    ok &= _rf1->findRoot(x1,xmin,xmax,ymin) ;
-    ok &= _rf2->findRoot(x2,xmin,xmax,ymin) ;
-    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMin: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << std::endl ;
+   // Find lowest Y value that can be measured
+   // Start at 0.1 and iteratively lower limit by sqrt(10)
+   while (true) {
+      ok &= _rf1->findRoot(x1, xmin, xmax, ymin);
+      ok &= _rf2->findRoot(x2, xmin, xmax, ymin);
+      oocxcoutD(_self, Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName()
+                             << ") findMin: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok ? "T" : "F") << std::endl;
 
-    // Terminate in case of non-convergence
-    if (!ok) break ;
+      // Terminate in case of non-convergence
+      if (!ok)
+         break;
 
-    // Terminate if value of X no longer moves by >0.1 bin size
-    double X = _alpha->getVal()*x1 + (1-_alpha->getVal())*x2 ;
-    if (std::abs(X-Xlast)/(xmax-xmin)<0.0001) {
-      break ;
-    }
-    Xlast=X ;
+      // Terminate if value of X no longer moves by >0.1 bin size
+      double X = _alpha->getVal() * x1 + (1 - _alpha->getVal()) * x2;
+      if (std::abs(X - Xlast) / (xmax - xmin) < 0.0001) {
+         break;
+      }
+      Xlast = X;
 
-    // Store new Y value
-    _yatXmin = (Int_t)(nbins*(X-xmin)/(xmax-xmin)) ;
-    _yatX[_yatXmin] = ymin ;
-    _calcX[_yatXmin] = X ;
-    yminSave = ymin ;
-    Xsave=X ;
+      // Store new Y value
+      _yatXmin = (Int_t)(nbins * (X - xmin) / (xmax - xmin));
+      _yatX[_yatXmin] = ymin;
+      _calcX[_yatXmin] = X;
+      yminSave = ymin;
+      Xsave = X;
 
-    // Reduce ymin by half an order of magnitude
-    ymin /=sqrt(10.) ;
+      // Reduce ymin by half an order of magnitude
+      ymin /= sqrt(10.);
 
-    // Emergency break
-    if (ymin<_ycutoff) break ;
-  }
-  _yatX[_yatXmin] = yminSave ;
-  _calcX[_yatXmin] = Xsave ;
+      // Emergency break
+      if (ymin < _ycutoff)
+         break;
+   }
+   _yatX[_yatXmin] = yminSave;
+   _calcX[_yatXmin] = Xsave;
 
-  // Find highest Y value that can be measured
-  // Start at 1 - 0.1 and iteratively lower delta by sqrt(10)
-  ok = true ;
-  double deltaymax = 0.1;
-  double deltaymaxSave(-1);
-  Xlast=xmin ;
-  while(true) {
-    ok &= _rf1->findRoot(x1,xmin,xmax,1-deltaymax) ;
-    ok &= _rf2->findRoot(x2,xmin,xmax,1-deltaymax) ;
+   // Find highest Y value that can be measured
+   // Start at 1 - 0.1 and iteratively lower delta by sqrt(10)
+   ok = true;
+   double deltaymax = 0.1;
+   double deltaymaxSave(-1);
+   Xlast = xmin;
+   while (true) {
+      ok &= _rf1->findRoot(x1, xmin, xmax, 1 - deltaymax);
+      ok &= _rf2->findRoot(x2, xmin, xmax, 1 - deltaymax);
 
-    oocxcoutD(_self,Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName() << ") findMax: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok?"T":"F") << std::endl ;
+      oocxcoutD(_self, Eval) << "RooIntegralMorph::MorphCacheElem::findRange(" << _self->GetName()
+                             << ") findMax: x1 = " << x1 << " x2 = " << x2 << " ok = " << (ok ? "T" : "F") << std::endl;
 
-    // Terminate in case of non-convergence
-    if (!ok) break ;
+      // Terminate in case of non-convergence
+      if (!ok)
+         break;
 
-    // Terminate if value of X no longer moves by >0.1 bin size
-    double X = _alpha->getVal()*x1 + (1-_alpha->getVal())*x2 ;
-    if (std::abs(X-Xlast)/(xmax-xmin)<0.0001) {
-      break ;
-    }
-    Xlast=X ;
+      // Terminate if value of X no longer moves by >0.1 bin size
+      double X = _alpha->getVal() * x1 + (1 - _alpha->getVal()) * x2;
+      if (std::abs(X - Xlast) / (xmax - xmin) < 0.0001) {
+         break;
+      }
+      Xlast = X;
 
-    // Store new Y value
-    _yatXmax = (Int_t)(nbins*(X-xmin)/(xmax-xmin)) ;
-    _yatX[_yatXmax] = 1-deltaymax ;
-    _calcX[_yatXmax] = X ;
-    deltaymaxSave = deltaymax ;
-    Xsave=X ;
+      // Store new Y value
+      _yatXmax = (Int_t)(nbins * (X - xmin) / (xmax - xmin));
+      _yatX[_yatXmax] = 1 - deltaymax;
+      _calcX[_yatXmax] = X;
+      deltaymaxSave = deltaymax;
+      Xsave = X;
 
-    // Reduce ymin by half an order of magnitude
-    deltaymax /=sqrt(10.) ;
+      // Reduce ymin by half an order of magnitude
+      deltaymax /= sqrt(10.);
 
-    // Emergency break
-    if (deltaymax<_ycutoff) break ;
-  }
+      // Emergency break
+      if (deltaymax < _ycutoff)
+         break;
+   }
 
-  _yatX[_yatXmax] = 1-deltaymaxSave ;
-  _calcX[_yatXmax] = Xsave ;
+   _yatX[_yatXmax] = 1 - deltaymaxSave;
+   _calcX[_yatXmax] = Xsave;
 
-
-  // Initialize values out of range to 'out-of-range' (-2)
-  for (int i=0 ; i<_yatXmin ; i++)  _yatX[i] = -2 ;
-  for (int i=_yatXmax+1 ; i<nbins; i++) _yatX[i] = -2 ;
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): ymin = " << _yatX[_yatXmin] << " ymax = " << _yatX[_yatXmax] << std::endl;
-  oocxcoutD(_self,Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): xmin = " << _calcX[_yatXmin] << " xmax = " << _calcX[_yatXmax] << std::endl;
+   // Initialize values out of range to 'out-of-range' (-2)
+   for (int i = 0; i < _yatXmin; i++)
+      _yatX[i] = -2;
+   for (int i = _yatXmax + 1; i < nbins; i++)
+      _yatX[i] = -2;
+   oocxcoutD(_self, Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): ymin = " << _yatX[_yatXmin]
+                          << " ymax = " << _yatX[_yatXmax] << std::endl;
+   oocxcoutD(_self, Eval) << "RooIntegralMorph::findRange(" << _self->GetName() << "): xmin = " << _calcX[_yatXmin]
+                          << " xmax = " << _calcX[_yatXmax] << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -688,7 +706,7 @@ void RooIntegralMorph::MorphCacheElem::findRange()
 
 double RooIntegralMorph::evaluate() const
 {
-  return 0 ;
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -696,15 +714,15 @@ double RooIntegralMorph::evaluate() const
 /// cache the traversal of the x should be in the innermost loop, to minimize
 /// recalculation of the one-dimensional internal cache for a fixed value of alpha
 
-void RooIntegralMorph::preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const
+void RooIntegralMorph::preferredObservableScanOrder(const RooArgSet &obs, RooArgSet &orderedObs) const
 {
-  // Put x last to minimize cache faulting
-  orderedObs.removeAll() ;
+   // Put x last to minimize cache faulting
+   orderedObs.removeAll();
 
-  orderedObs.add(obs) ;
-  RooAbsArg* obsX = obs.find(x.arg().GetName()) ;
-  if (obsX) {
-    orderedObs.remove(*obsX) ;
-    orderedObs.add(*obsX) ;
-  }
+   orderedObs.add(obs);
+   RooAbsArg *obsX = obs.find(x.arg().GetName());
+   if (obsX) {
+      orderedObs.remove(*obsX);
+      orderedObs.add(*obsX);
+   }
 }

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -37,25 +37,26 @@ calculates the shape of the interpolated p.d.f. fbar(x) for all values
 of x for a given value of alpha,p,q and caches these values in a histogram
 (as implemented by RooAbsCachedPdf). The binning granularity of the cache
 can be controlled by the binning named "cache" on the RooRealVar representing
-the observable x. The fbar sampling algorithm is based on a recursive division
-mechanism with a built-in precision cutoff: First an initial sampling in
-64 equally spaced bins is made. Then the value of fbar is calculated in
-the center of each gap. If the calculated value deviates too much from
-the value obtained by linear interpolation from the edge bins, gap
-is recursively divided. This strategy makes it possible to define a very
-fine cache sampling (e.g. 1000 or 10000) bins without incurring a
-corresponding CPU penalty.
+the observable x. The fbar sampling algorithm first scans the range of
+calculable c.d.f. values with a coarse grid and a recursive gap division
+mechanism, and then polishes the c.d.f. value for each cache bin center with
+Newton iterations on the monotone map X(y) = alpha*x1(y) + (1-alpha)*x2(y).
+The residual inaccuracy of the cached p.d.f. is therefore dominated by the
+interpolation between the cache bin centers and decreases steeply with the
+number of cache bins: with O(1000) cache bins the difference between the
+cached shape and the exact morphed p.d.f. is typically at the 1e-7 level
+(measured as a Kolmogorov-Smirnov distance) for Gaussian input shapes.
 
 Note on numeric stability of the algorithm. Since the algorithm relies
 on a numeric inversion of cumulative distributions functions, some precision
 may be lost at the 'edges' of the same (i.e. at regions in x where the
-c.d.f. value is close to zero or one). The general sampling strategy is
-to start with 64 equally spaces samples in the range y=(0.01-0.99).
-Then the y ranges are pushed outward by reducing y (or the distance of y to 1.0)
-by a factor of sqrt(10) iteratively up to the point where the corresponding
-x value no longer changes significantly. For p.d.f.s with very flat tails
-such as Gaussians some part of the tail may be lost due to limitations
-in numeric precision in the CDF inversion step.
+c.d.f. value is close to zero or one). The sampling strategy is to start
+at y=0.1 (or the distance of y to 1.0) and push the y range outward by
+a factor of sqrt(10) iteratively up to the point where the corresponding
+x value no longer changes significantly, with a hard cutoff at y=1e-12.
+For p.d.f.s with very flat tails such as Gaussians some part of the tail
+may be lost due to limitations in numeric precision in the CDF inversion
+step.
 
 An effect related to the above limitation in numeric precision should
 be anticipated when floating the alpha parameter in a fit. If a p.d.f
@@ -244,7 +245,7 @@ RooIntegralMorph::MorphCacheElem::MorphCacheElem(RooIntegralMorph &self, const R
      _yatXmin(0),
      _yatXmax(0),
      _ccounter(0),
-     _ycutoff(1e-7)
+     _ycutoff(1e-12)
 {
   // Mark in base class that normalization of cached pdf is invariant under pdf parameters
 
@@ -329,6 +330,12 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
 
   // Get number of bins from PdfCacheElem histogram
   Int_t nbins = _x->numBins("cache") ;
+  if (nbins < 2) {
+    oocoutE(_self,Eval) << "RooIntegralMorph::MorphCacheElem::calculate(" << _self->GetName()
+         << ") ERROR: observable " << _x->GetName() << " has an empty binning for the cache histogram."
+         << " Define one with RooRealVar::setBins(nbins, \"cache\")." << std::endl ;
+    return ;
+  }
 
   // Initialize yatX array to 'un-calculated values (-1)'
   for (int i=0 ; i<nbins ; i++) {
@@ -396,34 +403,59 @@ void RooIntegralMorph::MorphCacheElem::calculate(TIterator* dIter)
     hist()->set(binIdx, 0, -1) ;
   }
 
-  double x1 = _x->getMin("cache");
-  double x2 = _x->getMin("cache");
-
   double xMax = _x->getMax("cache");
+  const double aval = _alpha->getVal() ;
+
+  // Lower bounds for the root finding in the loop below, exploiting the fact
+  // that the cumulative distribution functions increase monotonically: as y
+  // increases from bin to bin, the x values found in the previous bin are
+  // valid lower bounds for the current bin.
+  double x1lo = _x->getMin("cache");
+  double x2lo = _x->getMin("cache");
 
   // Transfer calculated values to histogram
-  for (int i=_yatXmin ; i<_yatXmax ; i++) {
+  for (int i=_yatXmin ; i<=_yatXmax ; i++) {
 
     double y = _yatX[i] ;
+    const double xBinC = xmin + (i+0.5)*binw ;
 
-    // Little optimization here exploiting the fact that th cumulative
-    // distribution functions increase monotonically, so we already know that
-    // the next x-value must be higher than the last one as y is increasing. So
-    // we can use the previous x values as lower bounds.
-    _rf1->findRoot(x1,x1,xMax,y) ;
-    _rf2->findRoot(x2,x2,xMax,y) ;
+    double x1 = x1lo ;
+    double x2 = x2lo ;
+    double f1x1 = 0 ;
+    double f2x2 = 0 ;
 
-    _x->setVal(x1);
-    double f1x1 = _pdf1->getVal(_nset.get());
-    _x->setVal(x2);
-    double f2x2 = _pdf2->getVal(_nset.get());
-    double fbarX = f1x1*f2x2 / ( _alpha->getVal()*f2x2 + (1-_alpha->getVal())*f1x1 ) ;
+    // The y values obtained from the recursive gap filling are only
+    // approximate solutions of X(y) == xBinC. Polish them with Newton
+    // iterations on the monotone map X(y) = alpha*x1(y) + (1-alpha)*x2(y),
+    // whose derivative is dX/dy = alpha/f1(x1) + (1-alpha)/f2(x2), so that
+    // the stored p.d.f. value corresponds to the bin center to full precision.
+    for (int iter=0 ; iter<10 ; iter++) {
+      bool ok = _rf1->findRoot(x1,x1lo,xMax,y) ;
+      ok &= _rf2->findRoot(x2,x2lo,xMax,y) ;
+      _x->setVal(x1);
+      f1x1 = _pdf1->getVal(_nset.get());
+      _x->setVal(x2);
+      f2x2 = _pdf2->getVal(_nset.get());
+      if (!ok || f1x1<=0 || f2x2<=0) break ;
+      const double X = aval*x1 + (1-aval)*x2 ;
+      if (std::abs(X-xBinC) < 1e-12*(xMax-xmin)) break ;
+      const double dXdy = aval/f1x1 + (1-aval)/f2x2 ;
+      const double yNew = y + (xBinC-X)/dXdy ;
+      if (!(yNew>0.) || !(yNew<1.) || yNew==y) break ;
+      y = yNew ;
+    }
+    _yatX[i] = y ;
+
+    double fbarX = f1x1*f2x2 / ( aval*f2x2 + (1-aval)*f1x1 ) ;
 
     dIter->Next() ;
     {
       const std::size_t binIdx = hist()->getIndex(*hist()->get(), /*fast=*/true);
       hist()->set(binIdx, fbarX, -1) ;
     }
+
+    x1lo = x1 ;
+    x2lo = x2 ;
   }
   // Zero output histogram above highest calculable X value
   for (int i=_yatXmax+1 ; i<nbins ; i++) {
@@ -544,7 +576,7 @@ void RooIntegralMorph::MorphCacheElem::interpolateGap(Int_t ixlo, Int_t ixhi)
   double xOffset = xBinC-_calcX[ixlo] ;
 
   for (int j=ixlo+1 ; j<ixhi ; j++) {
-    _yatX[j] = _yatX[ixlo]+(xOffset+(j-ixlo))*deltaY ;
+    _yatX[j] = _yatX[ixlo]+(xOffset/binw+(j-ixlo))*deltaY ;
     _calcX[j] = xmin + (j+0.5)*binw ;
   }
 

--- a/roofit/roofit/test/CMakeLists.txt
+++ b/roofit/roofit/test/CMakeLists.txt
@@ -13,6 +13,7 @@ ROOT_ADD_GTEST(testRooFit
     testRooCrystalBall.cxx
     testRooExponential.cxx
     testRooGaussian.cxx
+    testRooIntegralMorph.cxx
     testRooJohnson.cxx
     testRooKeysPdf.cxx
     testRooLandau.cxx

--- a/roofit/roofit/test/testRooIntegralMorph.cxx
+++ b/roofit/roofit/test/testRooIntegralMorph.cxx
@@ -1,0 +1,110 @@
+// Tests for RooIntegralMorph
+// Author: Jonas Rembser, CERN 08/2026
+
+#include <RooAddPdf.h>
+#include <RooArgSet.h>
+#include <RooConstVar.h>
+#include <RooGaussian.h>
+#include <RooIntegralMorph.h>
+#include <RooRealVar.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+namespace {
+
+/// Kolmogorov-Smirnov distance between the pdf (normalized on [-xr, xr]) and
+/// a true Gaussian with given mean and sigma, using a trapezoidal c.d.f. scan.
+double ksDistanceToGaussian(RooAbsPdf &pdf, RooRealVar &x, double mu, double sigma, double xr, int npts = 40001)
+{
+   RooArgSet nset{x};
+   const double h = 2 * xr / (npts - 1);
+
+   auto trueCdf = [&](double xv) {
+      const double z = std::sqrt(2.0) * sigma;
+      return 0.5 * (std::erf((xv - mu) / z) - std::erf((-xr - mu) / z));
+   };
+
+   std::vector<double> vals(npts);
+   for (int i = 0; i < npts; ++i) {
+      x.setVal(-xr + i * h);
+      vals[i] = pdf.getVal(nset);
+   }
+
+   double acc = 0.0;
+   double ks = 0.0;
+   const double tnorm = trueCdf(xr);
+   for (int i = 1; i < npts; ++i) {
+      acc += 0.5 * (vals[i - 1] + vals[i]) * h;
+   }
+   double cdf = 0.0;
+   for (int i = 1; i < npts; ++i) {
+      cdf += 0.5 * (vals[i - 1] + vals[i]) * h;
+      ks = std::max(ks, std::abs(cdf / acc - trueCdf(-xr + i * h) / tnorm));
+   }
+   return ks;
+}
+
+} // namespace
+
+/// Morphing between two Gaussians with different means and widths must
+/// reproduce a Gaussian with linearly-interpolated mean and width, since the
+/// quantile function of a Gaussian is linear in (mu, sigma). This is the
+/// N_{mu,sigma} benchmark from Baak et al., NIM A 771 (2015) 39-48, where the
+/// original implementation was reported to be limited to KS distances of about
+/// 1e-3 by implementation defects.
+TEST(RooIntegralMorph, GaussianMorphAccuracy)
+{
+   const double xr = 10.0;
+
+   for (double a : {0.25, 0.5, 0.75}) {
+      RooRealVar x{"x", "x", -xr, xr};
+      x.setBins(1000, "cache");
+      RooRealVar alpha{"alpha", "alpha", a, 0.0, 1.0};
+      RooGaussian g1{"g1", "", x, RooFit::RooConst(2.0), RooFit::RooConst(1.5)};
+      RooGaussian g2{"g2", "", x, RooFit::RooConst(-2.0), RooFit::RooConst(0.5)};
+      RooIntegralMorph morph{"morph", "", g1, g2, x, alpha};
+
+      // True morphed shape: Gaussian with interpolated mean and width
+      const double mu = a * 2.0 + (1 - a) * (-2.0);
+      const double sigma = a * 1.5 + (1 - a) * 0.5;
+
+      // With 1000 cache bins the achievable accuracy is limited by the
+      // interpolation of the cache histogram at about 1e-7 ... 1e-6.
+      EXPECT_LT(ksDistanceToGaussian(morph, x, mu, sigma, xr), 5e-6) << "alpha = " << a;
+   }
+}
+
+/// Morphing from a bimodal shape must yield a smooth, normalized and
+/// non-negative pdf (regions of near-zero density stress the c.d.f inversion).
+TEST(RooIntegralMorph, BimodalEndpoint)
+{
+   const double xr = 10.0;
+   RooRealVar x{"x", "x", -xr, xr};
+   x.setBins(1000, "cache");
+   RooRealVar alpha{"alpha", "alpha", 0.5, 0.0, 1.0};
+   RooGaussian ga{"ga", "", x, RooFit::RooConst(-4.0), RooFit::RooConst(0.4)};
+   RooGaussian gb{"gb", "", x, RooFit::RooConst(4.0), RooFit::RooConst(0.4)};
+   RooAddPdf p1{"p1", "", {ga, gb}, {RooFit::RooConst(0.5)}};
+   RooGaussian p2{"p2", "", x, RooFit::RooConst(0.0), RooFit::RooConst(2.0)};
+   RooIntegralMorph morph{"morph", "", p1, p2, x, alpha};
+
+   RooArgSet nset{x};
+   const int npts = 10001;
+   const double h = 2 * xr / (npts - 1);
+   double integral = 0.0;
+   double prev = 0.0;
+   for (int i = 0; i < npts; ++i) {
+      x.setVal(-xr + i * h);
+      const double v = morph.getVal(nset);
+      ASSERT_FALSE(std::isnan(v));
+      ASSERT_GE(v, 0.0);
+      if (i > 0) {
+         integral += 0.5 * (prev + v) * h;
+      }
+      prev = v;
+   }
+   EXPECT_NEAR(integral, 1.0, 1e-6);
+}

--- a/roofit/roofit/test/testRooIntegralMorph.cxx
+++ b/roofit/roofit/test/testRooIntegralMorph.cxx
@@ -4,13 +4,23 @@
 #include <RooAddPdf.h>
 #include <RooArgSet.h>
 #include <RooConstVar.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
 #include <RooGaussian.h>
 #include <RooIntegralMorph.h>
+#include <RooPolynomial.h>
+#include <RooRandom.h>
 #include <RooRealVar.h>
+#include <RooGlobalFunc.h>
+
+#include <TMath.h>
 
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <functional>
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace {
@@ -47,6 +57,73 @@ double ksDistanceToGaussian(RooAbsPdf &pdf, RooRealVar &x, double mu, double sig
    return ks;
 }
 
+/// Invert a monotone c.d.f. with safeguarded Newton iterations.
+double quantile(double y, const std::function<double(double)> &cdf, const std::function<double(double)> &pdf,
+                double xlo, double xhi)
+{
+   double a = xlo;
+   double b = xhi;
+   double x = 0.5 * (a + b);
+   for (int i = 0; i < 200; ++i) {
+      const double c = cdf(x) - y;
+      (c > 0 ? b : a) = x;
+      const double f = pdf(x);
+      double xNew = f > 0 ? x - c / f : 0.5 * (a + b);
+      if (!(xNew > a && xNew < b)) {
+         xNew = 0.5 * (a + b);
+      }
+      if (std::abs(xNew - x) < 1e-15 * (xhi - xlo)) {
+         return xNew;
+      }
+      x = xNew;
+   }
+   return x;
+}
+
+/// Kolmogorov-Smirnov distance between a pdf (normalized on [xlo, xhi]) and
+/// the exact integral morph of two shapes given by their analytic normalized
+/// c.d.f.s and p.d.f.s. The exact morphed c.d.f. is known parametrically: at
+/// x(y) = alpha * x1(y) + (1 - alpha) * x2(y) it takes the value y, where
+/// x1, x2 are the quantile functions of the input shapes.
+double ksDistanceToTrueMorph(RooAbsPdf &pdf, RooRealVar &x, double alpha, const std::function<double(double)> &cdf1,
+                             const std::function<double(double)> &pdf1, const std::function<double(double)> &cdf2,
+                             const std::function<double(double)> &pdf2)
+{
+   RooArgSet nset{x};
+   const double xlo = x.getMin();
+   const double xhi = x.getMax();
+
+   const int npts = 40001;
+   const double yMin = 1e-9;
+   const double yMax = 1. - 1e-9;
+
+   // Sample the morph pdf at the exact morphed quantile positions and build
+   // its c.d.f. with the trapezoidal rule on that grid.
+   std::vector<double> xMorph(npts);
+   std::vector<double> vals(npts);
+   for (int i = 0; i < npts; ++i) {
+      const double y = yMin + i * (yMax - yMin) / (npts - 1);
+      const double x1 = quantile(y, cdf1, pdf1, xlo, xhi);
+      const double x2 = quantile(y, cdf2, pdf2, xlo, xhi);
+      xMorph[i] = alpha * x1 + (1 - alpha) * x2;
+      x.setVal(xMorph[i]);
+      vals[i] = pdf.getVal(nset);
+   }
+
+   double acc = 0.0;
+   for (int i = 1; i < npts; ++i) {
+      acc += 0.5 * (vals[i - 1] + vals[i]) * (xMorph[i] - xMorph[i - 1]);
+   }
+   double cdf = 0.0;
+   double ks = 0.0;
+   for (int i = 1; i < npts; ++i) {
+      cdf += 0.5 * (vals[i - 1] + vals[i]) * (xMorph[i] - xMorph[i - 1]);
+      const double yTrue = (yMin + i * (yMax - yMin) / (npts - 1) - yMin) / (yMax - yMin);
+      ks = std::max(ks, std::abs(cdf / acc - yTrue));
+   }
+   return ks;
+}
+
 } // namespace
 
 /// Morphing between two Gaussians with different means and widths must
@@ -74,6 +151,134 @@ TEST(RooIntegralMorph, GaussianMorphAccuracy)
       // With 1000 cache bins the achievable accuracy is limited by the
       // interpolation of the cache histogram at about 1e-7 ... 1e-6.
       EXPECT_LT(ksDistanceToGaussian(morph, x, mu, sigma, xr), 5e-6) << "alpha = " << a;
+   }
+}
+
+namespace {
+
+/// The endpoint shapes of the morphing test from the rf705 tutorial (and the
+/// former stressRooFit test 705): a narrow Gaussian in the left half of the
+/// range and a falling polynomial, on x in [-20, 20]. The exact morphed shape
+/// has no closed form, but the analytic c.d.f.s of the endpoints are enough to
+/// compute it to high precision (see ksDistanceToTrueMorph).
+struct GaussPolySetup {
+   double xr = 20.0;
+   double mean = -10.0;
+   double sigma = 2.0;
+   double a1 = -0.03;
+   double a2 = -0.001;
+
+   double gaussCdfRaw(double xv) const { return 0.5 * (1.0 + std::erf((xv - mean) / (sigma * std::sqrt(2.0)))); }
+   double gaussNorm() const { return gaussCdfRaw(xr) - gaussCdfRaw(-xr); }
+   double polyPrim(double xv) const { return xv + 0.5 * a1 * xv * xv + a2 * xv * xv * xv / 3.0; }
+   double polyNorm() const { return polyPrim(xr) - polyPrim(-xr); }
+
+   std::function<double(double)> cdf1() const
+   {
+      return [*this](double xv) { return (gaussCdfRaw(xv) - gaussCdfRaw(-xr)) / gaussNorm(); };
+   }
+   std::function<double(double)> pdf1() const
+   {
+      return [*this](double xv) {
+         const double z = (xv - mean) / sigma;
+         return std::exp(-0.5 * z * z) / (sigma * std::sqrt(2 * TMath::Pi())) / gaussNorm();
+      };
+   }
+   std::function<double(double)> cdf2() const
+   {
+      return [*this](double xv) { return (polyPrim(xv) - polyPrim(-xr)) / polyNorm(); };
+   }
+   std::function<double(double)> pdf2() const
+   {
+      return [*this](double xv) { return (1.0 + a1 * xv + a2 * xv * xv) / polyNorm(); };
+   }
+};
+
+} // namespace
+
+/// Morphing between a Gaussian and a polynomial shape, checked against the
+/// exact morphed shape computed from the analytic c.d.f.s of the endpoints.
+/// Together with the following tests, this replaces the former stressRooFit
+/// test 705, which compared against stored reference results and therefore
+/// could not distinguish expected numerical changes from real regressions.
+TEST(RooIntegralMorph, GaussPolyMorphAccuracy)
+{
+   GaussPolySetup s;
+
+   for (double a : {0.125, 0.5, 0.875, 0.95}) {
+      RooRealVar x{"x", "x", -s.xr, s.xr};
+      x.setBins(1000, "cache");
+      RooRealVar alpha{"alpha", "alpha", a, 0.0, 1.0};
+      RooGaussian g1{"g1", "", x, RooFit::RooConst(s.mean), RooFit::RooConst(s.sigma)};
+      RooPolynomial g2{"g2", "", x, {RooFit::RooConst(s.a1), RooFit::RooConst(s.a2)}};
+      RooIntegralMorph morph{"morph", "", g1, g2, x, alpha};
+
+      // The accuracy at 1000 cache bins is limited by the histogram
+      // representation of the sharply falling tails to about 1e-4 (verified to
+      // be identical to an ideal RooHistPdf built from the exact morph pdf
+      // sampled at the same bin centers).
+      const double ks = ksDistanceToTrueMorph(morph, x, a, s.cdf1(), s.pdf1(), s.cdf2(), s.pdf2());
+      EXPECT_LT(ks, 3e-4) << "alpha = " << a;
+   }
+}
+
+/// With setCacheAlpha(true), the pdf is cached in two dimensions (x, alpha)
+/// and interpolated in alpha. Scanning the pdf over a grid in x and alpha must
+/// agree with the exact morphed shape within the coarser alpha sampling. This
+/// covers the two-dimensional pdf scan and the alpha-cache machinery of the
+/// former stressRooFit test 705.
+TEST(RooIntegralMorph, AlphaCacheScan)
+{
+   GaussPolySetup s;
+
+   RooRealVar x{"x", "x", -s.xr, s.xr};
+   x.setBins(1000, "cache");
+   RooRealVar alpha{"alpha", "alpha", 0.5, 0.0, 1.0};
+   alpha.setBins(50, "cache");
+   RooGaussian g1{"g1", "", x, RooFit::RooConst(s.mean), RooFit::RooConst(s.sigma)};
+   RooPolynomial g2{"g2", "", x, {RooFit::RooConst(s.a1), RooFit::RooConst(s.a2)}};
+   RooIntegralMorph morph{"morph", "", g1, g2, x, alpha};
+   morph.setCacheAlpha(true);
+
+   for (double a : {0.125, 0.375, 0.625, 0.875}) {
+      alpha.setVal(a);
+      const double ks = ksDistanceToTrueMorph(morph, x, a, s.cdf1(), s.pdf1(), s.cdf2(), s.pdf2());
+      // Measured about 1e-4 at this binning; well below the 1e-3 level of the
+      // implementation defects fixed in the same commit that added this test.
+      EXPECT_LT(ks, 5e-4) << "alpha = " << a;
+   }
+}
+
+/// Generating a toy dataset from the morph pdf and fitting it back must
+/// recover the true alpha, with the alpha cache enabled as in a realistic
+/// fitting application, on both the legacy and cpu evaluation backends. This
+/// covers the toy fit of the former stressRooFit test 705.
+TEST(RooIntegralMorph, GenerateAndFit)
+{
+   GaussPolySetup s;
+
+   RooRealVar x{"x", "x", -s.xr, s.xr};
+   x.setBins(1000, "cache");
+   RooRealVar alpha{"alpha", "alpha", 0.8, 0.0, 1.0};
+   alpha.setBins(50, "cache");
+   RooGaussian g1{"g1", "", x, RooFit::RooConst(s.mean), RooFit::RooConst(s.sigma)};
+   RooPolynomial g2{"g2", "", x, {RooFit::RooConst(s.a1), RooFit::RooConst(s.a2)}};
+   RooIntegralMorph morph{"morph", "", g1, g2, x, alpha};
+
+   RooRandom::randomGenerator()->SetSeed(12345);
+   std::unique_ptr<RooDataSet> data{morph.generate(x, 1000)};
+
+   morph.setCacheAlpha(true);
+
+   for (std::string backend : {"legacy", "cpu"}) {
+      alpha.setVal(0.5);
+      alpha.setError(0.0);
+      std::unique_ptr<RooFitResult> res{
+         morph.fitTo(*data, RooFit::EvalBackend(backend), RooFit::PrintLevel(-1), RooFit::Save())};
+      EXPECT_EQ(res->status(), 0) << backend;
+      EXPECT_NEAR(alpha.getVal(), 0.8, 5. * alpha.getError()) << backend;
+      EXPECT_LT(alpha.getError(), 0.1) << backend;
+      EXPECT_GT(alpha.getError(), 1e-4) << backend;
    }
 }
 

--- a/roofit/roofitcore/test/stressRooFit.cxx
+++ b/roofit/roofitcore/test/stressRooFit.cxx
@@ -147,7 +147,6 @@ int stressRooFit(const char *refFile, bool writeRef, int doVerbose, int oneTest,
    testList.push_back(new TestBasic702(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic703(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic704(fref, writeRef, doVerbose));
-   testList.push_back(new TestBasic705(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic706(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic707(fref, writeRef, doVerbose));
    testList.push_back(new TestBasic708(fref, writeRef, doVerbose));

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -34,7 +34,6 @@
 #include <RooHelpers.h>
 #include <RooHist.h>
 #include <RooHistPdf.h>
-#include <RooIntegralMorph.h>
 #include <RooKeysPdf.h>
 #include <RooLandau.h>
 #include <RooMCStudy.h>
@@ -3838,125 +3837,6 @@ public:
       regPlot(frame2, "rf704_plot2");
       regTH(hh_cos, "rf704_hh_cos");
       regTH(hh_sin, "rf704_hh_sin");
-
-      return true;
-   }
-};
-
-// Linear interpolation between p.d.f shapes using the 'Alex Read' algorithm.
-class TestBasic705 : public RooUnitTest {
-public:
-   double ctol() override { return 5e-2; } // very conservative, this is a numerically difficult test
-
-   TestBasic705(TFile *refFile, bool writeRef, int verbose)
-      : RooUnitTest("Linear morph operator p.d.f.", refFile, writeRef, verbose)
-   {
-   }
-   bool isTestAvailable() override { return !useCodegenBackend(); }
-   bool testCode() override
-   {
-
-      // C r e a t e   e n d   p o i n t   p d f   s h a p e s
-      // ------------------------------------------------------
-
-      // Observable
-      RooRealVar x("x", "x", -20, 20);
-
-      // Lower end point shape: a Gaussian
-      RooRealVar g1mean("g1mean", "g1mean", -10);
-      RooGaussian g1("g1", "g1", x, g1mean, 2.0);
-
-      // Upper end point shape: a Polynomial
-      RooPolynomial g2("g2", "g2", x, RooArgSet(-0.03, -0.001));
-
-      // C r e a t e   i n t e r p o l a t i n g   p d f
-      // -----------------------------------------------
-
-      // Create interpolation variable
-      RooRealVar alpha("alpha", "alpha", 0, 1.0);
-
-      // Specify sampling density on observable and interpolation variable
-      x.setBins(1000, "cache");
-      alpha.setBins(50, "cache");
-
-      // Construct interpolating pdf in (x,a) represent g1(x) at a=a_min
-      // and g2(x) at a=a_max
-      RooIntegralMorph lmorph("lmorph", "lmorph", g1, g2, x, alpha);
-
-      // P l o t   i n t e r p o l a t i n g   p d f   a t   v a r i o u s   a l p h a
-      // -----------------------------------------------------------------------------
-
-      // Show end points as blue curves
-      RooPlot *frame1 = x.frame();
-      g1.plotOn(frame1);
-      g2.plotOn(frame1);
-
-      // Show interpolated shapes in red
-      alpha.setVal(0.125);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt1"));
-      alpha.setVal(0.25);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt2"));
-      alpha.setVal(0.375);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt3"));
-      alpha.setVal(0.50);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt4"));
-      alpha.setVal(0.625);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt5"));
-      alpha.setVal(0.75);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt6"));
-      alpha.setVal(0.875);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt7"));
-      alpha.setVal(0.95);
-      lmorph.plotOn(frame1, LineColor(kRed), Name("alt8"));
-
-      // S h o w   2 D   d i s t r i b u t i o n   o f   p d f ( x , a l p h a )
-      // -----------------------------------------------------------------------
-
-      // Create 2D histogram
-      TH1 *hh = lmorph.createHistogram("hh", x, Binning(40), YVar(alpha, Binning(40)));
-      hh->SetLineColor(kBlue);
-
-      // F i t   p d f   t o   d a t a s e t   w i t h   a l p h a = 0 . 8
-      // -----------------------------------------------------------------
-
-      // Generate a toy dataset at alpha = 0.8
-      alpha = 0.8;
-      std::unique_ptr<RooDataSet> data{lmorph.generate(x, 1000)};
-
-      // Fit pdf to toy data
-      lmorph.setCacheAlpha(true);
-      {
-         // Get rid of the caching info prints
-         RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::Caching, true};
-         lmorph.fitTo(*data);
-      }
-
-      // Plot fitted pdf and data overlaid
-      RooPlot *frame2 = x.frame(Bins(100));
-      data->plotOn(frame2);
-      lmorph.plotOn(frame2);
-
-      // S c a n   - l o g ( L )   v s   a l p h a
-      // -----------------------------------------
-
-      // Show scan -log(L) of dataset w.r.t alpha
-      RooPlot *frame3 = alpha.frame(Bins(100), Range(0.5, 0.9));
-
-      // Make 2D pdf of histogram
-      {
-         // Get rid of the caching info prints
-         RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::Caching, true};
-         std::unique_ptr<RooAbsReal> nll{lmorph.createNLL(*data)};
-         nll->SetName("nll");
-         nll->plotOn(frame3, ShiftToZero());
-      }
-
-      lmorph.setCacheAlpha(false);
-
-      regPlot(frame1, "rf705_plot1");
-      regPlot(frame2, "rf705_plot2");
-      regPlot(frame3, "rf705_plot3");
-      regTH(hh, "rf705_hh");
 
       return true;
    }


### PR DESCRIPTION
The precision of RooIntegralMorph ("integral morphing", Alex Read's c.d.f. interpolation) was reported in Baak et al., NIM A 771 (2015) 39-48, Table 2, to be limited to Kolmogorov-Smirnov distances of about 1e-3 from the exact morphed shape, even for pure Gaussian inputs where the method is mathematically exact. The method itself supports precision at the 1e-14 level, as in Read's original Fortran implementation, so this pointed to implementation defects. Three are fixed here:

1. Unit-mixing bug in MorphCacheElem::interpolateGap(): the x offset of the gap boundary from its bin center was added to a bin *count* and multiplied by a per-bin y increment without dividing by the bin width first. This mis-assigned interpolated c.d.f. values by up to half a bin, causing percent-level errors in the cached p.d.f. bin values (the dominant defect).

2. The y values produced by the recursive gap-filling heuristics (with their 1% "centration quality" tolerance) were used as-is. They are now polished per bin with Newton iterations on the monotone map X(y) = alpha*x1(y) + (1-alpha)*x2(y), using dX/dy = alpha/f1(x1) + (1-alpha)/f2(x2), so every cached bin value corresponds to its bin center to root-finder precision. This also fixes an off-by-one in the transfer loop that zeroed the highest calculable bin and left the last histogram bin unfilled.

3. The tail cutoff _ycutoff is lowered from 1e-7 to 1e-12, which removes the corresponding 3e-7 floor on the K-S distance from truncating the p.d.f. tails.

With these fixes the cached shape is accurate up to the resolution of the cache histogram itself: the K-S distance for the Gaussian benchmark of the paper drops from 3e-4 to 1.3e-7 at 1000 cache bins and reaches 5e-11 at ~30000 bins, matching an ideal same-binned representation of the exact result at every binning tested, at a cache-fill cost of a few tens of milliseconds.

Also error out with a clear message instead of silently producing an all-zero p.d.f. when the cache binning has no bins (the default since variables default to zero bins).

Closes https://its.cern.ch/jira/browse/ROOT-10453

🤖 Done with the help of AI