### PR TITLE
[tmva][sofie] Constant-fold ROperator_Gemm when all inputs are initializers

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Gemm.hxx
@@ -259,6 +259,72 @@ namespace SOFIE{
                shapeY.erase(shapeY.end()-1);
          }
 
+         // Constant-fold Gemm/MatMul when A, B (and C) are all initializers, following the
+         // ROperator_BasicBinary pattern (compute now, skip Generate() entirely). Only full
+         // constant folding is handled; propagating just A or B (see the TODO above) would
+         // need a different mechanism than fIsOutputConstant's all-or-nothing fold.
+         bool canFold = !fIsDynamic
+            && model.IsInitializedTensor(fNA)
+            && model.IsInitializedTensor(fNB)
+            && (fNC.empty() || model.IsInitializedTensor(fNC))
+            && fShapeA.size() <= 2       // exclude stacked/batched MatMul
+            && !fBroadcastBias           // exclude bias requiring run-time broadcast
+            && !fCheckBiasShapeAtRuntime;
+
+         if (canFold) {
+            auto shapeA_i = ConvertShapeToInt(fShapeA);
+            auto shapeB_i = ConvertShapeToInt(fShapeB);
+            size_t dimA = shapeA_i.size();
+            size_t dimB = shapeB_i.size();
+            size_t m = fAttrTransA ? shapeA_i[dimA - 1] : shapeA_i[dimA - 2];
+            size_t k = fAttrTransA ? shapeA_i[dimA - 2] : shapeA_i[dimA - 1];
+            size_t n = fAttrTransB ? shapeB_i[dimB - 2] : shapeB_i[dimB - 1];
+
+            auto dataA = static_cast<T *>(model.GetInitializedTensorData(fNA).get());
+            auto dataB = static_cast<T *>(model.GetInitializedTensorData(fNB).get());
+
+            // plain host-side 2D matrix multiply: Y = alpha * op(A) * op(B)
+            std::vector<T> dataY(m * n, T(0));
+            for (size_t i = 0; i < m; i++) {
+               for (size_t j = 0; j < n; j++) {
+                  T sum{};
+                  for (size_t p = 0; p < k; p++) {
+                     T aVal = fAttrTransA ? dataA[p * m + i] : dataA[i * k + p];
+                     T bVal = fAttrTransB ? dataB[j * k + p] : dataB[p * n + j];
+                     sum += aVal * bVal;
+                  }
+                  dataY[i * n + j] = static_cast<T>(fAttrAlpha) * sum;
+               }
+            }
+            // Y += beta * C (fBroadcastBias is false here, so C already matches Y's length)
+            if (!fNC.empty()) {
+               auto dataC = static_cast<T *>(model.GetInitializedTensorData(fNC).get());
+               for (size_t idx = 0; idx < dataY.size(); idx++)
+                  dataY[idx] += static_cast<T>(fAttrBeta) * dataC[idx];
+            }
+            // fuse ReLU now since Generate() will be skipped entirely for a constant output
+            if (fActivation == EActivationType::RELU) {
+               for (auto &v : dataY)
+                  v = std::max(v, T(0));
+            }
+
+            model.AddConstantTensor<T>(fNY, shapeY, dataY.data());
+            // flag the operand tensors to not be written in the generated code or weight file
+            model.SetNotWritableInitializedTensor(fNA);
+            model.SetNotWritableInitializedTensor(fNB);
+            if (!fNC.empty())
+               model.SetNotWritableInitializedTensor(fNC);
+            fIsOutputConstant = true;
+
+            if (model.Verbose()) {
+               std::cout << "Gemm (or MatMul) " << fNA << " , " << fNB;
+               if (!fNC.empty())
+                  std::cout << " , " << fNC;
+               std::cout << " ---> " << fNY << " (constant) " << ConvertShapeToString(shapeY) << std::endl;
+            }
+            return;
+         }
+
          if (!fIsDynamic)
             model.AddIntermediateTensor(fNY, model.GetTensorType(fNA), shapeY);
          else
