### PR TITLE
[CI] remove quotes from ROOT_CTEST_EXTRA_FLAGS in alma10-asan.txt

### DIFF
--- a/.github/workflows/root-ci-config/buildconfig/alma10-asan.txt
+++ b/.github/workflows/root-ci-config/buildconfig/alma10-asan.txt
@@ -9,4 +9,4 @@ minimal=ON
 roottest=ON
 testing=ON
 LSAN_OPTIONS=verbosity=1:log_threads=1
-ROOT_CTEST_CUSTOM_FLAGS="-E \(gtest-core-metacling-TClingTest$\|roottest-cling-specialobj-runf02$\|roottest-root-collection-DeleteWarning$\|roottest-root-io-evolution-fixarr2$\|roottest-root-meta-rlibmap$\|roottest-root-tree-cloning-runtreeCloneTest2$\|roottest-root-treeproxy-vectorint-vectorint$\)"
+ROOT_CTEST_CUSTOM_FLAGS=-E \(gtest-core-metacling-TClingTest$\|roottest-cling-specialobj-runf02$\|roottest-root-collection-DeleteWarning$\|roottest-root-io-evolution-fixarr2$\|roottest-root-meta-rlibmap$\|roottest-root-tree-cloning-runtreeCloneTest2$\|roottest-root-treeproxy-vectorint-vectorint$\)


### PR DESCRIPTION
The quotes cause the -E ... flags to be invoked with quotes around it, which ctest doesn't like in some platforms (like alma10)


