### PR TITLE
[roottest] Temporarily disable test

### DIFF
--- a/roottest/root/io/cpp11Containers/CMakeLists.txt
+++ b/roottest/root/io/cpp11Containers/CMakeLists.txt
@@ -3,12 +3,13 @@ ROOTTEST_GENERATE_REFLEX_DICTIONARY(unorderedMap
                                     SELECTION unorderedMap_selection.xml
                                     FIXTURES_SETUP root-io-cpp11Containers-unorderedMapDict-fixture)
 
-ROOTTEST_ADD_TEST(unorderedMap
-                  MACRO  execUnorderedMap.C
-                  OUTREF execUnorderedMap.ref
-                  FIXTURES_REQUIRED root-io-cpp11Containers-unorderedMapDict-fixture
-                  FIXTURES_SETUP root-io-cpp11Containers-unorderedMap-fixture
-                  LABELS longtest)
+# Test temporarily disabled due to a performance regression in LLVM22 leading to sporadic failures.
+# ROOTTEST_ADD_TEST(unorderedMap
+#                   MACRO  execUnorderedMap.C
+#                   OUTREF execUnorderedMap.ref
+#                   FIXTURES_REQUIRED root-io-cpp11Containers-unorderedMapDict-fixture
+#                   FIXTURES_SETUP root-io-cpp11Containers-unorderedMap-fixture
+#                   LABELS longtest)
 
 # Copy of the test above, written as a compiled C++ program based on gtest. Useful for more fine-grained view on
 # potential test failures
@@ -47,13 +48,14 @@ if(NOT 32BIT AND NOT MSVC)
                                        root-io-cpp11Containers-forwardList-fixture
                      FIXTURES_SETUP root-io-cpp11Containers-unorderedSet-fixture)
 
-   ROOTTEST_ADD_TEST(Names
-                     COPY_TO_BUILDDIR auxCode.h commonUtils.h
-                     MACRO  execcpp11ContainersNames.C
-                     OUTREF execcpp11ContainersNames.ref
-                     FIXTURES_REQUIRED root-io-cpp11Containers-unorderedSet-fixture
-                                       root-io-cpp11Containers-forwardList-fixture
-                                       root-io-cpp11Containers-unorderedMap-fixture)
+# Test temporarily disabled due to a performance regression in LLVM22 leading to sporadic failures.
+#    ROOTTEST_ADD_TEST(Names
+#                      COPY_TO_BUILDDIR auxCode.h commonUtils.h
+#                      MACRO  execcpp11ContainersNames.C
+#                      OUTREF execcpp11ContainersNames.ref
+#                      FIXTURES_REQUIRED root-io-cpp11Containers-unorderedSet-fixture
+#                                        root-io-cpp11Containers-forwardList-fixture
+#                                        root-io-cpp11Containers-unorderedMap-fixture)
 endif()
 
 


### PR DESCRIPTION
The test is disabled as it sporadically fails due to a performance degradation in LLVM22. That could be fixed by backporting patches from LLVM23, e.g. as done by https://github.com/root-project/root/pull/23284.

The test coverage for the "unorderedMap" test is kept via "unorderedMapUnitTests", a fully-compiled googletest-based rewrite which had already been added to the test suite. The "Names" test is currently not being replaced.
