### PR TITLE
[RF] Support FitGauss() also in RooMCStudy::plotParam() and friends

### DIFF
--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -72,7 +72,11 @@ for usage examples.
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
 
+#include <TAxis.h>
+
 #include <snprintf.h>
+
+#include <algorithm>
 #include <iostream>
 
 
@@ -908,6 +912,98 @@ RooAbsData* RooMCStudy::genData(Int_t sampleNum) const
   return  static_cast<RooAbsData*>(_genDataList.At(sampleNum)) ;
 }
 
+namespace {
+
+// Fits a Gaussian p.d.f. to the distribution of the frame's plot variable in
+// the given dataset, overlays the fitted p.d.f. on the frame and adds a box
+// with the fitted mean and sigma. Implementation detail of RooMCStudy.
+void fitGaussAndPlotOnFrame(RooPlot &frame, RooDataSet &fitParData, RooAbsPdf &gauss, RooRealVar &mean,
+                            RooRealVar &sigma)
+{
+   gauss.fitTo(fitParData, RooFit::Minos(false), RooFit::PrintLevel(-1));
+   gauss.plotOn(&frame);
+
+   // Instead of using paramOn() without command arguments to plot the fit
+   // parameters, we are building the parameter label ourselves for more
+   // flexibility and pass this together with an appropriate layout
+   // parametrization to paramOn().
+   const int sigDigits = 2;
+   const char *options = "ELU";
+   std::stringstream ss;
+   ss << "Fit parameters:\n"
+      << "#mu: " << mean.format(sigDigits, options) << "\n#sigma: " << sigma.format(sigDigits, options);
+   // We set the parameters constant to disable the default label. Still, we
+   // use param() on as a wrapper for the text box generation.
+   mean.setConstant(true);
+   sigma.setConstant(true);
+   gauss.paramOn(&frame, RooFit::Label(ss.str().c_str()), RooFit::Layout(0.60, 0.9, 0.9));
+}
+
+// Fits a Gaussian to the distribution of the variable plotted in the frame.
+// The initial values of the Gaussian parameters are taken from the moments of
+// the plotted distribution. Implementation detail of RooMCStudy::plotParam(),
+// which is also used by RooMCStudy::plotError() and RooMCStudy::plotNLL().
+void fitGaussToFrame(RooPlot &frame, RooDataSet &fitParData)
+{
+   // Build the Gaussian fit model for the plotted variable, then fit it and
+   // plot it. We have to use the RooWorkspace factory here, because different
+   // from the RooMCStudy class, the RooGaussian is not in RooFitCore.
+   RooWorkspace ws;
+   auto plotVar = frame.getPlotVar();
+   const std::string plotVarName = plotVar->GetName();
+   ws.import(*plotVar);
+   ws.factory("Gaussian::frameGauss(" + plotVarName + ", frameMean[0.0, 0.0, 1.0], frameSigma[1.0, 0.1, 10.0])");
+
+   RooRealVar &mean = *ws.var("frameMean");
+   RooRealVar &sigma = *ws.var("frameSigma");
+
+   // Seed the Gaussian with the moments of the plotted distribution, so that
+   // the fit also converges for distributions that are much narrower than the
+   // frame range. The values are set here and not passed via the factory
+   // string above, because the limited precision of the string representation
+   // would matter for variables with large absolute values.
+   auto const *dataVar = static_cast<RooRealVar const *>(fitParData.get()->find(plotVarName.c_str()));
+   if (!dataVar) {
+      oocoutE(nullptr, Plotting) << "RooMCStudy: no Gaussian fit for '" << plotVarName
+                                 << "', which is not in the dataset of fit parameters." << std::endl;
+      return;
+   }
+   const double dataMean = fitParData.mean(*dataVar);
+   const double dataSigma = fitParData.sigma(*dataVar);
+
+   // The mean is limited to the plotted range, extended if necessary such that
+   // it also covers the seed value.
+   mean.setRange(std::min(frame.GetXaxis()->GetXmin(), dataMean), std::max(frame.GetXaxis()->GetXmax(), dataMean));
+   mean.setVal(dataMean);
+
+   // Fall back to the frame range if the distribution has no spread at all,
+   // which can happen for example if there is only a single successful fit.
+   const double sigmaSeed =
+      dataSigma > 0.0 ? dataSigma : 0.05 * (frame.GetXaxis()->GetXmax() - frame.GetXaxis()->GetXmin());
+   sigma.setRange(0.01 * sigmaSeed, 10. * sigmaSeed);
+   sigma.setVal(sigmaSeed);
+
+   fitGaussAndPlotOnFrame(frame, fitParData, *ws.pdf("frameGauss"), mean, sigma);
+}
+
+// Fits a Gaussian to the pull distribution, plots the fit and prints the fit
+// parameters on the canvas. Implementation detail of RooMCStudy::plotPull().
+void fitGaussToPulls(RooPlot& frame, RooDataSet& fitParData)
+{
+   // Build the Gaussian fit mode for the pulls, then fit it and plot it. We
+   // have to use the RooWorkspace factory here, because different from the
+   // RooMCStudy class, the RooGaussian is not in RooFitCore.
+   RooWorkspace ws;
+   auto plotVar = frame.getPlotVar();
+   const std::string plotVarName = plotVar->GetName();
+   ws.import(*plotVar);
+   ws.factory("Gaussian::pullGauss(" + plotVarName  + ", pullMean[0.0, -10.0, 10.0], pullSigma[1.0, 0.1, 5.0])");
+
+   fitGaussAndPlotOnFrame(frame, fitParData, *ws.pdf("pullGauss"), *ws.var("pullMean"), *ws.var("pullSigma"));
+}
+
+} // namespace
+
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -937,6 +1033,7 @@ RooPlot* RooMCStudy::plotParamOn(RooPlot* frame, const RooCmdArg& arg1, const Ro
 /// <tr><td> FrameBins(int bins)              <td> Set default number of bins of frame to given number
 /// <tr><td> Frame()                       <td> Pass supplied named arguments to RooAbsRealLValue::frame() function. See there
 ///     for list of allowed arguments
+/// <tr><td> FitGauss(bool flag)            <td> Add a gaussian fit to the frame
 /// </table>
 /// If no frame specifications are given, the AutoRange() feature will be used to set the range
 /// Any other named argument is passed to the RooAbsData::plotOn() call. See that function for allowed options
@@ -975,7 +1072,22 @@ RooPlot* RooMCStudy::plotParam(const RooRealVar& param, const RooCmdArg& arg1, c
 
   RooPlot* frame = makeFrameAndPlotCmd(param, cmdList) ;
   if (frame) {
+
+    // Pick up optional FitGauss command from list
+    RooCmdConfig pc("RooMCStudy::plotParam(" + std::string(_genModel->GetName()) + ")");
+    pc.defineInt("fitGauss","FitGauss",0,0) ;
+    pc.allowUndefined() ;
+    pc.process(cmdList) ;
+    bool fitGauss=pc.getInt("fitGauss") ;
+
+    // Pass stripped command list to plotOn()
+    RooCmdConfig::stripCmdList(cmdList,"FitGauss") ;
     _fitParData->plotOn(frame, cmdList) ;
+
+    // Add Gaussian fit if requested
+    if (fitGauss) {
+      fitGaussToFrame(*frame, *_fitParData);
+    }
   }
 
   return frame ;
@@ -992,6 +1104,7 @@ RooPlot* RooMCStudy::plotParam(const RooRealVar& param, const RooCmdArg& arg1, c
 /// <tr><td> FrameBins(int bins)              <td> Set default number of bins of frame to given number
 /// <tr><td> Frame()                       <td> Pass supplied named arguments to RooAbsRealLValue::frame() function. See there
 ///     for list of allowed arguments
+/// <tr><td> FitGauss(bool flag)            <td> Add a gaussian fit to the frame
 /// </table>
 ///
 /// If no frame specifications are given, the AutoRange() feature will be used to set the range.
@@ -1016,6 +1129,7 @@ RooPlot* RooMCStudy::plotNLL(const RooCmdArg& arg1, const RooCmdArg& arg2,
 /// <tr><td> FrameBins(int bins)              <td> Set default number of bins of frame to given number
 /// <tr><td> Frame()                       <td> Pass supplied named arguments to RooAbsRealLValue::frame() function. See there
 ///     for list of allowed arguments
+/// <tr><td> FitGauss(bool flag)            <td> Add a gaussian fit to the frame
 /// </table>
 ///
 /// If no frame specifications are given, the AutoRange() feature will be used to set a default range.
@@ -1041,46 +1155,6 @@ RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, c
   return frame ;
 }
 
-namespace {
-
-// Fits a Gaussian to the pull distribution, plots the fit and prints the fit
-// parameters on the canvas. Implementation detail of RooMCStudy::plotPull().
-void fitGaussToPulls(RooPlot& frame, RooDataSet& fitParData)
-{
-   // Build the Gaussian fit mode for the pulls, then fit it and plot it. We
-   // have to use the RooWorkspace factory here, because different from the
-   // RooMCStudy class, the RooGaussian is not in RooFitCore.
-   RooWorkspace ws;
-   auto plotVar = frame.getPlotVar();
-   const std::string plotVarName = plotVar->GetName();
-   ws.import(*plotVar);
-   ws.factory("Gaussian::pullGauss(" + plotVarName  + ", pullMean[0.0, -10.0, 10.0], pullSigma[1.0, 0.1, 5.0])");
-
-   RooRealVar& pullMean = *ws.var("pullMean");
-   RooRealVar& pullSigma = *ws.var("pullSigma");
-   RooAbsPdf& pullGauss = *ws.pdf("pullGauss");
-
-   pullGauss.fitTo(fitParData, RooFit::Minos(false), RooFit::PrintLevel(-1)) ;
-   pullGauss.plotOn(&frame) ;
-
-   // Instead of using paramOn() without command arguments to plot the fit
-   // parameters, we are building the parameter label ourselves for more
-   // flexibility and pass this together with an appropriate layout
-   // parametrization to paramOn().
-   const int sigDigits = 2;
-   const char * options = "ELU";
-   std::stringstream ss;
-   ss << "Fit parameters:\n"
-      << "#mu: " << pullMean.format(sigDigits, options)
-      << "\n#sigma: " << pullSigma.format(sigDigits, options);
-   // We set the parameters constant to disable the default label. Still, we
-   // use param() on as a wrapper for the text box generation.
-   pullMean.setConstant(true);
-   pullSigma.setConstant(true);
-   pullGauss.paramOn(&frame, RooFit::Label(ss.str().c_str()), RooFit::Layout(0.60, 0.9, 0.9));
-}
-
-} // namespace
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/test/testRooMCStudy.cxx
+++ b/roofit/roofitcore/test/testRooMCStudy.cxx
@@ -3,9 +3,12 @@
 
 #include <RooAbsPdf.h>
 #include <RooArgSet.h>
+#include <RooCurve.h>
 #include <RooDataSet.h>
+#include <RooGlobalFunc.h>
 #include <RooHelpers.h>
 #include <RooMCStudy.h>
+#include <RooPlot.h>
 #include <RooRandom.h>
 #include <RooRealVar.h>
 #include <RooWorkspace.h>
@@ -13,8 +16,10 @@
 #include "gtest_wrapper.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -40,6 +45,38 @@ std::vector<double> getColumn(RooDataSet const &data, const char *name)
       out.push_back(var->getVal());
    }
    return out;
+}
+
+/// Returns the peak position and the width of the last curve on the frame,
+/// estimated from the full width at half maximum. Used to validate the
+/// Gaussian that FitGauss() fits to the plotted distribution.
+std::pair<double, double> curvePeakAndWidth(RooPlot &frame)
+{
+   // Not frame.getCurve(), because that returns the last item on the frame,
+   // which is the box with the fit parameters and not the fitted curve.
+   auto *curve = static_cast<RooCurve *>(frame.findObject(nullptr, RooCurve::Class()));
+   if (curve == nullptr) {
+      throw std::runtime_error("frame has no curve");
+   }
+   const int nPoints = curve->GetN();
+   double yMax = -std::numeric_limits<double>::infinity();
+   double xPeak = 0.0;
+   for (int i = 0; i < nPoints; ++i) {
+      if (curve->GetPointY(i) > yMax) {
+         yMax = curve->GetPointY(i);
+         xPeak = curve->GetPointX(i);
+      }
+   }
+   double xLo = std::numeric_limits<double>::infinity();
+   double xHi = -std::numeric_limits<double>::infinity();
+   for (int i = 0; i < nPoints; ++i) {
+      if (curve->GetPointY(i) >= 0.5 * yMax) {
+         xLo = std::min(xLo, curve->GetPointX(i));
+         xHi = std::max(xHi, curve->GetPointX(i));
+      }
+   }
+   // 2 * sqrt(2 * log(2)) converts the full width at half maximum to a sigma
+   return {xPeak, (xHi - xLo) / 2.3548200450309493};
 }
 
 } // namespace
