### PR TITLE
[geom] Fix solid safety and polygon normals

### DIFF
--- a/geom/geom/src/TGeoArb8.cxx
+++ b/geom/geom/src/TGeoArb8.cxx
@@ -2097,7 +2097,7 @@ TGeoGtra::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact
 {
    if (iact < 3 && safe) {
       // compute safe distance
-      *safe = Safety(point, kTRUE);
+      *safe = Safety(point, kFALSE);
       if (iact == 0)
          return TGeoShape::Big();
       if (iact == 1 && step < *safe)

--- a/geom/geom/src/TGeoEltu.cxx
+++ b/geom/geom/src/TGeoEltu.cxx
@@ -170,38 +170,7 @@ TGeoEltu::DistFromInside(const Double_t *point, const Double_t *dir, Int_t iact,
    Double_t safz2 = fDz + point[2];
 
    if (iact < 3 && safe) {
-      Double_t x0 = TMath::Abs(point[0]);
-      Double_t y0 = TMath::Abs(point[1]);
-      Double_t x1 = x0;
-      Double_t y1 = TMath::Sqrt((fRmin - x0) * (fRmin + x0)) * fRmax / fRmin;
-      Double_t y2 = y0;
-      Double_t x2 = TMath::Sqrt((fRmax - y0) * (fRmax + y0)) * fRmin / fRmax;
-      Double_t d1 = (x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0);
-      Double_t d2 = (x2 - x0) * (x2 - x0) + (y2 - y0) * (y2 - y0);
-      Double_t x3, y3;
-
-      Double_t safz = TMath::Min(safz1, safz2);
-      for (Int_t i = 0; i < 8; i++) {
-         if (fRmax < fRmin) {
-            x3 = 0.5 * (x1 + x2);
-            y3 = TMath::Sqrt((fRmin - x3) * (fRmin + x3)) * fRmax / fRmin;
-            ;
-         } else {
-            y3 = 0.5 * (y1 + y2);
-            x3 = TMath::Sqrt((fRmax - y3) * (fRmax + y3)) * fRmin / fRmax;
-         }
-         if (d1 < d2) {
-            x2 = x3;
-            y2 = y3;
-            d2 = (x2 - x0) * (x2 - x0) + (y2 - y0) * (y2 - y0);
-         } else {
-            x1 = x3;
-            y1 = y3;
-            d1 = (x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0);
-         }
-      }
-      Double_t safr = TMath::Sqrt(d1) - 1.0E-3;
-      *safe = TMath::Min(safz, safr);
+      *safe = Safety(point, kTRUE);
       if (iact == 0)
          return TGeoShape::Big();
       if ((iact == 1) && (*safe > step))
@@ -412,6 +381,10 @@ Double_t TGeoEltu::Safety(const Double_t *point, Bool_t /*in*/) const
       return 0.;
 
    if (in) {
+      // Within the elliptical projection, an outside point reaches the end cap first.
+      safz = fDz - TMath::Abs(point[2]);
+      if (safz < 0.)
+         return -safz;
       x1 = fRmin * TMath::Sqrt(1. - (y0 * y0) / (fRmax * fRmax));
       y1 = fRmax * TMath::Sqrt(1. - (x0 * x0) / (fRmin * fRmin));
       dx = x1 - x0;
@@ -419,7 +392,6 @@ Double_t TGeoEltu::Safety(const Double_t *point, Bool_t /*in*/) const
       if (TMath::Abs(dx) < TGeoShape::Tolerance())
          return 0;
       safr = dx * dy / TMath::Sqrt(dx * dx + dy * dy);
-      safz = fDz - TMath::Abs(point[2]);
       return TMath::Min(safr, safz);
    }
 

--- a/geom/geom/src/TGeoPgon.cxx
+++ b/geom/geom/src/TGeoPgon.cxx
@@ -276,14 +276,10 @@ void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_
       s1 = TMath::Sin(phi1);
       c2 = TMath::Cos(phi2);
       s2 = TMath::Sin(phi2);
-      if (TGeoShape::IsCloseToPhi(1E-5, point, c1, s1, c2, s2)) {
-         TGeoShape::NormalPhi(point, dir, norm, c1, s1, c2, s2);
-         return;
-      }
    } // Phi done
 
    Int_t ipl = TMath::BinarySearch(fNz, fZ, point[2]);
-   if (ipl == (fNz - 1) || ipl < 0) {
+   if (point[2] >= fZ[fNz - 1] || ipl < 0) {
       // point outside Z range
       norm[2] = TMath::Sign(1., dir[2]);
       return;
@@ -299,31 +295,27 @@ void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_
       phi += 360.;
    Double_t ddp = phi - fPhi1;
    Int_t ipsec = Int_t(ddp / divphi);
+   // A point on or just outside a phi cut belongs to the nearest end sector.
+   if (ipsec >= fNedges)
+      ipsec = (ddp - fDphi < 360. - ddp) ? fNedges - 1 : 0;
    Double_t ph0 = (fPhi1 + divphi * (ipsec + 0.5)) * TMath::DegToRad();
    // compute projected distance
    Double_t r, rsum, rpgon, ta, calf;
    r = TMath::Abs(point[0] * TMath::Cos(ph0) + point[1] * TMath::Sin(ph0));
-   if (dz < 1E-5) {
-      if (iplclose == 0 || iplclose == (fNz - 1)) {
-         norm[2] = TMath::Sign(1., dir[2]);
-         return;
-      }
-      if (iplclose == ipl && TGeoShape::IsSameWithinTolerance(fZ[ipl], fZ[ipl - 1])) {
-         if (r < TMath::Max(fRmin[ipl], fRmin[ipl - 1]) || r > TMath::Min(fRmax[ipl], fRmax[ipl - 1])) {
-            norm[2] = TMath::Sign(1., dir[2]);
-            return;
-         }
-      } else {
-         if (TGeoShape::IsSameWithinTolerance(fZ[iplclose], fZ[iplclose + 1])) {
-            if (r < TMath::Max(fRmin[iplclose], fRmin[iplclose + 1]) ||
-                r > TMath::Min(fRmax[iplclose], fRmax[iplclose + 1])) {
-               norm[2] = TMath::Sign(1., dir[2]);
-               return;
-            }
-         }
-      }
+   Double_t safz = TGeoShape::Big();
+   if (iplclose == 0 || iplclose == (fNz - 1)) {
+      safz = dz;
+   } else if (iplclose == ipl && TGeoShape::IsSameWithinTolerance(fZ[ipl], fZ[ipl - 1])) {
+      if (r < TMath::Max(fRmin[ipl], fRmin[ipl - 1]) || r > TMath::Min(fRmax[ipl], fRmax[ipl - 1]))
+         safz = dz;
+   } else if (TGeoShape::IsSameWithinTolerance(fZ[iplclose], fZ[iplclose + 1])) {
+      if (r < TMath::Max(fRmin[iplclose], fRmin[iplclose + 1]) || r > TMath::Min(fRmax[iplclose], fRmax[iplclose + 1]))
+         safz = dz;
    } //-> Z done
 
+   // At a repeated z plane, use a section with nonzero height for the radial faces.
+   while (ipl < fNz - 2 && fZ[ipl] == fZ[ipl + 1])
+      ++ipl;
    dz = fZ[ipl + 1] - fZ[ipl];
    rmin1 = fRmin[ipl];
    rmin2 = fRmin[ipl + 1];
@@ -333,7 +325,7 @@ void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_
       ta = (rmin2 - rmin1) / dz;
       calf = 1. / TMath::Sqrt(1 + ta * ta);
       rpgon = rmin1 + (point[2] - fZ[ipl]) * ta;
-      safe = TMath::Abs(r - rpgon);
+      safe = TMath::Abs(r - rpgon) * calf;
       norm[0] = calf * TMath::Cos(ph0);
       norm[1] = calf * TMath::Sin(ph0);
       norm[2] = -calf * ta;
@@ -341,10 +333,22 @@ void TGeoPgon::ComputeNormal(const Double_t *point, const Double_t *dir, Double_
    ta = (fRmax[ipl + 1] - fRmax[ipl]) / dz;
    calf = 1. / TMath::Sqrt(1 + ta * ta);
    rpgon = fRmax[ipl] + (point[2] - fZ[ipl]) * ta;
-   if (safe > TMath::Abs(rpgon - r)) {
+   Double_t safr = TMath::Abs(rpgon - r) * calf;
+   if (safe > safr) {
+      safe = safr;
       norm[0] = calf * TMath::Cos(ph0);
       norm[1] = calf * TMath::Sin(ph0);
       norm[2] = -calf * ta;
+   }
+   // Compare face distances instead of letting a fixed tolerance select a nearby face.
+   if (safz < safe) {
+      safe = safz;
+      norm[0] = norm[1] = 0.;
+      norm[2] = 1.;
+   }
+   if (is_seg && TGeoShape::IsCloseToPhi(safe, point, c1, s1, c2, s2)) {
+      TGeoShape::NormalPhi(point, dir, norm, c1, s1, c2, s2);
+      return;
    }
    if (norm[0] * dir[0] + norm[1] * dir[1] + norm[2] * dir[2] < 0) {
       norm[0] = -norm[0];

--- a/geom/geom/src/TGeoSphere.cxx
+++ b/geom/geom/src/TGeoSphere.cxx
@@ -437,58 +437,19 @@ TGeoSphere::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t ia
    Double_t sdist = TGeoBBox::DistFromOutside(point, dir, fDX, fDY, fDZ, fOrigin, step);
    if (sdist >= step)
       return TGeoShape::Big();
-   Double_t saf[6];
-   Double_t r1, r2, z1, z2, dz, si, ci;
-   Double_t rxy2 = point[0] * point[0] + point[1] * point[1];
-   Double_t rxy = TMath::Sqrt(rxy2);
-   r2 = rxy2 + point[2] * point[2];
-   Double_t r = TMath::Sqrt(r2);
-   Bool_t rzero = kFALSE;
-   Double_t phi = 0;
-   if (r < 1E-20)
-      rzero = kTRUE;
-   // localize theta
-   Double_t th = 0.;
-   if (TestShapeBit(kGeoThetaSeg) && (!rzero)) {
-      th = TMath::ACos(point[2] / r) * TMath::RadToDeg();
-   }
-   // localize phi
-   if (TestShapeBit(kGeoPhiSeg)) {
-      phi = TMath::ATan2(point[1], point[0]) * TMath::RadToDeg();
-      if (phi < 0)
-         phi += 360.;
-   }
    if (iact < 3 && safe) {
-      saf[0] = (r < fRmin) ? fRmin - r : TGeoShape::Big();
-      saf[1] = (r > fRmax) ? (r - fRmax) : TGeoShape::Big();
-      saf[2] = saf[3] = saf[4] = saf[5] = TGeoShape::Big();
-      if (TestShapeBit(kGeoThetaSeg)) {
-         if (th < fTheta1) {
-            saf[2] = r * TMath::Sin((fTheta1 - th) * TMath::DegToRad());
-         }
-         if (th > fTheta2) {
-            saf[3] = r * TMath::Sin((th - fTheta2) * TMath::DegToRad());
-         }
-      }
-      if (TestShapeBit(kGeoPhiSeg)) {
-         Double_t dph1 = phi - fPhi1;
-         if (dph1 < 0)
-            dph1 += 360.;
-         if (dph1 <= 90.)
-            saf[4] = rxy * TMath::Sin(dph1 * TMath::DegToRad());
-         Double_t dph2 = fPhi2 - phi;
-         if (dph2 < 0)
-            dph2 += 360.;
-         if (dph2 > 90.)
-            saf[5] = rxy * TMath::Sin(dph2 * TMath::DegToRad());
-      }
-      *safe = saf[TMath::LocMin(6, &saf[0])];
+      // Reuse the outside lower bound, including the angular-cut constraints.
+      *safe = Safety(point, kFALSE);
       if (iact == 0)
          return TGeoShape::Big();
       if (iact == 1 && step < *safe)
          return TGeoShape::Big();
    }
    // compute distance to shape
+   Double_t r1, r2, z1, z2, dz, si, ci;
+   Double_t rxy2 = point[0] * point[0] + point[1] * point[1];
+   r2 = rxy2 + point[2] * point[2];
+   Double_t r = TMath::Sqrt(r2);
    // first check if any crossing at all
    Double_t snxt = TGeoShape::Big();
    Double_t rdotn = point[0] * dir[0] + point[1] * dir[1] + point[2] * dir[2];

--- a/geom/geom/src/TGeoXtru.cxx
+++ b/geom/geom/src/TGeoXtru.cxx
@@ -607,7 +607,7 @@ TGeoXtru::DistFromOutside(const Double_t *point, const Double_t *dir, Int_t iact
 {
    ThreadData_t &td = GetThreadData();
    if (iact < 3 && safe) {
-      *safe = Safety(point, kTRUE);
+      *safe = Safety(point, kFALSE);
       if (iact == 0)
          return TGeoShape::Big();
       if (iact == 1 && step < *safe)

--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -24,6 +24,10 @@ ROOT_ADD_GTEST(tessellated
   test_tessellated.cxx
   LIBRARIES Geom)
 
+ROOT_ADD_GTEST(shape_safety
+  test_shape_safety.cxx
+  LIBRARIES Geom)
+
 ROOT_ADD_GTEST(overlap_navigation
   test_overlap_navigation.cxx
   LIBRARIES Geom)

--- a/geom/test/CMakeLists.txt
+++ b/geom/test/CMakeLists.txt
@@ -28,6 +28,10 @@ ROOT_ADD_GTEST(shape_safety
   test_shape_safety.cxx
   LIBRARIES Geom)
 
+ROOT_ADD_GTEST(pgon_normal
+  test_pgon_normal.cxx
+  LIBRARIES Geom)
+
 ROOT_ADD_GTEST(overlap_navigation
   test_overlap_navigation.cxx
   LIBRARIES Geom)

--- a/geom/test/test_pgon_normal.cxx
+++ b/geom/test/test_pgon_normal.cxx
@@ -1,0 +1,136 @@
+#include "TGeoManager.h"
+#include "TGeoPgon.h"
+#include "TMath.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace {
+
+// ROOT orients normals towards the direction. Check parallelism independently of sign.
+void CheckNormal(const TGeoPgon &shape, const double *point, const double *expected)
+{
+   for (double sign : {-1., 1.}) {
+      const double direction[] = {sign * expected[0], sign * expected[1], sign * expected[2]};
+      double normal[3];
+      shape.ComputeNormal(point, direction, normal);
+      EXPECT_NEAR(normal[1] * expected[2] - normal[2] * expected[1], 0., 1.e-12);
+      EXPECT_NEAR(normal[2] * expected[0] - normal[0] * expected[2], 0., 1.e-12);
+      EXPECT_NEAR(normal[0] * expected[1] - normal[1] * expected[0], 0., 1.e-12);
+      EXPECT_NEAR(normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2], 1., 1.e-12);
+      EXPECT_GT(normal[0] * direction[0] + normal[1] * direction[1] + normal[2] * direction[2], 0.);
+   }
+}
+
+TEST(TGeoPgon, NormalNearPhiCut)
+{
+   const int verbose = TGeoManager::GetVerboseLevel();
+   TGeoManager::SetVerboseLevel(0);
+   TGeoManager manager("pgon_normal", "polygon normal tests");
+   TGeoManager::SetVerboseLevel(verbose);
+   TGeoPgon shape(15., 270., 8, 2);
+   shape.DefineSection(0, -15., 3., 10.);
+   shape.DefineSection(1, 15., 3., 10.);
+
+   // A recorded radial exit lies about 6.4e-6 cm from the phi plane.
+   const double exit[] = {3.0281659171434625, .81140121787309871, 8.3339698762290197};
+   const double innerNormal[] = {std::cos(31.875 * TMath::DegToRad()), std::sin(31.875 * TMath::DegToRad()), 0.};
+   CheckNormal(shape, exit, innerNormal);
+
+   for (double phi : {15., 285.}) {
+      const double angle = phi * TMath::DegToRad();
+      const double faceAngle = (phi == 15. ? 31.875 : 268.125) * TMath::DegToRad();
+      const double radialNormal[] = {std::cos(faceAngle), std::sin(faceAngle), 0.};
+      const double phiNormal[] = {-std::sin(angle), std::cos(angle), 0.};
+      for (double offset : {1.e-8, 1.e-6}) {
+         SCOPED_TRACE(testing::Message() << "phi=" << phi << ", offset=" << offset);
+         const double nearAngle = angle + (phi == 15. ? offset : -offset);
+         for (double radius : {3., 10.}) {
+            const double r = radius / std::cos(nearAngle - faceAngle);
+            const double point[] = {r * std::cos(nearAngle), r * std::sin(nearAngle), 0.};
+            CheckNormal(shape, point, radialNormal);
+         }
+         // A displaced phi point must still choose phi when radial faces are farther away.
+         const double phiPoint[] = {6. * std::cos(nearAngle), 6. * std::sin(nearAngle), 0.};
+         CheckNormal(shape, phiPoint, phiNormal);
+      }
+      const double phiPoint[] = {6. * std::cos(angle), 6. * std::sin(angle), 0.};
+      CheckNormal(shape, phiPoint, phiNormal);
+      const double outsideAngle = angle + (phi == 15. ? -1.e-8 : 1.e-8);
+      const double outsidePoint[] = {6. * std::cos(outsideAngle), 6. * std::sin(outsideAngle), 0.};
+      CheckNormal(shape, outsidePoint, phiNormal);
+   }
+}
+
+TEST(TGeoPgon, NormalNearEndCap)
+{
+   const int verbose = TGeoManager::GetVerboseLevel();
+   TGeoManager::SetVerboseLevel(0);
+   TGeoManager manager("pgon_cap_normal", "polygon cap normal tests");
+   TGeoManager::SetVerboseLevel(verbose);
+   TGeoPgon shape(15., 270., 8, 2);
+   shape.DefineSection(0, -15., 3., 10.);
+   shape.DefineSection(1, 15., 3., 10.);
+   const double angle = 15. * TMath::DegToRad();
+   const double phiNormal[] = {-std::sin(angle), std::cos(angle), 0.};
+   const double capNormal[] = {0., 0., 1.};
+   const double faceAngle = 31.875 * TMath::DegToRad();
+   const double radialNormal[] = {std::cos(faceAngle), std::sin(faceAngle), 0.};
+   for (double sign : {-1., 1.}) {
+      const double radialPoint[] = {10. * std::cos(faceAngle), 10. * std::sin(faceAngle), sign * (15. - 1.e-6)};
+      CheckNormal(shape, radialPoint, radialNormal);
+      const double phiPoint[] = {6. * std::cos(angle), 6. * std::sin(angle), sign * (15. - 1.e-6)};
+      CheckNormal(shape, phiPoint, phiNormal);
+      for (double gap : {0., 1.e-8}) {
+         const double capPoint[] = {6. * std::cos(angle + 1.e-6), 6. * std::sin(angle + 1.e-6), sign * (15. - gap)};
+         CheckNormal(shape, capPoint, capNormal);
+      }
+   }
+}
+
+TEST(TGeoPgon, NormalNearSlopedFace)
+{
+   const int verbose = TGeoManager::GetVerboseLevel();
+   TGeoManager::SetVerboseLevel(0);
+   TGeoManager manager("pgon_slope_normal", "polygon sloped normal tests");
+   TGeoManager::SetVerboseLevel(verbose);
+   TGeoPgon shape(15., 270., 8, 2);
+   shape.DefineSection(0, -15., 3., 10.);
+   shape.DefineSection(1, 15., 3., 40.);
+   const double angle = 15. * TMath::DegToRad();
+   const double faceAngle = 31.875 * TMath::DegToRad();
+   const double radialNormal[] = {std::cos(faceAngle) * std::sqrt(0.5), std::sin(faceAngle) * std::sqrt(0.5),
+                                  -std::sqrt(0.5)};
+   const double phiNormal[] = {-std::sin(angle), std::cos(angle), 0.};
+   // Compare perpendicular distances: the radial separation must include the slope.
+   for (double gap : {3.e-6, 6.e-6}) {
+      const double r = (25. - gap) / std::cos(angle + 1.e-7 - faceAngle);
+      const double point[] = {r * std::cos(angle + 1.e-7), r * std::sin(angle + 1.e-7), 0.};
+      CheckNormal(shape, point, gap == 3.e-6 ? radialNormal : phiNormal);
+   }
+}
+
+TEST(TGeoPgon, NormalAtZDiscontinuity)
+{
+   const int verbose = TGeoManager::GetVerboseLevel();
+   TGeoManager::SetVerboseLevel(0);
+   TGeoManager manager("pgon_step_normal", "polygon step normal tests");
+   TGeoManager::SetVerboseLevel(verbose);
+   TGeoPgon shape(0., 360., 4, 4);
+   shape.DefineSection(0, -15., 0., 10.);
+   shape.DefineSection(1, 0., 0., 10.);
+   shape.DefineSection(2, 0., 0., 6.);
+   shape.DefineSection(3, 15., 0., 6.);
+   const double radialNormal[] = {std::sqrt(0.5), std::sqrt(0.5), 0.};
+   const double capNormal[] = {0., 0., 1.};
+   for (double z : {-1.e-6, 0., 1.e-6}) {
+      const double ledgePoint[] = {8. * radialNormal[0], 8. * radialNormal[1], z};
+      CheckNormal(shape, ledgePoint, capNormal);
+      // Within the common cross section, the internal z plane is not a face.
+      const double commonPoint[] = {5. * radialNormal[0], 5. * radialNormal[1], z};
+      CheckNormal(shape, commonPoint, radialNormal);
+   }
+}
+
+} // namespace

--- a/geom/test/test_shape_safety.cxx
+++ b/geom/test/test_shape_safety.cxx
@@ -1,0 +1,76 @@
+#include "TGeoEltu.h"
+#include "TGeoManager.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <memory>
+
+namespace {
+
+class ShapeSafety : public testing::Test {
+protected:
+   int fVerbose = TGeoManager::GetVerboseLevel();
+   std::unique_ptr<TGeoManager> fManager;
+
+   void SetUp() override
+   {
+      TGeoManager::SetVerboseLevel(0);
+      fManager = std::make_unique<TGeoManager>("safety", "shape safety tests");
+   }
+
+   void TearDown() override
+   {
+      fManager.reset();
+      TGeoManager::SetVerboseLevel(fVerbose);
+   }
+};
+
+TEST_F(ShapeSafety, EltuOutsideEndCaps)
+{
+   TGeoEltu shape(5., 10., 15.);
+   const std::array<std::array<double, 3>, 4> points = {
+      {{0., 0., 20.}, {3.741789718811936, -5.653856736807612, -20.911110224363568}, {4., 4., 20.}, {-4., -4., -20.}}};
+   for (const auto &point : points) {
+      SCOPED_TRACE(testing::PrintToString(point));
+      ASSERT_FALSE(shape.Contains(point.data()));
+      const double direction[] = {0., 0., point[2] > 0. ? -1. : 1.};
+      const double capDistance = std::abs(point[2]) - 15.;
+      EXPECT_DOUBLE_EQ(shape.Safety(point.data(), false), capDistance);
+      EXPECT_DOUBLE_EQ(shape.DistFromOutside(point.data(), direction, 3), capDistance);
+   }
+}
+
+TEST_F(ShapeSafety, EltuExitNearLateralSurface)
+{
+   // A circular section provides an exact radial distance as an independent upper bound.
+   for (double b : {5., 10.}) {
+      TGeoEltu shape(5., b, 15.);
+      for (double gap : {1.e-6, 1.e-4, 0.1}) {
+         SCOPED_TRACE(testing::Message() << "b=" << b << ", gap=" << gap);
+         const double point[] = {0.6 * (5. - gap), 0.8 * b * (1. - gap / 5.), 0.};
+         const double direction[] = {0.6, 0.8, 0.};
+         ASSERT_TRUE(shape.Contains(point));
+         const double distance = shape.DistFromInside(point, direction, 3);
+         if (b == 5.)
+            EXPECT_NEAR(distance, gap, 1.e-12);
+         const double expected = shape.Safety(point, true);
+         ASSERT_GT(expected, 0.);
+         for (int action : {0, 1, 2}) {
+            SCOPED_TRACE(action);
+            double safety = -1.;
+            const double result = shape.DistFromInside(point, direction, action, TGeoShape::Big(), &safety);
+            EXPECT_GE(safety, 0.);
+            EXPECT_LE(safety, distance + 1.e-12);
+            EXPECT_DOUBLE_EQ(safety, expected);
+            EXPECT_DOUBLE_EQ(result, action == 0 ? TGeoShape::Big() : distance);
+         }
+         double safety = -1.;
+         EXPECT_EQ(shape.DistFromInside(point, direction, 1, 0.5 * expected, &safety), TGeoShape::Big());
+         EXPECT_DOUBLE_EQ(safety, expected);
+      }
+   }
+}
+
+} // namespace

--- a/geom/test/test_shape_safety.cxx
+++ b/geom/test/test_shape_safety.cxx
@@ -77,8 +77,9 @@ TEST_F(ShapeSafety, EltuExitNearLateralSurface)
          const double direction[] = {0.6, 0.8, 0.};
          ASSERT_TRUE(shape.Contains(point));
          const double distance = shape.DistFromInside(point, direction, 3);
-         if (b == 5.)
+         if (b == 5.) {
             EXPECT_NEAR(distance, gap, 1.e-12);
+         }
          const double expected = shape.Safety(point, true);
          ASSERT_GT(expected, 0.);
          for (int action : {0, 1, 2}) {

--- a/geom/test/test_shape_safety.cxx
+++ b/geom/test/test_shape_safety.cxx
@@ -1,5 +1,8 @@
+#include "TGeoArb8.h"
 #include "TGeoEltu.h"
 #include "TGeoManager.h"
+#include "TGeoSphere.h"
+#include "TGeoXtru.h"
 
 #include <gtest/gtest.h>
 
@@ -26,6 +29,27 @@ protected:
       TGeoManager::SetVerboseLevel(fVerbose);
    }
 };
+
+void CheckEntrySafety(const TGeoShape &shape, const double *point, const double *direction)
+{
+   ASSERT_FALSE(shape.Contains(point));
+   const double expected = shape.Safety(point, false);
+   ASSERT_GT(expected, 0.);
+   const double distance = shape.DistFromOutside(point, direction, 3);
+   ASSERT_LT(distance, TGeoShape::Big());
+   for (int action : {0, 1, 2}) {
+      SCOPED_TRACE(action);
+      double safety = -1.;
+      const double result = shape.DistFromOutside(point, direction, action, TGeoShape::Big(), &safety);
+      EXPECT_GE(safety, 0.);
+      EXPECT_DOUBLE_EQ(safety, expected);
+      EXPECT_LE(safety, distance + 1.e-12);
+      EXPECT_DOUBLE_EQ(result, action == 0 ? TGeoShape::Big() : distance);
+   }
+   double safety = -1.;
+   EXPECT_EQ(shape.DistFromOutside(point, direction, 1, 0.5 * expected, &safety), TGeoShape::Big());
+   EXPECT_DOUBLE_EQ(safety, expected);
+}
 
 TEST_F(ShapeSafety, EltuOutsideEndCaps)
 {
@@ -71,6 +95,57 @@ TEST_F(ShapeSafety, EltuExitNearLateralSurface)
          EXPECT_DOUBLE_EQ(safety, expected);
       }
    }
+}
+
+TEST_F(ShapeSafety, GtraEntry)
+{
+   TGeoGtra shape(15., 0., 0., 15., 8., 5., 10., 0., 8., 5., 10., 0.);
+   for (double sign : {-1., 1.}) {
+      const double point[] = {0., 0., sign * 20.}, direction[] = {0., 0., -sign};
+      EXPECT_DOUBLE_EQ(shape.Safety(point, false), 5.);
+      CheckEntrySafety(shape, point, direction);
+   }
+}
+
+TEST_F(ShapeSafety, XtruEntry)
+{
+   TGeoXtru shape(2);
+   const double x[] = {-5., 5., 5., -5.}, y[] = {-10., -10., 10., 10.};
+   shape.DefinePolygon(4, x, y);
+   shape.DefineSection(0, -15.);
+   shape.DefineSection(1, 15.);
+   const std::array<std::array<double, 3>, 3> points = {{{0., 0., 20.}, {0., 0., -20.}, {8., 0., 0.}}};
+   for (const auto &point : points) {
+      const double direction[] = {point[0] > 0. ? -1. : 0., 0., point[2] == 0. ? 0. : -std::copysign(1., point[2])};
+      CheckEntrySafety(shape, point.data(), direction);
+   }
+}
+
+TEST_F(ShapeSafety, SphereEntryThroughThetaCut)
+{
+   TGeoSphere shape(0., 10., 20., 150., 15., 285.);
+   // Outside theta1 but inside the radial and phi ranges. The old optional safety
+   // used the sine of a phi separation greater than 180 degrees and became negative.
+   const double point[] = {0.5638675685705744, 3.1849154358102036, 9.116139441428437};
+   const double direction[] = {-0.7131596062860449, 0.23833579772843216, -0.6592415516964061};
+   CheckEntrySafety(shape, point, direction);
+}
+
+TEST_F(ShapeSafety, SphereEntryThroughPhiCut)
+{
+   TGeoSphere shape(0., 10., 0., 180., 15., 285.);
+   const double point[] = {5., 0., 0.}, direction[] = {0., 1., 0.};
+   CheckEntrySafety(shape, point, direction);
+}
+
+TEST_F(ShapeSafety, SphereEntryThroughRadialSurfaces)
+{
+   TGeoSphere shape(2., 10.);
+   const double innerPoint[] = {0., 0., 1.}, innerDirection[] = {0., 0., 1.};
+   CheckEntrySafety(shape, innerPoint, innerDirection);
+   // Inside the bounding box, so its rejection does not skip the optional safety.
+   const double outerPoint[] = {8., 8., 0.}, outerDirection[] = {-std::sqrt(0.5), -std::sqrt(0.5), 0.};
+   CheckEntrySafety(shape, outerPoint, outerDirection);
 }
 
 } // namespace


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Comparing native TGeo solids with VecGeom wrappers exposed ROOT queries returning negative safeties or the normal of a neighboring face. These violate the safety lower-bound and closest-face contracts used by geometry navigation.

- **TGeoEltu:** return the positive distance to an end cap for outside points whose projection is inside the ellipse. Reuse `Safety(point, true)` for optional exit safety, replacing an iterative estimate minus a fixed offset that could become negative near the lateral surface.
- **TGeoGtra, TGeoXtru, TGeoSphere:** use `Safety(point, false)` for optional entry safety. Gtra and Xtru requested the inside bound; Sphere's separate angular calculation could produce negative values across theta or phi cuts. Remove the obsolete sphere calculations.
- **TGeoPgon:** select the normal using perpendicular distances to radial, phi, and horizontal faces. The previous fixed-tolerance checks could select a nearby phi or z face before considering the actual radial face. Include radial slopes, select the end sector for points around phi cuts, and avoid zero-height sections at repeated z planes. Preserve ROOT's direction-facing normal convention.

Add 11 native regression cases covering both caps, near-surface safety, distance-query action modes, radial and angular entries, competing polygon faces, and z discontinuities. They require neither VecGeom nor an external geometry file. Public interfaces and persistent data layouts are unchanged.

## Validation

Built with GCC 13, C++17, RelWithDebInfo, `testing=ON`, `gdml=ON`, `imt=ON`, and `vecgeom=OFF`.

- On the upstream base, 10 of the 11 new cases fail; the radial sphere control passes.
- With the fixes, all 11 new cases pass, and `ctest -R '^gtest-geom-' --output-on-failure` passes all 10 geometry test executables, including GDML and navigation tests.

## Checklist:

- [x] tested changes locally
- [x]  added implementation comments and regressions; no public API documentation changes needed.

Assisted by Codex (GPT-6).
