### PR TITLE
[rootcanvas] select canvas x11 window before closing it [6.40]

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -804,10 +804,6 @@ void TCanvas::Close(Option_t *option)
       TPad::Close(option);
 
       if (!IsBatch() && !IsWeb()) {
-         //select current canvas
-         if (fPainter)
-            fPainter->SelectDrawable(fCanvasID);
-
          DeleteCanvasPainter();
 
          if (fCanvasImp)

--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -726,7 +726,11 @@ void TRootCanvas::Close()
       else gged->Hide();
    }
 
-   gVirtualX->CloseWindow();
+   if (fCanvasID != -1) {
+      gVirtualX->SelectWindow(fCanvasID);
+      gVirtualX->CloseWindow();
+      fCanvasID = -1;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Backport of fixes from bigger PR https://github.com/root-project/root/pull/23312

Correctly select canvas window in TRootCanvas before closing it.
Before `gVirtualX->SelectWindow(fCanvasID)` was done in the TCanvas::Close(), 
but it was replaced by `fPainter->SelectDrawable(fCanvasID)`. 
For the case of GL it does not really select `gVirtualX` window.

After such change selection can be removed from TCanvas::Close()