### PR TITLE
[RF] Add a clad pushforward for MathFuncs::binNumber

### DIFF
--- a/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
+++ b/roofit/roofitcore/inc/RooFit/Detail/MathFuncs.h
@@ -865,17 +865,47 @@ double stepFunctionIntegral(double xmin, double xmax, std::size_t nBins, DoubleA
 
 } // namespace RooFit::Detail::MathFuncs
 
+namespace clad {
+// Only declared, never defined here: clad's own headers exist exclusively
+// inside the interpreter, but this header is also compiled normally.
+template <typename T, typename U>
+struct ValueAndPushforward;
+} // namespace clad
+
 namespace clad::custom_derivatives {
 namespace RooFit::Detail::MathFuncs {
 
-// Clad can't generate the pullback for binNumber because of the
+// Clad can't generate the derivatives for binNumber because of the
 // std::lower_bound usage. But since binNumber returns an integer, and such
-// functions have mathematically no derivatives anyway, we just declare a
-// custom dummy pullback that does nothing.
+// functions have mathematically no derivatives anyway, we just declare custom
+// dummy derivatives that do nothing.
+//
+// Both directions have to be covered: the pullback alone is enough for
+// gradients, but Hessians also run the forward pass over binNumber, and
+// without a pushforward clad descends into std::lower_bound.
 
 template <class... Types>
 void binNumber_pullback(Types...)
 {
+}
+
+// The second parameter is unused. It is what keeps the return type of the
+// pushforward below dependent, so that clad::ValueAndPushforward only has to be
+// complete once that template is instantiated. That happens under clad and
+// nowhere else, while parsing the declaration happens in every build that
+// includes this header. A class template is needed here: an alias template
+// would be expanded eagerly and defeat the purpose.
+template <typename T, typename>
+struct ValueAndPushforwardOf {
+   using type = ::clad::ValueAndPushforward<T, T>;
+};
+
+template <typename DoubleArray, class... Types>
+typename ValueAndPushforwardOf<unsigned int, DoubleArray>::type
+binNumber_pushforward(double x, double coef, DoubleArray boundaries, unsigned int nBoundaries, int nbins, int blo,
+                      Types...)
+{
+   return {::RooFit::Detail::MathFuncs::binNumber(x, coef, boundaries, nBoundaries, nbins, blo), 0};
 }
 
 } // namespace RooFit::Detail::MathFuncs


### PR DESCRIPTION
**This is a spinoff from https://github.com/root-project/root/pull/21622**

binNumber uses std::lower_bound, which clad can't differentiate. That was already handled for reverse mode by a dummy binNumber_pullback, but Hessians also run the forward pass over binNumber, and without a pushforward clad descends into std::lower_bound and warns about differentiating __builtin_constant_p and about unsupported typedef declarations, before failing outright.

Declare the forward-mode counterpart, zero-valued for the same reason as the pullback: binNumber returns an integer, so it has no derivative.

Since MathFuncs.h is compiled normally as well as parsed by cling, while clad::ValueAndPushforward only exists inside the interpreter, the type is forward-declared and the return type is kept dependent so that it is only completed when clad instantiates the template.

🤖 Done with the help of AI

