### PR TITLE
[Python] Check std::array type without string matching

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
+++ b/bindings/pyroot/pythonizations/test/rdataframe_asnumpy.py
@@ -120,7 +120,7 @@ class RDataFrameAsNumpy(unittest.TestCase):
         npy = df.AsNumpy()
         self.assertEqual(npy["x"].size, 5)
         self.assertEqual(list(npy["x"][0]), [0, 0, 0])
-        self.assertIn("array<unsigned int,3>", str(type(npy["x"][0])))
+        self.assertIs(type(npy["x"][0]), ROOT.std.array["unsigned int", 3])
 
     def test_read_th1f(self):
         """


### PR DESCRIPTION
This is more general than matching the type name, which depends on how types get represented by cppyy.