@@ -122,6 +159,100 @@ TEST(RooMCStudy, GenParDataSetInternalConstraints)
    EXPECT_EQ(genParData->numEntries(), nToys);
    EXPECT_NE(genParData->get()->find("s"), nullptr);
    EXPECT_NE(mcstudy.fitParDataSet().get()->find("s_gen"), nullptr);
+}
+
+/// Covers GitHub issue #12387: the FitGauss() command argument should work
+/// not only for plotPull(), but also for the functions that plot the fitted
+/// values, their errors and the NLL distribution, because users need Gaussian
+/// fits of the parameter distribution for linearity tests.
+TEST(RooMCStudy, FitGauss)
+{
+   RooRandom::randomGenerator()->SetSeed(4357);
+   RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING};
+
+   RooWorkspace ws;
+   fillModel(ws);
+
+   RooMCStudy mcstudy{*ws.pdf("pdf"), *ws.var("x"), RooFit::Silence(), RooFit::FitOptions(RooFit::PrintLevel(-1))};
+   mcstudy.generateAndFit(50, 200);
+
+   // Without FitGauss(), the frame only contains the data histogram
+   std::unique_ptr<RooPlot> frame1{mcstudy.plotParam(*ws.var("s"), RooFit::Bins(40))};
+   ASSERT_NE(frame1, nullptr);
+   EXPECT_EQ(frame1->numItems(), 1);
+
+   // With FitGauss(), the fitted Gaussian curve and the box with the fitted
+   // mean and sigma are added to the frame
+   std::unique_ptr<RooPlot> frame2{mcstudy.plotParam(*ws.var("s"), RooFit::Bins(40), RooFit::FitGauss(true))};
+   ASSERT_NE(frame2, nullptr);
+   EXPECT_EQ(frame2->numItems(), 3);
+
+   // FitGauss() is also supported by plotError() and plotNLL(), which are
+   // implemented via plotParam()
+   std::unique_ptr<RooPlot> frame3{mcstudy.plotError(*ws.var("s"), RooFit::Bins(40), RooFit::FitGauss(true))};
+   ASSERT_NE(frame3, nullptr);
+   EXPECT_EQ(frame3->numItems(), 3);
+
+   std::unique_ptr<RooPlot> frame4{mcstudy.plotNLL(RooFit::Bins(40), RooFit::FitGauss(true))};
+   ASSERT_NE(frame4, nullptr);
+   EXPECT_EQ(frame4->numItems(), 3);
+
+   // The existing FitGauss() support in plotPull() must be unchanged
+   std::unique_ptr<RooPlot> frame5{mcstudy.plotPull(*ws.var("s"), RooFit::Bins(40), RooFit::FitGauss(true))};
+   ASSERT_NE(frame5, nullptr);
+   EXPECT_EQ(frame5->numItems(), 3);
+}
+
+/// Also covers GitHub issue #12387: the Gaussian that FitGauss() adds must
+/// actually describe the plotted distribution. The parameters of that Gaussian
+/// are seeded from the moments of the distribution, because seeding them from
+/// the frame range instead fails in two ways: the fitted width runs into a
+/// limit if the distribution is much narrower than the frame, and the fitted
+/// mean is off if the frame range can't be represented precisely enough in the
+/// RooWorkspace factory expression that builds the Gaussian.
+TEST(RooMCStudy, FitGaussSeeding)
+{
+   // Both the width of the frame relative to the distribution and the absolute
+   // scale of the fitted parameter are relevant here, so they are scanned.
+   // The offset 1000000.5 is deliberately a value that a low-precision string
+   // representation of the frame range would not resolve.
+   for (double offset : {0.0, 1000000.5}) {
+      for (bool wideFrame : {false, true}) {
+         RooRandom::randomGenerator()->SetSeed(4357);
+         RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING};
+
+         RooWorkspace ws;
+         ws.factory("x[" + std::to_string(offset - 10.0) + ", " + std::to_string(offset + 10.0) + "]");
+         ws.factory("Gaussian::pdf(x, m[" + std::to_string(offset) + ", " + std::to_string(offset - 5.0) + ", " +
+                    std::to_string(offset + 5.0) + "], s[1.0, 0.1, 5.0])");
+
+         RooMCStudy mcstudy{*ws.pdf("pdf"), *ws.var("x"), RooFit::Silence(),
+                            RooFit::FitOptions(RooFit::PrintLevel(-1))};
+         // Many events per toy, so that the distribution of the fitted parameter is
+         // much narrower than the wide frame range below.
+         mcstudy.generateAndFit(100, 5000);
+
+         auto const &fitParData = mcstudy.fitParDataSet();
+         auto const &mFit = static_cast<RooRealVar const &>(*fitParData.get()->find("m"));
+         const double dataMean = fitParData.mean(mFit);
+         const double dataSigma = fitParData.sigma(mFit);
+
+         // Without FrameRange(), the frame is auto-ranged around the
+         // distribution. With it, the frame is much wider than the distribution.
+         RooCmdArg frameRange = wideFrame ? RooFit::Range(offset - 5.0, offset + 5.0) : RooCmdArg::none();
+         std::unique_ptr<RooPlot> frame{
+            mcstudy.plotParam(*ws.var("m"), RooFit::Bins(40), RooFit::FitGauss(true), frameRange)};
+         ASSERT_NE(frame, nullptr);
+         ASSERT_EQ(frame->numItems(), 3);
+
+         auto const [peak, width] = curvePeakAndWidth(*frame);
+         const std::string ctx =
+            "offset = " + std::to_string(offset) + ", wideFrame = " + std::to_string(wideFrame);
+         EXPECT_NEAR(peak, dataMean, 0.5 * dataSigma) << ctx;
+         EXPECT_GT(width, 0.5 * dataSigma) << ctx;
+         EXPECT_LT(width, 2.0 * dataSigma) << ctx;
+      }
+   }
 }
 
 /// Covers the fitParData/genParData size mismatch from the discussion in

