### PR TITLE
[core] deprecate implementation detail zip headers since there is RZip public interface

### DIFF
--- a/README/ReleaseNotes/v642/index.md
+++ b/README/ReleaseNotes/v642/index.md
@@ -77,6 +77,7 @@ The `TMVA_SOFIE_GNN` tutorials have been migrated to this workflow and produce i
 * The header `snprintf.h` is deprecated (will emit warnings) and will be removed in ROOT 6.44. Use instead `<cstdio>`.
 * The header `Strlen.h` is deprecated and will be removed in ROOT 6.44. Use `<cstring>` directly as a replacement. `NEED_STRING` macro should not be defined or an error will be raised.
 * The header `Rstrstream.h` is deprecated and will be removed after ROOT 6.44, use instead `<sstream>`.
+* The headers `ZipLZMA.h`, `ZipLZ4.h` and `ZipZSTD.h` are deprecated and will be removed in ROOT 6.46, use instead the public methods in the `RZip.h` interface.
 
 ## Build System
 

--- a/builtins/zip/ZInflate.c
+++ b/builtins/zip/ZInflate.c
@@ -20,6 +20,7 @@ static const int qflag = 0;
 #include "zlib.h"
 #include "RConfigure.h"
 
+// TEMPORARY DUPLICATION OF ZipLZMA.h until header is removed from public interface and can be made fully private
 // @(#)root/lzma:$Id$
 // Author: David Dagenhart   May 2011
 
