### PR TITLE
[tmva][sofie] Adds the missing ONNX operators Asinh, Acosh, and Atanh to TMVA SOFIE.

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx
@@ -9,7 +9,7 @@ namespace TMVA {
 namespace Experimental {
 namespace SOFIE {
 
-enum class EBasicUnaryOperator { kReciprocal, kSqrt , kNeg, kExp, kLog, kSin, kCos, kAbs, kSoftplus, kAtan, kFloor };
+enum class EBasicUnaryOperator { kReciprocal, kSqrt , kNeg, kExp, kLog, kSin, kCos, kAbs, kSoftplus, kAtan, kFloor, kAsinh, kAcosh, kAtanh };
 
 template <typename T, EBasicUnaryOperator Op>
 struct UnaryOpTraits {
@@ -82,6 +82,26 @@ template <typename T>
 struct UnaryOpTraits<T, EBasicUnaryOperator::kFloor> {
    static std::string Name() { return "Floor"; }
    static std::string Op(const std::string &X) { return "std::floor(" + X + ")"; }
+};
+
+template <typename T>
+struct UnaryOpTraits<T, EBasicUnaryOperator::kAsinh> {
+   static std::string Name() { return "Asinh"; }
+   static std::string Op(const std::string &X) { return "std::asinh(" + X + ")"; }
+};
+
+template <typename T>
+struct UnaryOpTraits<T, EBasicUnaryOperator::kAcosh> {
+   // acosh is only defined for X >= 1; std::acosh returns NaN outside this domain
+   static std::string Name() { return "Acosh"; }
+   static std::string Op(const std::string &X) { return "std::acosh(" + X + ")"; }
+};
+
+template <typename T>
+struct UnaryOpTraits<T, EBasicUnaryOperator::kAtanh> {
+   // atanh is only defined for |X| < 1; std::atanh returns NaN/inf outside this domain
+   static std::string Name() { return "Atanh"; }
+   static std::string Op(const std::string &X) { return "std::atanh(" + X + ")"; }
 };
 
 template <typename T, EBasicUnaryOperator Op>

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -1397,6 +1397,50 @@ TEST(ONNX, Sin)
    expectNear(output, correct_output, DEFAULT_TOLERANCE);
 }
 
+TEST(ONNX, Asinh)
+{
+   std::vector<float> input({
+     -0.786738,-0.197796,-0.187787,0.142758,0.876096,-0.653239,0.145444,-1.107658,2.259171,-0.947054,-0.506689,1.801250
+   });
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "Asinh", input);
+
+   std::vector<float> correct_output;
+   for (float x : input)
+      correct_output.push_back(std::asinh(x));
+   expectNear(output, correct_output, DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, Acosh)
+{
+   // acosh is only defined for x >= 1
+   std::vector<float> input({
+     1.0, 1.001, 1.5, 2.0, 3.789, 5.234, 10.0, 1.234, 7.891, 2.345, 1.999, 100.0
+   });
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "Acosh", input);
+
+   std::vector<float> correct_output;
+   for (float x : input)
+      correct_output.push_back(std::acosh(x));
+   expectNear(output, correct_output, DEFAULT_TOLERANCE);
+}
+
+TEST(ONNX, Atanh)
+{
+   // atanh is only defined for |x| < 1
+   std::vector<float> input({
+     -0.99,-0.786738,-0.5,-0.197796,0.0,0.142758,0.5,0.876096,-0.653239,0.3,0.99,-0.142758
+   });
+
+   ASSERT_INCLUDE_AND_RUN(std::vector<float>, "Atanh", input);
+
+   std::vector<float> correct_output;
+   for (float x : input)
+      correct_output.push_back(std::atanh(x));
+   expectNear(output, correct_output, DEFAULT_TOLERANCE);
+}
+
 TEST(ONNX, Cos)
 {
    // Preparing the random input

--- a/tmva/sofie/test/generate_input_models.py
+++ b/tmva/sofie/test/generate_input_models.py
@@ -4825,6 +4825,60 @@ def make_Sin():
     return _model(graph, opset=7, ir_version=10, producer_name='onnx-example')
 
 
+def make_Asinh():
+    """Ops: Asinh"""
+    nodes = [
+        helper.make_node('Asinh', ['input'], ['output']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'asinh_test',
+        inputs=[
+            _vi('input', FLOAT, [3, 4]),
+        ],
+        outputs=[
+            _vi('output', FLOAT, [3, 4]),
+        ],
+    )
+    return _model(graph, opset=9, ir_version=10, producer_name='onnx-example')
+
+
+def make_Acosh():
+    """Ops: Acosh"""
+    nodes = [
+        helper.make_node('Acosh', ['input'], ['output']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'acosh_test',
+        inputs=[
+            _vi('input', FLOAT, [3, 4]),
+        ],
+        outputs=[
+            _vi('output', FLOAT, [3, 4]),
+        ],
+    )
+    return _model(graph, opset=9, ir_version=10, producer_name='onnx-example')
+
+
+def make_Atanh():
+    """Ops: Atanh"""
+    nodes = [
+        helper.make_node('Atanh', ['input'], ['output']),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        'atanh_test',
+        inputs=[
+            _vi('input', FLOAT, [3, 4]),
+        ],
+        outputs=[
+            _vi('output', FLOAT, [3, 4]),
+        ],
+    )
+    return _model(graph, opset=9, ir_version=10, producer_name='onnx-example')
+
+
 def make_Slice():
     """Ops: Slice"""
     nodes = [
@@ -5247,6 +5301,7 @@ def make_Where():
 
 MODELS = {
     'Abs': make_Abs,
+    'Acosh': make_Acosh,
     'Add': make_Add,
     'AddBroadcast1': make_AddBroadcast1,
     'AddBroadcast2': make_AddBroadcast2,
@@ -5255,6 +5310,8 @@ MODELS = {
     'AddBroadcast5': make_AddBroadcast5,
     'AddBroadcast6': make_AddBroadcast6,
     'AddBroadcast7': make_AddBroadcast7,
+    'Asinh': make_Asinh,
+    'Atanh': make_Atanh,
     'AveragePool1d_CeilMode': make_AveragePool1d_CeilMode,
     'AveragePool1d_CeilMode_Overhang': make_AveragePool1d_CeilMode_Overhang,
     'AveragePool2d_CeilMode': make_AveragePool2d_CeilMode,

--- a/tmva/sofie_parsers/src/ParseBasicUnary.cxx
+++ b/tmva/sofie_parsers/src/ParseBasicUnary.cxx
@@ -90,6 +90,19 @@ ParserFuncSignature ParseAtan = [](RModelParser_ONNX &parser, const onnx::NodePr
    return ParseBasicUnary<EBasicUnaryOperator::kAtan>(parser, nodeproto);
 };
 
+//Parse Asinh
+ParserFuncSignature ParseAsinh = [](RModelParser_ONNX &parser, const onnx::NodeProto &nodeproto) {
+   return ParseBasicUnary<EBasicUnaryOperator::kAsinh>(parser, nodeproto);
+};
+//Parse Acosh
+ParserFuncSignature ParseAcosh = [](RModelParser_ONNX &parser, const onnx::NodeProto &nodeproto) {
+   return ParseBasicUnary<EBasicUnaryOperator::kAcosh>(parser, nodeproto);
+};
+//Parse Atanh
+ParserFuncSignature ParseAtanh = [](RModelParser_ONNX &parser, const onnx::NodeProto &nodeproto) {
+   return ParseBasicUnary<EBasicUnaryOperator::kAtanh>(parser, nodeproto);
+};
+
 //Parse Floor
 ParserFuncSignature ParseFloor = [](RModelParser_ONNX &parser, const onnx::NodeProto &nodeproto) {
    return ParseBasicUnary<EBasicUnaryOperator::kFloor>(parser, nodeproto);

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -29,6 +29,9 @@ extern ParserFuncSignature ParseCos;
 extern ParserFuncSignature ParseAbs;
 extern ParserFuncSignature ParseSoftplus;
 extern ParserFuncSignature ParseAtan;
+extern ParserFuncSignature ParseAsinh;
+extern ParserFuncSignature ParseAcosh;
+extern ParserFuncSignature ParseAtanh;
 extern ParserFuncSignature ParseFloor;
 // Binary operators
 extern ParserFuncSignature ParseAdd;
@@ -318,6 +321,9 @@ RModelParser_ONNX::RModelParser_ONNX() noexcept : fOperatorsMapImpl(std::make_un
    RegisterOperator("Abs", ParseAbs);
    RegisterOperator("Softplus", ParseSoftplus);
    RegisterOperator("Atan", ParseAtan);
+   RegisterOperator("Asinh", ParseAsinh);
+   RegisterOperator("Acosh", ParseAcosh);
+   RegisterOperator("Atanh", ParseAtanh);
    RegisterOperator("Floor", ParseFloor);
    // Binary operators
    RegisterOperator("Add", ParseAdd);


### PR DESCRIPTION
**This Pull Request**
Adds the missing ONNX operators `Asinh`, `Acosh`, and `Atanh` to TMVA SOFIE.

**Changes & Fixes**
* **`tmva/sofie/inc/TMVA/ROperator_BasicUnary.hxx`**: Added `Asinh`, `Acosh`, and `Atanh` to the `EBasicUnaryOperator` enum and their corresponding `UnaryOpTraits` specializations, following the same pattern already used for `Sin`, `Cos`, and `Atan`. A comment notes that `Acosh` and `Atanh` have restricted domains (x >= 1 and |x| < 1 respectively) and rely on `std::acosh` and `std::atanh` returning NaN outside those ranges.
* **`tmva/sofie_parsers/src/ParseBasicUnary.cxx` & `tmva/sofie_parsers/src/RModelParser_ONNX.cxx`**: Added the corresponding parser lambdas and operator registrations, matching the existing `ParseAtan` pattern exactly.
* **`tmva/sofie/test/generate_input_models.py` & `tmva/sofie/test/TestCustomModelsFromONNX.cxx`**: Added tests for all three operators, utilizing domain appropriate input values for `Acosh` and `Atanh`.

**Checklist**
- [x] Tested changes locally
- [x] Updated the docs (if necessary)

This PR fixes #23275 

@guitargeek, following up on our conversation, this PR implements Asinh, Acosh, and Atanh as outlined in the issue. Please let me know if this looks good to you or if you need any adjustments.Thanks!