--- a/tutorials/roofit/roofit/rf801_mcstudy.C
+++ b/tutorials/roofit/roofit/rf801_mcstudy.C
@@ -87,8 +87,10 @@ void rf801_mcstudy()
    // E x p l o r e   r e s u l t s   o f   s t u d y
    // ------------------------------------------------
 
-   // Make plots of the distributions of mean, the error on mean and the pull of mean
-   RooPlot *frame1 = mcstudy->plotParam(mean, Bins(40));
+   // Make plots of the distributions of mean, the error on mean and the pull of mean.
+   // The FitGauss() option overlays a Gaussian fit of the plotted distribution,
+   // which is for example useful for linearity studies of the fitted parameter.
+   RooPlot *frame1 = mcstudy->plotParam(mean, Bins(40), FitGauss(true));
    RooPlot *frame2 = mcstudy->plotError(mean, Bins(40));
    RooPlot *frame3 = mcstudy->plotPull(mean, Bins(40), FitGauss(true));
 

--- a/tutorials/roofit/roofit/rf801_mcstudy.py
+++ b/tutorials/roofit/roofit/rf801_mcstudy.py
@@ -80,8 +80,10 @@ mcstudy.generateAndFit(1000)
 # ------------------------------------------------
 
 # Make plots of the distributions of mean, error on mean and the pull of
