### PR TITLE
[clang] Simplify updating `CodeGenOptions`

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -556,8 +556,7 @@ namespace cling {
 
   llvm::Module* IncrementalParser::StartModule() {
     return m_Interpreter->withLLVMContextDo([&](llvm::LLVMContext* Ctx) {
-      return getCodeGenerator()->StartModule(makeModuleName(), *Ctx,
-                                             getCI()->getCodeGenOpts());
+      return getCodeGenerator()->StartModule(makeModuleName(), *Ctx);
     });
   }
 

--- a/interpreter/llvm-project/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/interpreter/llvm-project/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -113,9 +113,6 @@ public:
   /// enable codegen in interactive processing environments.
   llvm::Module* StartModule(llvm::StringRef ModuleName, llvm::LLVMContext &C);
 
-  llvm::Module *StartModule(llvm::StringRef ModuleName, llvm::LLVMContext &C,
-                            const CodeGenOptions &CGO);
-
   void forgetGlobal(llvm::GlobalValue *GV);
   void forgetDecl(llvm::StringRef MangledName);
 };

--- a/interpreter/llvm-project/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/interpreter/llvm-project/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -38,7 +38,7 @@ namespace clang {
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS; // Only used for debug info.
     const HeaderSearchOptions &HeaderSearchOpts; // Only used for debug info.
     const PreprocessorOptions &PreprocessorOpts; // Only used for debug info.
-    CodeGenOptions CodeGenOpts;                  // Intentionally copied in.
+    const CodeGenOptions &CodeGenOpts;
 
     unsigned HandlingTopLevelDecls;
 
@@ -265,12 +265,6 @@ namespace clang {
         OldBuilder->moveLazyEmissionStates(Builder.get());
 
       return M.get();
-    }
-
-    llvm::Module *StartModule(llvm::StringRef ModuleName, llvm::LLVMContext &C,
-                              const CodeGenOptions &CGO) {
-      CodeGenOpts = CGO;
-      return StartModule(ModuleName, C);
     }
 
     void forgetGlobal(llvm::GlobalValue *GV) {
@@ -509,13 +503,6 @@ void CodeGenerator::print(llvm::raw_ostream& out) {
 llvm::Module *CodeGenerator::StartModule(llvm::StringRef ModuleName,
                                          llvm::LLVMContext &C) {
   return static_cast<CodeGeneratorImpl*>(this)->StartModule(ModuleName, C);
-}
-
-llvm::Module *CodeGenerator::StartModule(llvm::StringRef ModuleName,
-                                         llvm::LLVMContext &C,
-                                         const CodeGenOptions &CGO) {
-  return static_cast<CodeGeneratorImpl *>(this)->StartModule(ModuleName, C,
-                                                             CGO);
 }
 
 void CodeGenerator::forgetGlobal(llvm::GlobalValue *GV) {


### PR DESCRIPTION
This works now since upstream commit https://github.com/llvm/llvm-project/commit/ddeab07ca63235f8d952e1171b56fdb0f2d761c9 changed the intentional copy in `CodeGeneratorImpl` to a reference with a single copy of the `CodeGenOptions` stored in the `CompilerInvocation`.

This reverts the downstream modifications from commit 0d60867be9, allowing to drop one more Clang patch.