### PR TITLE
[http] Don't enable civetweb debug tracing in Debug builds

### DIFF
--- a/builtins/civetweb/CMakeLists.txt
+++ b/builtins/civetweb/CMakeLists.txt
@@ -123,6 +123,10 @@ ExternalProject_Add(BUILTIN_CIVETWEB
     -DCIVETWEB_BUILD_TESTING=FALSE
     -DCIVETWEB_ENABLE_ASAN=OFF # If set to ON, you need to set below link_library interface to UBSAN libs
     -DCIVETWEB_ENABLE_CXX=ON
+    # civetweb defines -DDEBUG for Debug builds, which activates its DEBUG_TRACE
+    # macro (~130 call sites) and floods stderr with per-request output.
+    # Note the same option also gates civetweb's assertions.
+    -DCIVETWEB_ENABLE_DEBUG_TOOLS=OFF
     ${ROOT_SSL_API}
     -DCIVETWEB_ENABLE_SSL_DYNAMIC_LOADING=OFF # If set to ON, you need to set below link_library interface to CMAKE_DL_LIBS
     -DCIVETWEB_ENABLE_WEBSOCKETS=ON


### PR DESCRIPTION
builtins/civetweb forwards CMAKE_BUILD_TYPE to the external project, and civetweb's CMakeLists adds -DDEBUG for Debug builds via its CIVETWEB_ENABLE_DEBUG_TOOLS option, which defaults to ON. That activates the DEBUG_TRACE macro (~130 call sites in src/civetweb.c), so every ROOT Debug build with builtin civetweb writes per-request tracing to stderr, which makes the console output of web-based applications hard to read.

Pass CIVETWEB_ENABLE_DEBUG_TOOLS=OFF explicitly. Note the option gates civetweb's assertions as well as the tracing, so this disables both.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

