### PR TITLE
[tmva][sofie] Reset operator-fusion state for each parsed graph

### DIFF
--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -660,6 +660,16 @@ void RModelParser_ONNX::ParseONNXGraph(RModel & rmodel, const onnx::GraphProto &
    if (verbose)
       std::cout << "\nParsing Graph - " << graphName << std::endl;
 
+   // fFusedOperators is keyed by node index, so it is only valid for the graph
+   // being parsed: neither a second model parsed with the same parser nor a
+   // subgraph (e.g. of the If operator) may inherit it.
+   struct FusedOperatorsGuard {
+      std::map<int, std::pair<EFusedOp, int>> &fMap;
+      std::map<int, std::pair<EFusedOp, int>> fSaved;
+      FusedOperatorsGuard(std::map<int, std::pair<EFusedOp, int>> &map) : fMap(map) { fSaved.swap(fMap); }
+      ~FusedOperatorsGuard() { fMap.swap(fSaved); }
+   } fusedOperatorsGuard{fFusedOperators};
+
    std::unordered_set<std::string> initializer_names;
    for (int i = 0; i < graph.initializer_size(); i++) {
       initializer_names.insert(graph.initializer(i).name());


### PR DESCRIPTION
RModelParser_ONNX::fFusedOperators records operator-fusion decisions (e.g. Gemm+Relu) keyed by node index, but was never cleared.  Reusing one parser instance for a second model replayed the stale fusion decisions of the first model against unrelated nodes, leading to wrong models or crashes (e.g. a segfault in ParseFuseGemmRelu when the stale index points to a zero-input Constant node).

The map is also per-graph state: ParseONNXGraph is called recursively for the subgraphs of the If operator, whose node indices would collide with those of the enclosing graph.

🤖 Done with the help of AI