### PR TITLE
[rootcanvas] fix GL canvas flicking with enabled tooltip

### DIFF
--- a/gui/gui/src/TRootCanvas.cxx
+++ b/gui/gui/src/TRootCanvas.cxx
@@ -1822,8 +1822,11 @@ Bool_t TRootCanvas::HandleContainerButton(Event_t *event)
    if (event->fType == kButtonPress) {
       if (fToolTip && fCanvas->GetShowToolTips()) {
          fToolTip->Hide();
-         gVirtualX->UpdateWindowW(gVirtualX->GetWindowContext(fCanvasID), 0);
-         gSystem->ProcessEvents();
+         // do not sync GL canvas - avoid flicking
+         if (!fCanvas->UseGL() && (fCanvasID != -1)) {
+            gVirtualX->UpdateWindowW(gVirtualX->GetWindowContext(fCanvasID), 0);
+            gSystem->ProcessEvents();
+         }
       }
       fButton = button;
       if (button == kButton1) {


### PR DESCRIPTION
When TRootCanvas shows tooltips it also call sync for X11 canvas with mouse click event. 
It should not be done for GL-based canvas.

For the future it should be moved to `TCanvas::Flush()` method where sync of all pixmaps / doublebuffers is implemented including GL support.

Issue exists since ever but was never observed while both GL and tooltips are disabled by default 
and most probably never tested together.