### PR TITLE
[graphics] auto colors in TMultiGraph and THStack

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -30,7 +30,6 @@
 #include "TQObject.h"
 
 #include "GuiTypes.h"
-#include "TString.h"
 #include "Buttons.h"
 
 // forward declarations
@@ -44,6 +43,7 @@ class TH1F;
 class TFrame;
 class TLegend;
 class TBox;
+class TString;
 class TVirtualViewer3D;
 class TVirtualPadPainter;
 
@@ -273,7 +273,7 @@ public:
    virtual void     XYtoPixel(Double_t x, Double_t y, Int_t &xpixel, Int_t &ypixel) const = 0;
    virtual void     XYtoPixel(Double_t x, Double_t y, Double_t &xpixel, Double_t &ypixel) const = 0;
 
-   virtual Int_t    IncrementPaletteColor(Int_t i, TString opt) = 0;
+   virtual Int_t    IncrementPaletteColor(Int_t i, const TString &opt) = 0;
    virtual Int_t    NextPaletteColor() = 0;
 
    virtual Bool_t   PlaceBox(TObject *o, Double_t w, Double_t h, Double_t &xl, Double_t &yb, Option_t* opt = "lb") = 0;

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -399,7 +399,7 @@ public:
    void              ResetToolTip(TObject *tip) override;
    void              CloseToolTip(TObject *tip) override;
 
-   Int_t             IncrementPaletteColor(Int_t i, TString opt) override;
+   Int_t             IncrementPaletteColor(Int_t i, const TString &opt) override;
    Int_t             NextPaletteColor() override;
 
    void              DrawCollideGrid();

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3129,15 +3129,18 @@ void TPad::ls(Option_t *option) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Increment (i==1) or set (i>1) the number of autocolor in the pad.
 