-# mean
-frame1 = mcstudy.plotParam(mean, Bins=40)
+# mean. The FitGauss option overlays a Gaussian fit of the plotted
+# distribution, which is for example useful for linearity studies of the
+# fitted parameter.
+frame1 = mcstudy.plotParam(mean, Bins=40, FitGauss=True)
 frame2 = mcstudy.plotError(mean, Bins=40)
 frame3 = mcstudy.plotPull(mean, Bins=40, FitGauss=True)
 


### PR DESCRIPTION
So far, the FitGauss() command argument that overlays a Gaussian fit of the plotted distribution was only implemented for RooMCStudy::plotPull(). It is now also supported by plotParam(), and hence by plotError() and plotNLL(), which are implemented in terms of plotParam(). Fitting the distribution of the parameter itself with a Gaussian is what one needs for linearity studies, which is why it was requested in the issue.

The code that fits the Gaussian, overlays it and adds the box with the fitted parameters is shared between the pull and the parameter case.

The parameters of the Gaussian are seeded from the moments of the plotted distribution. Seeding them from the frame range instead would fail in two ways: the fitted width runs into the parameter limit if the distribution is much narrower than the frame, and the fitted mean is off if the frame range is not resolved by the precision of the RooWorkspace factory expression that builds the Gaussian.

Closes #12387.

🤖 Done with the help of AI