### PR TITLE
[core] Add missing standard library includes

### DIFF
--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -1,13 +1,6 @@
 #ifndef ROOT_TEfficiency_cxx
 #define ROOT_TEfficiency_cxx
 
-//standard header
-#include <vector>
-#include <string>
-#include <cmath>
-#include <cstdlib>
-#include <cassert>
-
 //ROOT headers
 #include "Math/DistFuncMathCore.h"
 #include "TBinomialEfficiencyFitter.h"
@@ -32,6 +25,14 @@
 
 // file with extra class for FC method
 #include "TEfficiencyHelper.h"
+
+//standard header
+#include <vector>
+#include <string>
+#include <cmath>
+#include <cstdlib>
+#include <cassert>
+#include <ostream>
 
 //default values
 const Double_t kDefBetaAlpha = 1;

--- a/hist/hist/src/TF12.cxx
+++ b/hist/hist/src/TF12.cxx
@@ -13,6 +13,7 @@
 #include "TH1.h"
 #include "TVirtualPad.h"
 
+#include <ostream>
 
 /** \class TF12
     \ingroup Functions

--- a/hist/hist/test/test_tkde.cxx
+++ b/hist/hist/test/test_tkde.cxx
@@ -10,6 +10,7 @@
 #include "TH1.h"
 #include "Math/DistFuncMathCore.h"
 
+#include <iostream>
 
 struct TestKDE {
 

--- a/math/mathcore/test/fit/testGraphFit.cxx
+++ b/math/mathcore/test/fit/testGraphFit.cxx
@@ -20,6 +20,7 @@
 #include "TStyle.h"
 
 #include <vector>
+#include <iostream>
 #include <iterator>
 #include <cassert>
 

--- a/math/mathcore/test/testDistSampler.cxx
+++ b/math/mathcore/test/testDistSampler.cxx
@@ -9,6 +9,9 @@
 #include "TRandom.h"
 #include "TError.h"
 #include "TCanvas.h"
+
+#include <iostream>
+
 // double Pdf(double x) {
 // }
 

--- a/test/stress.cxx
+++ b/test/stress.cxx
@@ -71,7 +71,6 @@
 //_____________________________batch only_____________________
 #ifndef __CLING__
 
-#include <cstdlib>
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TH1.h>
@@ -99,6 +98,9 @@
 #include <Compression.h>
 #include <snprintf.h>
 #include "Event.h"
+
+#include <cstdlib>
+#include <iostream>
 
 void stress(Int_t nevent, Int_t style, Int_t printSubBenchmark, UInt_t portion );
 void stress1();

--- a/tutorials/analysis/unfold/testUnfold2.C
+++ b/tutorials/analysis/unfold/testUnfold2.C
@@ -78,6 +78,8 @@
 #include <TGraph.h>
 #include "TUnfold.h"
 
+#include <iostream>
+
 
 TRandom *rnd=nullptr;
 

--- a/tutorials/hist/hist101_TH1_autobinning.C
+++ b/tutorials/hist/hist101_TH1_autobinning.C
@@ -19,6 +19,8 @@
 #include "TFile.h"
 #include "TStyle.h"
 
+#include <iostream>
+
 TF1 *gam = new TF1("gam", "1/(1+0.1*x*0.1*x)", -100., 100.);
 TF1 *gam1 = new TF1("gam", "1/(1+0.1*x*0.1*x)", -1., .25);
 TF1 *iga = new TF1("inv gam", "1.-1/(1+0.1*x*0.1*x)", -100., 100.);

--- a/tutorials/math/fit/FitHistoInFile.C
+++ b/tutorials/math/fit/FitHistoInFile.C
@@ -19,6 +19,8 @@
 #include "TFile.h"
 #include "TStyle.h"
 
+#include <iostream>
+
 // Function parameters are passed as an array to TF1. Here, we
 // define the position of each parameter in this array.
 // Note: N_PAR will give us the total number of parameters. Make

--- a/tutorials/math/goftest.C
+++ b/tutorials/math/goftest.C
@@ -13,7 +13,6 @@
 ///
 /// \author Bartolomeu Rabacal
 
-#include <cassert>
 #include "TCanvas.h"
 #include "TPaveText.h"
 #include "TH1.h"
@@ -22,6 +21,9 @@
 #include "Math/Functor.h"
 #include "TRandom3.h"
 #include "Math/DistFunc.h"
+
+#include <cassert>
+#include <iostream>
 
 // need to use Functor1D
 double landau(double x) {


### PR DESCRIPTION
Several files use std::cout/std::cerr or std::ostream without including <iostream> or <ostream> themselves, and only compile because Math/ParamFunctor.h transitively pulls in <iostream>.

Add the includes where they are used, so that ParamFunctor.h can drop its own <iostream> include without breaking these translation units.

Where a file already listed standard library headers before its ROOT includes, reorder them to follow the convention of ROOT headers first, then other libraries, then the standard library.

FYI, @hageboeck 

