### PR TITLE
[tmva][sofie] Move the ONNX message classes out of the global namespace

### DIFF
--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -8,17 +8,17 @@
 #include <unordered_map>
 #include <fstream>
 
-// forward declaration
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
+// forward declaration of the messages defined in sofie_parsers/src/onnx.hxx
 namespace onnx {
 class NodeProto;
 class GraphProto;
 class ModelProto;
 class TensorProto;
 } // namespace onnx
-
-namespace TMVA {
-namespace Experimental {
-namespace SOFIE {
 
 class RModelParser_ONNX;
 

--- a/tmva/sofie_parsers/src/onnx.hxx
+++ b/tmva/sofie_parsers/src/onnx.hxx
@@ -20,6 +20,18 @@
 #include <string>
 #include <vector>
 
+// The messages live in TMVA::Experimental::SOFIE::onnx, not in the global onnx
+// namespace the protoc-generated headers use. The real ONNX C++ library ships
+// inside the `onnx` Python wheel, and when that extension module is loaded in
+// the same process (as any PyTorch ONNX export does) its exported symbols
+// interpose ours on ELF platforms: SOFIE would then call protobuf's
+// onnx::TensorProto destructor on an object with this file's layout.
+// Unqualified `onnx::` inside namespace SOFIE still names these classes, so
+// the parser sources need no change.
+namespace TMVA {
+namespace Experimental {
+namespace SOFIE {
+
 namespace onnx {
 
 // ---------------------------------------------------------------------------
@@ -659,5 +671,9 @@ private:
 };
 
 } // namespace onnx
+
+} // namespace SOFIE
+} // namespace Experimental
+} // namespace TMVA
 
 #endif


### PR DESCRIPTION
SOFIE's dependency-free ONNX reader defines classes like onnx::TensorProto in the global `onnx` namespace, mirroring the protoc-generated headers it replaced. The real ONNX C++ library lives in that same namespace and ships inside the `onnx` Python wheel as onnx_cpp2py_export. Whenever that extension module is loaded into the same process -- which every PyTorch ONNX export does -- and its build exports those symbols, ELF symbol interposition makes SOFIE's calls resolve to protobuf's implementation. The parser then runs protobuf's onnx::TensorProto destructor over an object with SOFIE's layout and segfaults.

Put the messages in TMVA::Experimental::SOFIE::onnx instead. Unqualified `onnx::` inside namespace SOFIE still names them, so none of the operator parsers change.