### PR TITLE
[tmva][sofie] Fix Range output-size expression for symbolic INT64 inputs

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Range.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Range.hxx
@@ -96,7 +96,7 @@ public:
          fShape = {Dim{"range_size_" + fNStart + "_" + fNLimit}};
          model.AddDynamicTensor(fNOutput, type, fShape);
       } else if (res1 == 1 && res2 == 1 && res3 == 1) {
-         size_t number_of_elements = std::max(static_cast<int>(std::ceil((limit_value - start_value) / delta_value )) , 0 );
+         size_t number_of_elements = std::max(static_cast<int>(std::ceil(static_cast<float>(limit_value - start_value) / delta_value)) , 0 );
          fIsOutputConstant = true;
 
          // compute output
@@ -123,12 +123,12 @@ public:
                if (start == "0")
                   s <<  limit;
                else
-                  s << "std::max((" << limit << " - " << start << "),0L)";
+                  s << "((" << limit << " > " << start << ") ? (" << limit << " - " << start << ") : 0)";
             } else {
                if (start == "0")
-                  s <<  "((" << limit << ")/" << delta << ")";
+                  s <<  "((" << limit << " + " << delta << " - 1)/" << delta << ")";
                else
-                  s << "std::max((" << limit << " - " << start << ")/"<< delta << "),0L)";
+                  s << "((" << limit << " > " << start << ") ? ((" << limit << " - " << start << " + " << delta << " - 1)/" << delta << ") : 0)";
             }
          } else {
             throw

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -1292,6 +1292,53 @@ TEST(ONNX, RangeInt)
 
    expectEqual(output, ref.i64("output0"));
 }
