### PR TITLE
[RF] do not rely on a backward compatibility header

### DIFF
--- a/roofit/histfactory/src/FlexibleInterpVar.cxx
+++ b/roofit/histfactory/src/FlexibleInterpVar.cxx
@@ -22,7 +22,6 @@
 
 #include "HistFactoryInterpolationCodeUtils.h"
 
-#include <Riostream.h>
 #include <TMath.h>
 
 

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -42,7 +42,6 @@
 
 #include "HistFactoryInterpolationCodeUtils.h"
 
-#include "Riostream.h"
 #include "TBuffer.h"
 
 #include "RooAbsReal.h"

--- a/roofit/roofit/src/RooBCPEffDecay.cxx
+++ b/roofit/roofit/src/RooBCPEffDecay.cxx
@@ -22,7 +22,6 @@ This function can be analytically convolved with any RooResolutionModel implemen
 */
 
 
-#include "Riostream.h"
 #include "RooRealVar.h"
 #include "RooRandom.h"
 #include "RooBCPEffDecay.h"

--- a/roofit/roofit/src/RooBDecay.cxx
+++ b/roofit/roofit/src/RooBDecay.cxx
@@ -24,8 +24,6 @@ of CP violation, mixing and life time differences. This function can
 be analytically convolved with any RooResolutionModel implementation.
 **/
 
-#include "Riostream.h"
-#include "TMath.h"
 #include "RooBDecay.h"
 #include "RooRealVar.h"
 #include "RooRandom.h"

--- a/roofit/roofit/src/RooBMixDecay.cxx
+++ b/roofit/roofit/src/RooBMixDecay.cxx
@@ -22,8 +22,6 @@ the decay of B mesons with the effects of B0/B0bar mixing.
 This function can be analytically convolved with any RooResolutionModel implementation
 **/
 
-#include "Riostream.h"
-#include "TMath.h"
 #include "RooRealVar.h"
 #include "RooBMixDecay.h"
 #include "RooRealIntegral.h"

--- a/roofit/roofit/src/RooBreitWigner.cxx
+++ b/roofit/roofit/src/RooBreitWigner.cxx
@@ -22,7 +22,6 @@ Class RooBreitWigner is a RooAbsPdf implementation
 that models a non-relativistic Breit-Wigner shape
 **/
 
-#include "Riostream.h"
 #include <cmath>
 
 #include "RooBreitWigner.h"

--- a/roofit/roofit/src/RooCFunction1Binding.cxx
+++ b/roofit/roofit/src/RooCFunction1Binding.cxx
@@ -22,7 +22,6 @@ class cannot be persisted in a RooWorkspace without registering the function
 pointer first using RooCFunction1Binding<T1,T2>::register().
 **/
 
-#include "Riostream.h"
 #include "RooCFunction1Binding.h"
 
 

--- a/roofit/roofit/src/RooCFunction2Binding.cxx
+++ b/roofit/roofit/src/RooCFunction2Binding.cxx
@@ -22,7 +22,6 @@ class cannot be persisted in a RooWorkspace without registering the function
 pointer first using RooCFunction2Binding<T1,T2,T3>::register().
 **/
 
-#include "Riostream.h"
 #include "RooCFunction2Binding.h"
 
 

--- a/roofit/roofit/src/RooCFunction3Binding.cxx
+++ b/roofit/roofit/src/RooCFunction3Binding.cxx
@@ -22,7 +22,6 @@ class cannot be persisted in a RooWorkspace without registering the function
 pointer first using RooCFunction3Binding<T1,T2,T3,T4>::register().
 **/
 
-#include "Riostream.h"
 #include "RooCFunction3Binding.h"
 
 

--- a/roofit/roofit/src/RooCFunction4Binding.cxx
+++ b/roofit/roofit/src/RooCFunction4Binding.cxx
@@ -22,7 +22,6 @@ class cannot be persisted in a RooWorkspace without registering the function
 pointer first using RooCFunction4Binding<T1,T2,T3,T4>::register().
 **/
 
-#include "Riostream.h"
 #include "RooCFunction4Binding.h"
 
 

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -24,8 +24,6 @@ the number of degrees of freedom and the probability of the chi-squared
 is store in the summary dataset.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsPdf.h"
 #include "RooDataSet.h"
 #include "RooRealVar.h"

--- a/roofit/roofit/src/RooFunctor1DBinding.cxx
+++ b/roofit/roofit/src/RooFunctor1DBinding.cxx
@@ -26,7 +26,6 @@ pointer first using RooCFunction1Binding<T1,T2>::register().
     \ingroup Roofit
 **/
 
-#include "Riostream.h"
 #include "RooFunctor1DBinding.h"
 
 using std::ostream;

--- a/roofit/roofit/src/RooFunctorBinding.cxx
+++ b/roofit/roofit/src/RooFunctorBinding.cxx
@@ -39,8 +39,8 @@ class cannot be persisted in a RooWorkspace without registering the function
 pointer first using RooCFunction1Binding<T1,T2>::register().
 **/
 
-#include "Riostream.h"
 #include "RooFunctorBinding.h"
+#include <iostream>
 
 using std::endl, std::ostream, std::string;
 

--- a/roofit/roofit/src/RooGaussModel.cxx
+++ b/roofit/roofit/src/RooGaussModel.cxx
@@ -23,7 +23,6 @@ for analytical convolutions with classes inheriting from RooAbsAnaConvPdf
 **/
 
 #include "TMath.h"
-#include "Riostream.h"
 #include "RooGaussModel.h"
 #include "RooMath.h"
 #include "RooRealConstant.h"

--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -79,15 +79,12 @@ in calculation speed.
 
 **/
 
-#include "Riostream.h"
-
 #include "RooIntegralMorph.h"
 #include "RooAbsCategory.h"
 #include "RooBrentRootFinder.h"
 #include "RooAbsFunc.h"
 #include "RooRealVar.h"
 #include "RooDataHist.h"
-#include "TH1.h"
 
 using std::flush, std::endl;
 

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -34,8 +34,6 @@ describe the same process or not.
 // #define USE_UBLAS 1
 // #undef USE_UBLAS
 
-#include "Riostream.h"
-
 #include "RooAbsCollection.h"
 #include "RooArgList.h"
 #include "RooArgProxy.h"
@@ -71,7 +69,6 @@ describe the same process or not.
 #include <sstream>
 #include <stdexcept>
 #include <type_traits>
-#include <typeinfo>
 
 using std::string, std::make_unique, std::vector;
 

--- a/roofit/roofit/src/RooMathCoreReg.cxx
+++ b/roofit/roofit/src/RooMathCoreReg.cxx
@@ -15,7 +15,6 @@
 
 **/
 
-#include "Riostream.h"
 #include "RooMathCoreReg.h"
 #include "RooCFunction1Binding.h"
 #include "RooCFunction2Binding.h"

--- a/roofit/roofit/src/RooMomentMorph.cxx
+++ b/roofit/roofit/src/RooMomentMorph.cxx
@@ -13,10 +13,7 @@
 
 **/
 
-#include "Riostream.h"
-
 #include "RooMomentMorph.h"
-#include "RooAbsCategory.h"
 #include "RooRealConstant.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
@@ -28,8 +25,6 @@
 #include "RooChangeTracker.h"
 
 #include "TMath.h"
-#include "TH1.h"
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// coverity[UNINIT_CTOR]

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -13,10 +13,7 @@
 
 **/
 
-#include "Riostream.h"
-
 #include "RooMomentMorphFunc.h"
-#include "RooAbsCategory.h"
 #include "RooRealConstant.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
@@ -28,7 +25,6 @@
 #include "RooChangeTracker.h"
 
 #include "TMath.h"
-#include "TH1.h"
 
 using std::string, std::vector;
 

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -31,13 +31,10 @@
 
 #include "RooFit/Detail/Algorithms.h"
 
-#include <Riostream.h>
-
 #include <TMap.h>
 #include <TMath.h>
 #include <TVector.h>
 
-#include <algorithm>
 #include <map>
 
 using std::string, std::vector;

--- a/roofit/roofit/src/RooNonCPEigenDecay.cxx
+++ b/roofit/roofit/src/RooNonCPEigenDecay.cxx
@@ -43,11 +43,9 @@ get the parameters used here you have to change the sign of both
 where Q denotes the charge of the \f$\rho\f$ meson.
 **/
 
