### PR TITLE
[llvm] Backport ORC dependence propagation performance fix

### DIFF
--- a/interpreter/llvm-project/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
+++ b/interpreter/llvm-project/llvm/include/llvm/ExecutionEngine/Orc/WaitingOnGraph.h
@@ -266,9 +266,9 @@ public:
     }
 
     SuperNodeDepsMap SuperNodeDeps;
-    hoistDeps(SuperNodeDeps, SNs, ElemToSN);
-    propagateSuperNodeDeps(SuperNodeDeps);
-    sinkDeps(SNs, SuperNodeDeps);
+    for (auto &SN : SNs)
+      hoistDeps(SN.get(), SuperNodeDeps, ElemToSN);
+    propagateDeps(SuperNodeDeps);
 
     // Pre-coalesce nodes.
     Coalescer().coalesce(SNs, ElemToSN);
@@ -296,25 +296,16 @@ public:
     // First process any dependencies on nodes with external state.
     auto FailedSNs = processExternalDeps(NewSNs, GetExternalState);
 
-    // Collect the PendingSNs whose dep sets are about to be modified.
+    SuperNodeDepsMap SuperNodeDeps;
+
+    // Collect the PendingSNs whose dep sets are about to be modified. Hoisting
+    // the deps tells us whether the node was affected by this emit.
     std::vector<std::unique_ptr<SuperNode>> ModifiedPendingSNs;
+    DenseSet<SuperNode *> ModifiedPendingSNSet;
     for (size_t I = 0; I != PendingSNs.size();) {
       auto &SN = PendingSNs[I];
-      bool Remove = false;
-      for (auto &[Container, Elems] : SN->Deps) {
-        auto I = ElemToNewSN.find(Container);
-        if (I == ElemToNewSN.end())
-          continue;
-        for (auto Elem : Elems) {
-          if (I->second.contains(Elem)) {
-            Remove = true;
-            break;
-          }
-        }
-        if (Remove)
-          break;
-      }
-      if (Remove) {
+      if (hoistDeps(SN.get(), SuperNodeDeps, ElemToNewSN)) {
+        ModifiedPendingSNSet.insert(SN.get());
         ModifiedPendingSNs.push_back(std::move(SN));
         std::swap(SN, PendingSNs.back());
         PendingSNs.pop_back();
@@ -322,25 +313,22 @@ public:
         ++I;
     }
 
-    // Remove cycles from the graphs.
-    SuperNodeDepsMap SuperNodeDeps;
-    hoistDeps(SuperNodeDeps, ModifiedPendingSNs, ElemToNewSN);
-
+    // Remove SNs whose deps have been modified from the coalescer.
     CoalesceToPendingSNs.remove(
-        [&](SuperNode *SN) { return SuperNodeDeps.count(SN); });
+        [&](SuperNode *SN) { return ModifiedPendingSNSet.count(SN); });
 
-    hoistDeps(SuperNodeDeps, NewSNs, ElemToPendingSN);
-    propagateSuperNodeDeps(SuperNodeDeps);
-    sinkDeps(NewSNs, SuperNodeDeps);
-    sinkDeps(ModifiedPendingSNs, SuperNodeDeps);
+    for (auto &SN : NewSNs)
+      hoistDeps(SN.get(), SuperNodeDeps, ElemToPendingSN);
+
+    propagateDeps(SuperNodeDeps);
+    propagateFailures(FailedSNs, SuperNodeDeps);
 
     // Process supernodes. Pending first, since we'll update PendingSNs when we
     // incorporate NewSNs.
     std::vector<std::unique_ptr<SuperNode>> ReadyNodes, FailedNodes;
-    processReadyOrFailed(ModifiedPendingSNs, ReadyNodes, FailedNodes,
-                         SuperNodeDeps, FailedSNs, &ElemToPendingSN);
-    processReadyOrFailed(NewSNs, ReadyNodes, FailedNodes, SuperNodeDeps,
-                         FailedSNs, nullptr);
+    processReadyOrFailed(ModifiedPendingSNs, ReadyNodes, FailedNodes, FailedSNs,
+                         &ElemToPendingSN);
+    processReadyOrFailed(NewSNs, ReadyNodes, FailedNodes, FailedSNs, nullptr);
 
     CoalesceToPendingSNs.coalesce(ModifiedPendingSNs, ElemToPendingSN);
     CoalesceToPendingSNs.coalesce(NewSNs, ElemToPendingSN);
@@ -488,73 +476,129 @@ public:
   }
 
 private:
