### PR TITLE
[RF] Avoid deprecation warnings when building RooFit tests

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -509,6 +509,9 @@ if(fftw3)
   target_link_libraries(RooFitCore PRIVATE FFTW::Double)
 endif()
 
+# Used to silence deprecation warnings when testing deprecated features
+target_compile_definitions(RooFitCore PUBLIC ROOFIT_BUILDS_ITSELF)
+
 target_include_directories(RooFitCore PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>)
 
 # The SMatrix package is header-only, but it's only exposed via the Smatrix

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -267,9 +267,15 @@ public:
    EvalBackend(std::string const &name);
 
    static EvalBackend Legacy()
-      R__DEPRECATED(6, 44, "The legacy evaluation backend will be removed in ROOT 6.44. "
-                           "Use the default \"cpu\" evaluation backend, i.e. simply don't pass any EvalBackend() "
-                           "command argument.");
+// Deprecation macro skipped when building RooFit itself, so we don't get
+// warnings when unit testing deprecated features.
+#ifndef ROOFIT_BUILDS_ITSELF
+      R__DEPRECATED(6, 44,
+                    "The legacy evaluation backend will be removed in ROOT 6.44. "
+                    "Use the default \"cpu\" evaluation backend, i.e. simply don't pass any EvalBackend() "
+                    "command argument.")
+#endif
+         ;
    static EvalBackend Cpu();
    static EvalBackend Cuda();
    static EvalBackend Codegen();


### PR DESCRIPTION
Follows up on 177d13dc870a0b21, bringing back the good old `ROOFIT_BUILDS_ITSELF` macro for this development cycle to avoid compilation warnings when building RooFit's own unit tests.

Emergency PR because the warnings make Debian 13 red in the CI, because of the `dev=ON` flag of that configuration. Once again, I didn't catch it in the original PR, because the Debian 13 build in that PR was green. I think it's a problem with the CI configuration.