-#include "Riostream.h"
 #include "RooRealVar.h"
 #include "RooRandom.h"
 #include "RooNonCPEigenDecay.h"
-#include "TMath.h"
 #include "RooRealIntegral.h"
 
 

--- a/roofit/roofit/src/RooTFnBinding.cxx
+++ b/roofit/roofit/src/RooTFnBinding.cxx
@@ -15,8 +15,6 @@
   functions RooFit::bindFunction().
 **/
 
-#include "Riostream.h"
-
 #include "RooTFnBinding.h"
 #include "TF3.h"
 

--- a/roofit/roofit/src/RooTFnPdfBinding.cxx
+++ b/roofit/roofit/src/RooTFnPdfBinding.cxx
@@ -13,10 +13,7 @@
 
 **/
 
-#include "Riostream.h"
-
 #include "RooTFnPdfBinding.h"
-#include "RooAbsCategory.h"
 #include "TF3.h"
 
 using std::ostream;

--- a/roofit/roofit/src/RooTMathReg.cxx
+++ b/roofit/roofit/src/RooTMathReg.cxx
@@ -15,7 +15,6 @@
 
 **/
 
-#include "Riostream.h"
 #include "RooTMathReg.h"
 #include "RooCFunction1Binding.h"
 #include "RooCFunction2Binding.h"

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -36,8 +36,6 @@ input.
 #include <RooMsgService.h>
 #include <RooRealProxy.h>
 
-#include <Riostream.h>
-
 template <class Base_t>
 class RooAbsSelfCached : public Base_t {
 public:

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -99,7 +99,6 @@
 
 #include "RooFit/Detail/RooNormalizedPdf.h"
 #include "RooMsgService.h"
-#include "Riostream.h"
 #include "RooResolutionModel.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"

--- a/roofit/roofitcore/src/RooAbsBinning.cxx
+++ b/roofit/roofitcore/src/RooAbsBinning.cxx
@@ -31,11 +31,9 @@ This class defines the interface to retrieve bin boundaries, ranges etc.
 #include "TBuffer.h"
 #include "TClass.h"
 
-#include "Riostream.h"
+#include <ostream>
 
 using std::ostream;
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -28,8 +28,9 @@ by the user to getVal() and on which parameters need to be tracked
 for changes to trigger a refilling of the cache histogram.
 **/
 
-#include "Riostream.h"
-using std::string, std::endl, std::ostream;
+#include <string>
+#include <ostream>
+ using std::string, std::endl, std::ostream;
 
 #include "TString.h"
 #include "RooAbsCachedReal.h"
@@ -40,17 +41,11 @@ using std::string, std::endl, std::ostream;
 #include "RooChangeTracker.h"
 #include "RooExpensiveObjectCache.h"
 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Constructor
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-RooAbsCachedReal::RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder) :
-  RooAbsReal(name,title),
-  _cacheMgr(this,10),
-  _ipOrder(ipOrder),
-  _disableCache(false)
+ RooAbsCachedReal::RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder)
+    : RooAbsReal(name, title), _cacheMgr(this, 10), _ipOrder(ipOrder), _disableCache(false)
  {
  }
 

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -41,13 +41,13 @@ for changes to trigger a refilling of the cache histogram.
 #include "RooChangeTracker.h"
 #include "RooExpensiveObjectCache.h"
 
- ////////////////////////////////////////////////////////////////////////////////
- /// Constructor
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor
 
- RooAbsCachedReal::RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder)
-    : RooAbsReal(name, title), _cacheMgr(this, 10), _ipOrder(ipOrder), _disableCache(false)
- {
- }
+RooAbsCachedReal::RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder)
+   : RooAbsReal(name, title), _cacheMgr(this, 10), _ipOrder(ipOrder), _disableCache(false)
+{
+}
 
 
 

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -34,8 +34,7 @@ prototype data etc..
 #include "RooMsgService.h"
 #include "RooGlobalFunc.h"
 
-#include "Riostream.h"
-
+#include <ostream>
 
 using std::ostream;
 

--- a/roofit/roofitcore/src/RooAbsHiddenReal.cxx
+++ b/roofit/roofitcore/src/RooAbsHiddenReal.cxx
@@ -26,12 +26,11 @@ printing methods with versions that do not reveal the objects value
 and it has a protected version of getVal()
 **/
 
-#include "Riostream.h"
-
-#include "RooArgSet.h"
 #include "RooAbsHiddenReal.h"
 #include "RooCategory.h"
 #include "RooMsgService.h"
+
+#include <ostream>
 
 using std::ostream, std::istream, std::endl;
 

--- a/roofit/roofitcore/src/RooAbsIntegrator.cxx
+++ b/roofit/roofitcore/src/RooAbsIntegrator.cxx
@@ -23,11 +23,10 @@ Abstract interface for integrators of real-valued
 functions that implement the RooAbsFunc interface.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsIntegrator.h"
 #include "RooMsgService.h"
-#include "TClass.h"
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooAbsMoment.cxx
+++ b/roofit/roofitcore/src/RooAbsMoment.cxx
@@ -23,12 +23,6 @@
 #include <RooAbsMoment.h>
 #include <RooRealVar.h>
 
-#include <Riostream.h>
-
-#include <cmath>
-#include <string>
-
-
 ////////////////////////////////////////////////////////////////////////////////
 
 RooAbsMoment::RooAbsMoment(const char* name, const char* title, RooAbsReal& func, RooRealVar& x, Int_t orderIn, bool takeRoot) :

--- a/roofit/roofitcore/src/RooAbsNumGenerator.cxx
+++ b/roofit/roofitcore/src/RooAbsNumGenerator.cxx
@@ -25,20 +25,18 @@ Abstract base class for MC event generator
 implementations like RooAcceptReject and RooFoam
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsNumGenerator.h"
 #include "RooAbsReal.h"
 #include "RooCategory.h"
 #include "RooRealVar.h"
 #include "RooDataSet.h"
-#include "RooRandom.h"
 #include "RooErrorHandler.h"
 
 #include "RooMsgService.h"
 #include "RooRealBinding.h"
 
 #include <cassert>
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -39,18 +39,12 @@ parallelized calculation of test statistics.
 
 #include "RooAbsOptTestStatistic.h"
 
-#include "Riostream.h"
-#include "TClass.h"
-#include <cstring>
-
 #include "RooAbsData.h"
 #include "RooAbsDataStore.h"
 #include "RooAbsPdf.h"
-#include "RooAddPdf.h"
 #include "RooArgSet.h"
 #include "RooBinSamplingPdf.h"
 #include "RooBinning.h"
-#include "RooCategory.h"
 #include "RooDataHist.h"
 #include "RooDataSet.h"
 #include "RooErrorHandler.h"
@@ -59,11 +53,13 @@ parallelized calculation of test statistics.
 #include "RooMsgService.h"
 #include "RooProdPdf.h"
 #include "RooProduct.h"
-#include "RooRealSumPdf.h"
 #include "RooRealVar.h"
 #include "RooVectorDataStore.h"
 
 #include "ROOT/StringUtils.hxx"
+
+#include <cstring>
+#include <ostream>
 
 using std::ostream;
 

--- a/roofit/roofitcore/src/RooAbsProxy.cxx
+++ b/roofit/roofitcore/src/RooAbsProxy.cxx
@@ -14,9 +14,10 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-#include "Riostream.h"
 #include "RooAbsProxy.h"
 #include "RooArgSet.h"
+
+#include <ostream>
 
 /**
 \file RooAbsProxy.cxx

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -23,12 +23,12 @@ Abstract base class for RooStudyManager modules
 
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsStudy.h"
 #include "RooMsgService.h"
 #include "RooDataSet.h"
 #include "TList.h"
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooAcceptReject.cxx
+++ b/roofit/roofitcore/src/RooAcceptReject.cxx
@@ -28,23 +28,17 @@ classes to take care of generation of observables for which p.d.fs
 do not define internal methods
 **/
 
-#include "Riostream.h"
-
 #include "RooAcceptReject.h"
 #include "RooAbsReal.h"
 #include "RooCategory.h"
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooRandom.h"
-#include "RooErrorHandler.h"
 #include "RooPrintable.h"
 #include "RooMsgService.h"
 #include "RooRealBinding.h"
 #include "RooNumGenFactory.h"
 #include "RooNumGenConfig.h"
