### PR TITLE
[webgui] detect github actions

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -666,8 +666,8 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator(bool _edge) : BrowserCreator(tru
       // in starting from version 151 one have to allow use of unsafe swiftshader
       if (fChromeVersion > 150)
          extra_arg = "--enable-unsafe-swiftshader";
-      // in docker disable shared memory usage because of limited resources
-      if (!gSystem->AccessPathName("/.dockerenv", kFileExists))
+      // in docker or github actions disable shared memory usage because of limited resources
+      if (!gSystem->AccessPathName("/.dockerenv", kFileExists) || gSystem->Getenv("GITHUB_ACTIONS"))
          extra_arg.Append(" --disable-dev-shm-usage");
       // old or newest browser with standard headless mode
       fBatchExec = gEnv->GetValue((fEnvPrefix + "Batch").c_str(), TString::Format("fork:--headless --no-sandbox --disable-extensions --disable-audio-output %s $geometry --dump-dom $url", extra_arg.Data()).Data());

--- a/test/stressGraphics.cxx
+++ b/test/stressGraphics.cxx
@@ -4857,13 +4857,6 @@ int main(int argc, char *argv[])
    gROOT->SetBatch();
    TApplication theApp("App", &argc, argv);
 
-   if ((gSkip3D == 0) && gWebMode && (TString("chrome") == gROOT->GetWebDisplay())) {
-      if (!gSystem->AccessPathName("/.dockerenv", kFileExists)) {
-         printf("!!! Disable 3D tests with chrome when running in the docker !!!\n");
-         gSkip3D = 1;
-      }
-   }
-
    gBenchmark = new TBenchmark();
 
    stressGraphics(verbose, generate, keep);


### PR DESCRIPTION
When running chrome in docker or on github actions (CI), disable shared memory usage for the chrome adding `--disable-dev-shm-usage` running flag.  This should help to run stressGraphics --web=chrome test