-  // Replace individual dependencies with supernode dependencies.
+  // Replace individual dependencies on SN with supernode dependencies.
   //
-  // For all dependencies in SNs, if the corresponding node is defined in
-  // ElemToSN then remove the individual dependency and record the dependency
-  // on the corresponding supernode in SuperNodeDeps.
-  static void hoistDeps(SuperNodeDepsMap &SuperNodeDeps,
-                        std::vector<std::unique_ptr<SuperNode>> &SNs,
+  // For all dependencies of SN, if the corresponding node is defined in
+  // ElemToSN then remove the individual dependency and record SN as a
+  // *dependant* of the defining supernode in SuperNodeDeps.
+  //
+  // Note that SuperNodeDeps maps a node to the nodes that depend on *it*
+  // (i.e. edges point in the direction that information flows during
+  // propagation). This lets propagateDeps push each node's dep set forward
+  // to its dependants exactly once per change, rather than recomputing a
+  // reachable set per node.
+  //
+  // Returns true if any dependencies were hoisted.
+  static bool hoistDeps(SuperNode *SN, SuperNodeDepsMap &SuperNodeDeps,
                         ElemToSuperNodeMap &ElemToSN) {
-    for (auto &SN : SNs) {
-      auto &SNDeps = SuperNodeDeps[SN.get()];
-      for (auto &[DefContainer, DefElems] : ElemToSN) {
-        auto I = SN->Deps.find(DefContainer);
-        if (I == SN->Deps.end())
+    bool Changed = false;
+    SmallVector<ContainerId> ContainersToRemove;
+    for (auto &[Container, Elems] : SN->Deps) {
+      auto I = ElemToSN.find(Container);
+      if (I == ElemToSN.end())
+        continue;
+      auto &ContainerElemToSN = I->second;
+
+      SmallVector<ElementId> ElemsToRemove;
+      for (auto &Elem : Elems) {
+        auto J = ContainerElemToSN.find(Elem);
+        if (J == ContainerElemToSN.end())
           continue;
-        for (auto &[DefElem, DefSN] : DefElems)
-          if (I->second.erase(DefElem) && DefSN != SN.get())
-            SNDeps.insert(DefSN);
-        if (I->second.empty())
-          SN->Deps.erase(I);
+        if (J->second != SN)
+          SuperNodeDeps[J->second].insert(SN);
+        ElemsToRemove.push_back(Elem);
       }
+
+      for (auto &Elem : ElemsToRemove)
+        Elems.erase(Elem);
+      Changed |= !ElemsToRemove.empty();
+
+      if (Elems.empty())
+        ContainersToRemove.push_back(Container);
     }
+    for (auto &Container : ContainersToRemove)
+      SN->Deps.erase(Container);
+
+    return Changed;
   }
 
-  // Compute transitive closure of deps for each node.
-  static void propagateSuperNodeDeps(SuperNodeDepsMap &SuperNodeDeps) {
-    for (auto &[SN, Deps] : SuperNodeDeps) {
-      DenseSet<SuperNode *> Reachable;
-      SmallVector<SuperNode *> Worklist(Deps.begin(), Deps.end());
+  // Merge Src into Dst. Returns true if any new elements were added to Dst.
+  static bool mergeDeps(ContainerElementsMap &Dst,
+                        const ContainerElementsMap &Src) {
+    bool Changed = false;
+    for (auto &[Container, Elems] : Src) {
+      auto &DstElems = Dst[Container];
+      size_t OrigSize = DstElems.size();
+      DstElems.insert(Elems.begin(), Elems.end());
+      Changed |= DstElems.size() != OrigSize;
+    }
+    return Changed;
+  }
+
+  // Compute the transitive closure of deps for each node.
+  //
+  // This is a monotone fixpoint: each node's dep set only grows, so a node
+  // only needs to be revisited when its dep set actually changed. Because
+  // the closure is accumulated directly into SuperNode::Deps there is no
+  // separate "sink" step, and the cost no longer depends on the (address
+  // determined) order in which SuperNodeDeps happens to be enumerated.
+  static void propagateDeps(SuperNodeDepsMap &SuperNodeDeps) {
+    // Early exit for self-contained emits.
+    if (SuperNodeDeps.empty())
+      return;
+
+    SmallVector<SuperNode *> Worklist;
+    Worklist.reserve(SuperNodeDeps.size());
+    for (auto &[SN, SNDependants] : SuperNodeDeps)
+      Worklist.push_back(SN);
+
+    while (true) {
+      DenseSet<SuperNode *> ToVisitNext;
 
       while (!Worklist.empty()) {
-        auto *DepSN = Worklist.pop_back_val();
-        if (DepSN == SN)
-          continue;
-        if (!Reachable.insert(DepSN).second)
-          continue;
-        auto I = SuperNodeDeps.find(DepSN);
+        auto *SN = Worklist.pop_back_val();
+        auto I = SuperNodeDeps.find(SN);
         if (I == SuperNodeDeps.end())
           continue;
-        for (auto *DepSNDep : I->second)
-          Worklist.push_back(DepSNDep);
+
+        for (auto *DependantSN : I->second)
+          if (mergeDeps(DependantSN->Deps, SN->Deps))
+            ToVisitNext.insert(DependantSN);
       }
 
-      Deps = std::move(Reachable);
+      if (ToVisitNext.empty())
+        break;
+
+      Worklist.append(ToVisitNext.begin(), ToVisitNext.end());
     }
   }
 
-  // Sink SuperNode dependencies back to dependencies on individual nodes.
-  static void sinkDeps(std::vector<std::unique_ptr<SuperNode>> &SNs,
-                       SuperNodeDepsMap &SuperNodeDeps) {
-    for (auto &SN : SNs) {
-      auto I = SuperNodeDeps.find(SN.get());
+  // Propagate failure along the dependant edges: anything that (transitively)
+  // depends on a failed node has also failed.
+  static void propagateFailures(DenseSet<SuperNode *> &FailedNodes,
+                                SuperNodeDepsMap &SuperNodeDeps) {
+    if (FailedNodes.empty())
+      return;
+
+    SmallVector<SuperNode *> Worklist(FailedNodes.begin(), FailedNodes.end());
+
+    while (!Worklist.empty()) {
+      auto *SN = Worklist.pop_back_val();
+      auto I = SuperNodeDeps.find(SN);
       if (I == SuperNodeDeps.end())
         continue;
 
-      for (auto *DepSN : I->second) {
-        assert(DepSN != SN.get() && "Unexpected self-dependence for SN");
-        for (auto &[Container, Elems] : DepSN->Deps)
-          SN->Deps[Container].insert(Elems.begin(), Elems.end());
-      }
+      for (auto *DependantSN : I->second)
+        if (FailedNodes.insert(DependantSN).second)
+          Worklist.push_back(DependantSN);
     }
   }
 
   template <typename GetExternalStateFn>
-  static std::vector<SuperNode *>
+  static DenseSet<SuperNode *>
   processExternalDeps(std::vector<std::unique_ptr<SuperNode>> &SNs,
                       GetExternalStateFn &GetExternalState) {
-    std::vector<SuperNode *> FailedSNs;
+    DenseSet<SuperNode *> FailedSNs;
     for (auto &SN : SNs) {
       bool SNHasError = false;
       SmallVector<ContainerId> ContainersToRemove;
@@ -581,7 +625,7 @@ private:
       for (auto &Container : ContainersToRemove)
         SN->Deps.erase(Container);
       if (SNHasError)
-        FailedSNs.push_back(SN.get());
+        FailedSNs.insert(SN.get());
     }
 
     return FailedSNs;
@@ -590,8 +634,7 @@ private:
   void processReadyOrFailed(std::vector<std::unique_ptr<SuperNode>> &SNs,
                             std::vector<std::unique_ptr<SuperNode>> &Ready,
                             std::vector<std::unique_ptr<SuperNode>> &Failed,
-                            SuperNodeDepsMap &SuperNodeDeps,
-                            const std::vector<SuperNode *> &FailedSNs,
+                            const DenseSet<SuperNode *> &FailedSNs,
                             ElemToSuperNodeMap *ElemToSNs) {
 
     SmallVector<SuperNode *> ToRemoveFromElemToSNs;
@@ -599,15 +642,9 @@ private:
     for (size_t I = 0; I != SNs.size();) {
       auto &SN = SNs[I];
 
-      bool SNFailed = false;
-      assert(SuperNodeDeps.count(SN.get()));
-      auto &SNSuperNodeDeps = SuperNodeDeps[SN.get()];
-      for (auto *FailedSN : FailedSNs) {
-        if (FailedSN == SN.get() || SNSuperNodeDeps.count(FailedSN)) {
-          SNFailed = true;
-          break;
-        }
-      }
+      // Failure has already been propagated transitively by
+      // propagateFailures, so a direct lookup is sufficient here.
+      bool SNFailed = FailedSNs.count(SN.get());
 
       bool SNReady = SN->Deps.empty();
 


### PR DESCRIPTION
Backport of upstream LLVM commit db5ffb04ab0b5c4e193d2c31e635e69f42deaaaf ("[ORC] WaitingOnGraph perf: faster dependence propagation.", PR llvm/llvm-project#183272), which is not present in the LLVM 22.

This fixes the intermittent timeout of rootest-root-io-cpp11Containers-unorderedMap.

Analysis
--------
The roottest test root/io/cpp11Containers/unorderedMap (and related) showed a bistable runtime: the same test, in the same environment, would sometimes complete quickly and sometimes timeout (300s).  With a debug build of LLVM we observed the test to usually run in ~800 seconds (40 seconds with a Release build) and sometimes take ~18 hours. Profiling attributed essentially all of the extra time to WaitingOnGraph::propagateSuperNodeDeps().

propagateSuperNodeDeps() computed, for every SuperNode, the transitive closure of its dependence set with a per-node DFS. Its total cost is

    sum over X in closure(SN) of |Deps(X)| at the time X is expanded

which means the result depends critically on the order in which nodes are expanded:

  * If nodes happen to be visited in topological order, each node's dependants are already fully expanded when they are reached and the algorithm behaves like O(V + E).
  * If nodes happen to be visited in reverse topological order, each node re-expands a nearly-complete closure from scratch, degrading to roughly O(V^3).

The visitation order came from iterating a DenseMap keyed on SuperNode*, and DenseMapInfo<T*>::getHashValue() hashes the raw pointer value:

    (unsigned((uintptr_t)P) >> 4) ^ (unsigned((uintptr_t)P) >> 9)

so the traversal order is a function of ASLR and heap layout. Two runs of the same binary on the same input could therefore land on opposite ends of that complexity range. The algorithm also mutated Deps in place while iterating (Deps = std::move(Reachable)) and de-duplicated work on pop rather than on push, which further inflated the worklist.

A second amplifier was sinkDeps(), which re-expanded the computed closures back into per-symbol dependence maps. This inflated the dependence sets and prevented the Coalescer from merging SuperNodes (coalescing requires exact equality of the dependence sets), so the graph stayed large and every subsequent emit paid the cost again.

Because both traversal orders compute the same closure, this never showed up as a correctness failure -- only as the 800s / 18h runtime split.

Solution
--------
Adopt upstream's rewrite:

  * Invert the edges in SuperNodeDepsMap: SuperNodeDeps[SN] now holds the set of SuperNodes that depend on SN, so information flows forward along dependence edges instead of being pulled backwards by a DFS.
  * Replace the per-node reachable-set DFS with propagateDeps(), a monotone fixpoint that merges a node's dependence set into each of its dependants and only re-visits a dependant when its set actually grew. Convergence no longer depends on the initial worklist order, so the address-order sensitivity disappears.
  * Accumulate the closure directly into SuperNode::Deps, which removes the need for sinkDeps() entirely and keeps dependence sets small enough for the Coalescer to merge nodes.
  * Compute failure propagation transitively once, in the new propagateFailures(), instead of rediscovering it per node.
  * hoistDeps() now returns whether it modified the node, which lets emit() identify the pending SuperNodes whose dependence sets changed (and therefore must be removed from the coalescer) without a separate scan. processExternalDeps() returns a DenseSet<SuperNode *> and processReadyOrFailed() consumes it directly.

Validation
----------
  * Differential test: 4000 randomised emit/fail scenarios driven through both the old and new implementations produce identical Ready and Failed sets (assertions enabled).
  * Performance on a synthetic dependence chain (time in simplify()):

        N       old        new       speedup
        500     0.0485s    0.0002s    221x
        1000    0.3762s    0.0005s    811x
        2000    1.9467s    0.0014s   1376x
        4000   21.4621s    0.0034s   6321x

    The old implementation scales ~8-11x per doubling of N; the new one ~2.4x.
  * libLLVMOrcJIT.a builds and links cleanly.

References
----------
  * Upstream commit: db5ffb04ab0b5c4e193d2c31e635e69f42deaaaf
  * Upstream PR:     https://github.com/llvm/llvm-project/pull/183272
  * Upstream issue:  https://github.com/llvm/llvm-project/issues/179611
  * Follow-up (perf regression infrastructure):
                     https://github.com/llvm/llvm-project/issues/183251

The fix first ships in LLVM 23 (verified present at tag llvmorg-23.1.0 and absent from release/22.x as of 22.1.8), so it cannot be picked up from an LLVM 22 point release. This patch can be dropped once ROOT's vendored LLVM moves to 23 or later.

---
Diagnosed, backported and validated with the assistance of Claude Opus 5.