-
-#include "TFoam.h"
-#include "TNamed.h"
 
 #include <cassert>
 

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -24,21 +24,18 @@
 Adaptive one-dimensional numerical integration algorithm.
 **/
 
-
-#include "Riostream.h"
-
-#include "TClass.h"
 #include "RooAdaptiveIntegratorND.h"
 #include "RooFunctor.h"
 #include "RooArgSet.h"
 #include "RooRealVar.h"
-#include "RooNumber.h"
 #include "RooMsgService.h"
 #include "RooNumIntFactory.h"
 #include "Math/AdaptiveIntegratorMultiDim.h"
 #include "Math/Functor.h"
 
 #include <cassert>
+#include <string>
+#include <ostream>
 
 using std::endl, std::string;
 

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -29,15 +29,10 @@ with a probability proportional to its associated coefficient.
 
 #include "RooAddGenContext.h"
 
-#include "Riostream.h"
-#include "TClass.h"
-
 #include "RooDataSet.h"
 #include "RooRandom.h"
 
 #include <sstream>
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -24,10 +24,7 @@ when constructed with two sets, it sums the product of the terms
 in the two sets.
 **/
 
-
-#include "Riostream.h"
 #include "RooAddition.h"
-#include "RooRealSumFunc.h"
 #include "RooRealSumPdf.h"
 #include "RooProduct.h"
 #include "RooErrorHandler.h"
@@ -42,10 +39,7 @@ in the two sets.
 #include "RooChi2Var.h"
 #endif
 
-#include <algorithm>
-#include <cmath>
-
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with a single set consisting of RooAbsReal.

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -22,9 +22,6 @@
 Efficient implementation of the generator context specific for binned pdfs.
 **/
 
-#include "Riostream.h"
-
-
 #include "RooMsgService.h"
 #include "RooBinnedGenContext.h"
 #include "RooAbsPdf.h"
@@ -33,8 +30,10 @@ Efficient implementation of the generator context specific for binned pdfs.
 #include "RooDataSet.h"
 #include "RooRandom.h"
 
-using std::endl, std::vector, std::ostream;
+#include <ostream>
+#include <vector>
 
+using std::endl, std::vector, std::ostream;
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -26,7 +26,6 @@ the user to add single bin boundaries, mirrored pairs, or sets of
 uniformly spaced boundaries.
 **/
 
-#include <Riostream.h>
 #include <RooAbsPdf.h>
 #include <RooBinning.h>
 #include <RooDouble.h>
@@ -41,6 +40,7 @@ uniformly spaced boundaries.
 
 #include <algorithm>
 #include <cmath>
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooBinningCategory.cxx
+++ b/roofit/roofitcore/src/RooBinningCategory.cxx
@@ -28,9 +28,7 @@ the inputVar. The name of this binning is passed in the constructor.
 
 #include "RooBinningCategory.h"
 
-#include "Riostream.h"
-#include "RooStreamParser.h"
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with input function to be mapped and name and index of default

--- a/roofit/roofitcore/src/RooBrentRootFinder.cxx
+++ b/roofit/roofitcore/src/RooBrentRootFinder.cxx
@@ -26,9 +26,10 @@ in the GNU scientific library (v0.99).
 
 #include "RooBrentRootFinder.h"
 #include "RooAbsFunc.h"
-#include <cmath>
-#include "Riostream.h"
 #include "RooMsgService.h"
+
+#include <cmath>
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooCachedPdf.cxx
@@ -18,8 +18,6 @@ Implementation of RooAbsCachedPdf that can cache
 any external RooAbsPdf input function provided in the constructor.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsPdf.h"
 #include "RooCachedPdf.h"
 #include "RooAbsReal.h"
@@ -29,7 +27,7 @@ any external RooAbsPdf input function provided in the constructor.
 
 using std::endl;
 
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor taking name, title and function to be cached. To control

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -29,20 +29,19 @@ any external RooAbsReal input function provided in the constructor.
 
 #include <ostream>
 
- using std::endl;
+using std::endl;
 
- ////////////////////////////////////////////////////////////////////////////////
- /// Constructor taking name, title and function to be cached. To control
- /// granularity of the binning of the cache histogram set the desired properties
- /// in the binning named "cache" in the observables of the function
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor taking name, title and function to be cached. To control
+/// granularity of the binning of the cache histogram set the desired properties
+/// in the binning named "cache" in the observables of the function
 
- RooCachedReal::RooCachedReal(const char *name, const char *title, RooAbsReal &_func)
-    : RooAbsCachedReal(name, title), func("func", "func", this, _func), _useCdfBoundaries(false), _cacheSource(false)
- {
+RooCachedReal::RooCachedReal(const char *name, const char *title, RooAbsReal &_func)
+   : RooAbsCachedReal(name, title), func("func", "func", this, _func), _useCdfBoundaries(false), _cacheSource(false)
+{
    // Choose same expensive object cache as input function
    setExpensiveObjectCache(_func.expensiveObjectCache()) ;
- }
-
+}
 
 
 

--- a/roofit/roofitcore/src/RooCachedReal.cxx
+++ b/roofit/roofitcore/src/RooCachedReal.cxx
@@ -18,8 +18,6 @@ Implementation of RooAbsCachedReal that can cache
 any external RooAbsReal input function provided in the constructor.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsPdf.h"
 #include "RooCachedReal.h"
 #include "RooAbsReal.h"
@@ -29,20 +27,17 @@ any external RooAbsReal input function provided in the constructor.
 #include "RooHistPdf.h"
 #include "RooChangeTracker.h"
 
-using std::endl;
+#include <ostream>
 
+ using std::endl;
 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Constructor taking name, title and function to be cached. To control
+ /// granularity of the binning of the cache histogram set the desired properties
+ /// in the binning named "cache" in the observables of the function
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor taking name, title and function to be cached. To control
-/// granularity of the binning of the cache histogram set the desired properties
-/// in the binning named "cache" in the observables of the function
-
-RooCachedReal::RooCachedReal(const char *name, const char *title, RooAbsReal& _func) :
-   RooAbsCachedReal(name,title),
-   func("func","func",this,_func),
-   _useCdfBoundaries(false),
-   _cacheSource(false)
+ RooCachedReal::RooCachedReal(const char *name, const char *title, RooAbsReal &_func)
+    : RooAbsCachedReal(name, title), func("func", "func", this, _func), _useCdfBoundaries(false), _cacheSource(false)
  {
    // Choose same expensive object cache as input function
    setExpensiveObjectCache(_func.expensiveObjectCache()) ;

--- a/roofit/roofitcore/src/RooChangeTracker.cxx
+++ b/roofit/roofitcore/src/RooChangeTracker.cxx
@@ -30,15 +30,10 @@ observable propagates a valueDirty flag when an event is loaded even
 though usually only one observable actually changes.
 **/
 
-
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooChangeTracker.h"
 #include "RooAbsReal.h"
 #include "RooAbsCategory.h"
 #include "RooArgSet.h"
-#include "RooMsgService.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -23,14 +23,12 @@
 #include "RooAbsPdf.h"
 #include "RooCmdConfig.h"
 #include "RooMsgService.h"
-
-#include "Riostream.h"
-#include "TClass.h"
-
 #include "RooRealVar.h"
 #include "RooAbsDataStore.h"
 
 #include <ROOT/StringUtils.hxx>
+
+#include <ostream>
 
 RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal &func, RooDataHist &data, bool extended,
                        RooDataHist::ErrorType etype, RooAbsTestStatistic::Configuration const &cfg)

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -601,11 +601,18 @@ void codegenImpl(CLASS_NAME &arg, CodegenContext &ctx);
 #include <RooAbsReal.h>
 #include <RooAbsCategory.h>
 
-#include <Riostream.h>
 #include <TMath.h>
 
 #include <cmath>
-
+#ifdef __APPLE__
+// Workaround for https://github.com/llvm/llvm-project/issues/138683
+// Include <chrono> before <fstream> to ensure _FilesystemClock is defined
+// Can be removed once the upstream issue is fixed.
+#include <chrono>
+#endif
+#include <fstream>
+#include <iostream>
+#include <iomanip>
 
 CLASS_NAME::CLASS_NAME(const char *name, const char *title,
 )";

--- a/roofit/roofitcore/src/RooCmdArg.cxx
+++ b/roofit/roofitcore/src/RooCmdArg.cxx
@@ -28,10 +28,7 @@ created using global helper functions defined in RooGlobalFunc.h
 that create and fill these generic containers
 **/
 