@@ -48,6 +49,7 @@ void R__unzipLZMA(int *srcsize, const unsigned char *src, int *tgtsize, unsigned
 
 #endif
 
+// TEMPORARY DUPLICATION OF ZipLZ4.h until header is removed from public interface and can be made fully private
 // Author: Brian Bockelman March 2015
 
 /*************************************************************************

--- a/builtins/zip/ZInflate.c
+++ b/builtins/zip/ZInflate.c
@@ -19,8 +19,63 @@ static const int qflag = 0;
 
 #include "zlib.h"
 #include "RConfigure.h"
-#include "ZipLZMA.h"
-#include "ZipLZ4.h"
+
+// @(#)root/lzma:$Id$
+// Author: David Dagenhart   May 2011
+
+/*************************************************************************
+ * Copyright (C) 1995-2011, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZMA
+#define ROOT_ZipLZMA
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void R__zipLZMA(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+
+void R__unzipLZMA(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+// Author: Brian Bockelman March 2015
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZ4
+#define ROOT_ZipLZ4
+
+// NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
+// #ifdef's to avoid problems with C code.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void R__zipLZ4(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+void R__unzipLZ4(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+
 
 /* inflate.c -- put in the public domain by Mark Adler
    version c14o, 23 August 1994 */

--- a/core/lz4/inc/ZipLZ4.h
+++ b/core/lz4/inc/ZipLZ4.h
@@ -11,6 +11,8 @@
 #ifndef ROOT_ZipLZ4
 #define ROOT_ZipLZ4
 
+#warning "This header is deprecated and will be removed in 6.46, use instead methods within RZip.h"
+
 // NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
 // #ifdef's to avoid problems with C code.
 #ifdef __cplusplus

--- a/core/lz4/src/ZipLZ4.cxx
+++ b/core/lz4/src/ZipLZ4.cxx
@@ -8,6 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+// TEMPORARY DUPLICATION OF ZipLZ4.h until header is removed from public interface and can be made fully private
 // Author: Brian Bockelman March 2015
 
 /*************************************************************************

--- a/core/lz4/src/ZipLZ4.cxx
+++ b/core/lz4/src/ZipLZ4.cxx
@@ -8,7 +8,32 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ZipLZ4.h"
+// Author: Brian Bockelman March 2015
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZ4
+#define ROOT_ZipLZ4
+
+// NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
+// #ifdef's to avoid problems with C code.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void R__zipLZ4(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+void R__unzipLZ4(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
 
 #include "ROOT/RConfig.hxx"
 

--- a/core/lzma/inc/ZipLZMA.h
+++ b/core/lzma/inc/ZipLZMA.h
@@ -12,6 +12,8 @@
 #ifndef ROOT_ZipLZMA
 #define ROOT_ZipLZMA
 
+#warning "This header is deprecated and will be removed in 6.46, use instead methods within RZip.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/core/lzma/src/ZipLZMA.c
+++ b/core/lzma/src/ZipLZMA.c
@@ -12,7 +12,34 @@
 #ifdef _MSC_VER
 #define LZMA_API_STATIC
 #endif
-#include "ZipLZMA.h"
+// @(#)root/lzma:$Id$
+// Author: David Dagenhart   May 2011
+
+/*************************************************************************
+ * Copyright (C) 1995-2011, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZMA
+#define ROOT_ZipLZMA
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void R__zipLZMA(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+
+void R__unzipLZMA(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
 #include "lzma.h"
 #include <stdio.h>
 

--- a/core/lzma/src/ZipLZMA.c
+++ b/core/lzma/src/ZipLZMA.c
@@ -12,6 +12,7 @@
 #ifdef _MSC_VER
 #define LZMA_API_STATIC
 #endif
+// TEMPORARY DUPLICATION OF ZipLZMA.h until header is removed from public interface and can be made fully private
 // @(#)root/lzma:$Id$
 // Author: David Dagenhart   May 2011
 

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -11,6 +11,7 @@
 #include "RZip.h"
 #include "Bits.h"
 
+// TEMPORARY DUPLICATION OF ZipLZ4.h until header is removed from public interface and can be made fully private
 // Author: Brian Bockelman March 2015
 
 /*************************************************************************
@@ -37,7 +38,7 @@ void R__unzipLZ4(int *srcsize, const unsigned char *src, int *tgtsize, unsigned 
 
 #endif
 
-
+// TEMPORARY DUPLICATION OF ZipLZMA.h until header is removed from public interface and can be made fully private
 // @(#)root/lzma:$Id$
 // Author: David Dagenhart   May 2011
 
@@ -66,6 +67,7 @@ void R__unzipLZMA(int *srcsize, const unsigned char *src, int *tgtsize, unsigned
 
 #endif
 
+// TEMPORARY DUPLICATION OF ZipZSTD.h until header is removed from public interface and can be made fully private
 // Original Author: Brian Bockelman
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/core/zip/src/RZip.cxx
+++ b/core/zip/src/RZip.cxx
@@ -10,9 +10,87 @@
 #include "RConfigure.h"
 #include "RZip.h"
 #include "Bits.h"
-#include "ZipLZMA.h"
-#include "ZipLZ4.h"
-#include "ZipZSTD.h"
+
+// Author: Brian Bockelman March 2015
+
+/*************************************************************************
+ * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZ4
+#define ROOT_ZipLZ4
+
+// NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
+// #ifdef's to avoid problems with C code.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void R__zipLZ4(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+void R__unzipLZ4(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+
+// @(#)root/lzma:$Id$
+// Author: David Dagenhart   May 2011
+
+/*************************************************************************
+ * Copyright (C) 1995-2011, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipLZMA
+#define ROOT_ZipLZMA
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void R__zipLZMA(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+
+void R__unzipLZMA(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+// Original Author: Brian Bockelman
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipZSTD
+#define ROOT_ZipZSTD
+
+// NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
+// #ifdef's to avoid problems with C code.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void R__zipZSTD(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+void R__unzipZSTD(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
 
 #include "zlib.h"
 

--- a/core/zstd/inc/ZipZSTD.h
+++ b/core/zstd/inc/ZipZSTD.h
@@ -10,6 +10,8 @@
 #ifndef ROOT_ZipZSTD
 #define ROOT_ZipZSTD
 
+#warning "This header is deprecated and will be removed in 6.46, use instead methods within RZip.h"
+
 // NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
 // #ifdef's to avoid problems with C code.
 #ifdef __cplusplus

--- a/core/zstd/src/ZipZSTD.cxx
+++ b/core/zstd/src/ZipZSTD.cxx
@@ -8,7 +8,31 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ZipZSTD.h"
+// Original Author: Brian Bockelman
+/*************************************************************************
+ * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_ZipZSTD
+#define ROOT_ZipZSTD
+
+// NOTE: the ROOT compression libraries aren't consistently written in C++; hence the
+// #ifdef's to avoid problems with C code.
+#ifdef __cplusplus
+extern "C" {
+#endif
+void R__zipZSTD(int cxlevel, int *srcsize, const char *src, int *tgtsize, char *tgt, int *irep);
+void R__unzipZSTD(int *srcsize, const unsigned char *src, int *tgtsize, unsigned char *tgt, int *irep);
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
 
 #include "ROOT/RConfig.hxx"
 

--- a/core/zstd/src/ZipZSTD.cxx
+++ b/core/zstd/src/ZipZSTD.cxx
@@ -8,6 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
+// TEMPORARY DUPLICATION OF ZipZSTD.h until header is removed from public interface and can be made fully private
 // Original Author: Brian Bockelman
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This is necessary step before https://github.com/root-project/root/pull/23270

At the moment, the headers are just copy-pasted where used. Once they are fully removed in 6.46, one can recreate them in a private folder. I wanted to prevent now creating them with the same name in two different folders which calls for problems.