+
+// constant INT64 Range(0, 5, 2) folds at generation time; the count is ceiled, not floored
+TEST(ONNX, Range_ConstantFolding)
+{
+   std::vector<int64_t> correct_output = {0, 2, 4};
+   ASSERT_INCLUDE_AND_RUN_0(std::vector<int64_t>, "Range_ConstantFolding");
+   expectEqual(output, correct_output);
+}
+
+// Range(1, K, 1) with the limit K read via Shape; the emitted size expression must compile
+TEST(ONNX, RangeWithDynShapeStart)
+{
+   std::vector<float> input(5);
+   std::vector<int64_t> correct_output = {1, 2, 3, 4};
+
+   // model is dynamic in K, use K = 5
+   ASSERT_INCLUDE_AND_RUN_SESSION_ARGS(std::vector<int64_t>, "RangeWithDynShapeStart",
+                                       "\"RangeWithDynShapeStart_FromONNX.dat\", 5", 5, input);
+
+   expectEqual(output, correct_output);
+}
+
+// Range(0, K, 2): the symbolic count is ceil(K / delta), not the floored (K)/delta
+TEST(ONNX, RangeWithDynShapeDelta)
+{
+   std::vector<float> input(5);
+   std::vector<int64_t> correct_output = {0, 2, 4};
+
+   // model is dynamic in K, use K = 5
+   ASSERT_INCLUDE_AND_RUN_SESSION_ARGS(std::vector<int64_t>, "RangeWithDynShapeDelta",
+                                       "\"RangeWithDynShapeDelta_FromONNX.dat\", 5", 5, input);
+
+   expectEqual(output, correct_output);
+}
+
+// Range(1, K, 2): both start and delta in play; pre-fix expression had unbalanced parentheses
+TEST(ONNX, RangeWithDynShapeStartDelta)
+{
+   std::vector<float> input(5);
+   std::vector<int64_t> correct_output = {1, 3};
+
+   // model is dynamic in K, use K = 5
+   ASSERT_INCLUDE_AND_RUN_SESSION_ARGS(std::vector<int64_t>, "RangeWithDynShapeStartDelta",
+                                       "\"RangeWithDynShapeStartDelta_FromONNX.dat\", 5", 5, input);
+
+   expectEqual(output, correct_output);
+}
 TEST(ONNX, Tile5D)
 {
    SofieReference ref = readReference("Tile5D");

--- a/tmva/sofie/test/generate_input_models.py
+++ b/tmva/sofie/test/generate_input_models.py
@@ -4497,6 +4497,67 @@ def make_RangeInt():
     return _model(graph, opset=19, ir_version=9)
 
 
+def make_Range_ConstantFolding():
+    """Ops: Range"""
+    nodes = [
+        helper.make_node('Range', ['start', 'limit', 'delta'], ['Y']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'Range_ConstantFolding',
+        inputs=[],
+        outputs=[
+            _vi('Y', INT64, [3]),
+        ],
+        initializer=[
+            _tensor('start', INT64, [], [0]),
+            _tensor('limit', INT64, [], [5]),
+            _tensor('delta', INT64, [], [2]),
+        ],
+    )
+    return _model(graph, opset=19, ir_version=9)
+
+
+def _range_symbolic(name, start, delta):
+    """Range whose limit is a symbolic dimension read via Shape and Gather."""
+    nodes = [
+        helper.make_node('Shape', ['X'], ['xshape']),
+        helper.make_node('Gather', ['xshape', 'i0'], ['limit'], axis=0),
+        helper.make_node('Range', ['start', 'limit', 'delta'], ['Y']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        name,
+        inputs=[
+            _vi('X', FLOAT, ['K']),
+        ],
+        outputs=[
+            _vi('Y', INT64, ['M']),
+        ],
+        initializer=[
+            _tensor('i0', INT64, [], [0]),
+            _tensor('start', INT64, [], [start]),
+            _tensor('delta', INT64, [], [delta]),
+        ],
+    )
+    return _model(graph, opset=19, ir_version=9)
+
+
+def make_RangeWithDynShapeStart():
+    """Ops: Range, Shape, Gather"""
+    return _range_symbolic('RangeWithDynShapeStart', start=1, delta=1)
+
+
+def make_RangeWithDynShapeDelta():
+    """Ops: Range, Shape, Gather"""
+    return _range_symbolic('RangeWithDynShapeDelta', start=0, delta=2)
+
+
+def make_RangeWithDynShapeStartDelta():
+    """Ops: Range, Shape, Gather"""
+    return _range_symbolic('RangeWithDynShapeStartDelta', start=1, delta=2)
+
+
 def make_Reciprocal():
     """Ops: Reciprocal"""
     nodes = [
@@ -5298,6 +5359,10 @@ MODELS = {
     'RandomUniform': make_RandomUniform,
     'RangeFloat': make_RangeFloat,
     'RangeInt': make_RangeInt,
+    'RangeWithDynShapeDelta': make_RangeWithDynShapeDelta,
+    'RangeWithDynShapeStart': make_RangeWithDynShapeStart,
+    'RangeWithDynShapeStartDelta': make_RangeWithDynShapeStartDelta,
+    'Range_ConstantFolding': make_Range_ConstantFolding,
     'Reciprocal': make_Reciprocal,
     'ReduceMean': make_ReduceMean,
     'ReduceMean_kFirst': make_ReduceMean_kFirst,


### PR DESCRIPTION
## Changes or fixes:

Fixes the output-size expression that Range emits for symbolic INT64 inputs, see #23186. Examples below are the emitted code for `limit = K` (a symbolic input dimension read via Shape/Gather, a `size_t` in the generated code), `start = 1`, `delta = 2`:

- `start != 0, delta == 1`: `std::max((K - 1),0L)` mixed unsigned/signed and did not compile; now `((K > 1) ? (K - 1) : 0)`
- `start == 0, delta != 1`: `((K)/2)` floored the count; now ceiled via `((K + 2 - 1)/2)`
- `start != 0, delta != 1`: misplaced parenthesis (one-argument `std::max`) plus both issues above; now `((K > 1) ? ((K - 1 + 2 - 1)/2) : 0)`
- constant INT64 path: `std::ceil` after an integer division was a no-op; cast to float before dividing

All branches now follow the ONNX formula `max(ceil((limit - start)/delta), 0)`. FLOAT branch unchanged.

Four models have been added (`Range_ConstantFolding`, `RangeWithDynShape{Start,Delta,StartDelta}`) with gtests for the checking the new changes

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #23186

**AI-assistance disclosure** : parts of this change were developed with AI assistance; I have fully reviewed, understood it and take responsibility for it.
