### PR TITLE
[cmake] Set policy CMP0116 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ foreach(directoryName IN ITEMS ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_I
 endforeach()
 
 set(policy_new CMP0072 CMP0076 CMP0077 CMP0079
+    CMP0116 # Ninja generators transform DEPFILEs from add_custom_command()
     CMP0135 # Timestamps of downloaded archives are set to time of extraction
     CMP0144 # <PACKAGENAME>_ROOT (converted to upper case) can be used to search for dependencies
     CMP0156 CMP0179 #deduplicate static libraries when linker supports it
@@ -39,13 +40,6 @@ set(policy_new CMP0072 CMP0076 CMP0077 CMP0079
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)
-  endif()
-endforeach()
-
-set(policy_old CMP0116)
-foreach(policy ${policy_old})
-  if(POLICY ${policy})
-    cmake_policy(SET ${policy} OLD)
   endif()
 endforeach()
 


### PR DESCRIPTION
This effectively reverts 7392b023d10, which forced CMP0116 to OLD to silence warnings from LLVM's TableGen.cmake when building with `builtin_llvm=OFF`. The LLVM code has since learned to deal with the policy being NEW: TableGen.cmake now checks the policy state and only uses DEPFILE when it is NEW (with fallbacks for older CMake versions and for Windows), and the shared CMakePolicy.cmake in the LLVM sources no longer sets CMP0116 to OLD.

Since ROOT requires CMake 3.20, which is exactly the version that introduced CMP0116, NEW is also what we would get without any explicit policy setting.

With this change, tablegen invocations under the Ninja generator use depfiles instead of globbing all `*.td` files in the include directories.

Suggested by Philippe in the review of PR #23011:
https://github.com/root-project/root/pull/23011#discussion_r3722241244