-
-
 #include "RooCmdArg.h"
-#include "Riostream.h"
 #include "RooArgSet.h"
 
 #include "RooFitImplHelpers.h"

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -32,12 +32,11 @@ subsequently explicitly smeared with the resolution model distribution.
 #include "RooAbsAnaConvPdf.h"
 #include "RooNumConvPdf.h"
 #include "RooFFTConvPdf.h"
-#include "RooProdPdf.h"
 #include "RooDataSet.h"
 #include "RooArgSet.h"
 #include "RooTruthModel.h"
-#include "Riostream.h"
 
+#include <ostream>
 
 using std::ostream;
 

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -48,6 +48,8 @@ To retrieve a RooCurve from a RooPlot, use RooPlot::getCurve().
 
 #include "TMath.h"
 #include "TAxis.h"
+#include "TMatrixD.h"
+#include "TVectorD.h"
 #include "Math/Util.h"
 
 #include <iomanip>

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -46,15 +46,17 @@ To retrieve a RooCurve from a RooPlot, use RooPlot::getCurve().
 #include "RooProduct.h"
 #include "RooConstVar.h"
 
-#include "Riostream.h"
 #include "TMath.h"
 #include "TAxis.h"
-#include "TMatrixD.h"
-#include "TVectorD.h"
 #include "Math/Util.h"
+
 #include <iomanip>
 #include <deque>
 #include <algorithm>
+#include <ostream>
+#include <list>
+#include <vector>
+#include <cmath>
 
 using std::ostream, std::list, std::vector, std::min;
 

--- a/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
+++ b/roofit/roofitcore/src/RooDLLSignificanceMCSModule.cxx
@@ -30,8 +30,6 @@ on underlying normal sampling distributions and a MC study is a good way
 to test that assumption.
 **/
 
-#include "Riostream.h"
-
 #include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "TString.h"
@@ -39,7 +37,7 @@ to test that assumption.
 #include "RooDLLSignificanceMCSModule.h"
 #include "RooMsgService.h"
 
-
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -44,7 +44,6 @@ See RooAbsDataHelper, rf408_RDataFrameToRooFit.C
 
 #include "RooDataHist.h"
 
-#include "Riostream.h"
 #include "RooMsgService.h"
 #include "RooDataHistSliceIter.h"
 #include "RooAbsLValue.h"
@@ -72,8 +71,10 @@ See RooAbsDataHelper, rf408_RDataFrameToRooFit.C
 #include "TH1.h"
 #include "TTree.h"
 #include "TBuffer.h"
-#include "TMath.h"
 #include "Math/Util.h"
+
+#include <string>
+#include <ostream>
 
 using std::string, std::ostream;
 

--- a/roofit/roofitcore/src/RooDerivative.cxx
+++ b/roofit/roofitcore/src/RooDerivative.cxx
@@ -24,13 +24,11 @@ of any RooAbsReal as calculated (numerically) by the MathCore Richardson
 derivator class.
 **/
 
-#include "Riostream.h"
 #include <cmath>
 
 #include "RooDerivative.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
-#include "RooErrorHandler.h"
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
@@ -39,8 +37,7 @@ derivator class.
 #include "Math/WrappedFunction.h"
 #include "Math/RichardsonDerivator.h"
 
-
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -26,10 +26,8 @@ Two-dimensional ellipse that can be used to represent an error contour.
 #include "TMath.h"
 #include "RooMsgService.h"
 
-#include "Riostream.h"
-#include "TClass.h"
 #include <cmath>
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a 2-dimensional ellipse centered at `(x1,x2)` that represents the confidence

--- a/roofit/roofitcore/src/RooExtendPdf.cxx
+++ b/roofit/roofitcore/src/RooExtendPdf.cxx
@@ -35,8 +35,6 @@ is the set of remaining dependents.
 the nominal integration range \f$ \mathrm{normRegion}[x] \f$.
 */
 
-#include "Riostream.h"
-
 #include "RooArgList.h"
 #include "RooConstVar.h"
 #include "RooExtendPdf.h"
@@ -50,6 +48,8 @@ the nominal integration range \f$ \mathrm{normRegion}[x] \f$.
 #include "RooFitImplHelpers.h"
 
 #include <RooFit/Detail/NormalizationHelpers.h>
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooFirstMoment.cxx
+++ b/roofit/roofitcore/src/RooFirstMoment.cxx
@@ -31,9 +31,6 @@
 #include <RooNumIntConfig.h>
 #include <RooProduct.h>
 
-#include <Riostream.h>
-
-#include <cmath>
 #include <string>
 
 

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -43,8 +43,6 @@
 /// the names of the arguments are not hard coded.
 ///
 
-#include "Riostream.h"
-
 #include "RooFormulaVar.h"
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
@@ -57,6 +55,9 @@
 #include "RooNLLVar.h"
 #include "RooChi2Var.h"
 #endif
+
+#include <iostream>
+#include <list>
 
 using std::ostream, std::istream, std::list;
 

--- a/roofit/roofitcore/src/RooFracRemainder.cxx
+++ b/roofit/roofitcore/src/RooFracRemainder.cxx
@@ -27,9 +27,6 @@ a constrained split
 **/
 
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooFracRemainder.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
@@ -37,9 +34,9 @@ a constrained split
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 
+#include <ostream>
+
 using std::endl;
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with given set of input fractions. All arguments in sumSet must be of type RooAbsReal.

--- a/roofit/roofitcore/src/RooFunctor.cxx
+++ b/roofit/roofitcore/src/RooFunctor.cxx
@@ -22,9 +22,6 @@
 
 Lightweight interface adaptor that exports a RooAbsPdf as a functor.
 **/
-
-#include "Riostream.h"
-
 #include "RooFunctor.h"
 #include "RooRealBinding.h"
 #include "RooAbsReal.h"
@@ -32,7 +29,6 @@ Lightweight interface adaptor that exports a RooAbsPdf as a functor.
 #include "RooArgSet.h"
 
 #include <cassert>
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -28,7 +28,6 @@ use a RooAcceptReject sampling technique.
 **/
 
 #include "RooMsgService.h"
-#include "Riostream.h"
 
 #include "RooGenContext.h"
 #include "RooAbsPdf.h"
@@ -43,6 +42,8 @@ use a RooAcceptReject sampling technique.
 
 #include "TString.h"
 
+#include <string>
+#include <ostream>
 
 using std::endl, std::string, std::ostream;
 

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -22,8 +22,6 @@
 Abstract base class for RooStudyManager modules
 **/
 
-#include "Riostream.h"
-
 #include "RooGenFitStudy.h"
 #include "RooWorkspace.h"
 #include "RooMsgService.h"
@@ -33,7 +31,7 @@ Abstract base class for RooStudyManager modules
 #include "RooGlobalFunc.h"
 #include "RooFitResult.h"
 
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -32,16 +32,10 @@ Partial integrals, which factorise and can be calculated, are calculated
 analytically. Remaining non-factorising observables are integrated numerically.
 **/
 
-
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooGenProdProj.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
-#include "RooErrorHandler.h"
 #include "RooProduct.h"
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor for a normalization projection of the product of p.d.f.s _prodSet

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -28,8 +28,6 @@ class documentation.
 **/
 
 #include "RooGenericPdf.h"
-#include "Riostream.h"
-#include "RooStreamParser.h"
 #include "RooMsgService.h"
 #include "RooArgList.h"
 #include "RooFormulaUtils.h"
@@ -37,6 +35,7 @@ class documentation.
 
 #include "TFormula.h"
 
+#include <iostream>
 using std::istream, std::ostream, std::endl;
 
 

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -30,14 +30,11 @@ integration, following the VEGAS algorithm.
 #include "RooAbsFunc.h"
 #include "RooNumber.h"
 #include "RooRandom.h"
-#include "TMath.h"
 #include "RooMsgService.h"
 
 #include <cmath>
-#include "Riostream.h"
 #include <iomanip>
-
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with given function binding

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -36,10 +36,9 @@ a RooPlot.
 #include "RooConstVar.h"
 
 #include "TH1.h"
-#include "Riostream.h"
+
 #include <iomanip>
-
-
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create an empty histogram that can be filled with the addBin()

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -30,10 +30,9 @@ a specified area of a Poisson or Binomail error distribution.
 
 #include "Math/QuantFuncMathCore.h" // ROOT::Math::chisquared_quantile, chisquared_quantile_c
 
