### PR TITLE
[RF] Make the code emitted by codegen locale-independent

### DIFF
--- a/roofit/codegen/CMakeLists.txt
+++ b/roofit/codegen/CMakeLists.txt
@@ -34,3 +34,5 @@ if(NOT CMAKE_VERSION VERSION_LESS "3.23.0")
           inc/RooFit/CodegenImpl.h
   )
 endif()
+
+ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/codegen/src/CodegenImpl.cxx
+++ b/roofit/codegen/src/CodegenImpl.cxx
@@ -66,6 +66,7 @@
 
 #include <TInterpreter.h>
 
+#include <locale>
 #include <unordered_set>
 
 namespace RooFit::Experimental {
@@ -76,6 +77,9 @@ namespace {
 std::string doubleToString(double val)
 {
    std::stringstream ss;
+   // The formatting must not depend on the global locale: a comma decimal
+   // separator (e.g. from a German locale) would corrupt the generated C++.
+   ss.imbue(std::locale::classic());
    ss << std::setprecision(std::numeric_limits<double>::max_digits10) << val;
    return ss.str();
 }

--- a/roofit/codegen/test/CMakeLists.txt
+++ b/roofit/codegen/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+ROOT_ADD_GTEST(testCodegen testCodegen.cxx LIBRARIES RooFitCore RooFit RooFitCodegen)

--- a/roofit/codegen/test/testCodegen.cxx
+++ b/roofit/codegen/test/testCodegen.cxx
@@ -1,0 +1,114 @@
+// Tests for the C++ code that the RooFit codegen backend generates.
+// Author: Jonas Rembser, CERN 2026
+
+#include <RooFit/CodegenContext.h>
+
+#include <RooChebychev.h>
+#include <RooConstVar.h>
+#include <RooGaussian.h>
+#include <RooRealVar.h>
+
+#include <gtest/gtest.h>
+
+#include <locale>
+#include <regex>
+#include <sstream>
+#include <string>
+
+namespace {
+
+/// Formats decimal points as ',' like a German locale does. Such a locale is
+/// not installed on every test machine, so it is built from a custom facet
+/// instead of requested by name. The resulting locale is unnamed, so making it
+/// global does not also switch the C locale that std::strtod() uses.
+struct CommaPunct : std::numpunct<char> {
+   char do_decimal_point() const override { return ','; }
+};
+
+/// Generate the code for `arg` with `loc` as the global locale, restoring the
+/// previous global locale even if code generation throws.
+std::string codeUnderLocale(RooAbsArg &arg, std::locale const &loc)
+{
+   const std::locale old = std::locale::global(loc);
+   std::string code;
+   try {
+      RooFit::Experimental::CodegenContext ctx;
+      ctx.buildFunction(arg);
+      code = ctx.collectedCode();
+   } catch (...) {
+      std::locale::global(old);
+      throw;
+   }
+   std::locale::global(old);
+   return code;
+}
+
+/// Erase the global counter from the generated function name, which differs
+/// between two code generations of the same model.
+std::string normalized(std::string const &code)
+{
+   return std::regex_replace(code, std::regex{"roo_codegen_[0-9]+"}, "roo_codegen_N");
+}
+
+/// How a plain stream formats 0.5 under `loc`, to verify that the facet is
+/// actually in effect (otherwise the tests below would pass vacuously).
+std::string formatWithStream(double val, std::locale const &loc)
+{
+   const std::locale old = std::locale::global(loc);
+   std::stringstream ss;
+   ss << val;
+   std::locale::global(old);
+   return ss.str();
+}
+
+} // namespace
+
+// The generated code is C++ source, so its number formatting must not follow
+// the global locale: under a comma-decimal locale the literals came out as
+// "0,5", which does not compile, and inside a function call argument list the
+// comma even turns one argument into two.
+TEST(RooFitCodegen, ValueLiteralsAreLocaleIndependent)
+{
+   const std::locale comma{std::locale::classic(), new CommaPunct};
+   ASSERT_EQ(formatWithStream(0.5, comma), "0,5");
+
+   RooRealVar x{"x", "x", 0.5, -10, 10};
+   RooRealVar mean{"mean", "mean", 1.25};
+   RooConstVar sigma{"sigma", "sigma", 0.75};
+   RooGaussian gauss{"gauss", "gauss", x, mean, sigma};
+   x.setConstant(true);
+   mean.setConstant(true);
+
+   const std::string code = codeUnderLocale(gauss, comma);
+
+   EXPECT_EQ(normalized(code), normalized(codeUnderLocale(gauss, std::locale::classic())));
+   for (const char *literal : {"0.5", "1.25", "0.75"}) {
+      EXPECT_NE(code.find(literal), std::string::npos) << literal << " missing from:\n" << code;
+   }
+   for (const char *corrupted : {"0,5", "1,25", "0,75"}) {
+      EXPECT_EQ(code.find(corrupted), std::string::npos) << corrupted << " emitted in:\n" << code;
+   }
+}
+
+// Same for the doubles that the codegen implementations pass to the generated
+// function calls directly (here the observable range of RooChebychev), which
+// are formatted by CodegenContext::buildArg() and not by codegen's
+// doubleToString().
+TEST(RooFitCodegen, CallArgumentsAreLocaleIndependent)
+{
+   const std::locale comma{std::locale::classic(), new CommaPunct};
+
+   RooRealVar x{"x", "x", 0.125, -0.5, 2.25};
+   RooRealVar a1{"a1", "a1", 0.375};
+   RooChebychev cheby{"cheby", "cheby", x, a1};
+
+   const std::string code = codeUnderLocale(cheby, comma);
+
+   EXPECT_EQ(normalized(code), normalized(codeUnderLocale(cheby, std::locale::classic())));
+   for (const char *literal : {"-0.5", "2.25", "0.375"}) {
+      EXPECT_NE(code.find(literal), std::string::npos) << literal << " missing from:\n" << code;
+   }
+   for (const char *corrupted : {"0,5", "2,25", "0,375"}) {
+      EXPECT_EQ(code.find(corrupted), std::string::npos) << corrupted << " emitted in:\n" << code;
+   }
+}

--- a/roofit/roofitcore/inc/RooFit/CodegenContext.h
+++ b/roofit/roofitcore/inc/RooFit/CodegenContext.h
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <iomanip>
+#include <locale>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -139,6 +140,7 @@ private:
    std::string buildArg(T x)
    {
       std::stringstream ss;
+      ss.imbue(std::locale::classic()); // the generated code is C++, not locale-dependent text
       ss << std::setprecision(std::numeric_limits<double>::max_digits10) << x;
       return ss.str();
    }
@@ -215,6 +217,7 @@ std::string CodegenContext::buildArgSpanImpl(std::span<const T> arr)
    unsigned int n = arr.size();
    std::string arrName = getTmpVarName();
    std::stringstream ss;
+   ss.imbue(std::locale::classic()); // the generated code is C++, not locale-dependent text
    ss << typeName<T>() << " " << arrName << "[" << n << "] = {";
    for (unsigned int i = 0; i < n; i++) {
       ss << " " << arr[i] << ",";

--- a/roofit/roofitcore/src/RooFit/CodegenContext.cxx
+++ b/roofit/roofitcore/src/RooFit/CodegenContext.cxx
@@ -22,6 +22,7 @@
 #include <cctype>
 #include <charconv>
 #include <fstream>
+#include <locale>
 #include <type_traits>
 #include <unordered_map>
 
@@ -285,6 +286,7 @@ std::string CodegenContext::buildArg(std::span<const double> arr)
 CodegenContext::ScopeRAII::ScopeRAII(RooAbsArg const *arg, CodegenContext &ctx) : _ctx(ctx), _arg(arg)
 {
    std::ostringstream os;
+   os.imbue(std::locale::classic()); // the generated code is C++, not locale-dependent text
    Option_t *opts = nullptr;
    arg->printStream(os, _arg->defaultPrintContents(opts), _arg->defaultPrintStyle(opts));
    _fn = os.str();


### PR DESCRIPTION
The codegen backend formats the numbers it writes into the generated C++ with default-constructed streams, which follow the global locale. Under a comma-decimal locale (a German one, say) the emitted literals came out as "0,5": that does not compile, and inside a call argument list the comma even turns one argument into two, so the generated code silently changes meaning instead of failing.

Imbue the classic locale on every stream whose output ends up in the generated code: CodegenImpl's doubleToString(), which formats the value of RooConstVar/RooRealVar and the analytical integrals, plus CodegenContext's buildArg() for double arguments, buildArgSpanImpl() for the emitted arrays (where a grouping separator would corrupt integers the same way), and the stream that renders the node descriptions into the code comments.

Add a regression test that generates the code for a RooGaussian with constant parameters and for a RooChebychev (whose observable range is passed to the generated call as a plain double) under a comma-decimal locale, built from a custom numpunct facet because no such OS locale is installed everywhere. Both must produce exactly the code they produce under the classic locale. This is the first test for the codegen package, so it also adds roofit/codegen/test/.

🤖 Done with the help of AI

