### PR TITLE
[pdf] Fix calculation of kerning distances in generated PDF files

### DIFF
--- a/graf2d/postscript/src/TPDF.cxx
+++ b/graf2d/postscript/src/TPDF.cxx
@@ -1943,7 +1943,7 @@ void TPDF::Text(Double_t xx, Double_t yy, const char *chars)
             tmp[0] = chars[i-1];
             UInt_t width=0;
             t.GetTextAdvance(width, &tmp[0], kFALSE);
-            Double_t wwl = gPad->AbsPixeltoX(width - charDeltas[i]) - gPad->AbsPixeltoX(0);
+            Double_t wwl = gPad->AbsPixeltoX((Int_t)width - charDeltas[i]) - gPad->AbsPixeltoX(0);
             wwl -= 0.5*(gPad->AbsPixeltoX(1) - gPad->AbsPixeltoX(0)); // half a pixel ~ rounding error
             charDeltas[i] = (Int_t)((1000.0/Float_t(fontsize))*(XtoPDF(wwl) - XtoPDF(0))/scale);
         }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Note that this uses the system fonts on Fedora rather than the bundled fonts in the root sources.

Using the following test program
```
void ttest()
{
  auto c = new TCanvas("c", "", 300, 100);
  auto t = new TText(0.1, 0.4, "Raw assymmetry");
  t->SetTextSize(0.5);
  t->SetTextFont(132);
  t->Draw();
  c->Print("ttest.pdf");
  c->Print("ttest.eps");
  c->Print("ttest.png");
}
```
The .eps and .png images look like expected. But the .pdf image only shows the initial capital "R", not the full "Raw assymmetry" text.

After decompressing the generated .pdf file:

cpdf -decompress ttest.pdf -o ttest.dec.pdf

the decompressed file shows that the kerning distances are incorrect:
```
[(R)  -2147483648(a)  24(w)  -2147483648( )  0(a)  0(s)  -2147483648(s)  17(y)  0(m)  0(m)  8(e)  8(t)  0(r)  -2147483648(y) ]
```
Something has clearly gone wrong here. -2147483648 is the minimum value that can be stored in a 16 bit signed integer.

The origin of the problem is a calculation of a difference between a UInt_t (i.e. unsigned) value and an Int_t (i.e. signed) value in the TPDF::Text() method. Casting the UInt_t to an Int_t before calculating the difference, as done in this commit, fixes the problem. With this change the kerning distances are better:
```
[(R)  -2(a)  24(w)  -2( )  0(a)  0(s)  -2(s)  17(y)  0(m)  0(m)  8(e)  8(t)  0(r)  -2(y) ]
```
and the generated .pdf file shows the complete text. The generated .png and .eps files do not change (except for the time stamp in the .eps file).

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