-#include "Riostream.h"
-
 #include <cassert>
 #include <cmath>
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -29,8 +29,6 @@ negative content, the bin contents are clipped to zero and the bin errors are ke
 The input histogram is not modified.
 **/
 
-#include "Riostream.h"
-
 #include "RooCategory.h"
 #include "RooCurve.h"
 #include "RooDataHist.h"
@@ -39,7 +37,6 @@ The input histogram is not modified.
 #include "RooHistPdf.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
-#include "RooUniformBinning.h"
 #include "RooWorkspace.h"
 
 #include "TError.h"
@@ -47,6 +44,7 @@ The input histogram is not modified.
 
 #include <algorithm>
 #include <cmath>
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor from a RooDataHist. RooDataHist dimensions

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
@@ -34,11 +34,7 @@ and the outer two pieces, if required are calculated using a 1/x transform
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 
-#include "Riostream.h"
-#include <cmath>
-#include "TClass.h"
-
-
+#include <ostream>
 
 // Register this class with RooNumIntConfig
 

--- a/roofit/roofitcore/src/RooInvTransform.cxx
+++ b/roofit/roofitcore/src/RooInvTransform.cxx
@@ -28,11 +28,6 @@ range cannot include zero.
 
 #include "RooInvTransform.h"
 
-#include "Riostream.h"
-#include <cmath>
-
-;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -34,7 +34,6 @@ Use RooAbsCollection derived objects for public use
 #include "RooAbsData.h"
 #include "RooMsgService.h"
 
-#include "Riostream.h"
 #include "TBuffer.h"
 #include "TROOT.h"
 
@@ -42,7 +41,7 @@ Use RooAbsCollection derived objects for public use
 #include <list>
 #include <memory>
 #include <vector>
-
+#include <ostream>
 
 /// \cond ROOFIT_INTERNAL
 

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -27,19 +27,15 @@ in G. P. Lepage, J. Comp. Phys. 27, 192(1978). This implementation is
 based on a C version from the 0.9 beta release of the GNU scientific library.
 **/
 
-#include "Riostream.h"
-
-#include "TMath.h"
 #include "RooMCIntegrator.h"
 #include "RooArgSet.h"
-#include "RooNumber.h"
 #include "RooNumIntFactory.h"
 #include "RooRealVar.h"
 #include "RooCategory.h"
 #include "RooMsgService.h"
 
 #include <cmath>
-
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -26,13 +26,13 @@
 
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
-#include "Riostream.h"
 #include "RooAbsCache.h"
 
 #include "TBuffer.h"
 #include "TString.h"
 #include "TRegexp.h"
 
