### PR TITLE
Revert "[doc] Update htmlheader to include versions.js"

### DIFF
--- a/documentation/doxygen/htmlheader.html
+++ b/documentation/doxygen/htmlheader.html
@@ -56,7 +56,6 @@ $extrastylesheet
    <div class="dropdown-content">
    </div>
 </div>
-<script type="text/javascript" src="../versions.js"></script>
 <script type="text/javascript" src="../selectversion.js"></script>
 <!-- END version select -->
   <br> $projectbrief </td>


### PR DESCRIPTION
This reverts commit aea2feac6f65e62bad14555dc921b6bc6bb73c17.

A better solution was devised that doesn't imply changing the html for the docs, which doesn't work for old versions.

See also https://github.com/root-project/web/pull/1242