-Int_t TPad::IncrementPaletteColor(Int_t i, TString opt)
+Int_t TPad::IncrementPaletteColor(Int_t i, const TString &opt)
 {
-   if (opt.Index("pfc")>=0 || opt.Index("plc")>=0 || opt.Index("pmc")>=0) {
-       if (i==1) fNumPaletteColor++;
-       else      fNumPaletteColor = i;
-       return    fNumPaletteColor;
-   } else {
-      return 0;
+   TString opt1 = opt;
+   opt1.ToLower();
+
+   if (opt1.Contains("pfc") || opt1.Contains("plc") || opt1.Contains("pmc")) {
+      if (i == 1) fNumPaletteColor++;
+      else      fNumPaletteColor = i;
+      return    fNumPaletteColor;
    }
+
+   return 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -733,8 +733,10 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
          }
       } else if (obj->InheritsFrom(TMultiGraph::Class())) {
          // workaround for TMultiGraph
+         auto mg = static_cast<TMultiGraph *>(obj);
+         // assign auto-colors if any
+         mg->BuildPrimitives(iter.GetOption());
          if (opt.Contains("A")) {
-            auto mg = static_cast<TMultiGraph *>(obj);
             TVirtualPad::TContext ctxt(kFALSE);
             mg->GetHistogram(); // force creation of histogram without any drawings
             has_histo = true;

--- a/hist/hist/inc/TMultiGraph.h
+++ b/hist/hist/inc/TMultiGraph.h
@@ -43,12 +43,15 @@ protected:
    TMultiGraph(const TMultiGraph&) = delete;
    TMultiGraph& operator=(const TMultiGraph&) = delete;
 
+   void BuildAndPaint(Option_t *chopt, Bool_t paint);
+
 public:
    TMultiGraph();
    TMultiGraph(const char *name, const char *title);
    ~TMultiGraph() override;
 
    virtual void      Add(TGraph *graph, Option_t *chopt = "");
+   void              BuildPrimitives(Option_t *chopt = "") { BuildAndPaint(chopt, kFALSE); }
    void              Browse(TBrowser *b) override;
    Int_t             DistancetoPrimitive(Int_t px, Int_t py) override;
    void              Draw(Option_t *chopt = "") override;

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -861,41 +861,38 @@ void TGraph::Draw(Option_t *option)
    TString opt = option;
    opt.ToLower();
 
-   if (opt.Contains("same")) {
+   if (opt.Contains("same"))
       opt.ReplaceAll("same", "");
-   }
 
    // in case of option *, set marker style to 3 (star) and replace
    // * option by option P.
-   Ssiz_t pos;
-   if ((pos = opt.Index("*")) != kNPOS) {
+   auto pos = opt.Index("*");
+   if (pos != kNPOS) {
       SetMarkerStyle(3);
-      opt.Replace(pos, 1, "p");
+      opt[pos] = 'p';
    }
 
    // If no option is specified, it is defined as "alp" in case there is
    // no current pad or if the current pad has no axis defined and if there is
    // no default option set using TGraph::SetOption. If fOption is set using
    // TGraph::SetOption, it is used as default option.
-   if ((!option || !strlen(option))) {
-      Option_t *topt = (!fOption.IsNull()) ? fOption.Data() : "alp";
-      if (gPad) {
-         if (!gPad->GetListOfPrimitives()->FindObject("TFrame"))
-            opt = topt;
-      } else {
-         opt = topt;
+   if (!option || !*option) {
+      if (!gPad || !gPad->GetListOfPrimitives()->FindObject("TFrame")) {
+         opt = !fOption.IsNull() ? fOption.Data() : "alp";
+         opt.ToLower();
       }
    }
 
    if (gPad) {
-      if (!gPad->IsEditable()) gROOT->MakeDefCanvas();
-      if (opt.Contains("a")) gPad->Clear();
+      if (!gPad->IsEditable())
+         gROOT->MakeDefCanvas();
+      if (opt.Contains("a"))
+         gPad->Clear();
    }
 
    AppendPad(opt);
 
    gPad->IncrementPaletteColor(1, opt);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -497,6 +497,10 @@ Double_t THStack::GetMaximum(Option_t *option, Double_t maxval)
 {
    TString opt = option;
    opt.ToLower();
+   // exclude option which can conflict with "e" draw option
+   opt.ReplaceAll("same", "");
+   opt.ReplaceAll("candle", "");
+   opt.ReplaceAll("lego", "");
    Bool_t lerr = opt.Contains("e");
    Double_t themax = -std::numeric_limits<Double_t>::max();
    if (!fHists) return 0;
@@ -550,6 +554,10 @@ Double_t THStack::GetMinimum(Option_t *option, Double_t minval)
 
    TString opt = option;
    opt.ToLower();
+   // exclude option which can conflict with "e" draw option
+   opt.ReplaceAll("same", "");
+   opt.ReplaceAll("candle", "");
+   opt.ReplaceAll("lego", "");
    Bool_t lerr = opt.Contains("e");
    Bool_t logy = gPad ? gPad->GetLogy() : kFALSE;
    Double_t themin = std::numeric_limits<Double_t>::max();

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -715,39 +715,34 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stac
    if (!fHists) return;
    if (!fHists->GetSize()) return;
 
-   char option[128];
-   strlcpy(option,choptin,128);
+   TString opt = choptin;
+   opt.ToLower();
 
    // Automatic color
-   char *l1 = strstr(option,"pfc"); // Automatic Fill Color
-   char *l2 = strstr(option,"plc"); // Automatic Line Color
-   char *l3 = strstr(option,"pmc"); // Automatic Marker Color
-   if (l1 || l2 || l3) {
-      TString opt1 = option;
-      if (l1) memcpy(l1,"   ",3);
-      if (l2) memcpy(l2,"   ",3);
-      if (l3) memcpy(l3,"   ",3);
-      TString ws = option;
-      if (ws.IsWhitespace()) strncpy(option,"\0",1);
+   Bool_t pfc = opt.Contains("pfc"); // Automatic Fill Color
+   Bool_t plc = opt.Contains("plc"); // Automatic Line Color
+   Bool_t pmc = opt.Contains("pmc"); // Automatic Marker Color
+   if (pfc || plc || pmc) {
       Int_t nhists = fHists->GetSize();
-      gPad->IncrementPaletteColor(nhists, opt1);
+      gPad->IncrementPaletteColor(nhists, opt);
       for (Int_t i = 0; i < nhists; i++) {
          auto ic = gPad->NextPaletteColor();
          auto hAti = static_cast<TH1 *>(fHists->At(i));
-         if (l1) hAti->SetFillColor(ic);
-         if (l2) hAti->SetLineColor(ic);
-         if (l3) hAti->SetMarkerColor(ic);
+         if (pfc) hAti->SetFillColor(ic);
+         if (plc) hAti->SetLineColor(ic);
+         if (pmc) hAti->SetMarkerColor(ic);
          if (fStack) {
             auto hsAti = static_cast<TH1 *>(fStack->At(i));
-            if (l1) hsAti->SetFillColor(ic);
-            if (l2) hsAti->SetLineColor(ic);
-            if (l3) hsAti->SetMarkerColor(ic);
+            if (pfc) hsAti->SetFillColor(ic);
+            if (plc) hsAti->SetLineColor(ic);
+            if (pmc) hsAti->SetMarkerColor(ic);
          }
       }
+      opt.ReplaceAll("pfc", "");
+      opt.ReplaceAll("plc", "");
+      opt.ReplaceAll("pmc", "");
    }
 
-   TString opt = option;
-   opt.ToLower();
    opt.ReplaceAll(" ","");
    Bool_t lsame = kFALSE;
    if (opt.Contains("same")) {
@@ -850,10 +845,10 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint, Bool_t rebuild_stac
    }
 
    Double_t themax,themin;
-   if (fMaximum == -1111) themax = GetMaximum(option);
+   if (fMaximum == -1111) themax = GetMaximum(choptin);
    else                   themax = fMaximum;
    if (fMinimum == -1111) {
-      themin = GetMinimum(option);
+      themin = GetMinimum(choptin);
       if (gPad->GetLogy()){
          if (themin>0)  themin *= .9;
          else           themin = themax*1.e-3;

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1147,42 +1147,48 @@ TAxis *TMultiGraph::GetYaxis()
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint all the graphs of this multigraph.
 
-void TMultiGraph::Paint(Option_t *choptin)
+void TMultiGraph::Paint(Option_t *opt)
+{
+   BuildAndPaint(opt, kTRUE);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Fill automatic colors and then paint multigraph
+
+void TMultiGraph::BuildAndPaint(Option_t *mgropt, Bool_t paint)
 {
    const TPickerStackGuard pushGuard(this);
 
    if (!fGraphs) return;
    if (fGraphs->GetSize() == 0) return;
 
-   char option[128];
-   strlcpy(option,choptin,128);
-   Int_t nch = choptin ? strlen(choptin) : 0;
-   for (Int_t i=0;i<nch;i++) option[i] = toupper(option[i]);
+   TString chopt = mgropt;
+   chopt.ToUpper();
+   Bool_t pfc = chopt.Contains("PFC"); // Automatic Fill Color
+   Bool_t plc = chopt.Contains("PLC"); // Automatic Line Color
+   Bool_t pmc = chopt.Contains("PMC"); // Automatic Marker Color
 
-   // Automatic color
-   char *l1 = strstr(option,"PFC"); // Automatic Fill Color
-   char *l2 = strstr(option,"PLC"); // Automatic Line Color
-   char *l3 = strstr(option,"PMC"); // Automatic Marker Color
-   if (l1 || l2 || l3) {
-      TString opt1 = option; opt1.ToLower();
-      if (l1) memcpy(l1,"   ",3);
-      if (l2) memcpy(l2,"   ",3);
-      if (l3) memcpy(l3,"   ",3);
-      auto lnk = fGraphs->FirstLink();
+   if (pfc || plc || pmc) {
       Int_t ngraphs = fGraphs->GetSize();
-      Int_t ic;
-      gPad->IncrementPaletteColor(ngraphs, opt1);
-      for (Int_t i=0;i<ngraphs;i++) {
-         ic = gPad->NextPaletteColor();
-         auto gAti = (TGraph*)(fGraphs->At(i));
-         if (l1) gAti->SetFillColor(ic);
-         if (l2) gAti->SetLineColor(ic);
-         if (l3) gAti->SetMarkerColor(ic);
-         lnk = lnk->Next();
+      gPad->IncrementPaletteColor(ngraphs, chopt);
+      for (Int_t i = 0; i < ngraphs; i++) {
+         Int_t ic = gPad->NextPaletteColor();
+         auto gAti = (TGraph *)(fGraphs->At(i));
+         if (pfc)
+            gAti->SetFillColor(ic);
+         if (plc)
+            gAti->SetLineColor(ic);
+         if (pmc)
+            gAti->SetMarkerColor(ic);
       }
+      chopt.ReplaceAll("PFC", "");
+      chopt.ReplaceAll("PLC", "");
+      chopt.ReplaceAll("PMC", "");
    }
 
-   TString chopt = option;
+   if (!paint)
+      return;
 
    auto l = strstr(chopt.Data(), "3D");
    if (l) {

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -90108,13 +90108,14 @@ class TPadPainter extends ObjectPainter {
    /** @summary Provides automatic color
     * @desc Uses ROOT colors palette if possible
     * @private */
-   getAutoColor(numprimitives) {
-      numprimitives = Math.max(numprimitives || (this.#num_primitives || 5) - (this.#num_specials || 0), 2);
-
-      let indx = this.#auto_color_cnt ?? 0;
-      this.#auto_color_cnt = (indx + 1) % numprimitives;
-      if (indx >= numprimitives)
-         indx = numprimitives - 1;
+   getAutoColor(numprimitives, indx) {
+      if (!numprimitives || indx === undefined) {
+         numprimitives = Math.max(numprimitives || (this.#num_primitives || 5) - (this.#num_specials || 0), 2);
+         indx = this.#auto_color_cnt ?? 0;
+         this.#auto_color_cnt = (indx + 1) % numprimitives;
+         if (indx >= numprimitives)
+            indx = numprimitives - 1;
+      }
 
       let indexes = this._getCustomPaletteIndexes();
       if (!indexes) {
@@ -91867,12 +91868,6 @@ class TPadPainter extends ObjectPainter {
             const opt = createWebObjectOptions(sub);
             if (opt)
                elem.primitives.push(opt);
-            if (sub.$copywebid && opt?.fcust) {
-               // workaround for stack histograms to assign attributes to original histo
-               const opt2 = Object.assign({}, opt);
-               opt2.snapid = sub.getPrimary().getSnapId() + '#' + sub.$copywebid;
-               elem.primitives.push(opt2);
-            }
          }
       });
 
@@ -96741,7 +96736,7 @@ class THistPainter extends ObjectPainter {
       if (o._pfc > 1 || o._plc > 1 || o._pmc > 1) {
          const pp = this.getPadPainter();
          if (isFunc(pp?.getAutoColor)) {
-            const icolor = pp.getAutoColor(histo.$num_histos);
+            const icolor = pp.getAutoColor();
             this.#auto_exec = '';
             if (o._pfc > 1) {
                o._pfc = 1;
@@ -108551,7 +108546,7 @@ let TGraphPainter$1 = class TGraphPainter extends ObjectPainter {
       if (o._pfc > 1 || o._plc > 1 || o._pmc > 1) {
          const pp = this.getPadPainter();
          if (isFunc(pp?.getAutoColor)) {
-            const icolor = pp.getAutoColor(graph.$num_graphs);
+            const icolor = pp.getAutoColor();
             this.#auto_exec = ''; // can be reused when sending option back to server
             if (o._pfc > 1) {
                o._pfc = 1;
@@ -172375,8 +172370,6 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
       }
       if (!o.pads)
          hopt += ' same nostat';
-      if (!this.getPadPainter()?.getSnapId())
-         hopt += o.auto;
       return hopt;
    }
 
@@ -172390,36 +172383,39 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
       if (indx >= nhists)
          return this;
 
-      const rindx = o.horder ? indx : nhists - indx - 1,
-            h_id = `hists_${rindx}`, s_id = `stack_${rindx}`,
+      const rindx = o.nostack ? indx : nhists - indx - 1,
             hist = hlst.arr[rindx],
             hopt = this.getHistDrawOption(hist, stack.fHists.opt[rindx]);
-      let dom;
+      let pp;
 
       if (pad_painter) {
          // handling of 'pads' draw option
-         const subpad_painter = pad_painter.getSubPadPainter(indx + 1);
-         if (!subpad_painter)
+         pp = pad_painter.getSubPadPainter(indx + 1);
+         if (!pp)
             return this;
-         subpad_painter.cleanPrimitives(true);
-         dom = subpad_painter;
+         pp.cleanPrimitives(true);
       } else {
          // special handling of stacked histograms
          // also used to provide tooltips
          if ((rindx > 0) && !o.nostack)
             hist.$baseh = hlst.arr[rindx - 1];
-         // this number used for auto colors creation
-         if (o.auto)
-            hist.$num_histos = nhists;
-         dom = this.#firstpainter?.getPadPainter() || this.getDrawDom();
+         pp = this.#firstpainter?.getPadPainter() || getElementPadPainter(this.getDrawDom());
       }
 
-      return this.drawHist(dom, hist, hopt).then(subp => {
+      // assign auto color to histogram, exclude web canvas
+      if ((o._pfc || o._plc || o._pmc) && pp && !pp.getSnapId()) {
+         const col = pp.getAutoColor(nhists, rindx);
+         if (o._pfc)
+            hist.fFillColor = col;
+         if (o._plc)
+            hist.fLineColor = col;
+         if (o._pmc)
+            hist.fMarkerColor = col;
+      }
+
+      return this.drawHist(pp, hist, hopt).then(subp => {
          if (subp) {
-            subp.setSecondaryId(this, o.nostack ? h_id : s_id);
-            // workaround to assign weboptions also back to original histogram
-            if (!o.nostack)
-               subp.$copywebid = h_id;
+            subp.setSecondaryId(this, o.nostack ? `hists_${rindx}` : `stack_${rindx}`);
             this.#painters.push(subp);
          }
          return this.drawNextHisto(indx + 1, pad_painter);
@@ -172428,7 +172424,7 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
 
    /** @summary Decode draw options of THStack painter */
    decodeOptions(opt) {
-      const o = this.setOptions({ ndim: 1, nostack: false, same: false, horder: true, has_errors: false, draw_errors: false, hopt: '', auto: '' }),
+      const o = this.setOptions({ ndim: 1, nostack: false, same: false, has_errors: false, draw_errors: false, _pfc: false, _pmc: false, _plc: false, hopt: '' }),
             stack = this.getObject(),
             hist = stack.fHistogram || stack.fHists?.arr[0] || this.#stack?.arr[0];
 
@@ -172460,11 +172456,9 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
       o.same = d.check('SAME');
 
       d.check('NOCLEAR'); // ignore option
-
-      ['PFC', 'PLC', 'PMC'].forEach(f => {
-         if (d.check(f))
-            o.auto += ' ' + f;
-      });
+      o._pfc = d.check('PFC');
+      o._plc = d.check('PLC');
+      o._pmc = d.check('PMC');
 
       if (d.check('PADS', true)) {
          o.pads = true;
@@ -172485,8 +172479,6 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
       // if any histogram appears with pre-calculated errors, use E for all histograms
       if (!o.nostack && o.has_errors && !dolego && !d.check('HIST') && (o.hopt.indexOf('E') < 0))
          o.draw_errors = true;
-
-      o.horder = o.nostack || dolego;
    }
 
    /** @summary Create main histogram for THStack axis drawing */
@@ -172583,7 +172575,7 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
       } else {
          this.#did_update = 2;
          for (let indx = 0; indx < nhists; ++indx) {
-            const rindx = o.horder ? indx : nhists - indx - 1,
+            const rindx = o.nostack ? indx : nhists - indx - 1,
                   hist = hlst.arr[rindx];
             this.#painters[indx].updateObject(hist, this.getHistDrawOption(hist, stack.fHists.opt[rindx]));
          }
@@ -172635,7 +172627,7 @@ let THStackPainter$2 = class THStackPainter extends ObjectPainter {
                   hlst = o.nostack ? stack.fHists : this.#stack,
                   nhists = hlst?.arr?.length ?? 0;
             for (let indx = 0; indx < nhists; ++indx) {
-               const rindx = o.horder ? indx : nhists - indx - 1,
+               const rindx = o.nostack ? indx : nhists - indx - 1,
                      hist = hlst.arr[rindx];
                this.#painters[indx].decodeOptions(this.getHistDrawOption(hist, stack.fHists.opt[rindx]));
             }
@@ -176698,7 +176690,9 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
    #painters; // array of sub-painters
    #funcs_handler; // special instance for functions drawing
    #restopt; // remaining part of draw options
-   #auto; // extra options for auto colors
+   #pfc; // extra options for auto colors
+   #plc; // extra options for auto colors
+   #pmc; // extra options for auto colors
    #is3d; // if 3d drawing
    #pads;  // pads draw option
    #pads_columns; // number pads columns
@@ -176717,7 +176711,9 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
       this.#painters = [];
       this.#is3d = undefined;
       this.#pads = undefined;
-      this.#auto = undefined;
+      this.#pfc = undefined;
+      this.#pmc = undefined;
+      this.#plc = undefined;
       this.#restopt = undefined;
       super.cleanup();
    }
@@ -176747,7 +176743,7 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
 
       // TODO: handle changing number of graphs
       for (let i = 0; i < ngr; ++i) {
-         if (this.#painters[i].updateObject(graphs.arr[i], (graphs.opt[i] || this.#restopt) + this.#auto))
+         if (this.#painters[i].updateObject(graphs.arr[i], (graphs.opt[i] || this.#restopt)))
             isany = true;
       }
 
@@ -176939,37 +176935,37 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
          return this;
 
       const gr = graphs.arr[indx],
-            draw_opt = (graphs.opt[indx] || this.#restopt) + this.#auto,
-            pos3d = graphs.arr.length - indx,
-            subid = `graphs_${indx}`;
+            draw_opt = (graphs.opt[indx] || this.#restopt),
+            pos3d = graphs.arr.length - indx;
+      let pp;
 
       // handling of 'pads' draw option
       if (pad_painter) {
-         const subpad_painter = pad_painter.getSubPadPainter(indx + 1);
-         if (!subpad_painter)
+         pp = pad_painter.getSubPadPainter(indx + 1);
+         if (!pp)
             return this;
 
-         subpad_painter.cleanPrimitives(true);
+         pp.cleanPrimitives(true);
+      } else
+         pp = this.#firstpainter?.getPadPainter() || getElementPadPainter(this.getDrawDom());
 
-         return this.drawGraph(subpad_painter, gr, draw_opt, pos3d).then(subp => {
-            if (subp) {
-               subp.setSecondaryId(this, subid);
-               this.#painters.push(subp);
-            }
-            return this.drawNextGraph(indx + 1, pad_painter);
-         });
+      // assign auto color to graph, exclude web canvas
+      if ((this.#pfc || this.#plc || this.#pmc) && pp && !pp.getSnapId()) {
+         const col = pp.getAutoColor(graphs.arr.length, indx);
+         if (this.#pfc)
+            gr.fFillColor = col;
+         if (this.#plc)
+            gr.fLineColor = col;
+         if (this.#pmc)
+            gr.fMarkerColor = col;
       }
 
-      // used in automatic colors numbering
-      if (this.#auto)
-         gr.$num_graphs = graphs.arr.length;
-
-      return this.drawGraph(this.getPadPainter(), gr, draw_opt, pos3d).then(subp => {
+      return this.drawGraph(pp, gr, draw_opt, pos3d).then(subp => {
          if (subp) {
-            subp.setSecondaryId(this, subid);
+            subp.setSecondaryId(this, `graphs_${indx}`);
             this.#painters.push(subp);
          }
-         return this.drawNextGraph(indx + 1);
+         return this.drawNextGraph(indx + 1, pad_painter);
       });
    }
 
@@ -176994,14 +176990,12 @@ let TMultiGraphPainter$2 = class TMultiGraphPainter extends ObjectPainter {
             mgraph = this.getObject();
 
       this.#is3d = d.check('3D');
-      this.#auto = '';
       this.#pads = d.check('PADS', true);
       if (this.#pads)
          this.#pads_columns = d.partAsInt();
-      ['PFC', 'PLC', 'PMC'].forEach(f => {
-         if (d.check(f))
-            this.#auto += ' ' + f;
-      });
+      this.#pfc = d.check('PFC');
+      this.#plc = d.check('PLC');
+      this.#pmc = d.check('PMC');
 
       let hopt = '', pad_painter = null;
       if (d.check('FB') && this.is3d())

--- a/js/changes.md
+++ b/js/changes.md
@@ -6,6 +6,7 @@
 1. Improve `TGraph` update
 1. When draw TH2/TF2 with "surf same" draw option, only lines are drawn
 1. Implement new "POLF" and "POLN" draw options for polar coordinates for `TH2`
+1. Adjust automatic colors handling in `THStack` and `TMultiGraph`
 1. Use "JSROOT" label for main pad button, hide it after 5 seconds from the drawing
 1. Let preserve `BigInt` values when calling `rntupleProcess()` function #418
 1. Use `8.6g`/`10.8g` format for float/double historgam content-to-text conversion in tooltips

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -606,13 +606,14 @@ class TPadPainter extends ObjectPainter {
    /** @summary Provides automatic color
     * @desc Uses ROOT colors palette if possible
     * @private */
-   getAutoColor(numprimitives) {
-      numprimitives = Math.max(numprimitives || (this.#num_primitives || 5) - (this.#num_specials || 0), 2);
-
-      let indx = this.#auto_color_cnt ?? 0;
-      this.#auto_color_cnt = (indx + 1) % numprimitives;
-      if (indx >= numprimitives)
-         indx = numprimitives - 1;
+   getAutoColor(numprimitives, indx) {
+      if (!numprimitives || indx === undefined) {
+         numprimitives = Math.max(numprimitives || (this.#num_primitives || 5) - (this.#num_specials || 0), 2);
+         indx = this.#auto_color_cnt ?? 0;
+         this.#auto_color_cnt = (indx + 1) % numprimitives;
+         if (indx >= numprimitives)
+            indx = numprimitives - 1;
+      }
 
       let indexes = this._getCustomPaletteIndexes();
       if (!indexes) {
@@ -2365,12 +2366,6 @@ class TPadPainter extends ObjectPainter {
             const opt = createWebObjectOptions(sub);
             if (opt)
                elem.primitives.push(opt);
-            if (sub.$copywebid && opt?.fcust) {
-               // workaround for stack histograms to assign attributes to original histo
-               const opt2 = Object.assign({}, opt);
-               opt2.snapid = sub.getPrimary().getSnapId() + '#' + sub.$copywebid;
-               elem.primitives.push(opt2);
-            }
          }
       });
 

--- a/js/modules/hist2d/TGraphPainter.mjs
+++ b/js/modules/hist2d/TGraphPainter.mjs
@@ -1042,7 +1042,7 @@ class TGraphPainter extends ObjectPainter {
       if (o._pfc > 1 || o._plc > 1 || o._pmc > 1) {
          const pp = this.getPadPainter();
          if (isFunc(pp?.getAutoColor)) {
-            const icolor = pp.getAutoColor(graph.$num_graphs);
+            const icolor = pp.getAutoColor();
             this.#auto_exec = ''; // can be reused when sending option back to server
             if (o._pfc > 1) {
                o._pfc = 1;

--- a/js/modules/hist2d/THStackPainter.mjs
+++ b/js/modules/hist2d/THStackPainter.mjs
@@ -1,7 +1,7 @@
 import { clone, create, createHistogram, setHistogramTitle, BIT,
          gStyle, clTH1F, clTH2, clTH2F, clTObjArray, kNoZoom, kNoStats } from '../core.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
-import { ObjectPainter, EAxisBits } from '../base/ObjectPainter.mjs';
+import { ObjectPainter, EAxisBits, getElementPadPainter } from '../base/ObjectPainter.mjs';
 import { TH1Painter } from './TH1Painter.mjs';
 import { TH2Painter } from './TH2Painter.mjs';
 import { ensureTCanvas } from '../gpad/TCanvasPainter.mjs';
@@ -215,8 +215,6 @@ class THStackPainter extends ObjectPainter {
       }
       if (!o.pads)
          hopt += ' same nostat';
-      if (!this.getPadPainter()?.getSnapId())
-         hopt += o.auto;
       return hopt;
    }
 
@@ -230,36 +228,39 @@ class THStackPainter extends ObjectPainter {
       if (indx >= nhists)
          return this;
 
-      const rindx = o.horder ? indx : nhists - indx - 1,
-            h_id = `hists_${rindx}`, s_id = `stack_${rindx}`,
+      const rindx = o.nostack ? indx : nhists - indx - 1,
             hist = hlst.arr[rindx],
             hopt = this.getHistDrawOption(hist, stack.fHists.opt[rindx]);
-      let dom;
+      let pp;
 
       if (pad_painter) {
          // handling of 'pads' draw option
-         const subpad_painter = pad_painter.getSubPadPainter(indx + 1);
-         if (!subpad_painter)
+         pp = pad_painter.getSubPadPainter(indx + 1);
+         if (!pp)
             return this;
-         subpad_painter.cleanPrimitives(true);
-         dom = subpad_painter;
+         pp.cleanPrimitives(true);
       } else {
          // special handling of stacked histograms
          // also used to provide tooltips
          if ((rindx > 0) && !o.nostack)
             hist.$baseh = hlst.arr[rindx - 1];
-         // this number used for auto colors creation
-         if (o.auto)
-            hist.$num_histos = nhists;
-         dom = this.#firstpainter?.getPadPainter() || this.getDrawDom();
+         pp = this.#firstpainter?.getPadPainter() || getElementPadPainter(this.getDrawDom());
       }
 
-      return this.drawHist(dom, hist, hopt).then(subp => {
+      // assign auto color to histogram, exclude web canvas
+      if ((o._pfc || o._plc || o._pmc) && pp && !pp.getSnapId()) {
+         const col = pp.getAutoColor(nhists, rindx);
+         if (o._pfc)
+            hist.fFillColor = col;
+         if (o._plc)
+            hist.fLineColor = col;
+         if (o._pmc)
+            hist.fMarkerColor = col;
+      }
+
+      return this.drawHist(pp, hist, hopt).then(subp => {
          if (subp) {
-            subp.setSecondaryId(this, o.nostack ? h_id : s_id);
-            // workaround to assign weboptions also back to original histogram
-            if (!o.nostack)
-               subp.$copywebid = h_id;
+            subp.setSecondaryId(this, o.nostack ? `hists_${rindx}` : `stack_${rindx}`);
             this.#painters.push(subp);
          }
          return this.drawNextHisto(indx + 1, pad_painter);
@@ -268,7 +269,7 @@ class THStackPainter extends ObjectPainter {
 
    /** @summary Decode draw options of THStack painter */
    decodeOptions(opt) {
-      const o = this.setOptions({ ndim: 1, nostack: false, same: false, horder: true, has_errors: false, draw_errors: false, hopt: '', auto: '' }),
+      const o = this.setOptions({ ndim: 1, nostack: false, same: false, has_errors: false, draw_errors: false, _pfc: false, _pmc: false, _plc: false, hopt: '' }),
             stack = this.getObject(),
             hist = stack.fHistogram || stack.fHists?.arr[0] || this.#stack?.arr[0];
 
@@ -300,11 +301,9 @@ class THStackPainter extends ObjectPainter {
       o.same = d.check('SAME');
 
       d.check('NOCLEAR'); // ignore option
-
-      ['PFC', 'PLC', 'PMC'].forEach(f => {
-         if (d.check(f))
-            o.auto += ' ' + f;
-      });
+      o._pfc = d.check('PFC');
+      o._plc = d.check('PLC');
+      o._pmc = d.check('PMC');
 
       if (d.check('PADS', true)) {
          o.pads = true;
@@ -325,8 +324,6 @@ class THStackPainter extends ObjectPainter {
       // if any histogram appears with pre-calculated errors, use E for all histograms
       if (!o.nostack && o.has_errors && !dolego && !d.check('HIST') && (o.hopt.indexOf('E') < 0))
          o.draw_errors = true;
-
-      o.horder = o.nostack || dolego;
    }
 
    /** @summary Create main histogram for THStack axis drawing */
@@ -423,7 +420,7 @@ class THStackPainter extends ObjectPainter {
       } else {
          this.#did_update = 2;
          for (let indx = 0; indx < nhists; ++indx) {
-            const rindx = o.horder ? indx : nhists - indx - 1,
+            const rindx = o.nostack ? indx : nhists - indx - 1,
                   hist = hlst.arr[rindx];
             this.#painters[indx].updateObject(hist, this.getHistDrawOption(hist, stack.fHists.opt[rindx]));
          }
@@ -475,7 +472,7 @@ class THStackPainter extends ObjectPainter {
                   hlst = o.nostack ? stack.fHists : this.#stack,
                   nhists = hlst?.arr?.length ?? 0;
             for (let indx = 0; indx < nhists; ++indx) {
-               const rindx = o.horder ? indx : nhists - indx - 1,
+               const rindx = o.nostack ? indx : nhists - indx - 1,
                      hist = hlst.arr[rindx];
                this.#painters[indx].decodeOptions(this.getHistDrawOption(hist, stack.fHists.opt[rindx]));
             }

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -1295,7 +1295,7 @@ class THistPainter extends ObjectPainter {
       if (o._pfc > 1 || o._plc > 1 || o._pmc > 1) {
          const pp = this.getPadPainter();
          if (isFunc(pp?.getAutoColor)) {
-            const icolor = pp.getAutoColor(histo.$num_histos);
+            const icolor = pp.getAutoColor();
             this.#auto_exec = '';
             if (o._pfc > 1) {
                o._pfc = 1;

--- a/js/modules/hist2d/TMultiGraphPainter.mjs
+++ b/js/modules/hist2d/TMultiGraphPainter.mjs
@@ -1,6 +1,6 @@
 import { create, createHistogram, clTH1F, clTH2F, clTObjString, clTHashList, kNoZoom, kNoStats, BIT } from '../core.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
-import { ObjectPainter } from '../base/ObjectPainter.mjs';
+import { ObjectPainter, getElementPadPainter } from '../base/ObjectPainter.mjs';
 import { FunctionsHandler } from './THistPainter.mjs';
 import { TH1Painter, PadDrawOptions } from './TH1Painter.mjs';
 import { TGraphPainter } from './TGraphPainter.mjs';
@@ -21,7 +21,9 @@ class TMultiGraphPainter extends ObjectPainter {
    #painters; // array of sub-painters
    #funcs_handler; // special instance for functions drawing
    #restopt; // remaining part of draw options
-   #auto; // extra options for auto colors
+   #pfc; // extra options for auto colors
+   #plc; // extra options for auto colors
+   #pmc; // extra options for auto colors
    #is3d; // if 3d drawing
    #pads;  // pads draw option
    #pads_columns; // number pads columns
@@ -40,7 +42,9 @@ class TMultiGraphPainter extends ObjectPainter {
       this.#painters = [];
       this.#is3d = undefined;
       this.#pads = undefined;
-      this.#auto = undefined;
+      this.#pfc = undefined;
+      this.#pmc = undefined;
+      this.#plc = undefined;
       this.#restopt = undefined;
       super.cleanup();
    }
@@ -70,7 +74,7 @@ class TMultiGraphPainter extends ObjectPainter {
 
       // TODO: handle changing number of graphs
       for (let i = 0; i < ngr; ++i) {
-         if (this.#painters[i].updateObject(graphs.arr[i], (graphs.opt[i] || this.#restopt) + this.#auto))
+         if (this.#painters[i].updateObject(graphs.arr[i], (graphs.opt[i] || this.#restopt)))
             isany = true;
       }
 
@@ -262,37 +266,37 @@ class TMultiGraphPainter extends ObjectPainter {
          return this;
 
       const gr = graphs.arr[indx],
-            draw_opt = (graphs.opt[indx] || this.#restopt) + this.#auto,
-            pos3d = graphs.arr.length - indx,
-            subid = `graphs_${indx}`;
+            draw_opt = (graphs.opt[indx] || this.#restopt),
+            pos3d = graphs.arr.length - indx;
+      let pp;
 
       // handling of 'pads' draw option
       if (pad_painter) {
-         const subpad_painter = pad_painter.getSubPadPainter(indx + 1);
-         if (!subpad_painter)
+         pp = pad_painter.getSubPadPainter(indx + 1);
+         if (!pp)
             return this;
 
-         subpad_painter.cleanPrimitives(true);
+         pp.cleanPrimitives(true);
+      } else
+         pp = this.#firstpainter?.getPadPainter() || getElementPadPainter(this.getDrawDom());
 
-         return this.drawGraph(subpad_painter, gr, draw_opt, pos3d).then(subp => {
-            if (subp) {
-               subp.setSecondaryId(this, subid);
-               this.#painters.push(subp);
-            }
-            return this.drawNextGraph(indx + 1, pad_painter);
-         });
+      // assign auto color to graph, exclude web canvas
+      if ((this.#pfc || this.#plc || this.#pmc) && pp && !pp.getSnapId()) {
+         const col = pp.getAutoColor(graphs.arr.length, indx);
+         if (this.#pfc)
+            gr.fFillColor = col;
+         if (this.#plc)
+            gr.fLineColor = col;
+         if (this.#pmc)
+            gr.fMarkerColor = col;
       }
 
-      // used in automatic colors numbering
-      if (this.#auto)
-         gr.$num_graphs = graphs.arr.length;
-
-      return this.drawGraph(this.getPadPainter(), gr, draw_opt, pos3d).then(subp => {
+      return this.drawGraph(pp, gr, draw_opt, pos3d).then(subp => {
          if (subp) {
-            subp.setSecondaryId(this, subid);
+            subp.setSecondaryId(this, `graphs_${indx}`);
             this.#painters.push(subp);
          }
-         return this.drawNextGraph(indx + 1);
+         return this.drawNextGraph(indx + 1, pad_painter);
       });
    }
 
@@ -317,14 +321,12 @@ class TMultiGraphPainter extends ObjectPainter {
             mgraph = this.getObject();
 
       this.#is3d = d.check('3D');
-      this.#auto = '';
       this.#pads = d.check('PADS', true);
       if (this.#pads)
          this.#pads_columns = d.partAsInt();
-      ['PFC', 'PLC', 'PMC'].forEach(f => {
-         if (d.check(f))
-            this.#auto += ' ' + f;
-      });
+      this.#pfc = d.check('PFC');
+      this.#plc = d.check('PLC');
+      this.#pmc = d.check('PMC');
 
       let hopt = '', pad_painter = null;
       if (d.check('FB') && this.is3d())


### PR DESCRIPTION
Both classes support "PFC", "PLC" and "PMC" draw option to assign auto-colors to histograms and graphs.

THStack provides `BuildPrimitives` method to handle autocolors without painting. 
Now also `TMultiGraph::BuildPrimitives()` will be implemented - to let assign autocolors in `TWebCanvas`

Improve code around "PFC", "PLC" and "PMC" options analysis in THStack and TMultiGraph. Use TString instead of plain character manipulations.

Improve `TPad::IncrementPaletteColor()` method. Change signature to `const TString &`, always convert to lower case to avoid any case mismatch

Fix `THStack::GetMinimum()/GetMaximum()` methods while option string may contain "e" symbols from other draw option.

Update TWebCanvas and JSROOT to work with new autocolor functionality in TMultiGraph, 
This let avoid several workarounds in the JavaScript code