+#include <ostream>
 
 class RooMappedCategoryCache : public RooAbsCache {
   public:

--- a/roofit/roofitcore/src/RooMoment.cxx
+++ b/roofit/roofitcore/src/RooMoment.cxx
@@ -20,10 +20,6 @@
 \ingroup Roofitcore
 **/
 
-
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooMoment.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
@@ -37,8 +33,9 @@
 #include "RooConstVar.h"
 #include "RooRealIntegral.h"
 #include "RooNumIntConfig.h"
-#include <string>
 
+#include <cmath>
+#include <string>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/src/RooMultiVarGaussian.cxx
+++ b/roofit/roofitcore/src/RooMultiVarGaussian.cxx
@@ -22,18 +22,20 @@
 Multivariate Gaussian p.d.f. with correlations
 **/
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooMultiVarGaussian.h"
 #include "RooAbsReal.h"
 #include "RooRealVar.h"
 #include "RooRandom.h"
-#include "RooMath.h"
 #include "RooGlobalFunc.h"
 #include "RooConstVar.h"
 #include "TDecompChol.h"
 #include "RooFitResult.h"
+
+#include <cmath>
+#include <list>
+#include <map>
+#include <vector>
+#include <ostream>
 
 using std::string, std::list, std::map, std::vector;
 

--- a/roofit/roofitcore/src/RooNumCdf.cxx
+++ b/roofit/roofitcore/src/RooNumCdf.cxx
@@ -24,16 +24,11 @@ upper bound is guaranteed to converge to exactly one, at all interpolation
 orders.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsPdf.h"
 #include "RooNumCdf.h"
 #include "RooAbsReal.h"
-#include "RooMsgService.h"
-#include "RooDataHist.h"
 #include "RooHistPdf.h"
 #include "RooRealVar.h"
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct a cumulative distribution function from given input p.d.f over observable x.

--- a/roofit/roofitcore/src/RooNumConvPdf.cxx
+++ b/roofit/roofitcore/src/RooNumConvPdf.cxx
@@ -58,23 +58,17 @@ calls that MINUIT needs to fit your function as function of the
 convolution precision.
 **/
 
-#include "Riostream.h"
 #include "RooNumConvPdf.h"
-#include "RooArgList.h"
 #include "RooRealVar.h"
 #include "RooFormulaVar.h"
 #include "RooCustomizer.h"
 #include "RooConvIntegrandBinding.h"
-#include "RooNumIntFactory.h"
 #include "RooGenContext.h"
 #include "RooConvGenContext.h"
 
-
+#include <ostream>
 
 using std::ostream;
-
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooNumConvolution.cxx
+++ b/roofit/roofitcore/src/RooNumConvolution.cxx
@@ -56,6 +56,7 @@ calls that MINUIT needs to fit your function as function of the
 convolution precision.
 **/
 
+#include "TH2F.h"
 #include "RooNumConvolution.h"
 #include "RooRealVar.h"
 #include "RooCustomizer.h"

--- a/roofit/roofitcore/src/RooNumConvolution.cxx
+++ b/roofit/roofitcore/src/RooNumConvolution.cxx
@@ -56,10 +56,7 @@ calls that MINUIT needs to fit your function as function of the
 convolution precision.
 **/
 
-#include "Riostream.h"
-#include "TH2F.h"
 #include "RooNumConvolution.h"
-#include "RooArgList.h"
 #include "RooRealVar.h"
 #include "RooCustomizer.h"
 #include "RooConvIntegrandBinding.h"
@@ -68,6 +65,7 @@ convolution precision.
 #include "RooConvGenContext.h"
 #include "RooMsgService.h"
 
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooNumGenConfig.cxx
+++ b/roofit/roofitcore/src/RooNumGenConfig.cxx
@@ -24,14 +24,13 @@ numeric integrators used by RooRealIntegral. RooRealIntegral and RooAbsPdf
 use this class in the (normalization) integral configuration interface
 **/
 
-#include "Riostream.h"
-
 #include "RooNumGenConfig.h"
 #include "RooArgSet.h"
 #include "RooAbsNumGenerator.h"
 #include "RooNumGenFactory.h"
 #include "RooMsgService.h"
 
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooNumGenFactory.cxx
+++ b/roofit/roofitcore/src/RooNumGenFactory.cxx
@@ -30,21 +30,14 @@ the nature of the integration limits (closed or open ended) and
 the preference of the caller as encoded in the configuration object.
 **/
 
-#include "TClass.h"
-#include "Riostream.h"
-
 #include "RooNumGenFactory.h"
 #include "RooArgSet.h"
-#include "RooAbsFunc.h"
 #include "RooNumGenConfig.h"
-#include "RooNumber.h"
-
 #include "RooAcceptReject.h"
 #include "RooFoamGenerator.h"
-
-
 #include "RooMsgService.h"
 
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor. Register all known integrators by calling

--- a/roofit/roofitcore/src/RooNumIntConfig.cxx
+++ b/roofit/roofitcore/src/RooNumIntConfig.cxx
@@ -24,14 +24,12 @@ numeric integrators used by RooRealIntegral. RooRealIntegral and RooAbsPdf
 use this class in the (normalization) integral configuration interface
 **/
 
-#include "Riostream.h"
-
 #include "RooNumIntConfig.h"
 #include "RooArgSet.h"
-#include "RooAbsIntegrator.h"
 #include "RooNumIntFactory.h"
 #include "RooMsgService.h"
 
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooNumIntFactory.cxx
+++ b/roofit/roofitcore/src/RooNumIntFactory.cxx
@@ -28,24 +28,19 @@ the nature of the integration limits (closed or open ended) and
 the preference of the caller as encoded in the configuration object.
 **/
 
-#include "TClass.h"
-#include "TSystem.h"
-#include "Riostream.h"
-
 #include "RooNumIntFactory.h"
 #include "RooArgSet.h"
 #include "RooAbsFunc.h"
 #include "RooNumIntConfig.h"
 #include "RooNumber.h"
-
 #include "RooRombergIntegrator.h"
 #include "RooBinIntegrator.h"
 #include "RooImproperIntegrator1D.h"
 #include "RooMCIntegrator.h"
 #include "RooAdaptiveIntegratorND.h"
-
 #include "RooMsgService.h"
 
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register all known integrators by calling

--- a/roofit/roofitcore/src/RooNumIntFactory.cxx
+++ b/roofit/roofitcore/src/RooNumIntFactory.cxx
@@ -28,6 +28,8 @@ the nature of the integration limits (closed or open ended) and
 the preference of the caller as encoded in the configuration object.
 **/
 
+#include "TSystem.h"
+
 #include "RooNumIntFactory.h"
 #include "RooArgSet.h"
 #include "RooAbsFunc.h"

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -25,28 +25,28 @@ cached in a histogram. The cache histogram is automatically recalculated
 when any of the parameters of the input p.d.f. has changed.
 **/
 
-#include "Riostream.h"
-
 #include "RooAbsPdf.h"
 #include "RooNumRunningInt.h"
 #include "RooAbsReal.h"
-#include "RooMsgService.h"
 #include "RooDataHist.h"
 #include "RooHistPdf.h"
 #include "RooRealVar.h"
 
-////////////////////////////////////////////////////////////////////////////////
-/// Construct running integral of function '_func' over x_print from
-/// the lower bound on _x to the present value of _x using a numeric
-/// sampling technique. The sampling frequency is controlled by the
-/// binning named 'bname' and a default second order interpolation
-/// is applied to smooth the histogram-based c.d.f.
+#include <ostream>
 
-RooNumRunningInt::RooNumRunningInt(const char *name, const char *title, RooAbsReal& _func, RooRealVar& _x, const char* bname) :
-   RooAbsCachedReal(name,title),
-   func("func","func",this,_func),
-   x("x","x",this,_x),
-   _binningName(bname?bname:"cache")
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Construct running integral of function '_func' over x_print from
+ /// the lower bound on _x to the present value of _x using a numeric
+ /// sampling technique. The sampling frequency is controlled by the
+ /// binning named 'bname' and a default second order interpolation
+ /// is applied to smooth the histogram-based c.d.f.
+
+ RooNumRunningInt::RooNumRunningInt(const char *name, const char *title, RooAbsReal &_func, RooRealVar &_x,
+                                    const char *bname)
+    : RooAbsCachedReal(name, title),
+      func("func", "func", this, _func),
+      x("x", "x", this, _x),
+      _binningName(bname ? bname : "cache")
  {
    setInterpolationOrder(2) ;
  }

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -34,22 +34,22 @@ when any of the parameters of the input p.d.f. has changed.
 
 #include <ostream>
 
- ////////////////////////////////////////////////////////////////////////////////
- /// Construct running integral of function '_func' over x_print from
- /// the lower bound on _x to the present value of _x using a numeric
- /// sampling technique. The sampling frequency is controlled by the
- /// binning named 'bname' and a default second order interpolation
- /// is applied to smooth the histogram-based c.d.f.
+////////////////////////////////////////////////////////////////////////////////
+/// Construct running integral of function '_func' over x_print from
+/// the lower bound on _x to the present value of _x using a numeric
+/// sampling technique. The sampling frequency is controlled by the
+/// binning named 'bname' and a default second order interpolation
+/// is applied to smooth the histogram-based c.d.f.
 
- RooNumRunningInt::RooNumRunningInt(const char *name, const char *title, RooAbsReal &_func, RooRealVar &_x,
-                                    const char *bname)
-    : RooAbsCachedReal(name, title),
-      func("func", "func", this, _func),
-      x("x", "x", this, _x),
-      _binningName(bname ? bname : "cache")
- {
+RooNumRunningInt::RooNumRunningInt(const char *name, const char *title, RooAbsReal &_func, RooRealVar &_x,
+                                   const char *bname)
+   : RooAbsCachedReal(name, title),
+     func("func", "func", this, _func),
+     x("x", "x", this, _x),
+     _binningName(bname ? bname : "cache")
+{
    setInterpolationOrder(2) ;
- }
+}
 
 
 

--- a/roofit/roofitcore/src/RooObjCacheManager.cxx
+++ b/roofit/roofitcore/src/RooObjCacheManager.cxx
@@ -28,11 +28,11 @@ by forwarding these calls to the RooAbsCacheElement interface functions, which
 have a sensible default implementation.
 **/
 
-#include "Riostream.h"
-#include <vector>
 #include "RooObjCacheManager.h"
 #include "RooMsgService.h"
 
+#include <ostream>
+#include <vector>
 
 bool RooObjCacheManager::_clearObsList(false) ;
 

--- a/roofit/roofitcore/src/RooParamBinning.cxx
+++ b/roofit/roofitcore/src/RooParamBinning.cxx
@@ -30,8 +30,7 @@ by the RooRealVar::setRange() that takes RooAbsReal references as arguments
 #include "RooParamBinning.h"
 #include "RooMsgService.h"
 
-#include "Riostream.h"
-
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooPlotable.cxx
+++ b/roofit/roofitcore/src/RooPlotable.cxx
@@ -26,10 +26,10 @@ most useful implementation of RooPlotable are RooHist and RooCurve.
 
 #include "RooPlotable.h"
 #include "TObject.h"
-#include "Riostream.h"
+
+#include <ostream>
 
 using std::endl, std::ostream;
-
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooPrintable.cxx
+++ b/roofit/roofitcore/src/RooPrintable.cxx
@@ -34,7 +34,10 @@ given a Print() option string.
 
 #include "RooPrintable.h"
 
-#include <ostream>
+#include "TNamed.h"
+#include "TClass.h"
+
+#include <iostream>
 #include <iomanip>
 
 using std::ostream, std::setw;

--- a/roofit/roofitcore/src/RooPrintable.cxx
+++ b/roofit/roofitcore/src/RooPrintable.cxx
@@ -34,10 +34,8 @@ given a Print() option string.
 
 #include "RooPrintable.h"
 
-#include "Riostream.h"
+#include <ostream>
 #include <iomanip>
-#include "TNamed.h"
-#include "TClass.h"
 
 using std::ostream, std::setw;
 

--- a/roofit/roofitcore/src/RooProdGenContext.cxx
+++ b/roofit/roofitcore/src/RooProdGenContext.cxx
@@ -25,16 +25,14 @@ component generator contexts that are used to generate the dependents
 for each component PDF sequentially.
 **/
 
-#include "Riostream.h"
 #include "RooMsgService.h"
-
 #include "RooProdGenContext.h"
 #include "RooProdPdf.h"
 #include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "RooGlobalFunc.h"
 
-
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -22,33 +22,30 @@ the -log(L) of the best fit. Note that this function is slow to evaluate
 as a MIGRAD minimization step is executed for each function evaluation
 **/
 
-#include "Riostream.h"
-
 #include "RooProfileLL.h"
 #include "RooAbsReal.h"
 #include "RooMinimizer.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
 
+#include <ostream>
 
+ ////////////////////////////////////////////////////////////////////////////////
+ /// Constructor of profile likelihood given input likelihood nll w.r.t
+ /// the given set of variables. The input log likelihood is minimized w.r.t
+ /// to all other variables of the likelihood at each evaluation and the
+ /// value of the global log likelihood minimum is always subtracted.
 
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor of profile likelihood given input likelihood nll w.r.t
-/// the given set of variables. The input log likelihood is minimized w.r.t
-/// to all other variables of the likelihood at each evaluation and the
-/// value of the global log likelihood minimum is always subtracted.
-
-RooProfileLL::RooProfileLL(const char *name, const char *title,
-            RooAbsReal& nllIn, const RooArgSet& observables) :
-  RooAbsReal(name,title),
-  _nll("input","-log(L) function",this,nllIn),
-  _obs("paramOfInterest","Parameters of interest",this),
-  _par("nuisanceParam","Nuisance parameters",this,false,false)
-{
-  // Determine actual parameters and observables
-  nllIn.getObservables(&observables, _obs) ;
-  nllIn.getParameters(&observables, _par) ;
-}
+ RooProfileLL::RooProfileLL(const char *name, const char *title, RooAbsReal &nllIn, const RooArgSet &observables)
+    : RooAbsReal(name, title),
+      _nll("input", "-log(L) function", this, nllIn),
+      _obs("paramOfInterest", "Parameters of interest", this),
+      _par("nuisanceParam", "Nuisance parameters", this, false, false)
+ {
+    // Determine actual parameters and observables
+    nllIn.getObservables(&observables, _obs);
+    nllIn.getParameters(&observables, _par);
+ }
 
 
 

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -30,22 +30,22 @@ as a MIGRAD minimization step is executed for each function evaluation
 
 #include <ostream>
 
- ////////////////////////////////////////////////////////////////////////////////
- /// Constructor of profile likelihood given input likelihood nll w.r.t
- /// the given set of variables. The input log likelihood is minimized w.r.t
- /// to all other variables of the likelihood at each evaluation and the
- /// value of the global log likelihood minimum is always subtracted.
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor of profile likelihood given input likelihood nll w.r.t
+/// the given set of variables. The input log likelihood is minimized w.r.t
+/// to all other variables of the likelihood at each evaluation and the
+/// value of the global log likelihood minimum is always subtracted.
 
- RooProfileLL::RooProfileLL(const char *name, const char *title, RooAbsReal &nllIn, const RooArgSet &observables)
-    : RooAbsReal(name, title),
-      _nll("input", "-log(L) function", this, nllIn),
-      _obs("paramOfInterest", "Parameters of interest", this),
-      _par("nuisanceParam", "Nuisance parameters", this, false, false)
- {
-    // Determine actual parameters and observables
-    nllIn.getObservables(&observables, _obs);
-    nllIn.getParameters(&observables, _par);
- }
+RooProfileLL::RooProfileLL(const char *name, const char *title, RooAbsReal &nllIn, const RooArgSet &observables)
+   : RooAbsReal(name, title),
+     _nll("input", "-log(L) function", this, nllIn),
+     _obs("paramOfInterest", "Parameters of interest", this),
+     _par("nuisanceParam", "Nuisance parameters", this, false, false)
+{
+   // Determine actual parameters and observables
+   nllIn.getObservables(&observables, _obs);
+   nllIn.getParameters(&observables, _par);
+}
 
 
 

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -27,8 +27,6 @@ The performance of <pre>f->createProjection(x)->createProjection(y)</pre>
 is therefore identical to that of <pre>f->createProjection(RooArgSet(x,y))</pre>
 **/
 
-#include "Riostream.h"
-
 #include "RooProjectedPdf.h"
 #include "RooMsgService.h"
 #include "RooAbsReal.h"
@@ -37,6 +35,8 @@ is therefore identical to that of <pre>f->createProjection(RooArgSet(x,y))</pre>
 #include "RooRatio.h"
 #include "RooWrapperPdf.h"
 #include "RooFitImplHelpers.h"
+
+#include <ostream>
 
  ////////////////////////////////////////////////////////////////////////////////
  /// Default constructor

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -34,7 +34,6 @@ number of expected events of an extended p.d.f
 **/
 
 
-#include "Riostream.h"
 #include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "RooRandom.h"
@@ -43,6 +42,8 @@ number of expected events of an extended p.d.f
 #include "RooAddition.h"
 #include "RooMsgService.h"
 #include "RooRandomizeParamMCSModule.h"
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooRangeBinning.cxx
+++ b/roofit/roofitcore/src/RooRangeBinning.cxx
@@ -26,9 +26,10 @@ the RooRealVar::setRange() method.
 
 #include "RooNumber.h"
 #include "RooMsgService.h"
-#include "Riostream.h"
 
 #include "RooRangeBinning.h"
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitcore/src/RooRangeBoolean.cxx
+++ b/roofit/roofitcore/src/RooRangeBoolean.cxx
@@ -22,15 +22,8 @@
 Returns `1.0` if variable is within given a range and `0.0` otherwise.
 **/
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooRangeBoolean.h"
 #include "RooAbsReal.h"
-#include "RooRealVar.h"
-#include "RooArgList.h"
-#include "RooMsgService.h"
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/src/RooRatio.cxx
+++ b/roofit/roofitcore/src/RooRatio.cxx
@@ -28,11 +28,7 @@ Represents the ratio of two RooAbsReal objects.
 
 #include "RooFit/Detail/MathFuncs.h"
 
-#include <Riostream.h>
-
 #include <TMath.h>
-
-#include <cmath>
 
 
 RooRatio::RooRatio()

--- a/roofit/roofitcore/src/RooRealMPFE.cxx
+++ b/roofit/roofitcore/src/RooRealMPFE.cxx
@@ -46,8 +46,6 @@ For general multiprocessing in ROOT, please refer to the TProcessExecutor class.
 
 **/
 
-#include "Riostream.h"
-
 #ifndef _WIN32
 #include "BidirMMapPipe.h"
 #endif
@@ -63,9 +61,9 @@ For general multiprocessing in ROOT, please refer to the TProcessExecutor class.
 #include "RooMsgService.h"
 #include "RooNLLVar.h"
 
-#include "Rtypes.h"
 #include "TSystem.h"
 
+#include <ostream>
 
 class RooRealMPFE ;
 

--- a/roofit/roofitcore/src/RooRecursiveFraction.cxx
+++ b/roofit/roofitcore/src/RooRecursiveFraction.cxx
@@ -25,18 +25,15 @@ from a set of recursive fractions: for a given set of input fractions
 \f$ {a_i} \f$, it returns \f$ a_n * \prod_{i=0}^{n-1} (1 - a_i) \f$.
 **/
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooRecursiveFraction.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
-#include "RooErrorHandler.h"
 #include "RooArgSet.h"
 #include "RooMsgService.h"
 
 #include <RooFit/Detail/MathFuncs.h>
 
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of plain RooAddPdf fraction from list of recursive fractions

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -62,11 +62,10 @@
  *
  */
 
-#include "TClass.h"
-#include "TMath.h"
-#include "Riostream.h"
 #include "RooResolutionModel.h"
 #include "RooMsgService.h"
+
+#include <ostream>
 
 using std::endl, std::ostream;
 

--- a/roofit/roofitcore/src/RooRombergIntegrator.cxx
+++ b/roofit/roofitcore/src/RooRombergIntegrator.cxx
@@ -34,9 +34,6 @@ apply a five-point series acceleration, and successively add more steps until th
 desired precision is reached.
 **/
 
-#include "Riostream.h"
-
-#include "TClass.h"
 #include "RooRombergIntegrator.h"
 #include "RooArgSet.h"
 #include "RooRealVar.h"
@@ -46,6 +43,7 @@ desired precision is reached.
 #include "RooMsgService.h"
 
 #include <cassert>
+#include <ostream>
 
 namespace {
 

--- a/roofit/roofitcore/src/RooSecondMoment.cxx
+++ b/roofit/roofitcore/src/RooSecondMoment.cxx
@@ -20,17 +20,11 @@
 \ingroup Roofitcore
 **/
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooSecondMoment.h"
 #include "RooAbsReal.h"
 #include "RooAbsPdf.h"
-#include "RooErrorHandler.h"
 #include "RooArgSet.h"
-#include "RooMsgService.h"
 #include "RooRealVar.h"
-#include "RooFunctor.h"
 #include "RooGlobalFunc.h"
 #include "RooConstVar.h"
 #include "RooRealIntegral.h"
@@ -38,10 +32,12 @@
 #include "RooFormulaVar.h"
 #include "RooLinearVar.h"
 #include "RooProduct.h"
+
 #include <string>
+#include <cmath>
+#include <ostream>
+
 using std::string;
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/src/RooSharedProperties.cxx
+++ b/roofit/roofitcore/src/RooSharedProperties.cxx
@@ -24,11 +24,6 @@ that can be stored in RooSharedPropertiesList.
 **/
 
 #include "RooSharedProperties.h"
-#include "RooMsgService.h"
-
-#include "Riostream.h"
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor

--- a/roofit/roofitcore/src/RooSharedProperties.cxx
+++ b/roofit/roofitcore/src/RooSharedProperties.cxx
@@ -25,6 +25,8 @@ that can be stored in RooSharedPropertiesList.
 
 #include "RooSharedProperties.h"
 
+#include <iostream>
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 

--- a/roofit/roofitcore/src/RooStreamParser.cxx
+++ b/roofit/roofitcore/src/RooStreamParser.cxx
@@ -33,18 +33,16 @@
 // from the context. The definition of what is punctuation can be redefined.
 //
 
-
-#include "Riostream.h"
-#include <cstdlib>
-
 #ifndef _WIN32
 #include <strings.h>
 #endif
 
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
-#include "RooNumber.h"
 #include "RooFitImplHelpers.h"
+
+#include <cstdlib>
+#include <istream>
 
 using std::istream, std::endl;
 

--- a/roofit/roofitcore/src/RooStringVar.cxx
+++ b/roofit/roofitcore/src/RooStringVar.cxx
@@ -24,12 +24,12 @@ A RooAbsArg implementing string values.
 
 #include "RooStringVar.h"
 
-#include "Riostream.h"
 #include "TTree.h"
 #include "RooStreamParser.h"
 #include "RooMsgService.h"
 #include "TBranch.h"
 
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with initial value. The size argument is ignored.

--- a/roofit/roofitcore/src/RooStudyManager.cxx
+++ b/roofit/roofitcore/src/RooStudyManager.cxx
@@ -38,7 +38,7 @@ repeated applications of generate-and-fit operations on a workspace
 #include "TSystem.h"
 
 #include <string>
-#include <ostream>
+#include <fstream>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/src/RooStudyManager.cxx
+++ b/roofit/roofitcore/src/RooStudyManager.cxx
@@ -24,9 +24,6 @@ repeated applications of generate-and-fit operations on a workspace
 
 **/
 
-
-#include "Riostream.h"
-
 #include "RooStudyManager.h"
 #include "RooWorkspace.h"
 #include "RooAbsStudy.h"
@@ -37,9 +34,11 @@ repeated applications of generate-and-fit operations on a workspace
 #include "TObjString.h"
 #include "TRegexp.h"
 #include "TKey.h"
-#include <string>
 #include "TROOT.h"
 #include "TSystem.h"
+
+#include <string>
+#include <ostream>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roofitcore/src/RooStudyPackage.cxx
+++ b/roofit/roofitcore/src/RooStudyPackage.cxx
@@ -25,9 +25,6 @@ repeated applications of generate-and-fit operations on a workspace
 **/
 
 
-
-#include "Riostream.h"
-
 #include "RooStudyPackage.h"
 #include "RooWorkspace.h"
 #include "RooAbsStudy.h"
@@ -37,7 +34,10 @@ repeated applications of generate-and-fit operations on a workspace
 #include "TRandom2.h"
 #include "RooRandom.h"
 #include "TMath.h"
-#include "TEnv.h"
+
+#include <list>
+#include <string>
+#include <ostream>
 
 using std::list, std::string;
 

--- a/roofit/roofitcore/src/RooSuperCategory.cxx
+++ b/roofit/roofitcore/src/RooSuperCategory.cxx
@@ -31,8 +31,6 @@ supercategory will propagate to its input categories.
 
 #include "RooSuperCategory.h"
 
-#include "Riostream.h"
-#include "RooStreamParser.h"
 #include "RooArgSet.h"
 #include "RooAbsCategoryLValue.h"
 #include "RooMsgService.h"
@@ -40,6 +38,7 @@ supercategory will propagate to its input categories.
 #include "TString.h"
 #include "TClass.h"
 
+#include <ostream>
 using std::endl, std::ostream;
 
 

--- a/roofit/roofitcore/src/RooTrace.cxx
+++ b/roofit/roofitcore/src/RooTrace.cxx
@@ -90,12 +90,13 @@ and there is no guarantee that this works.
 
 #include "RooTrace.h"
 #include "RooAbsArg.h"
-#include "Riostream.h"
 #include "RooMsgService.h"
-
-#include <iomanip>
 #include "TClass.h"
 
+#include <iomanip>
+#include <ostream>
+#include <string>
+#include <map>
 
 using std::ostream, std::setw, std::hex, std::dec, std::map, std::string;
 

--- a/roofit/roofitcore/src/RooTruthModel.cxx
+++ b/roofit/roofitcore/src/RooTruthModel.cxx
@@ -33,8 +33,6 @@ functions used in D mixing have been hand coded for increased execution speed.
 
 #include <RooFit/Detail/MathFuncs.h>
 
-#include <Riostream.h>
-
 #include <TError.h>
 
 #include <algorithm>

--- a/roofit/roofitcore/src/RooUniformBinning.cxx
+++ b/roofit/roofitcore/src/RooUniformBinning.cxx
@@ -30,8 +30,7 @@ e.g. the binning of class RooBinning.
 #include <RooFit/CodegenContext.h>
 #include <RooMsgService.h>
 
-#include <Riostream.h>
-
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -43,10 +43,7 @@ For integrands with integrable singularities the Wynn epsilon rule
 can be selected to speed up the convergence of these integrals.
 **/
 
-#include <cassert>
-#include <cstdlib>
 #include "TClass.h"
-#include "Riostream.h"
 #include "RooAdaptiveGaussKronrodIntegrator1D.h"
 #include "RooArgSet.h"
 #include "RooRealVar.h"
@@ -55,6 +52,9 @@ can be selected to speed up the convergence of these integrals.
 #include "TMath.h"
 #include "RooMsgService.h"
 
+#include <cassert>
+#include <cstdlib>
+#include <ostream>
 using std::endl;
 
 

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -47,8 +47,6 @@ reached
 #include <RooNumber.h>
 #include <RooRealVar.h>
 
-#include <Riostream.h>
-
 #include <TMath.h>
 
 #include <gsl/gsl_integration.h>
@@ -56,6 +54,7 @@ reached
 #include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitmore/src/RooMathMoreReg.cxx
+++ b/roofit/roofitmore/src/RooMathMoreReg.cxx
@@ -15,7 +15,6 @@
 
 **/
 
-#include "Riostream.h"
 #include "RooMathMoreReg.h"
 #include "RooCFunction1Binding.h"
 #include "RooCFunction2Binding.h"

--- a/roofit/roofitmore/src/RooNonCentralChiSquare.cxx
+++ b/roofit/roofitmore/src/RooNonCentralChiSquare.cxx
@@ -38,8 +38,6 @@ http://live.boost.org/doc/libs/1_42_0/libs/math/doc/sf_and_dist/html/math_toolki
 http://wesnoth.repositoryhosting.com/trac/wesnoth_wesnoth/browser/trunk/include/boost/math/distributions/non_central_chi_squared.hpp?rev=6
 **/
 
-#include "Riostream.h"
-
 #include "RooNonCentralChiSquare.h"
 #include "RooAbsReal.h"
 #include "RooAbsCategory.h"
@@ -48,10 +46,11 @@ http://wesnoth.repositoryhosting.com/trac/wesnoth_wesnoth/browser/trunk/include/
 //#include "RooNumber.h"
 #include "Math/DistFunc.h"
 
-
 #include "RooMsgService.h"
 
 #include "TError.h"
+
+#include <ostream>
 
 using std::endl;
 

--- a/roofit/roofitmore/src/RooSpHarmonic.cxx
+++ b/roofit/roofitmore/src/RooSpHarmonic.cxx
@@ -46,13 +46,11 @@ integrals, using the orthogonality properties of \f$Y_l^m\f$...
 
 **/
 
-#include "Riostream.h"
-#include <cmath>
-
 #include "RooSpHarmonic.h"
 #include "Math/SpecFunc.h"
 #include "TMath.h"
 
+#include <cmath>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/roofit/roostats/src/UpperLimitMCSModule.cxx
+++ b/roofit/roostats/src/UpperLimitMCSModule.cxx
@@ -16,19 +16,16 @@ upper limit for each toy-MC sample generated
 
 */
 
-#include "Riostream.h"
-
 #include "RooDataSet.h"
 #include "RooFitResult.h"
 #include "RooStats/UpperLimitMCSModule.h"
 #include "RooMsgService.h"
 #include "RooStats/ConfInterval.h"
-#include "RooStats/PointSetInterval.h"
 #include "RooStats/LikelihoodInterval.h"
-#include "RooStats/LikelihoodIntervalPlot.h"
 #include "RooStats/ProfileLikelihoodCalculator.h"
 #include "RooRealVar.h"
 
+#include <ostream>
 
 using namespace RooStats ;
 


### PR DESCRIPTION
use instead standard C++ headers, more fine-grained

and cleanup some unused headers on the go