@@ -287,6 +353,9 @@ namespace SOFIE{
       }
 
       std::string Generate(std::string opName) override {
+         if (fIsOutputConstant)
+            return ""; // no op for constant tensors
+
          opName = "op_" + opName;
 
          // if (fShapeA.empty() || fShapeB.empty() || fShapeY.empty() || (fNC != "" && fShapeC.empty())) {

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -537,6 +537,33 @@ TEST(ONNX, Mod_ConstantFolding)
    expectEqual(output, correct_output);
 }
 
+TEST(ONNX, Gemm_ConstantFolding)
+{
+   // A, B and bias C are all initializers, so this constant-folds instead of calling Gemm_Call.
+   // A = [[1,2,3],[4,5,6]], B = [[7,8],[9,10],[11,12]], C = [[1,1],[1,1]]
+   // Y = A*B + C = [[59,65],[140,155]]
+   std::vector<float> correct_output = {59, 65, 140, 155};
+   ASSERT_INCLUDE_AND_RUN_0(std::vector<float>, "Gemm_ConstantFolding");
+   expectNear(output, correct_output, DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, Gemm_ConstantFolding_Shared)
+{
+   // Node 1 (A1,B,C1 all initializers) folds; node 2 (A2 is a graph input, B shared with
+   // node 1, C2 an initializer) can't. Checks B still gets written to the weight file for
+   // node 2 despite node 1 marking it not-writable while folding.
+   // B is the identity: Y1 = A1+C1 = [[2,3],[4,5]], Y2 = A2+C2 = [[15,16],[17,18]]
+   std::vector<float> A2 = {5, 6, 7, 8};
+   std::vector<float> correct_Y1 = {2, 3, 4, 5};
+   std::vector<float> correct_Y2 = {15, 16, 17, 18};
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<std::vector<float>>, "Gemm_ConstantFolding_Shared", A2);
+
+   ASSERT_EQ(output.size(), 2u);
+   expectNear(output[0], correct_Y1, DEFAULT_TOLERANCE);
+   expectNear(output[1], correct_Y2, DEFAULT_TOLERANCE);
+}
+
    TEST(ONNX, ReduceMean)
 {
    SofieReference ref = readReference("ReduceMean");
@@ -1472,6 +1499,16 @@ TEST(ONNX, ScatterElements)
 
    ASSERT_INCLUDE_AND_RUN(std::vector<float>, "ScatterElements", input, indices, updates);
 
+   expectNear(output, correct_output, DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, MatMul_1D_Constant)
+{
+   // A is 1-D, B is 2-D, both initializers; A gets padded to (1,3) internally so this
+   // still constant-folds like a normal Gemm.
+   // A = [1,2,3], B = [[1,2],[3,4],[5,6]], Y = A.B = [22, 28]
+   std::vector<float> correct_output = {22, 28};
+   ASSERT_INCLUDE_AND_RUN_0(std::vector<float>, "MatMul_1D_Constant");
    expectNear(output, correct_output, DEFAULT_TOLERANCE);
 }
 

--- a/tmva/sofie/test/generate_input_models.py
+++ b/tmva/sofie/test/generate_input_models.py
@@ -1864,6 +1864,54 @@ def make_Gelu():
     return _model(graph, opset=20, ir_version=13)
 
 
+def make_Gemm_ConstantFolding():
+    """Ops: Gemm"""
+    nodes = [
+        helper.make_node('Gemm', ['A', 'B', 'C'], ['Y'], alpha=1.0, beta=1.0, transA=0, transB=0),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'Gemm_ConstantFolding',
+        inputs=[
+        ],
+        outputs=[
+            _vi('Y', FLOAT, [2, 2]),
+        ],
+        initializer=[
+            _tensor('A', FLOAT, [2, 3], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            _tensor('B', FLOAT, [3, 2], [7.0, 8.0, 9.0, 10.0, 11.0, 12.0]),
+            _tensor('C', FLOAT, [2, 2], [1.0, 1.0, 1.0, 1.0]),
+        ],
+    )
+    return _model(graph, opset=13, ir_version=13)
+
+
+def make_Gemm_ConstantFolding_Shared():
+    """Ops: Gemm x2 (shared initializer)"""
+    nodes = [
+        helper.make_node('Gemm', ['A1', 'B', 'C1'], ['Y1'], alpha=1.0, beta=1.0, transA=0, transB=0),
+        helper.make_node('Gemm', ['A2', 'B', 'C2'], ['Y2'], alpha=1.0, beta=1.0, transA=0, transB=0),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'Gemm_ConstantFolding_Shared',
+        inputs=[
+            _vi('A2', FLOAT, [2, 2]),
+        ],
+        outputs=[
+            _vi('Y1', FLOAT, [2, 2]),
+            _vi('Y2', FLOAT, [2, 2]),
+        ],
+        initializer=[
+            _tensor('A1', FLOAT, [2, 2], [1.0, 2.0, 3.0, 4.0]),
+            _tensor('B', FLOAT, [2, 2], [1.0, 0.0, 0.0, 1.0]),
+            _tensor('C1', FLOAT, [2, 2], [1.0, 1.0, 1.0, 1.0]),
+            _tensor('C2', FLOAT, [2, 2], [10.0, 10.0, 10.0, 10.0]),
+        ],
+    )
+    return _model(graph, opset=13, ir_version=13)
+
+
 def make_Greater():
     """Ops: Greater"""
     nodes = [
@@ -3459,6 +3507,27 @@ def make_Log():
         ],
     )
     return _model(graph, opset=14, ir_version=7, producer_name='pytorch', producer_version='1.13.1')
+
+
+def make_MatMul_1D_Constant():
+    """Ops: MatMul"""
+    nodes = [
+        helper.make_node('MatMul', ['A', 'B'], ['Y']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'MatMul_1D_Constant',
+        inputs=[
+        ],
+        outputs=[
+            _vi('Y', FLOAT, [2]),
+        ],
+        initializer=[
+            _tensor('A', FLOAT, [3], [1.0, 2.0, 3.0]),
+            _tensor('B', FLOAT, [3, 2], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        ],
+    )
+    return _model(graph, opset=13, ir_version=13)
 
 
 def make_MatMul_Stacked():
@@ -5169,6 +5238,8 @@ MODELS = {
     'GatherND_3': make_GatherND_3,
     'GatherNegativeIndices': make_GatherNegativeIndices,
     'Gelu': make_Gelu,
+    'Gemm_ConstantFolding': make_Gemm_ConstantFolding,
+    'Gemm_ConstantFolding_Shared': make_Gemm_ConstantFolding_Shared,
     'Greater': make_Greater,
     'GreaterOrEqual': make_GreaterOrEqual,
     'HardSigmoid': make_HardSigmoid,
@@ -5193,6 +5264,7 @@ MODELS = {
     'Linear_32': make_Linear_32,
     'Linear_64': make_Linear_64,
     'Log': make_Log,
+    'MatMul_1D_Constant': make_MatMul_1D_Constant,
     'MatMul_Stacked': make_MatMul_Stacked,
     'MatMul_Stacked2': make_MatMul_Stacked2,
     'Max': make_Max,


### PR DESCRIPTION
**This Pull Request**
Implements the `TODO` in `ROperator_Gemm::Initialize()` ("propagate A or B as specified by ONNX standard").

**Changes & Fixes**
* **`tmva/sofie/inc/TMVA/ROperator_Gemm.hxx`**: When `A`, `B`, and `C` (if present) are all ONNX initializers, `Gemm`/`MatMul` now folds to a constant at `Initialize()` time instead of generating a runtime `Gemm_Call`. This follows the same `fIsOutputConstant` pattern used by `ROperator_BasicBinary`. Dynamic shapes, stacked or batched `MatMul`, and run-time bias broadcasting still fall through to the normal runtime path unchanged.
* **Testing (`tmva/sofie/test/...`)**: Added three tests to `generate_input_models.py` and `TestCustomModelsFromONNX.cxx`:
  * `Gemm_ConstantFolding`
  * `Gemm_ConstantFolding_Shared` (a shared initializer between a folded and a non-folded node)
  * `MatMul_1D_Constant`

> **Note:** Partial constant propagation (meaning only one of `A`/`B` is constant) is out of scope for this PR. I am open to guidance if a different scope was intended.

**Checklist**
- [x] Tested changes locally
- [x] Updated the docs (if necessary)