### PR TITLE
[ntupleutil] add RNTupleInspector::GetPagesPerClusterDistribution

### DIFF
--- a/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
+++ b/tree/ntupleutil/inc/ROOT/RNTupleInspector.hxx
@@ -105,7 +105,9 @@ public:
          : fColumnDescriptor(colDesc),
            fCompressedPageSizes(compressedPageSizes),
            fElementSize(elemSize),
-           fNElements(nElems){};
+           fNElements(nElems)
+      {
+      }
       ~RColumnInspector() = default;
 
       const ROOT::RColumnDescriptor &GetDescriptor() const { return fColumnDescriptor; }
@@ -136,7 +138,9 @@ public:
 
    public:
       RFieldTreeInspector(const ROOT::RFieldDescriptor &fieldDesc, std::uint64_t onDiskSize, std::uint64_t inMemSize)
-         : fRootFieldDescriptor(fieldDesc), fCompressedSize(onDiskSize), fUncompressedSize(inMemSize){};
+         : fRootFieldDescriptor(fieldDesc), fCompressedSize(onDiskSize), fUncompressedSize(inMemSize)
+      {
+      }
       ~RFieldTreeInspector() = default;
 
       const ROOT::RFieldDescriptor &GetDescriptor() const { return fRootFieldDescriptor; }


### PR DESCRIPTION
Adding a method to create a histogram of number of pages per cluster in an RNTuple. Entries are aggregated in this way:
- each column type gets its own histogram
- pages of all columns of the same type are aggregated per-cluster

Example output:
<img width="1210" height="882" alt="image" src="https://github.com/user-attachments/assets/7e448e83-4882-4eed-88fa-0a705a080426" />

